### PR TITLE
feat(auth): add same-tab redirect mode for Plex OAuth automation

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -23,7 +23,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
-          cache: true
 
       - name: Install dependencies
         run: bun install

--- a/src/lib/client/auth-mode.ts
+++ b/src/lib/client/auth-mode.ts
@@ -1,0 +1,18 @@
+/**
+ * Detects whether the Plex login flow should use the same-tab redirect path
+ * instead of the default popup. Lets headless browsers / E2E automation
+ * complete OAuth without orchestrating a second window.
+ *
+ * Precedence: explicit `?auth=` query param overrides any heuristic.
+ */
+export function shouldUseRedirectAuth(searchParams: URLSearchParams): boolean {
+	const authParam = searchParams.get('auth');
+	if (authParam === 'redirect') return true;
+	if (authParam === 'popup') return false;
+
+	if (typeof navigator === 'undefined') return false;
+	if (navigator.webdriver === true) return true;
+
+	const ua = navigator.userAgent || '';
+	return /HeadlessChrome|Playwright|Puppeteer|Selenium/i.test(ua);
+}

--- a/src/lib/client/auth-mode.ts
+++ b/src/lib/client/auth-mode.ts
@@ -1,3 +1,8 @@
+interface AuthNavigator {
+	webdriver?: boolean;
+	userAgent?: string;
+}
+
 /**
  * Detects whether the Plex login flow should use the same-tab redirect path
  * instead of the default popup. Lets headless browsers / E2E automation
@@ -5,14 +10,17 @@
  *
  * Precedence: explicit `?auth=` query param overrides any heuristic.
  */
-export function shouldUseRedirectAuth(searchParams: URLSearchParams): boolean {
+export function shouldUseRedirectAuth(
+	searchParams: URLSearchParams,
+	currentNavigator: AuthNavigator | null = typeof navigator === 'undefined' ? null : navigator
+): boolean {
 	const authParam = searchParams.get('auth');
 	if (authParam === 'redirect') return true;
 	if (authParam === 'popup') return false;
 
-	if (typeof navigator === 'undefined') return false;
-	if (navigator.webdriver === true) return true;
+	if (!currentNavigator) return false;
+	if (currentNavigator.webdriver === true) return true;
 
-	const ua = navigator.userAgent || '';
+	const ua = currentNavigator.userAgent || '';
 	return /HeadlessChrome|Playwright|Puppeteer|Selenium/i.test(ua);
 }

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -1,0 +1,189 @@
+/**
+ * Shared client-side helpers for the Plex OAuth login flow.
+ *
+ * Two entry points share PIN-fetch and polling plumbing:
+ *  - `startPlexLoginPopup`   — opens Plex.tv in a popup, polls for the auth token
+ *    in the background, and finalises by exchanging the token at /auth/plex/callback.
+ *  - `startPlexLoginRedirect` — same-tab navigation to Plex.tv with `forwardUrl`
+ *    pointing back at /auth/plex/redirect; the redirect page then polls and
+ *    completes the callback. Designed for headless / E2E automation that
+ *    cannot reliably orchestrate popups.
+ */
+
+export const PIN_STORAGE_KEY = 'obzorarr_plex_pin';
+
+const POLL_INTERVAL_MS = 2000;
+const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+
+export type PlexLoginContext = 'landing' | 'onboarding';
+
+export interface PlexLoginUser {
+	id?: number;
+	plexId?: number;
+	username?: string;
+	isAdmin: boolean;
+}
+
+export interface PlexLoginPopupOptions {
+	context: PlexLoginContext;
+	onSuccess: (user: PlexLoginUser) => void | Promise<void>;
+	onError: (message: string) => void;
+	onPopupBlocked: (pinId: number, authUrl: string) => void;
+}
+
+export interface PlexLoginRedirectOptions {
+	context: PlexLoginContext;
+	onError: (message: string) => void;
+}
+
+export interface PlexLoginController {
+	cancel(): void;
+}
+
+interface PinResponse {
+	pinId: number;
+	authUrl: string;
+}
+
+async function fetchPin(redirectUrl?: string): Promise<PinResponse> {
+	const url = redirectUrl
+		? `/auth/plex?redirectUrl=${encodeURIComponent(redirectUrl)}`
+		: '/auth/plex';
+	const response = await fetch(url);
+	if (!response.ok) {
+		const errData = (await response.json().catch(() => ({}))) as { message?: string };
+		throw new Error(errData.message || 'Failed to initiate login');
+	}
+	return (await response.json()) as PinResponse;
+}
+
+function storePinForRedirect(pinId: number, context: PlexLoginContext): void {
+	sessionStorage.setItem(
+		PIN_STORAGE_KEY,
+		JSON.stringify({ pinId, createdAt: Date.now(), context })
+	);
+}
+
+export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginController {
+	let pollIntervalId: ReturnType<typeof setInterval> | null = null;
+	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+	let cancelled = false;
+	let authWindow: Window | null = null;
+
+	const cleanup = () => {
+		if (pollIntervalId) clearInterval(pollIntervalId);
+		if (timeoutId) clearTimeout(timeoutId);
+		pollIntervalId = null;
+		timeoutId = null;
+	};
+
+	const handlePopupBlocked = async () => {
+		try {
+			const redirectUrl = `${window.location.origin}/auth/plex/redirect`;
+			const { pinId, authUrl } = await fetchPin(redirectUrl);
+			if (cancelled) return;
+			opts.onPopupBlocked(pinId, authUrl);
+		} catch {
+			opts.onError('Unable to prepare redirect. Please try again.');
+		}
+	};
+
+	void (async () => {
+		try {
+			const { pinId, authUrl } = await fetchPin();
+			if (cancelled) return;
+
+			authWindow = window.open(authUrl, 'plex-auth', 'width=600,height=700');
+
+			if (!authWindow) {
+				await handlePopupBlocked();
+				return;
+			}
+
+			await new Promise((r) => setTimeout(r, 100));
+			if (cancelled) return;
+			if (authWindow.closed) {
+				await handlePopupBlocked();
+				return;
+			}
+
+			pollIntervalId = setInterval(async () => {
+				try {
+					const pollResponse = await fetch('/auth/plex', {
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify({ pinId })
+					});
+
+					if (!pollResponse.ok) {
+						if (pollResponse.status === 401) {
+							cleanup();
+							opts.onError('Authentication expired. Please try again.');
+						}
+						return;
+					}
+
+					const result = (await pollResponse.json()) as { pending: true } | { authToken: string };
+
+					if ('authToken' in result && result.authToken) {
+						cleanup();
+						authWindow?.close();
+
+						const callbackResponse = await fetch('/auth/plex/callback', {
+							method: 'POST',
+							headers: { 'Content-Type': 'application/json' },
+							body: JSON.stringify({ authToken: result.authToken })
+						});
+
+						if (!callbackResponse.ok) {
+							const errData = (await callbackResponse.json().catch(() => ({}))) as {
+								message?: string;
+							};
+							throw new Error(errData.message || 'Login failed');
+						}
+
+						const userData = (await callbackResponse.json()) as { user: PlexLoginUser };
+						await opts.onSuccess(userData.user);
+					}
+				} catch (err) {
+					cleanup();
+					opts.onError(err instanceof Error ? err.message : 'Login failed');
+				}
+			}, POLL_INTERVAL_MS);
+
+			timeoutId = setTimeout(() => {
+				cleanup();
+				opts.onError('Authentication timed out. Please try again.');
+			}, LOGIN_TIMEOUT_MS);
+		} catch (err) {
+			opts.onError(err instanceof Error ? err.message : 'Login failed');
+		}
+	})();
+
+	return {
+		cancel() {
+			cancelled = true;
+			cleanup();
+		}
+	};
+}
+
+export async function startPlexLoginRedirect(opts: PlexLoginRedirectOptions): Promise<void> {
+	try {
+		const redirectUrl = `${window.location.origin}/auth/plex/redirect`;
+		const { pinId, authUrl } = await fetchPin(redirectUrl);
+		storePinForRedirect(pinId, opts.context);
+		window.location.href = authUrl;
+	} catch (err) {
+		opts.onError(err instanceof Error ? err.message : 'Failed to initiate login');
+	}
+}
+
+export function commitRedirectFromPopupBlocked(
+	pinId: number,
+	authUrl: string,
+	context: PlexLoginContext
+): void {
+	storePinForRedirect(pinId, context);
+	window.location.href = authUrl;
+}

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -69,6 +69,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 	let timeoutId: ReturnType<typeof setTimeout> | null = null;
 	let cancelled = false;
 	let finished = false;
+	let succeeded = false;
 	let authWindow: Window | null = null;
 
 	const cleanup = () => {
@@ -76,6 +77,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 		if (timeoutId) clearTimeout(timeoutId);
 		pollIntervalId = null;
 		timeoutId = null;
+		authWindow?.close();
 		finished = true;
 	};
 
@@ -133,7 +135,6 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 
 					if ('authToken' in result && result.authToken) {
 						cleanup();
-						authWindow?.close();
 
 						const callbackResponse = await fetch('/auth/plex/callback', {
 							method: 'POST',
@@ -149,10 +150,11 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 						}
 
 						const userData = (await callbackResponse.json()) as { user: PlexLoginUser };
+						succeeded = true;
 						await opts.onSuccess(userData.user);
 					}
 				} catch (err) {
-					if (cancelled || finished) return;
+					if (cancelled || succeeded) return;
 					cleanup();
 					opts.onError(err instanceof Error ? err.message : 'Login failed');
 				}

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -70,6 +70,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 	let cancelled = false;
 	let finished = false;
 	let succeeded = false;
+	let timedOut = false;
 	let authWindow: Window | null = null;
 
 	const cleanup = () => {
@@ -154,7 +155,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 						await opts.onSuccess(userData.user);
 					}
 				} catch (err) {
-					if (cancelled || succeeded) return;
+					if (cancelled || succeeded || timedOut) return;
 					cleanup();
 					opts.onError(err instanceof Error ? err.message : 'Login failed');
 				}
@@ -162,6 +163,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 
 			timeoutId = setTimeout(() => {
 				if (finished) return;
+				timedOut = true;
 				cleanup();
 				opts.onError('Authentication timed out. Please try again.');
 			}, LOGIN_TIMEOUT_MS);
@@ -196,6 +198,12 @@ export function commitRedirectFromPopupBlocked(
 	authUrl: string,
 	context: PlexLoginContext
 ): void {
-	storePinForRedirect(pinId, context);
+	try {
+		storePinForRedirect(pinId, context);
+	} catch {
+		throw new Error(
+			'Unable to save login state. Storage may be blocked. Please enable cookies/storage for this site.'
+		);
+	}
 	window.location.href = authUrl;
 }

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -70,6 +70,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 	let cancelled = false;
 	let finished = false;
 	let succeeded = false;
+	let pinExpired = false;
 	let timedOut = false;
 	let authWindow: Window | null = null;
 
@@ -125,6 +126,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 
 					if (!pollResponse.ok) {
 						if (pollResponse.status === 401) {
+							pinExpired = true;
 							cleanup();
 							opts.onError('Authentication expired. Please try again.');
 						}
@@ -151,11 +153,11 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 						}
 
 						const userData = (await callbackResponse.json()) as { user: PlexLoginUser };
-						succeeded = true;
 						await opts.onSuccess(userData.user);
+						succeeded = true;
 					}
 				} catch (err) {
-					if (cancelled || succeeded || timedOut) return;
+					if (cancelled || succeeded || timedOut || pinExpired) return;
 					cleanup();
 					opts.onError(err instanceof Error ? err.message : 'Login failed');
 				}

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -12,8 +12,8 @@
 
 export const PIN_STORAGE_KEY = 'obzorarr_plex_pin';
 
-const POLL_INTERVAL_MS = 2000;
-const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+export const POLL_INTERVAL_MS = 2000;
+export const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
 
 export type PlexLoginContext = 'landing' | 'onboarding';
 
@@ -86,6 +86,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 			if (cancelled) return;
 			opts.onPopupBlocked(pinId, authUrl);
 		} catch {
+			if (cancelled) return;
 			opts.onError('Unable to prepare redirect. Please try again.');
 		}
 	};
@@ -151,7 +152,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 						await opts.onSuccess(userData.user);
 					}
 				} catch (err) {
-					if (cancelled) return;
+					if (cancelled || finished) return;
 					cleanup();
 					opts.onError(err instanceof Error ? err.message : 'Login failed');
 				}
@@ -163,6 +164,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 				opts.onError('Authentication timed out. Please try again.');
 			}, LOGIN_TIMEOUT_MS);
 		} catch (err) {
+			if (cancelled) return;
 			opts.onError(err instanceof Error ? err.message : 'Login failed');
 		}
 	})();

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -68,6 +68,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 	let pollIntervalId: ReturnType<typeof setInterval> | null = null;
 	let timeoutId: ReturnType<typeof setTimeout> | null = null;
 	let cancelled = false;
+	let finished = false;
 	let authWindow: Window | null = null;
 
 	const cleanup = () => {
@@ -75,6 +76,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 		if (timeoutId) clearTimeout(timeoutId);
 		pollIntervalId = null;
 		timeoutId = null;
+		finished = true;
 	};
 
 	const handlePopupBlocked = async () => {
@@ -109,11 +111,13 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 
 			pollIntervalId = setInterval(async () => {
 				try {
+					if (finished) return;
 					const pollResponse = await fetch('/auth/plex', {
 						method: 'POST',
 						headers: { 'Content-Type': 'application/json' },
 						body: JSON.stringify({ pinId })
 					});
+					if (finished) return;
 
 					if (!pollResponse.ok) {
 						if (pollResponse.status === 401) {
@@ -124,6 +128,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 					}
 
 					const result = (await pollResponse.json()) as { pending: true } | { authToken: string };
+					if (finished) return;
 
 					if ('authToken' in result && result.authToken) {
 						cleanup();
@@ -146,12 +151,14 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 						await opts.onSuccess(userData.user);
 					}
 				} catch (err) {
+					if (cancelled) return;
 					cleanup();
 					opts.onError(err instanceof Error ? err.message : 'Login failed');
 				}
 			}, POLL_INTERVAL_MS);
 
 			timeoutId = setTimeout(() => {
+				if (finished) return;
 				cleanup();
 				opts.onError('Authentication timed out. Please try again.');
 			}, LOGIN_TIMEOUT_MS);
@@ -163,6 +170,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 	return {
 		cancel() {
 			cancelled = true;
+			authWindow?.close();
 			cleanup();
 		}
 	};

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -24,16 +24,52 @@ export interface PlexLoginUser {
 	isAdmin: boolean;
 }
 
+interface PopupWindowHandle {
+	closed: boolean;
+	close(): void;
+}
+
+interface PopupWindowHost {
+	location: {
+		origin: string;
+	};
+	open(url?: string | URL, target?: string, features?: string): PopupWindowHandle | null;
+}
+
+interface LoginTimerHandle {
+	id: unknown;
+}
+
+interface LoginTimers {
+	setInterval(callback: () => void | Promise<void>, delay: number): LoginTimerHandle;
+	clearInterval(handle: LoginTimerHandle): void;
+	setTimeout(callback: () => void, delay: number): LoginTimerHandle;
+	clearTimeout(handle: LoginTimerHandle): void;
+}
+
 export interface PlexLoginPopupOptions {
 	context: PlexLoginContext;
 	onSuccess: (user: PlexLoginUser) => void | Promise<void>;
 	onError: (message: string) => void;
 	onPopupBlocked: (pinId: number, authUrl: string) => void;
+	window?: PopupWindowHost;
+	timers?: LoginTimers;
+}
+
+interface RedirectLocation {
+	origin: string;
+	href: string;
+}
+
+interface RedirectStorage {
+	setItem(key: string, value: string): void;
 }
 
 export interface PlexLoginRedirectOptions {
 	context: PlexLoginContext;
 	onError: (message: string) => void;
+	location?: RedirectLocation;
+	storage?: RedirectStorage;
 }
 
 export interface PlexLoginController {
@@ -51,32 +87,43 @@ async function fetchPin(redirectUrl?: string): Promise<PinResponse> {
 		: '/auth/plex';
 	const response = await fetch(url);
 	if (!response.ok) {
-		const errData = (await response.json().catch(() => ({}))) as { message?: string };
+		const errData = (await response.json().catch(() => ({}))) as {
+			message?: string;
+		};
 		throw new Error(errData.message || 'Failed to initiate login');
 	}
 	return (await response.json()) as PinResponse;
 }
 
-function storePinForRedirect(pinId: number, context: PlexLoginContext): void {
-	sessionStorage.setItem(
-		PIN_STORAGE_KEY,
-		JSON.stringify({ pinId, createdAt: Date.now(), context })
-	);
+function storePinForRedirect(
+	pinId: number,
+	context: PlexLoginContext,
+	storage: RedirectStorage = sessionStorage
+): void {
+	storage.setItem(PIN_STORAGE_KEY, JSON.stringify({ pinId, createdAt: Date.now(), context }));
 }
 
 export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginController {
-	let pollIntervalId: ReturnType<typeof setInterval> | null = null;
-	let timeoutId: ReturnType<typeof setTimeout> | null = null;
+	const getBrowserWindow = (): PopupWindowHost => opts.window ?? window;
+	const timers: LoginTimers = opts.timers ?? {
+		setInterval: (callback, delay) => ({ id: setInterval(callback, delay) }),
+		clearInterval: (handle) => clearInterval(handle.id as Parameters<typeof clearInterval>[0]),
+		setTimeout: (callback, delay) => ({ id: setTimeout(callback, delay) }),
+		clearTimeout: (handle) => clearTimeout(handle.id as Parameters<typeof clearTimeout>[0])
+	};
+	let pollIntervalId: LoginTimerHandle | null = null;
+	let timeoutId: LoginTimerHandle | null = null;
 	let cancelled = false;
 	let finished = false;
 	let succeeded = false;
+	let callbackInProgress = false;
 	let pinExpired = false;
 	let timedOut = false;
-	let authWindow: Window | null = null;
+	let authWindow: PopupWindowHandle | null = null;
 
 	const cleanup = () => {
-		if (pollIntervalId) clearInterval(pollIntervalId);
-		if (timeoutId) clearTimeout(timeoutId);
+		if (pollIntervalId) timers.clearInterval(pollIntervalId);
+		if (timeoutId) timers.clearTimeout(timeoutId);
 		pollIntervalId = null;
 		timeoutId = null;
 		authWindow?.close();
@@ -85,7 +132,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 
 	const handlePopupBlocked = async () => {
 		try {
-			const redirectUrl = `${window.location.origin}/auth/plex/redirect`;
+			const redirectUrl = `${getBrowserWindow().location.origin}/auth/plex/redirect`;
 			const { pinId, authUrl } = await fetchPin(redirectUrl);
 			if (cancelled) return;
 			opts.onPopupBlocked(pinId, authUrl);
@@ -100,21 +147,23 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 			const { pinId, authUrl } = await fetchPin();
 			if (cancelled) return;
 
-			authWindow = window.open(authUrl, 'plex-auth', 'width=600,height=700');
+			authWindow = getBrowserWindow().open(authUrl, 'plex-auth', 'width=600,height=700');
 
 			if (!authWindow) {
 				await handlePopupBlocked();
 				return;
 			}
 
-			await new Promise((r) => setTimeout(r, 100));
+			await new Promise<void>((resolve) => {
+				timers.setTimeout(resolve, 100);
+			});
 			if (cancelled) return;
 			if (authWindow.closed) {
 				await handlePopupBlocked();
 				return;
 			}
 
-			pollIntervalId = setInterval(async () => {
+			pollIntervalId = timers.setInterval(async () => {
 				try {
 					if (finished) return;
 					const pollResponse = await fetch('/auth/plex', {
@@ -137,33 +186,41 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 					if (finished) return;
 
 					if ('authToken' in result && result.authToken) {
+						callbackInProgress = true;
 						cleanup();
 
-						const callbackResponse = await fetch('/auth/plex/callback', {
-							method: 'POST',
-							headers: { 'Content-Type': 'application/json' },
-							body: JSON.stringify({ authToken: result.authToken })
-						});
+						try {
+							const callbackResponse = await fetch('/auth/plex/callback', {
+								method: 'POST',
+								headers: { 'Content-Type': 'application/json' },
+								body: JSON.stringify({ authToken: result.authToken })
+							});
 
-						if (!callbackResponse.ok) {
-							const errData = (await callbackResponse.json().catch(() => ({}))) as {
-								message?: string;
+							if (!callbackResponse.ok) {
+								const errData = (await callbackResponse.json().catch(() => ({}))) as {
+									message?: string;
+								};
+								throw new Error(errData.message || 'Login failed');
+							}
+
+							const userData = (await callbackResponse.json()) as {
+								user: PlexLoginUser;
 							};
-							throw new Error(errData.message || 'Login failed');
+							await opts.onSuccess(userData.user);
+							succeeded = true;
+						} catch (err) {
+							if (cancelled || succeeded || timedOut || pinExpired) return;
+							opts.onError(err instanceof Error ? err.message : 'Login failed');
 						}
-
-						const userData = (await callbackResponse.json()) as { user: PlexLoginUser };
-						await opts.onSuccess(userData.user);
-						succeeded = true;
 					}
 				} catch (err) {
-					if (cancelled || succeeded || timedOut || pinExpired) return;
+					if (cancelled || succeeded || timedOut || pinExpired || callbackInProgress) return;
 					cleanup();
 					opts.onError(err instanceof Error ? err.message : 'Login failed');
 				}
 			}, POLL_INTERVAL_MS);
 
-			timeoutId = setTimeout(() => {
+			timeoutId = timers.setTimeout(() => {
 				if (finished) return;
 				timedOut = true;
 				cleanup();
@@ -186,10 +243,12 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 
 export async function startPlexLoginRedirect(opts: PlexLoginRedirectOptions): Promise<void> {
 	try {
-		const redirectUrl = `${window.location.origin}/auth/plex/redirect`;
+		const location = opts.location ?? window.location;
+		const storage = opts.storage ?? sessionStorage;
+		const redirectUrl = `${location.origin}/auth/plex/redirect`;
 		const { pinId, authUrl } = await fetchPin(redirectUrl);
-		storePinForRedirect(pinId, opts.context);
-		window.location.href = authUrl;
+		storePinForRedirect(pinId, opts.context, storage);
+		location.href = authUrl;
 	} catch (err) {
 		opts.onError(err instanceof Error ? err.message : 'Failed to initiate login');
 	}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -113,7 +113,11 @@ function handleContinueWithRedirect(): void {
 	if (!pendingPinId || !pendingAuthUrl || !browser) return;
 
 	showPopupBlockedModal = false;
-	commitRedirectFromPopupBlocked(pendingPinId, pendingAuthUrl, 'landing');
+	try {
+		commitRedirectFromPopupBlocked(pendingPinId, pendingAuthUrl, 'landing');
+	} catch (err) {
+		oauthError = err instanceof Error ? err.message : 'Failed to initiate redirect login';
+	}
 }
 
 function handleCancelRedirect(): void {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -76,6 +76,8 @@ async function handlePlexLogin() {
 	const useRedirect = shouldUseRedirectAuth(new URL(window.location.href).searchParams);
 
 	if (useRedirect) {
+		loginController?.cancel();
+		loginController = null;
 		isRedirecting = true;
 		await startPlexLoginRedirect({
 			context: 'landing',

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,13 @@ import { animate } from 'motion';
 import { prefersReducedMotion } from 'svelte/motion';
 import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
+import { shouldUseRedirectAuth } from '$lib/client/auth-mode';
+import {
+	commitRedirectFromPopupBlocked,
+	type PlexLoginController,
+	startPlexLoginPopup,
+	startPlexLoginRedirect
+} from '$lib/client/plex-login';
 import PopupBlockedModal from '$lib/components/auth/PopupBlockedModal.svelte';
 import Logo from '$lib/components/Logo.svelte';
 import type { ActionData, PageData } from './$types';
@@ -30,15 +37,14 @@ $effect(() => {
 
 // Plex OAuth state
 let isOAuthLoading = $state(false);
+let isRedirecting = $state(false);
 let oauthError = $state<string | null>(null);
-let pollIntervalId: ReturnType<typeof setInterval> | null = null;
-let timeoutId: ReturnType<typeof setTimeout> | null = null;
+let loginController: PlexLoginController | null = null;
 
 // Popup fallback state
 let showPopupBlockedModal = $state(false);
 let pendingPinId = $state<number | null>(null);
 let pendingAuthUrl = $state<string | null>(null);
-const PIN_STORAGE_KEY = 'obzorarr_plex_pin';
 
 // Element refs for animation
 let heroContainer: HTMLElement | undefined = $state();
@@ -57,144 +63,54 @@ $effect(() => {
 // Cleanup polling on unmount
 $effect(() => {
 	return () => {
-		if (pollIntervalId) clearInterval(pollIntervalId);
-		if (timeoutId) clearTimeout(timeoutId);
+		loginController?.cancel();
+		loginController = null;
 	};
 });
 
-// Plex OAuth handler
 async function handlePlexLogin() {
-	isOAuthLoading = true;
+	if (!browser) return;
+
 	oauthError = null;
 
-	try {
-		const response = await fetch('/auth/plex');
-		if (!response.ok) {
-			const errData = await response.json().catch(() => ({}));
-			throw new Error(errData.message || 'Failed to initiate login');
-		}
-		const { pinId, authUrl } = (await response.json()) as { pinId: number; authUrl: string };
+	const useRedirect = shouldUseRedirectAuth(new URL(window.location.href).searchParams);
 
-		const authWindow = window.open(authUrl, 'plex-auth', 'width=600,height=700');
-
-		if (!authWindow) {
-			await handlePopupBlocked(pinId);
-			return;
-		}
-
-		await new Promise((r) => setTimeout(r, 100));
-		if (authWindow.closed) {
-			await handlePopupBlocked(pinId);
-			return;
-		}
-
-		pollIntervalId = setInterval(async () => {
-			try {
-				const pollResponse = await fetch('/auth/plex', {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ pinId })
-				});
-
-				if (!pollResponse.ok) {
-					const status = pollResponse.status;
-					if (status === 401) {
-						if (pollIntervalId) clearInterval(pollIntervalId);
-						pollIntervalId = null;
-						isOAuthLoading = false;
-						oauthError = 'Authentication expired. Please try again.';
-						return;
-					}
-					return;
-				}
-
-				const result = (await pollResponse.json()) as { pending: true } | { authToken: string };
-
-				if ('authToken' in result && result.authToken) {
-					if (pollIntervalId) clearInterval(pollIntervalId);
-					pollIntervalId = null;
-					authWindow?.close();
-
-					const callbackResponse = await fetch('/auth/plex/callback', {
-						method: 'POST',
-						headers: { 'Content-Type': 'application/json' },
-						body: JSON.stringify({ authToken: result.authToken })
-					});
-
-					if (!callbackResponse.ok) {
-						const errData = await callbackResponse.json().catch(() => ({}));
-						throw new Error((errData as { message?: string }).message || 'Login failed');
-					}
-
-					const userData = (await callbackResponse.json()) as {
-						user: { isAdmin: boolean };
-					};
-
-					window.location.href = userData.user.isAdmin ? '/admin' : '/dashboard';
-				}
-			} catch (err) {
-				if (pollIntervalId) clearInterval(pollIntervalId);
-				pollIntervalId = null;
-				isOAuthLoading = false;
-				oauthError = err instanceof Error ? err.message : 'Login failed';
+	if (useRedirect) {
+		isRedirecting = true;
+		await startPlexLoginRedirect({
+			context: 'landing',
+			onError: (message) => {
+				isRedirecting = false;
+				oauthError = message;
 			}
-		}, 2000);
-
-		timeoutId = setTimeout(
-			() => {
-				if (pollIntervalId) {
-					clearInterval(pollIntervalId);
-					pollIntervalId = null;
-				}
-				if (isOAuthLoading) {
-					isOAuthLoading = false;
-					oauthError = 'Authentication timed out. Please try again.';
-				}
-			},
-			5 * 60 * 1000
-		);
-	} catch (err) {
-		isOAuthLoading = false;
-		oauthError = err instanceof Error ? err.message : 'Login failed';
-	}
-}
-
-async function handlePopupBlocked(_originalPinId: number): Promise<void> {
-	try {
-		const redirectUrl = browser ? `${window.location.origin}/auth/plex/redirect` : '';
-		const response = await fetch(`/auth/plex?redirectUrl=${encodeURIComponent(redirectUrl)}`);
-		if (!response.ok) {
-			throw new Error('Failed to prepare redirect');
-		}
-		const { pinId, authUrl } = (await response.json()) as { pinId: number; authUrl: string };
-		pendingPinId = pinId;
-		pendingAuthUrl = authUrl;
-	} catch {
-		pendingPinId = null;
-		pendingAuthUrl = null;
-		isOAuthLoading = false;
-		oauthError = 'Unable to prepare redirect. Please try again.';
+		});
 		return;
 	}
 
-	isOAuthLoading = false;
-	showPopupBlockedModal = true;
+	isOAuthLoading = true;
+	loginController = startPlexLoginPopup({
+		context: 'landing',
+		onSuccess: (user) => {
+			window.location.href = user.isAdmin ? '/admin' : '/dashboard';
+		},
+		onError: (message) => {
+			isOAuthLoading = false;
+			oauthError = message;
+		},
+		onPopupBlocked: (pinId, authUrl) => {
+			isOAuthLoading = false;
+			pendingPinId = pinId;
+			pendingAuthUrl = authUrl;
+			showPopupBlockedModal = true;
+		}
+	});
 }
 
 function handleContinueWithRedirect(): void {
 	if (!pendingPinId || !pendingAuthUrl || !browser) return;
 
-	sessionStorage.setItem(
-		PIN_STORAGE_KEY,
-		JSON.stringify({
-			pinId: pendingPinId,
-			createdAt: Date.now(),
-			context: 'landing'
-		})
-	);
-
 	showPopupBlockedModal = false;
-	window.location.href = pendingAuthUrl;
+	commitRedirectFromPopupBlocked(pendingPinId, pendingAuthUrl, 'landing');
 }
 
 function handleCancelRedirect(): void {
@@ -280,9 +196,14 @@ function handleCancelRedirect(): void {
 					type="button"
 					class="login-button secondary"
 					onclick={handlePlexLogin}
-					disabled={isOAuthLoading}
+					disabled={isOAuthLoading || isRedirecting}
 				>
-					{#if isOAuthLoading}
+					{#if isRedirecting}
+						<span class="button-loading">
+							<span class="spinner" aria-hidden="true"></span>
+							Redirecting to Plex...
+						</span>
+					{:else if isOAuthLoading}
 						<span class="button-loading">
 							<span class="spinner" aria-hidden="true"></span>
 							Connecting to Plex...

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -88,6 +88,7 @@ async function handlePlexLogin() {
 	}
 
 	isOAuthLoading = true;
+	loginController?.cancel();
 	loginController = startPlexLoginPopup({
 		context: 'landing',
 		onSuccess: (user) => {

--- a/src/routes/auth/plex/redirect/+page.svelte
+++ b/src/routes/auth/plex/redirect/+page.svelte
@@ -1,15 +1,14 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { browser } from '$app/environment';
+import { LOGIN_TIMEOUT_MS, PIN_STORAGE_KEY, POLL_INTERVAL_MS } from '$lib/client/plex-login';
 
 type Status = 'loading' | 'success' | 'error' | 'cancelled';
 
 let status = $state<Status>('loading');
 let errorMessage = $state<string | null>(null);
 
-const PIN_STORAGE_KEY = 'obzorarr_plex_pin';
-const MAX_POLL_ATTEMPTS = 30;
-const POLL_INTERVAL_MS = 2000;
+const MAX_POLL_ATTEMPTS = Math.floor(LOGIN_TIMEOUT_MS / POLL_INTERVAL_MS);
 const PIN_MAX_AGE_MS = 15 * 60 * 1000;
 
 interface StoredPinData {

--- a/src/routes/auth/plex/redirect/+page.svelte
+++ b/src/routes/auth/plex/redirect/+page.svelte
@@ -91,6 +91,8 @@ onMount(async () => {
 
 async function pollForToken(pinId: number): Promise<string | null> {
 	for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+		if (attempt > 0) await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
 		const response = await fetch('/auth/plex', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
@@ -109,8 +111,6 @@ async function pollForToken(pinId: number): Promise<string | null> {
 		if ('authToken' in result && result.authToken) {
 			return result.authToken;
 		}
-
-		await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
 	}
 
 	return null;

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -228,7 +228,11 @@ function handleContinueWithRedirect(): void {
 	if (!pendingPinId || !pendingAuthUrl || !browser) return;
 
 	showPopupBlockedModal = false;
-	commitRedirectFromPopupBlocked(pendingPinId, pendingAuthUrl, 'onboarding');
+	try {
+		commitRedirectFromPopupBlocked(pendingPinId, pendingAuthUrl, 'onboarding');
+	} catch (err) {
+		oauthError = err instanceof Error ? err.message : 'Failed to initiate redirect login';
+	}
 }
 
 function handleCancelRedirect(): void {

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -185,6 +185,8 @@ async function handlePlexLogin() {
 	const useRedirect = shouldUseRedirectAuth(new URL(window.location.href).searchParams);
 
 	if (useRedirect) {
+		loginController?.cancel();
+		loginController = null;
 		isRedirecting = true;
 		await startPlexLoginRedirect({
 			context: 'onboarding',

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -197,6 +197,7 @@ async function handlePlexLogin() {
 	}
 
 	isOAuthLoading = true;
+	loginController?.cancel();
 	loginController = startPlexLoginPopup({
 		context: 'onboarding',
 		onSuccess: (user) => {

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -3,6 +3,13 @@ import { animate, stagger } from 'motion';
 import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
+import { shouldUseRedirectAuth } from '$lib/client/auth-mode';
+import {
+	commitRedirectFromPopupBlocked,
+	type PlexLoginController,
+	startPlexLoginPopup,
+	startPlexLoginRedirect
+} from '$lib/client/plex-login';
 import PopupBlockedModal from '$lib/components/auth/PopupBlockedModal.svelte';
 import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
 import * as Tooltip from '$lib/components/ui/tooltip';
@@ -12,15 +19,14 @@ import type { ActionData, PageData } from './$types';
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
 let isOAuthLoading = $state(false);
+let isRedirecting = $state(false);
 let oauthError = $state<string | null>(null);
-let pollIntervalId: ReturnType<typeof setInterval> | null = null;
-let timeoutId: ReturnType<typeof setTimeout> | null = null;
+let loginController: PlexLoginController | null = null;
 
 // Popup fallback state
 let showPopupBlockedModal = $state(false);
 let pendingPinId = $state<number | null>(null);
 let pendingAuthUrl = $state<string | null>(null);
-const PIN_STORAGE_KEY = 'obzorarr_plex_pin';
 
 // Bypasses SvelteKit data prop reactivity timing issues
 let localAuthState = $state<{
@@ -115,8 +121,8 @@ $effect(() => {
 
 $effect(() => {
 	return () => {
-		if (pollIntervalId) clearInterval(pollIntervalId);
-		if (timeoutId) clearTimeout(timeoutId);
+		loginController?.cancel();
+		loginController = null;
 	};
 });
 
@@ -172,145 +178,54 @@ async function fetchServers() {
 }
 
 async function handlePlexLogin() {
-	isOAuthLoading = true;
+	if (!browser) return;
+
 	oauthError = null;
 
-	try {
-		const response = await fetch('/auth/plex');
-		if (!response.ok) {
-			const errData = await response.json().catch(() => ({}));
-			throw new Error(errData.message || 'Failed to initiate login');
-		}
-		const { pinId, authUrl } = (await response.json()) as { pinId: number; authUrl: string };
+	const useRedirect = shouldUseRedirectAuth(new URL(window.location.href).searchParams);
 
-		const authWindow = window.open(authUrl, 'plex-auth', 'width=600,height=700');
-
-		if (!authWindow) {
-			await handlePopupBlocked(pinId);
-			return;
-		}
-
-		await new Promise((r) => setTimeout(r, 100));
-		if (authWindow.closed) {
-			await handlePopupBlocked(pinId);
-			return;
-		}
-
-		pollIntervalId = setInterval(async () => {
-			try {
-				const pollResponse = await fetch('/auth/plex', {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ pinId })
-				});
-
-				if (!pollResponse.ok) {
-					const status = pollResponse.status;
-					if (status === 401) {
-						if (pollIntervalId) clearInterval(pollIntervalId);
-						pollIntervalId = null;
-						isOAuthLoading = false;
-						oauthError = 'Authentication expired. Please try again.';
-						return;
-					}
-					return;
-				}
-
-				const result = (await pollResponse.json()) as { pending: true } | { authToken: string };
-
-				if ('authToken' in result && result.authToken) {
-					if (pollIntervalId) clearInterval(pollIntervalId);
-					pollIntervalId = null;
-					authWindow?.close();
-
-					const callbackResponse = await fetch('/auth/plex/callback', {
-						method: 'POST',
-						headers: { 'Content-Type': 'application/json' },
-						body: JSON.stringify({ authToken: result.authToken })
-					});
-
-					if (!callbackResponse.ok) {
-						const errData = await callbackResponse.json().catch(() => ({}));
-						throw new Error((errData as { message?: string }).message || 'Login failed');
-					}
-
-					const callbackData = (await callbackResponse.json()) as {
-						user: { id: number; plexId: number; username: string; isAdmin: boolean };
-					};
-
-					localAuthState = {
-						isAuthenticated: true,
-						isAdmin: callbackData.user.isAdmin,
-						username: callbackData.user.username
-					};
-
-					invalidateAll();
-
-					isOAuthLoading = false;
-				}
-			} catch (err) {
-				if (pollIntervalId) clearInterval(pollIntervalId);
-				pollIntervalId = null;
-				isOAuthLoading = false;
-				oauthError = err instanceof Error ? err.message : 'Login failed';
+	if (useRedirect) {
+		isRedirecting = true;
+		await startPlexLoginRedirect({
+			context: 'onboarding',
+			onError: (message) => {
+				isRedirecting = false;
+				oauthError = message;
 			}
-		}, 2000);
-
-		timeoutId = setTimeout(
-			() => {
-				if (pollIntervalId) {
-					clearInterval(pollIntervalId);
-					pollIntervalId = null;
-				}
-				if (isOAuthLoading) {
-					isOAuthLoading = false;
-					oauthError = 'Authentication timed out. Please try again.';
-				}
-			},
-			5 * 60 * 1000
-		);
-	} catch (err) {
-		isOAuthLoading = false;
-		oauthError = err instanceof Error ? err.message : 'Login failed';
-	}
-}
-
-async function handlePopupBlocked(_originalPinId: number): Promise<void> {
-	try {
-		const redirectUrl = browser ? `${window.location.origin}/auth/plex/redirect` : '';
-		const response = await fetch(`/auth/plex?redirectUrl=${encodeURIComponent(redirectUrl)}`);
-		if (!response.ok) {
-			throw new Error('Failed to prepare redirect');
-		}
-		const { pinId, authUrl } = (await response.json()) as { pinId: number; authUrl: string };
-		pendingPinId = pinId;
-		pendingAuthUrl = authUrl;
-	} catch {
-		pendingPinId = null;
-		pendingAuthUrl = null;
-		isOAuthLoading = false;
-		oauthError = 'Unable to prepare redirect. Please try again.';
+		});
 		return;
 	}
 
-	isOAuthLoading = false;
-	showPopupBlockedModal = true;
+	isOAuthLoading = true;
+	loginController = startPlexLoginPopup({
+		context: 'onboarding',
+		onSuccess: (user) => {
+			localAuthState = {
+				isAuthenticated: true,
+				isAdmin: user.isAdmin,
+				username: user.username ?? null
+			};
+			invalidateAll();
+			isOAuthLoading = false;
+		},
+		onError: (message) => {
+			isOAuthLoading = false;
+			oauthError = message;
+		},
+		onPopupBlocked: (pinId, authUrl) => {
+			isOAuthLoading = false;
+			pendingPinId = pinId;
+			pendingAuthUrl = authUrl;
+			showPopupBlockedModal = true;
+		}
+	});
 }
 
 function handleContinueWithRedirect(): void {
 	if (!pendingPinId || !pendingAuthUrl || !browser) return;
 
-	sessionStorage.setItem(
-		PIN_STORAGE_KEY,
-		JSON.stringify({
-			pinId: pendingPinId,
-			createdAt: Date.now(),
-			context: 'onboarding'
-		})
-	);
-
 	showPopupBlockedModal = false;
-	window.location.href = pendingAuthUrl;
+	commitRedirectFromPopupBlocked(pendingPinId, pendingAuthUrl, 'onboarding');
 }
 
 function handleCancelRedirect(): void {
@@ -625,9 +540,12 @@ function formatServerUrl(url: string | null): string {
 						type="button"
 						class="plex-button"
 						onclick={handlePlexLogin}
-						disabled={isOAuthLoading}
+						disabled={isOAuthLoading || isRedirecting}
 					>
-						{#if isOAuthLoading}
+						{#if isRedirecting}
+							<span class="button-spinner"></span>
+							<span>Redirecting to Plex...</span>
+						{:else if isOAuthLoading}
 							<span class="button-spinner"></span>
 							<span>Connecting to Plex...</span>
 						{:else}
@@ -677,9 +595,12 @@ function formatServerUrl(url: string | null): string {
 						type="button"
 						class="plex-button"
 						onclick={handlePlexLogin}
-						disabled={isOAuthLoading}
+						disabled={isOAuthLoading || isRedirecting}
 					>
-						{#if isOAuthLoading}
+						{#if isRedirecting}
+							<span class="button-spinner"></span>
+							<span>Redirecting to Plex...</span>
+						{:else if isOAuthLoading}
 							<span class="button-spinner"></span>
 							<span>Connecting to Plex...</span>
 						{:else}

--- a/tests/unit/auth-mode.test.ts
+++ b/tests/unit/auth-mode.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { shouldUseRedirectAuth } from '$lib/client/auth-mode';
+
+const REAL_CHROME_UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+const HEADLESS_CHROME_UA =
+	'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/120.0.0.0 Safari/537.36';
+
+interface NavigatorOverrides {
+	webdriver?: boolean;
+	userAgent?: string;
+}
+
+const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+
+function setNavigator(overrides: NavigatorOverrides | null): void {
+	if (overrides === null) {
+		Object.defineProperty(globalThis, 'navigator', {
+			value: undefined,
+			configurable: true,
+			writable: true
+		});
+		return;
+	}
+	Object.defineProperty(globalThis, 'navigator', {
+		value: { webdriver: overrides.webdriver ?? false, userAgent: overrides.userAgent ?? '' },
+		configurable: true,
+		writable: true
+	});
+}
+
+describe('shouldUseRedirectAuth', () => {
+	beforeEach(() => {
+		setNavigator({ webdriver: false, userAgent: REAL_CHROME_UA });
+	});
+
+	afterEach(() => {
+		if (originalDescriptor) {
+			Object.defineProperty(globalThis, 'navigator', originalDescriptor);
+		} else {
+			delete (globalThis as { navigator?: unknown }).navigator;
+		}
+	});
+
+	it('returns true when ?auth=redirect is present', () => {
+		const params = new URLSearchParams('auth=redirect');
+		expect(shouldUseRedirectAuth(params)).toBe(true);
+	});
+
+	it('returns false when ?auth=popup is present even on headless browsers', () => {
+		setNavigator({ webdriver: true, userAgent: HEADLESS_CHROME_UA });
+		const params = new URLSearchParams('auth=popup');
+		expect(shouldUseRedirectAuth(params)).toBe(false);
+	});
+
+	it('returns true when navigator.webdriver is true', () => {
+		setNavigator({ webdriver: true, userAgent: REAL_CHROME_UA });
+		expect(shouldUseRedirectAuth(new URLSearchParams())).toBe(true);
+	});
+
+	it('returns true when user agent contains HeadlessChrome', () => {
+		setNavigator({ webdriver: false, userAgent: HEADLESS_CHROME_UA });
+		expect(shouldUseRedirectAuth(new URLSearchParams())).toBe(true);
+	});
+
+	it('returns true when user agent contains Playwright/Puppeteer/Selenium', () => {
+		for (const tool of ['Playwright/1.44', 'Puppeteer/22.0', 'Selenium/4.0']) {
+			setNavigator({ webdriver: false, userAgent: `Mozilla/5.0 ${tool}` });
+			expect(shouldUseRedirectAuth(new URLSearchParams())).toBe(true);
+		}
+	});
+
+	it('returns false for default Chrome UA without webdriver flag', () => {
+		expect(shouldUseRedirectAuth(new URLSearchParams())).toBe(false);
+	});
+
+	it('returns false when navigator is undefined (SSR)', () => {
+		setNavigator(null);
+		expect(shouldUseRedirectAuth(new URLSearchParams())).toBe(false);
+	});
+});

--- a/tests/unit/auth-mode.test.ts
+++ b/tests/unit/auth-mode.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import { shouldUseRedirectAuth } from '$lib/client/auth-mode';
 
 const REAL_CHROME_UA =
@@ -6,76 +6,65 @@ const REAL_CHROME_UA =
 const HEADLESS_CHROME_UA =
 	'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/120.0.0.0 Safari/537.36';
 
-interface NavigatorOverrides {
+interface TestNavigator {
 	webdriver?: boolean;
 	userAgent?: string;
 }
 
-const originalDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
-
-function setNavigator(overrides: NavigatorOverrides | null): void {
-	if (overrides === null) {
-		Object.defineProperty(globalThis, 'navigator', {
-			value: undefined,
-			configurable: true,
-			writable: true
-		});
-		return;
-	}
-	Object.defineProperty(globalThis, 'navigator', {
-		value: { webdriver: overrides.webdriver ?? false, userAgent: overrides.userAgent ?? '' },
-		configurable: true,
-		writable: true
-	});
+function createNavigator(overrides: TestNavigator = {}): TestNavigator {
+	return {
+		webdriver: overrides.webdriver ?? false,
+		userAgent: overrides.userAgent ?? REAL_CHROME_UA
+	};
 }
 
 describe('shouldUseRedirectAuth', () => {
-	beforeEach(() => {
-		setNavigator({ webdriver: false, userAgent: REAL_CHROME_UA });
-	});
-
-	afterEach(() => {
-		if (originalDescriptor) {
-			Object.defineProperty(globalThis, 'navigator', originalDescriptor);
-		} else {
-			delete (globalThis as { navigator?: unknown }).navigator;
-		}
-	});
-
 	it('returns true when ?auth=redirect is present', () => {
 		const params = new URLSearchParams('auth=redirect');
-		expect(shouldUseRedirectAuth(params)).toBe(true);
+		expect(shouldUseRedirectAuth(params, createNavigator())).toBe(true);
 	});
 
 	it('returns false when ?auth=popup is present even on headless browsers', () => {
-		setNavigator({ webdriver: true, userAgent: HEADLESS_CHROME_UA });
 		const params = new URLSearchParams('auth=popup');
-		expect(shouldUseRedirectAuth(params)).toBe(false);
+		expect(
+			shouldUseRedirectAuth(
+				params,
+				createNavigator({ webdriver: true, userAgent: HEADLESS_CHROME_UA })
+			)
+		).toBe(false);
 	});
 
 	it('returns true when navigator.webdriver is true', () => {
-		setNavigator({ webdriver: true, userAgent: REAL_CHROME_UA });
-		expect(shouldUseRedirectAuth(new URLSearchParams())).toBe(true);
+		expect(shouldUseRedirectAuth(new URLSearchParams(), createNavigator({ webdriver: true }))).toBe(
+			true
+		);
 	});
 
 	it('returns true when user agent contains HeadlessChrome', () => {
-		setNavigator({ webdriver: false, userAgent: HEADLESS_CHROME_UA });
-		expect(shouldUseRedirectAuth(new URLSearchParams())).toBe(true);
+		expect(
+			shouldUseRedirectAuth(
+				new URLSearchParams(),
+				createNavigator({ userAgent: HEADLESS_CHROME_UA })
+			)
+		).toBe(true);
 	});
 
 	it('returns true when user agent contains Playwright/Puppeteer/Selenium', () => {
 		for (const tool of ['Playwright/1.44', 'Puppeteer/22.0', 'Selenium/4.0']) {
-			setNavigator({ webdriver: false, userAgent: `Mozilla/5.0 ${tool}` });
-			expect(shouldUseRedirectAuth(new URLSearchParams())).toBe(true);
+			expect(
+				shouldUseRedirectAuth(
+					new URLSearchParams(),
+					createNavigator({ userAgent: `Mozilla/5.0 ${tool}` })
+				)
+			).toBe(true);
 		}
 	});
 
 	it('returns false for default Chrome UA without webdriver flag', () => {
-		expect(shouldUseRedirectAuth(new URLSearchParams())).toBe(false);
+		expect(shouldUseRedirectAuth(new URLSearchParams(), createNavigator())).toBe(false);
 	});
 
 	it('returns false when navigator is undefined (SSR)', () => {
-		setNavigator(null);
-		expect(shouldUseRedirectAuth(new URLSearchParams())).toBe(false);
+		expect(shouldUseRedirectAuth(new URLSearchParams(), null)).toBe(false);
 	});
 });

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { PIN_STORAGE_KEY, startPlexLoginRedirect } from '$lib/client/plex-login';
+
+const originalFetch = globalThis.fetch;
+const originalWindow = (globalThis as { window?: unknown }).window;
+const originalSessionStorage = (globalThis as { sessionStorage?: unknown }).sessionStorage;
+
+interface MemoryStorage {
+	store: Map<string, string>;
+	getItem(key: string): string | null;
+	setItem(key: string, value: string): void;
+	removeItem(key: string): void;
+	clear(): void;
+}
+
+function createSessionStorage(): MemoryStorage {
+	const store = new Map<string, string>();
+	return {
+		store,
+		getItem: (k) => store.get(k) ?? null,
+		setItem: (k, v) => {
+			store.set(k, v);
+		},
+		removeItem: (k) => {
+			store.delete(k);
+		},
+		clear: () => store.clear()
+	};
+}
+
+interface MockLocation {
+	origin: string;
+	href: string;
+}
+
+function installBrowserGlobals(origin = 'https://obzorarr.example') {
+	const location: MockLocation = { origin, href: `${origin}/` };
+	const sessionStorage = createSessionStorage();
+	Object.defineProperty(globalThis, 'window', {
+		value: { location },
+		configurable: true,
+		writable: true
+	});
+	Object.defineProperty(globalThis, 'sessionStorage', {
+		value: sessionStorage,
+		configurable: true,
+		writable: true
+	});
+	return { location, sessionStorage };
+}
+
+function restoreBrowserGlobals() {
+	if (originalWindow === undefined) {
+		delete (globalThis as { window?: unknown }).window;
+	} else {
+		Object.defineProperty(globalThis, 'window', {
+			value: originalWindow,
+			configurable: true,
+			writable: true
+		});
+	}
+	if (originalSessionStorage === undefined) {
+		delete (globalThis as { sessionStorage?: unknown }).sessionStorage;
+	} else {
+		Object.defineProperty(globalThis, 'sessionStorage', {
+			value: originalSessionStorage,
+			configurable: true,
+			writable: true
+		});
+	}
+}
+
+describe('startPlexLoginRedirect', () => {
+	beforeEach(() => {
+		installBrowserGlobals();
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		restoreBrowserGlobals();
+	});
+
+	it('fetches PIN with same-origin redirectUrl, persists pin to sessionStorage, navigates to authUrl', async () => {
+		const fetchedUrls: string[] = [];
+		globalThis.fetch = mock(async (input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input.toString();
+			fetchedUrls.push(url);
+			return new Response(
+				JSON.stringify({ pinId: 4242, authUrl: 'https://app.plex.tv/auth#?code=ABCD' }),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } }
+			);
+		}) as unknown as typeof fetch;
+
+		const onError = mock(() => {});
+		const win = (globalThis as { window: { location: MockLocation } }).window;
+
+		await startPlexLoginRedirect({ context: 'landing', onError });
+
+		expect(onError).not.toHaveBeenCalled();
+		expect(fetchedUrls).toHaveLength(1);
+		const fetched = fetchedUrls[0] as string;
+		expect(fetched.startsWith('/auth/plex?redirectUrl=')).toBe(true);
+		const decoded = decodeURIComponent(fetched.split('redirectUrl=')[1] as string);
+		expect(decoded).toBe('https://obzorarr.example/auth/plex/redirect');
+
+		const stored = sessionStorage.getItem(PIN_STORAGE_KEY);
+		expect(stored).not.toBeNull();
+		const parsed = JSON.parse(stored as string) as {
+			pinId: number;
+			createdAt: number;
+			context: string;
+		};
+		expect(parsed.pinId).toBe(4242);
+		expect(parsed.context).toBe('landing');
+		expect(typeof parsed.createdAt).toBe('number');
+
+		expect(win.location.href).toBe('https://app.plex.tv/auth#?code=ABCD');
+	});
+
+	it('records the onboarding context when supplied', async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(JSON.stringify({ pinId: 1, authUrl: 'https://app.plex.tv/auth#?code=X' }), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' }
+				})
+		) as unknown as typeof fetch;
+
+		await startPlexLoginRedirect({ context: 'onboarding', onError: () => {} });
+
+		const parsed = JSON.parse(sessionStorage.getItem(PIN_STORAGE_KEY) as string) as {
+			context: string;
+		};
+		expect(parsed.context).toBe('onboarding');
+	});
+
+	it('reports an error and does not navigate when PIN fetch fails', async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(JSON.stringify({ message: 'Plex unreachable' }), {
+					status: 502,
+					headers: { 'Content-Type': 'application/json' }
+				})
+		) as unknown as typeof fetch;
+
+		const win = (globalThis as { window: { location: MockLocation } }).window;
+		const originalHref = win.location.href;
+		let receivedError: string | null = null;
+
+		await startPlexLoginRedirect({
+			context: 'landing',
+			onError: (msg) => {
+				receivedError = msg;
+			}
+		});
+
+		expect(receivedError).toBe('Plex unreachable');
+		expect(win.location.href).toBe(originalHref);
+		expect(sessionStorage.getItem(PIN_STORAGE_KEY)).toBeNull();
+	});
+});

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
-import { PIN_STORAGE_KEY, startPlexLoginRedirect } from '$lib/client/plex-login';
+import {
+	PIN_STORAGE_KEY,
+	startPlexLoginPopup,
+	startPlexLoginRedirect
+} from '$lib/client/plex-login';
 
 const originalFetch = globalThis.fetch;
-const originalWindow = (globalThis as { window?: unknown }).window;
-const originalSessionStorage = (globalThis as { sessionStorage?: unknown }).sessionStorage;
 
 interface MemoryStorage {
 	store: Map<string, string>;
@@ -33,51 +35,47 @@ interface MockLocation {
 	href: string;
 }
 
-function installBrowserGlobals(origin = 'https://obzorarr.example') {
-	const location: MockLocation = { origin, href: `${origin}/` };
-	const sessionStorage = createSessionStorage();
-	Object.defineProperty(globalThis, 'window', {
-		value: { location },
-		configurable: true,
-		writable: true
-	});
-	Object.defineProperty(globalThis, 'sessionStorage', {
-		value: sessionStorage,
-		configurable: true,
-		writable: true
-	});
-	return { location, sessionStorage };
+interface MockPopupWindow {
+	closed: boolean;
+	close(): void;
 }
 
-function restoreBrowserGlobals() {
-	if (originalWindow === undefined) {
-		delete (globalThis as { window?: unknown }).window;
-	} else {
-		Object.defineProperty(globalThis, 'window', {
-			value: originalWindow,
-			configurable: true,
-			writable: true
-		});
-	}
-	if (originalSessionStorage === undefined) {
-		delete (globalThis as { sessionStorage?: unknown }).sessionStorage;
-	} else {
-		Object.defineProperty(globalThis, 'sessionStorage', {
-			value: originalSessionStorage,
-			configurable: true,
-			writable: true
-		});
-	}
+interface MockWindow {
+	location: MockLocation;
+	open(url?: string | URL, target?: string, features?: string): MockPopupWindow | null;
+}
+
+function createTimerMocks(onInterval: (callback: () => Promise<void>) => void) {
+	return {
+		setInterval: (handler: () => Promise<void>) => {
+			onInterval(handler);
+			return { id: 1 };
+		},
+		clearInterval: () => {},
+		setTimeout: (handler: () => void, timeout: number) => {
+			if (timeout === 100) {
+				queueMicrotask(() => {
+					handler();
+				});
+			}
+			return { id: 1 };
+		},
+		clearTimeout: () => {}
+	};
 }
 
 describe('startPlexLoginRedirect', () => {
+	let location: MockLocation;
+	let sessionStorage: MemoryStorage;
+
 	beforeEach(() => {
-		installBrowserGlobals();
+		const origin = 'https://obzorarr.example';
+		location = { origin, href: `${origin}/` };
+		sessionStorage = createSessionStorage();
 	});
 
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
-		restoreBrowserGlobals();
 	});
 
 	it('fetches PIN with same-origin redirectUrl, persists pin to sessionStorage, navigates to authUrl', async () => {
@@ -86,15 +84,22 @@ describe('startPlexLoginRedirect', () => {
 			const url = typeof input === 'string' ? input : input.toString();
 			fetchedUrls.push(url);
 			return new Response(
-				JSON.stringify({ pinId: 4242, authUrl: 'https://app.plex.tv/auth#?code=ABCD' }),
+				JSON.stringify({
+					pinId: 4242,
+					authUrl: 'https://app.plex.tv/auth#?code=ABCD'
+				}),
 				{ status: 200, headers: { 'Content-Type': 'application/json' } }
 			);
 		}) as unknown as typeof fetch;
 
 		const onError = mock(() => {});
-		const win = (globalThis as { window: { location: MockLocation } }).window;
 
-		await startPlexLoginRedirect({ context: 'landing', onError });
+		await startPlexLoginRedirect({
+			context: 'landing',
+			onError,
+			location,
+			storage: sessionStorage
+		});
 
 		expect(onError).not.toHaveBeenCalled();
 		expect(fetchedUrls).toHaveLength(1);
@@ -114,19 +119,30 @@ describe('startPlexLoginRedirect', () => {
 		expect(parsed.context).toBe('landing');
 		expect(typeof parsed.createdAt).toBe('number');
 
-		expect(win.location.href).toBe('https://app.plex.tv/auth#?code=ABCD');
+		expect(location.href).toBe('https://app.plex.tv/auth#?code=ABCD');
 	});
 
 	it('records the onboarding context when supplied', async () => {
 		globalThis.fetch = mock(
 			async () =>
-				new Response(JSON.stringify({ pinId: 1, authUrl: 'https://app.plex.tv/auth#?code=X' }), {
-					status: 200,
-					headers: { 'Content-Type': 'application/json' }
-				})
+				new Response(
+					JSON.stringify({
+						pinId: 1,
+						authUrl: 'https://app.plex.tv/auth#?code=X'
+					}),
+					{
+						status: 200,
+						headers: { 'Content-Type': 'application/json' }
+					}
+				)
 		) as unknown as typeof fetch;
 
-		await startPlexLoginRedirect({ context: 'onboarding', onError: () => {} });
+		await startPlexLoginRedirect({
+			context: 'onboarding',
+			onError: () => {},
+			location,
+			storage: sessionStorage
+		});
 
 		const parsed = JSON.parse(sessionStorage.getItem(PIN_STORAGE_KEY) as string) as {
 			context: string;
@@ -143,19 +159,122 @@ describe('startPlexLoginRedirect', () => {
 				})
 		) as unknown as typeof fetch;
 
-		const win = (globalThis as { window: { location: MockLocation } }).window;
-		const originalHref = win.location.href;
+		const originalHref = location.href;
 		let receivedError: string | null = null;
 
 		await startPlexLoginRedirect({
 			context: 'landing',
+			location,
+			storage: sessionStorage,
 			onError: (msg) => {
 				receivedError = msg;
 			}
 		});
 
 		expect(receivedError).toBe('Plex unreachable');
-		expect(win.location.href).toBe(originalHref);
+		expect(location.href).toBe(originalHref);
 		expect(sessionStorage.getItem(PIN_STORAGE_KEY)).toBeNull();
+	});
+});
+
+describe('startPlexLoginPopup', () => {
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it('ignores stale poll failures once callback exchange has started', async () => {
+		const intervalCallbacks: Array<() => Promise<void>> = [];
+		let resolveIntervalRegistered: () => void = () => {};
+		const intervalRegistered = new Promise<void>((resolve) => {
+			resolveIntervalRegistered = resolve;
+		});
+		const timers = createTimerMocks((callback) => {
+			intervalCallbacks.push(callback);
+			resolveIntervalRegistered();
+		});
+
+		const popup: MockPopupWindow = { closed: false, close: mock(() => {}) };
+		const browserWindow: MockWindow = {
+			location: {
+				origin: 'https://obzorarr.example',
+				href: 'https://obzorarr.example/'
+			},
+			open: mock(() => popup) as unknown as MockWindow['open']
+		};
+
+		let pollCalls = 0;
+		let rejectFirstPoll: (err: Error) => void = () => {};
+		const firstPoll = new Promise<Response>((_, reject) => {
+			rejectFirstPoll = reject;
+		});
+		let resolveCallbackRequested: () => void = () => {};
+		const callbackRequested = new Promise<void>((resolve) => {
+			resolveCallbackRequested = resolve;
+		});
+		let resolveCallback: (response: Response) => void = () => {};
+		const callbackExchange = new Promise<Response>((resolve) => {
+			resolveCallback = resolve;
+		});
+
+		globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === 'string' ? input : input.toString();
+
+			if (url === '/auth/plex' && init?.method === 'POST') {
+				pollCalls += 1;
+				if (pollCalls === 1) return firstPoll;
+				return new Response(JSON.stringify({ authToken: 'plex-token' }), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' }
+				});
+			}
+
+			if (url === '/auth/plex/callback') {
+				resolveCallbackRequested();
+				return callbackExchange;
+			}
+
+			return new Response(
+				JSON.stringify({
+					pinId: 42,
+					authUrl: 'https://app.plex.tv/auth#?code=ABCD'
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } }
+			);
+		}) as unknown as typeof fetch;
+
+		const onSuccess = mock(async () => {});
+		const onError = mock(() => {});
+		const onPopupBlocked = mock(() => {});
+
+		startPlexLoginPopup({
+			context: 'landing',
+			onSuccess,
+			onError,
+			onPopupBlocked,
+			window: browserWindow,
+			timers
+		});
+		await intervalRegistered;
+
+		const poll = intervalCallbacks[0] as () => Promise<void>;
+		const staleTick = poll();
+		const successTick = poll();
+		await callbackRequested;
+
+		rejectFirstPoll(new Error('Network dropped'));
+		await staleTick;
+		expect(onError).not.toHaveBeenCalled();
+
+		resolveCallback(
+			new Response(JSON.stringify({ user: { id: 1, username: 'plex', isAdmin: true } }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+		await successTick;
+
+		expect(onSuccess).toHaveBeenCalledTimes(1);
+		expect(onError).not.toHaveBeenCalled();
+		expect(onPopupBlocked).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

Adds an automation-friendly same-tab redirect path to the Plex OAuth login flow. The popup remains the default for human users; headless browsers and AI agents now get the redirect path automatically.

The redirect target (`/auth/plex/redirect`) already existed as a popup-blocked fallback, so this promotes it to a first-class option without server-side changes.

## Changes

- **New: `src/lib/client/auth-mode.ts`** — `shouldUseRedirectAuth()` detects automation via `navigator.webdriver` and a narrow UA regex (`HeadlessChrome|Playwright|Puppeteer|Selenium`). Honors explicit `?auth=redirect` / `?auth=popup` overrides.
- **New: `src/lib/client/plex-login.ts`** — extracts the popup/poll/callback logic shared by the landing and onboarding pages into a cancellable controller. Adds `startPlexLoginRedirect()` and `commitRedirectFromPopupBlocked()`.
- **Refactor: `src/routes/+page.svelte`, `src/routes/onboarding/plex/+page.svelte`** — replace ~120 lines of inline OAuth logic per page with helper calls. Adds a brief "Redirecting to Plex..." button state when the redirect path is taken.
- **Tests:** `tests/unit/auth-mode.test.ts` (7 cases covering all detection branches) and `tests/unit/plex-login.test.ts` (3 cases covering redirect happy path, context propagation, and fetch error).

No server endpoint or schema changes.

## Test plan

- [ ] `bun test` — new tests pass; pre-existing suite unchanged
- [ ] Manual: visit `/`, click "Sign in with Plex" — popup behavior unchanged
- [ ] Manual: visit `/?auth=redirect`, click login — same-tab navigation to `app.plex.tv`, returns via `/auth/plex/redirect`, lands on `/admin` or `/dashboard`
- [ ] Manual: repeat both flows from `/onboarding/plex`
- [ ] Manual: run `agent-browser` against `/` — auto-detects `navigator.webdriver` and uses redirect path with no extra config
- [ ] Stealth automation that masks `navigator.webdriver` can opt in via `?auth=redirect`