### PR TITLE
fix: resolve 20 bugs found during E2E QA testing pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Requests flow through sequential hooks in `src/hooks.server.ts`:
 
 - **`src/lib/server/`** - Backend services (auth, sync, stats, plex client, etc.)
 - **`src/lib/components/`** - Svelte components
-  - `slides/` - Animated presentation slides (19 types)
+  - `slides/` - Animated presentation slides (16 built-in types + custom slides)
   - `ui/` - shadcn/bits-ui primitives
 - **`src/lib/stores/`** - Svelte runes stores (`*.svelte.ts`)
 - **`src/routes/`** - SvelteKit routes with SSR data loading

--- a/src/lib/components/slides/BingeSlide.svelte
+++ b/src/lib/components/slides/BingeSlide.svelte
@@ -29,7 +29,7 @@ function formatDuration(totalMinutes: number): string {
 		hours++;
 		minutes -= 60;
 	}
-	if (hours === 0) return `${minutes} minutes`;
+	if (hours === 0) return `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`;
 	if (minutes === 0) return `${hours} ${hours === 1 ? 'hour' : 'hours'}`;
 	return `${hours}h ${minutes}m`;
 }

--- a/src/lib/components/slides/BingeSlide.svelte
+++ b/src/lib/components/slides/BingeSlide.svelte
@@ -22,14 +22,29 @@ let {
 
 const hasBinge = $derived(longestBinge !== null);
 
-// Format duration
-const duration = $derived.by(() => {
-	if (!longestBinge) return '';
-	const hours = Math.floor(longestBinge.totalMinutes / 60);
-	const minutes = Math.round(longestBinge.totalMinutes % 60);
+function formatDuration(totalMinutes: number): string {
+	let hours = Math.floor(totalMinutes / 60);
+	let minutes = Math.round(totalMinutes % 60);
+	if (minutes >= 60) {
+		hours++;
+		minutes -= 60;
+	}
 	if (hours === 0) return `${minutes} minutes`;
 	if (minutes === 0) return `${hours} ${hours === 1 ? 'hour' : 'hours'}`;
 	return `${hours}h ${minutes}m`;
+}
+
+// Wall-clock session duration (endTime - startTime)
+const sessionDuration = $derived.by(() => {
+	if (!longestBinge) return '';
+	const sessionMinutes = (longestBinge.endTime - longestBinge.startTime) / 60;
+	return formatDuration(sessionMinutes);
+});
+
+// Total content runtime (sum of episode durations)
+const contentDuration = $derived.by(() => {
+	if (!longestBinge) return '';
+	return formatDuration(longestBinge.totalMinutes);
 });
 
 // Format date
@@ -119,7 +134,9 @@ $effect(() => {
 
 		{#if hasBinge && longestBinge}
 			<div bind:this={statEl} class="stat-container">
-				<span class="duration">{duration}</span>
+				<span class="duration">{sessionDuration}</span>
+				<span class="duration-label">session</span>
+				<span class="content-duration">{contentDuration} of content</span>
 				<span class="plays"
 					>{longestBinge.plays} {longestBinge.plays === 1 ? 'episode' : 'episodes'}</span
 				>
@@ -218,6 +235,20 @@ $effect(() => {
 			filter: drop-shadow(0 0 20px hsl(var(--primary) / 0.4));
 		}
 
+		.duration-label {
+			font-size: 1rem;
+			color: hsl(var(--muted-foreground));
+			text-transform: uppercase;
+			letter-spacing: 0.15em;
+			margin-top: -0.25rem;
+		}
+
+		.content-duration {
+			font-size: 1rem;
+			color: hsl(var(--muted-foreground));
+			margin-top: 0.5rem;
+		}
+
 		.plays {
 			font-size: 1.25rem;
 			color: hsl(var(--foreground));
@@ -287,6 +318,14 @@ $effect(() => {
 				max-width: 320px;
 			}
 
+			.duration-label {
+				font-size: 0.875rem;
+			}
+
+			.content-duration {
+				font-size: 0.875rem;
+			}
+
 			.plays {
 				font-size: 1.0625rem;
 			}
@@ -312,6 +351,14 @@ $effect(() => {
 
 			.duration {
 				font-size: clamp(2.75rem, 9vw, 4.5rem);
+			}
+
+			.duration-label {
+				font-size: 1.125rem;
+			}
+
+			.content-duration {
+				font-size: 1.125rem;
 			}
 
 			.plays {
@@ -342,6 +389,14 @@ $effect(() => {
 			.duration {
 				font-size: clamp(3rem, 10vw, 5rem);
 				filter: drop-shadow(0 0 30px hsl(var(--primary) / 0.5));
+			}
+
+			.duration-label {
+				font-size: 1.25rem;
+			}
+
+			.content-duration {
+				font-size: 1.25rem;
 			}
 
 			.plays {

--- a/src/lib/components/slides/ContentTypeSlide.svelte
+++ b/src/lib/components/slides/ContentTypeSlide.svelte
@@ -53,12 +53,17 @@ function formatCount(count: number): string {
 }
 
 function formatMinutes(minutes: number): string {
-	const hours = Math.floor(minutes / 60);
+	let hours = Math.floor(minutes / 60);
+	let mins = Math.round(minutes % 60);
+	if (mins >= 60) {
+		hours++;
+		mins -= 60;
+	}
 	if (hours >= 24) {
 		const days = Math.floor(hours / 24);
 		return `${days}d ${hours % 24}h`;
 	}
-	return `${hours}h ${Math.round(minutes % 60)}m`;
+	return `${hours}h ${mins}m`;
 }
 
 let container: HTMLElement | undefined = $state();

--- a/src/lib/components/slides/DistributionSlide.svelte
+++ b/src/lib/components/slides/DistributionSlide.svelte
@@ -252,8 +252,12 @@ function formatMinutes(minutes: number): string {
 
 function formatMinutesDetailed(minutes: number): string {
 	if (minutes < 60) return `${Math.round(minutes)} minutes`;
-	const hours = Math.floor(minutes / 60);
-	const mins = Math.round(minutes % 60);
+	let hours = Math.floor(minutes / 60);
+	let mins = Math.round(minutes % 60);
+	if (mins >= 60) {
+		hours++;
+		mins -= 60;
+	}
 	if (mins === 0) return `${hours} ${hours === 1 ? 'hour' : 'hours'}`;
 	return `${hours}h ${mins}m`;
 }

--- a/src/lib/components/slides/MarathonSlide.svelte
+++ b/src/lib/components/slides/MarathonSlide.svelte
@@ -35,8 +35,12 @@ const formattedDate = $derived.by(() => {
 });
 
 function formatDuration(minutes: number): string {
-	const hours = Math.floor(minutes / 60);
-	const mins = Math.round(minutes % 60);
+	let hours = Math.floor(minutes / 60);
+	let mins = Math.round(minutes % 60);
+	if (mins >= 60) {
+		hours++;
+		mins -= 60;
+	}
 	if (hours === 0) return `${mins} min`;
 	if (mins === 0) return `${hours} hr`;
 	return `${hours} hr ${mins} min`;

--- a/src/lib/components/slides/TopViewersSlide.svelte
+++ b/src/lib/components/slides/TopViewersSlide.svelte
@@ -52,8 +52,12 @@ function formatWatchTimeDetailed(minutes: number): string {
 	if (minutes < 60) {
 		return `${Math.round(minutes)} minutes`;
 	}
-	const hours = Math.floor(minutes / 60);
-	const mins = Math.round(minutes % 60);
+	let hours = Math.floor(minutes / 60);
+	let mins = Math.round(minutes % 60);
+	if (mins >= 60) {
+		hours++;
+		mins -= 60;
+	}
 	if (hours < 24) {
 		if (mins === 0) return `${hours} ${hours === 1 ? 'hour' : 'hours'}`;
 		return `${hours}h ${mins}m`;

--- a/src/lib/components/slides/WeekdayPatternsSlide.svelte
+++ b/src/lib/components/slides/WeekdayPatternsSlide.svelte
@@ -53,8 +53,12 @@ const weekendPercent = $derived(
 );
 
 function formatHours(minutes: number): string {
-	const hours = Math.floor(minutes / 60);
-	const mins = Math.round(minutes % 60);
+	let hours = Math.floor(minutes / 60);
+	let mins = Math.round(minutes % 60);
+	if (mins >= 60) {
+		hours++;
+		mins -= 60;
+	}
 	if (hours === 0) return `${mins}m`;
 	if (mins === 0) return `${hours}h`;
 	return `${hours}h ${mins}m`;

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -206,9 +206,12 @@ $effect(() => {
 					use:enhance={() => {
 						isUpdating = true;
 						return async ({ update }) => {
-							await update();
-							isUpdating = false;
-							optimisticMode = null;
+							try {
+								await update();
+							} finally {
+								isUpdating = false;
+								optimisticMode = null;
+							}
 						};
 					}}
 				>
@@ -259,8 +262,11 @@ $effect(() => {
 						use:enhance={() => {
 							isUpdating = true;
 							return async ({ update }) => {
-								await update();
-								isUpdating = false;
+								try {
+									await update();
+								} finally {
+									isUpdating = false;
+								}
 							};
 						}}
 						class="regenerate-form"

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -208,6 +208,7 @@ $effect(() => {
 						return async ({ update }) => {
 							await update();
 							isUpdating = false;
+							optimisticMode = null;
 						};
 					}}
 				>

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -33,6 +33,16 @@ let {
 let copied = $state(false);
 let copyTimeout: ReturnType<typeof setTimeout> | undefined;
 let isUpdating = $state(false);
+let optimisticMode = $state<ShareModeType | null>(null);
+
+// Reset optimistic state when server data updates
+$effect.pre(() => {
+	if (shareSettings?.mode) {
+		optimisticMode = null;
+	}
+});
+
+const displayMode = $derived(optimisticMode ?? shareSettings?.mode);
 
 // Computed URL based on mode
 const shareUrl = $derived.by(() => {
@@ -203,20 +213,23 @@ $effect(() => {
 				>
 					<div class="mode-options">
 						{#each availableModes as mode}
-							<label class="mode-option" class:active={shareSettings?.mode === mode}>
+							<label class="mode-option" class:active={displayMode === mode}>
 								<input
 									type="radio"
 									name="mode"
 									value={mode}
-									checked={shareSettings?.mode === mode}
+									checked={displayMode === mode}
 									disabled={isUpdating}
-									onchange={(e) => e.currentTarget.form?.requestSubmit()}
+									onchange={(e) => {
+										optimisticMode = mode as ShareModeType;
+										e.currentTarget.form?.requestSubmit();
+									}}
 								/>
 								<div class="mode-content">
 									<span class="mode-label">{modeLabels[mode as ShareModeType].label}</span>
 									<span class="mode-desc">{modeLabels[mode as ShareModeType].description}</span>
 								</div>
-								{#if shareSettings?.mode === mode}
+								{#if displayMode === mode}
 									<svg
 										xmlns="http://www.w3.org/2000/svg"
 										width="16"
@@ -238,7 +251,7 @@ $effect(() => {
 				</form>
 
 				<!-- Regenerate Token (admin only, private-link mode) -->
-				{#if isAdmin && shareSettings?.mode === 'private-link'}
+				{#if isAdmin && displayMode === 'private-link'}
 					<form
 						method="POST"
 						action="?/regenerateToken"

--- a/src/lib/components/wrapped/SlideRenderer.svelte
+++ b/src/lib/components/wrapped/SlideRenderer.svelte
@@ -128,6 +128,7 @@ const topViewers = $derived(!isUserStats(stats) ? stats.topViewers : []);
 		<CustomSlideComponent
 			title={customSlideData.title}
 			content={customSlideData.content}
+			renderedHtml={customSlideData.renderedHtml}
 			{active}
 			{onAnimationComplete}
 		/>

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -164,7 +164,7 @@ function animateTransition(direction: 'forward' | 'backward'): void {
 	}
 
 	transitionTimeout = setTimeout(() => {
-		if (mounted && isTransitioning) {
+		if (isTransitioning) {
 			finishTransition();
 		}
 	}, ANIMATION_DURATION + 100);
@@ -193,10 +193,18 @@ function animateTransition(direction: 'forward' | 'backward'): void {
 function finishTransition(): void {
 	if (!isTransitioning) return;
 
+	if (transitionTimeout) {
+		clearTimeout(transitionTimeout);
+		transitionTimeout = null;
+	}
+	if (activeEnterAnim) {
+		activeEnterAnim.stop();
+		activeEnterAnim = null;
+	}
+
 	showPreviousSlide = false;
 	previousSlideIndex = -1;
 	isTransitioning = false;
-	activeEnterAnim = null;
 	navigation.endAnimation();
 }
 

--- a/src/lib/server/security/rate-limit-handle.ts
+++ b/src/lib/server/security/rate-limit-handle.ts
@@ -1,9 +1,13 @@
-import type { Handle } from '@sveltejs/kit';
+import { error, type Handle } from '@sveltejs/kit';
 import { checkRateLimit, RATE_LIMIT_CONFIGS, type RateLimitConfig } from '$lib/server/ratelimit';
 
 function getConfigForPath(path: string): RateLimitConfig {
 	if (path === '/auth/plex') {
 		return RATE_LIMIT_CONFIGS.authPoll;
+	}
+
+	if (path === '/auth/logout' || path === '/auth/plex/callback') {
+		return RATE_LIMIT_CONFIGS.default;
 	}
 
 	if (path.startsWith('/auth/')) {
@@ -29,15 +33,22 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 	const result = checkRateLimit(ip, config);
 
 	if (!result.allowed) {
-		return new Response(JSON.stringify({ error: 'Too many requests' }), {
-			status: 429,
-			headers: {
-				'Content-Type': 'application/json',
-				'Retry-After': String(result.retryAfter ?? 60),
-				'X-RateLimit-Remaining': '0',
-				'X-RateLimit-Reset': String(result.resetTime)
-			}
-		});
+		const isApiRequest =
+			path.startsWith('/api/') || event.request.headers.get('accept')?.includes('application/json');
+
+		if (isApiRequest) {
+			return new Response(JSON.stringify({ error: 'Too many requests' }), {
+				status: 429,
+				headers: {
+					'Content-Type': 'application/json',
+					'Retry-After': String(result.retryAfter ?? 60),
+					'X-RateLimit-Remaining': '0',
+					'X-RateLimit-Reset': String(result.resetTime)
+				}
+			});
+		}
+
+		error(429, 'Too many requests');
 	}
 
 	const response = await resolve(event);

--- a/src/lib/server/security/rate-limit-handle.ts
+++ b/src/lib/server/security/rate-limit-handle.ts
@@ -34,7 +34,10 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 
 	if (!result.allowed) {
 		const isApiRequest =
-			path.startsWith('/api/') || event.request.headers.get('accept')?.includes('application/json');
+			path.startsWith('/api/') ||
+			path.startsWith('/auth/') ||
+			event.request.headers.get('accept')?.includes('application/json') ||
+			event.request.headers.get('content-type')?.includes('application/json');
 
 		if (isApiRequest) {
 			return new Response(JSON.stringify({ error: 'Too many requests' }), {

--- a/src/lib/server/stats/calculators/binge-detector.ts
+++ b/src/lib/server/stats/calculators/binge-detector.ts
@@ -27,7 +27,7 @@ export function detectAllBingeSessions(records: PlayHistoryRecord[]): BingeSessi
 		if (!currentSession) {
 			currentSession = {
 				startTime: record.viewedAt,
-				endTime: record.viewedAt,
+				endTime: record.viewedAt + duration,
 				plays: 1,
 				totalSeconds: duration
 			};
@@ -35,7 +35,7 @@ export function detectAllBingeSessions(records: PlayHistoryRecord[]): BingeSessi
 			const gap = record.viewedAt - currentSession.endTime;
 
 			if (gap <= BINGE_GAP_THRESHOLD_SECONDS) {
-				currentSession.endTime = record.viewedAt;
+				currentSession.endTime = record.viewedAt + duration;
 				currentSession.plays += 1;
 				currentSession.totalSeconds += duration;
 			} else {
@@ -48,7 +48,7 @@ export function detectAllBingeSessions(records: PlayHistoryRecord[]): BingeSessi
 
 				currentSession = {
 					startTime: record.viewedAt,
-					endTime: record.viewedAt,
+					endTime: record.viewedAt + duration,
 					plays: 1,
 					totalSeconds: duration
 				};

--- a/src/lib/slides/types.ts
+++ b/src/lib/slides/types.ts
@@ -60,6 +60,7 @@ export interface CustomSlide {
 	id: number;
 	title: string;
 	content: string;
+	renderedHtml?: string;
 	enabled: boolean;
 	sortOrder: number;
 	year: number | null;

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import ChevronRight from '@lucide/svelte/icons/chevron-right';
 import FileText from '@lucide/svelte/icons/file-text';
+import GalleryHorizontal from '@lucide/svelte/icons/gallery-horizontal';
 import Gift from '@lucide/svelte/icons/gift';
 import LayoutDashboard from '@lucide/svelte/icons/layout-dashboard';
 import LogOut from '@lucide/svelte/icons/log-out';
@@ -38,6 +39,7 @@ let { data, children }: Props = $props();
 const navItems: Array<{ href: string; label: string; icon: Component }> = [
 	{ href: '/admin', label: 'Dashboard', icon: LayoutDashboard },
 	{ href: '/admin/wrapped', label: 'Wrapped', icon: Gift },
+	{ href: '/admin/slides', label: 'Slides', icon: GalleryHorizontal },
 	{ href: '/admin/sync', label: 'Sync', icon: RefreshCw },
 	{ href: '/admin/users', label: 'Users', icon: Users },
 	{ href: '/admin/logs', label: 'Logs', icon: FileText },

--- a/src/routes/admin/logs/+page.server.ts
+++ b/src/routes/admin/logs/+page.server.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import {
 	deleteAllLogs,
 	getDistinctSources,
+	getLatestLogId,
 	getLogCountsByLevel,
 	getLogMaxCount,
 	getLogRetentionDays,
@@ -73,21 +74,31 @@ export const load: PageServerLoad = async ({ url }) => {
 	const limit = LimitSchema.parse(limitParam);
 	const cursor = CursorSchema.parse(cursorParam);
 
-	const [logsResult, sources, levelCounts, retentionDays, maxCount, debugEnabled, retentionStatus] =
-		await Promise.all([
-			queryLogs({ levels, search, source, fromTimestamp, toTimestamp, cursor, limit }),
-			getDistinctSources(),
-			getLogCountsByLevel(),
-			getLogRetentionDays(),
-			getLogMaxCount(),
-			isDebugEnabled(),
-			getRetentionSchedulerStatus()
-		]);
+	const [
+		logsResult,
+		sources,
+		levelCounts,
+		retentionDays,
+		maxCount,
+		debugEnabled,
+		retentionStatus,
+		latestLogId
+	] = await Promise.all([
+		queryLogs({ levels, search, source, fromTimestamp, toTimestamp, cursor, limit }),
+		getDistinctSources(),
+		getLogCountsByLevel(),
+		getLogRetentionDays(),
+		getLogMaxCount(),
+		isDebugEnabled(),
+		getRetentionSchedulerStatus(),
+		getLatestLogId()
+	]);
 
 	return {
 		logs: logsResult.logs,
 		hasMore: logsResult.hasMore,
 		totalCount: logsResult.totalCount,
+		latestLogId,
 		sources,
 		levelCounts,
 		settings: {

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -189,7 +189,7 @@ function connectSSE() {
 		eventSource.close();
 	}
 
-	const latestId = lastSeenStreamId > 0 ? lastSeenStreamId : (data.logs[0]?.id ?? 0);
+	const latestId = lastSeenStreamId > 0 ? lastSeenStreamId : (data.latestLogId ?? 0);
 
 	eventSource = new EventSource(`/admin/logs/stream?cursor=${latestId}`);
 

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -55,6 +55,7 @@ let autoScroll = $state(true);
 // SSE connection state
 let eventSource: EventSource | null = $state(null);
 let streamedLogs = $state<LogEntry[]>([]);
+let lastSeenStreamId = $state(0);
 let isConnected = $state(false);
 
 // Debounce timer for search
@@ -188,8 +189,7 @@ function connectSSE() {
 		eventSource.close();
 	}
 
-	// Get the latest log ID as cursor
-	const latestId = allLogs.length > 0 ? Math.max(...allLogs.map((l) => l.id)) : 0;
+	const latestId = lastSeenStreamId > 0 ? lastSeenStreamId : (data.logs[0]?.id ?? 0);
 
 	eventSource = new EventSource(`/admin/logs/stream?cursor=${latestId}`);
 
@@ -204,6 +204,9 @@ function connectSSE() {
 			if (data.type === 'log') {
 				// Add new log to streamed logs
 				streamedLogs = [data.log, ...streamedLogs];
+				if (data.log.id > lastSeenStreamId) {
+					lastSeenStreamId = data.log.id;
+				}
 
 				// Scroll to top if auto-scroll is enabled
 				if (autoScroll) {
@@ -244,6 +247,7 @@ function toggleAutoScroll() {
 
 	if (autoScroll) {
 		streamedLogs = []; // Clear old streamed logs
+		lastSeenStreamId = 0;
 		connectSSE();
 	} else {
 		disconnectSSE();

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -36,13 +36,19 @@ $effect.pre(() => {
 // Date range filter state
 let fromDate = $state('');
 let toDate = $state('');
+
+function toLocalDateTimeInput(ts: number): string {
+	const d = new Date(ts);
+	const pad = (n: number) => String(n).padStart(2, '0');
+	return (
+		`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+		`T${pad(d.getHours())}:${pad(d.getMinutes())}`
+	);
+}
+
 $effect.pre(() => {
-	fromDate = data.filters?.fromTimestamp
-		? new Date(data.filters.fromTimestamp).toISOString().slice(0, 16)
-		: '';
-	toDate = data.filters?.toTimestamp
-		? new Date(data.filters.toTimestamp).toISOString().slice(0, 16)
-		: '';
+	fromDate = data.filters?.fromTimestamp ? toLocalDateTimeInput(data.filters.fromTimestamp) : '';
+	toDate = data.filters?.toTimestamp ? toLocalDateTimeInput(data.filters.toTimestamp) : '';
 });
 let autoScroll = $state(true);
 
@@ -60,6 +66,8 @@ const filteredStreamedLogs = $derived(
 		if (selectedLevels.length > 0 && !selectedLevels.includes(log.level)) return false;
 		if (selectedSource && log.source !== selectedSource) return false;
 		if (searchText && !log.message.toLowerCase().includes(searchText.toLowerCase())) return false;
+		if (data.filters?.fromTimestamp && log.timestamp < data.filters.fromTimestamp) return false;
+		if (data.filters?.toTimestamp && log.timestamp > data.filters.toTimestamp) return false;
 		return true;
 	})
 );
@@ -403,7 +411,7 @@ $effect(() => {
 							a.href = url;
 							a.download = (result.data.exportFilename as string) || 'logs-export.json';
 							a.click();
-							URL.revokeObjectURL(url);
+							setTimeout(() => URL.revokeObjectURL(url), 100);
 						}
 					};
 				}}
@@ -441,7 +449,7 @@ $effect(() => {
 		<div class="logs-header">
 			<h2>Log Entries</h2>
 			<span class="logs-count">
-				Showing {allLogs.length} of {(data.totalCount + streamedLogs.length).toLocaleString()}
+				Showing {allLogs.length} of {(data.totalCount + filteredStreamedLogs.length).toLocaleString()}
 			</span>
 		</div>
 

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -32,6 +32,18 @@ let searchText = $state('');
 $effect.pre(() => {
 	searchText = data.filters?.search ?? '';
 });
+
+// Date range filter state
+let fromDate = $state('');
+let toDate = $state('');
+$effect.pre(() => {
+	fromDate = data.filters?.fromTimestamp
+		? new Date(data.filters.fromTimestamp).toISOString().slice(0, 16)
+		: '';
+	toDate = data.filters?.toTimestamp
+		? new Date(data.filters.toTimestamp).toISOString().slice(0, 16)
+		: '';
+});
 let autoScroll = $state(true);
 
 // SSE connection state
@@ -42,8 +54,18 @@ let isConnected = $state(false);
 // Debounce timer for search
 let searchDebounce: ReturnType<typeof setTimeout> | null = null;
 
-// Combined logs (initial + streamed)
-const allLogs = $derived([...streamedLogs, ...data.logs]);
+// Filter streamed logs to match active filters
+const filteredStreamedLogs = $derived(
+	streamedLogs.filter((log) => {
+		if (selectedLevels.length > 0 && !selectedLevels.includes(log.level)) return false;
+		if (selectedSource && log.source !== selectedSource) return false;
+		if (searchText && !log.message.toLowerCase().includes(searchText.toLowerCase())) return false;
+		return true;
+	})
+);
+
+// Combined logs (filtered streamed + server-filtered)
+const allLogs = $derived([...filteredStreamedLogs, ...data.logs]);
 
 // Available log levels
 const logLevels: LogLevelType[] = ['DEBUG', 'INFO', 'WARN', 'ERROR'];
@@ -100,6 +122,12 @@ function applyFilters(overrides?: { levels?: LogLevelType[]; search?: string; so
 	if (source) {
 		params.set('source', source);
 	}
+	if (fromDate) {
+		params.set('from', String(new Date(fromDate).getTime()));
+	}
+	if (toDate) {
+		params.set('to', String(new Date(toDate).getTime()));
+	}
 
 	const queryString = params.toString();
 	goto(`/admin/logs${queryString ? `?${queryString}` : ''}`, { replaceState: true });
@@ -135,6 +163,8 @@ function handleSourceChange(event: Event) {
 
 // Clear all filters
 function clearFilters() {
+	fromDate = '';
+	toDate = '';
 	goto('/admin/logs', { replaceState: true });
 }
 
@@ -319,6 +349,28 @@ $effect(() => {
 					{/each}
 				</select>
 			</div>
+
+			<!-- Date Range: After -->
+			<div class="filter-group">
+				<label class="filter-label" for="from-date">After</label>
+				<input
+					type="datetime-local"
+					id="from-date"
+					bind:value={fromDate}
+					onchange={() => applyFilters()}
+				/>
+			</div>
+
+			<!-- Date Range: Before -->
+			<div class="filter-group">
+				<label class="filter-label" for="to-date">Before</label>
+				<input
+					type="datetime-local"
+					id="to-date"
+					bind:value={toDate}
+					onchange={() => applyFilters()}
+				/>
+			</div>
 		</div>
 	</section>
 
@@ -339,7 +391,24 @@ $effect(() => {
 				{/if}
 			</button>
 
-			<form method="POST" action="?/exportLogs" use:enhance class="inline-form">
+			<form
+				method="POST"
+				action="?/exportLogs"
+				use:enhance={() => {
+					return async ({ result }) => {
+						if (result.type === 'success' && result.data?.exportData) {
+							const blob = new Blob([result.data.exportData as string], { type: 'application/json' });
+							const url = URL.createObjectURL(blob);
+							const a = document.createElement('a');
+							a.href = url;
+							a.download = (result.data.exportFilename as string) || 'logs-export.json';
+							a.click();
+							URL.revokeObjectURL(url);
+						}
+					};
+				}}
+				class="inline-form"
+			>
 				<button type="submit" class="control-button secondary"> Export JSON </button>
 			</form>
 		</div>
@@ -372,7 +441,7 @@ $effect(() => {
 		<div class="logs-header">
 			<h2>Log Entries</h2>
 			<span class="logs-count">
-				Showing {allLogs.length} of {data.totalCount.toLocaleString()}
+				Showing {allLogs.length} of {(data.totalCount + streamedLogs.length).toLocaleString()}
 			</span>
 		</div>
 
@@ -998,6 +1067,24 @@ $effect(() => {
 
 			.col-actions {
 				display: none;
+			}
+		}
+
+		@media (max-width: 480px) {
+			.controls-left,
+			.controls-right {
+				flex-direction: column;
+				width: 100%;
+			}
+
+			.control-button {
+				width: 100%;
+				justify-content: center;
+			}
+
+			.inline-form {
+				display: block;
+				width: 100%;
 			}
 		}
 </style>

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -115,6 +115,12 @@ function getLevelClass(level: LogLevelType): string {
 	}
 }
 
+// Preserve current filter query string on the export form so the server action sees them.
+const exportAction = $derived.by(() => {
+	const search = $page.url.searchParams.toString();
+	return search ? `?${search}&/exportLogs` : '?/exportLogs';
+});
+
 // Apply filters to URL (accepts overrides for derived values)
 function applyFilters(overrides?: { levels?: LogLevelType[]; search?: string; source?: string }) {
 	const params = new URLSearchParams();
@@ -411,7 +417,7 @@ $effect(() => {
 
 			<form
 				method="POST"
-				action="?/exportLogs"
+				action={exportAction}
 				use:enhance={() => {
 					return async ({ result }) => {
 						if (result.type === 'success' && result.data?.exportData) {

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -131,10 +131,16 @@ function applyFilters(overrides?: { levels?: LogLevelType[]; search?: string; so
 		params.set('source', source);
 	}
 	if (fromDate) {
-		params.set('from', String(new Date(fromDate).getTime()));
+		const fromTs = new Date(fromDate).getTime();
+		if (Number.isFinite(fromTs)) {
+			params.set('from', String(fromTs));
+		}
 	}
 	if (toDate) {
-		params.set('to', String(new Date(toDate).getTime()));
+		const toTs = new Date(toDate).getTime();
+		if (Number.isFinite(toTs)) {
+			params.set('to', String(toTs));
+		}
 	}
 
 	const queryString = params.toString();

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -381,7 +381,9 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 		</p>
 
 		<form method="POST" action="?/setFunFactFrequency" use:enhance>
-			<div class="frequency-options">
+			<!-- svelte-ignore a11y_click_events_have_key_events -->
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<div class="frequency-options" onclick={(e) => e.stopPropagation()}>
 				<label class="frequency-option">
 					<input type="radio" name="mode" value="few" bind:group={selectedFrequencyMode} />
 					<span class="frequency-label">

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -289,6 +289,7 @@ function getShareModeLabel(mode: string | null): string {
 
 		.users-table {
 			width: 100%;
+			min-width: 600px;
 			border-collapse: collapse;
 			font-size: 0.875rem;
 		}

--- a/src/routes/admin/wrapped/+page.svelte
+++ b/src/routes/admin/wrapped/+page.svelte
@@ -135,7 +135,7 @@ let { data }: Props = $props();
 				<ArrowRight class="config-arrow" />
 			</a>
 
-			<a href="/admin/settings" class="config-card">
+			<a href="/admin/settings?tab=appearance" class="config-card">
 				<div class="config-icon-wrap">
 					<Palette class="config-icon" />
 				</div>

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -1,0 +1,24 @@
+import { redirect } from '@sveltejs/kit';
+import { invalidateSession } from '$lib/server/auth/session';
+import { logger } from '$lib/server/logging';
+import type { RequestHandler } from './$types';
+
+const COOKIE_OPTIONS = {
+	path: '/'
+};
+
+export const GET: RequestHandler = async ({ cookies }) => {
+	const sessionId = cookies.get('session');
+
+	if (sessionId) {
+		try {
+			await invalidateSession(sessionId);
+		} catch (err) {
+			logger.error('Error invalidating session', 'Logout', { error: String(err) });
+		}
+	}
+
+	cookies.delete('session', COOKIE_OPTIONS);
+
+	redirect(303, '/');
+};

--- a/src/routes/plex/thumb/[...path]/+server.ts
+++ b/src/routes/plex/thumb/[...path]/+server.ts
@@ -19,6 +19,9 @@ function isAllowedPath(path: string): boolean {
 	return ALLOWED_PATH_PATTERNS.some((pattern) => pattern.test(path));
 }
 
+// Intentionally unauthenticated: shared/public wrapped pages render thumbnails
+// via getThumbUrl() without a user session. Path validation (ALLOWED_PATH_PATTERNS)
+// restricts access to Plex library metadata thumbnails only.
 export const GET: RequestHandler = async ({ params }) => {
 	const { path } = params;
 

--- a/src/routes/wrapped/[year]/+page.server.ts
+++ b/src/routes/wrapped/[year]/+page.server.ts
@@ -11,7 +11,8 @@ import {
 	getEnabledCustomSlides,
 	getEnabledSlides,
 	initializeDefaultSlideConfig,
-	intersperseFunFacts
+	intersperseFunFacts,
+	renderMarkdownSync
 } from '$lib/server/slides';
 import { getServerStatsWithAnonymization } from '$lib/server/stats/engine';
 import { triggerLiveSyncIfNeeded } from '$lib/server/sync/live-sync';
@@ -46,8 +47,12 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		getEnabledCustomSlides(year)
 	]);
 
-	const baseSlides = buildSlideRenderConfigs(slideConfigs, customSlides);
-	const customSlidesMap = customSlidesToMap(customSlides);
+	const customSlidesWithHtml = customSlides.map((slide) => ({
+		...slide,
+		renderedHtml: renderMarkdownSync(slide.content)
+	}));
+	const baseSlides = buildSlideRenderConfigs(slideConfigs, customSlidesWithHtml);
+	const customSlidesMap = customSlidesToMap(customSlidesWithHtml);
 
 	const frequencyConfig = await getFunFactFrequency();
 	let funFacts: Awaited<ReturnType<typeof generateFunFacts>> = [];

--- a/src/routes/wrapped/[year]/+page.svelte
+++ b/src/routes/wrapped/[year]/+page.svelte
@@ -76,7 +76,9 @@ function handleComplete(): void {
  * Handle close/exit action
  */
 function handleClose(): void {
-	if (window.history.length > 1) {
+	const isSameOrigin =
+		document.referrer !== '' && document.referrer.startsWith(window.location.origin);
+	if (isSameOrigin && window.history.length > 1) {
 		window.history.back();
 	} else {
 		goto('/');

--- a/src/routes/wrapped/[year]/+page.svelte
+++ b/src/routes/wrapped/[year]/+page.svelte
@@ -76,8 +76,11 @@ function handleComplete(): void {
  * Handle close/exit action
  */
 function handleClose(): void {
-	// Navigate back to home or previous page
-	window.history.back();
+	if (window.history.length > 1) {
+		window.history.back();
+	} else {
+		goto('/');
+	}
 }
 
 /**

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -28,7 +28,8 @@ import {
 	getEnabledCustomSlides,
 	getEnabledSlides,
 	initializeDefaultSlideConfig,
-	intersperseFunFacts
+	intersperseFunFacts,
+	renderMarkdownSync
 } from '$lib/server/slides';
 import { calculateUserStats } from '$lib/server/stats/engine';
 import { triggerLiveSyncIfNeeded } from '$lib/server/sync/live-sync';
@@ -123,8 +124,12 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		getEnabledCustomSlides(year)
 	]);
 
-	const baseSlides = buildSlideRenderConfigs(slideConfigs, customSlides);
-	const customSlidesMap = customSlidesToMap(customSlides);
+	const customSlidesWithHtml = customSlides.map((slide) => ({
+		...slide,
+		renderedHtml: renderMarkdownSync(slide.content)
+	}));
+	const baseSlides = buildSlideRenderConfigs(slideConfigs, customSlidesWithHtml);
+	const customSlidesMap = customSlidesToMap(customSlidesWithHtml);
 
 	const frequencyConfig = await getFunFactFrequency();
 	let funFacts: Awaited<ReturnType<typeof generateFunFacts>> = [];

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
@@ -82,8 +82,11 @@ function handleComplete(): void {
  * Handle close/exit action
  */
 function handleClose(): void {
-	// Navigate back to home or previous page
-	window.history.back();
+	if (window.history.length > 1) {
+		window.history.back();
+	} else {
+		goto('/');
+	}
 }
 
 /**

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
@@ -82,7 +82,9 @@ function handleComplete(): void {
  * Handle close/exit action
  */
 function handleClose(): void {
-	if (window.history.length > 1) {
+	const isSameOrigin =
+		document.referrer !== '' && document.referrer.startsWith(window.location.origin);
+	if (isSameOrigin && window.history.length > 1) {
 		window.history.back();
 	} else {
 		goto('/');

--- a/tests/property/stats.property.test.ts
+++ b/tests/property/stats.property.test.ts
@@ -550,10 +550,11 @@ describe('Property 14: Binge Session Detection', () => {
 
 				if (!result) return false;
 
+				const duration = record.duration ?? 0;
 				return (
 					result.plays === 1 &&
 					result.startTime === record.viewedAt &&
-					result.endTime === record.viewedAt
+					result.endTime === record.viewedAt + duration
 				);
 			}),
 			{ numRuns: 100 }
@@ -628,7 +629,7 @@ describe('Property 14: Binge Session Detection', () => {
 				ratingKey: 'rating-2',
 				title: 'Title 2',
 				type: 'movie',
-				viewedAt: 1704067200 + 3600, // 1 hour gap (exceeds 30 min threshold)
+				viewedAt: 1704067200 + 3600 + 3600, // 1 hour gap after end of previous play (exceeds 30 min threshold)
 				accountId: 1,
 				librarySectionId: 1,
 				thumb: null,


### PR DESCRIPTION
## Summary

Comprehensive bug fix pass addressing 20 issues found during E2E QA testing across 14 areas of the application. All fixes verified with `bun run check` (zero new type errors).

### Critical (2)
- **Logout 500 error**: Added `+server.ts` GET handler for `/auth/logout` so direct navigation works instead of returning HTTP 500
- **StoryMode blank screen**: Fixed animation race condition where `{#key}` block DOM destruction left `isAnimating` permanently stuck, causing unrecoverable blank slides

### High (3)
- **Close button about:blank**: Added `window.history.length` check with `goto('/')` fallback in both wrapped page variants
- **Export JSON broken**: Replaced bare `use:enhance` with custom callback that creates a Blob download from the server response
- **Rate limiter grouping**: Exempted `/auth/logout` and `/auth/plex/callback` from the restrictive auth rate limit pool (10 req/5min)

### Medium (6)
- **Rate limit raw JSON**: Page requests now trigger SvelteKit's error page instead of showing raw JSON
- **Missing Slides sidebar link**: Added "Slides" entry to admin navigation
- **SSE log filter bypass**: Streamed log entries now pass through active level/source/search filters before display
- **Custom slide raw markdown**: Pre-render markdown server-side and pass `renderedHtml` prop to `CustomSlide` component
- **Duration "9h 60m"**: Added 60-minute rollover normalization in 5 slide components (Distribution, ContentType, Marathon, TopViewers, WeekdayPatterns)
- **Date range filter UI**: Added After/Before datetime inputs wired to existing server-side `from`/`to` parameter support

### Low (9)
- Fixed Display Settings link to target `?tab=appearance`
- Documented intentional unauthenticated thumbnail proxy access (needed for shared pages)
- Fixed "Showing X of Y" log count to include SSE entries in total
- BingeSlide now shows wall-clock session duration as primary stat with content runtime as subtitle
- Prevented fun fact radio clicks from opening Create Custom Slide modal (stopPropagation)
- Added mobile responsive styles for users table and logs action buttons
- Fixed share modal radio button visual state lag
- Corrected CLAUDE.md slide count from "19 types" to "16 built-in types + custom slides"

## Test plan

- [ ] Verify GET `/auth/logout` returns 303 redirect (not 500)
- [ ] Rapidly navigate through wrapped slides 5+ times without blank screen
- [ ] Open wrapped page in new tab, press Escape -- navigates to `/` not `about:blank`
- [ ] Export JSON on logs page triggers browser file download
- [ ] Admin sidebar shows "Slides" link between Wrapped and Sync
- [ ] SSE streamed logs respect active filters
- [ ] Custom slides render markdown as HTML
- [ ] No "9h 60m" duration formatting anywhere
- [ ] Date range filter inputs visible and functional on logs page
- [ ] `bun run check` passes with no new errors