### PR TITLE
Fix verification checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 # OS
 .DS_Store
 Thumbs.db
+.claude/
 
 # Env
 .env

--- a/src/app.css
+++ b/src/app.css
@@ -1,6 +1,3 @@
-/* UnoCSS base styles */
-@unocss all;
-
 /* =============================================================================
    Base Theme Variables (Modern Minimal - Default)
    Using HSL color format for compatibility with shadcn-svelte

--- a/src/lib/server/db/client.ts
+++ b/src/lib/server/db/client.ts
@@ -1,4 +1,4 @@
-import { Database } from 'bun:sqlite';
+import type { Database as BunDatabase } from 'bun:sqlite';
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 import { drizzle } from 'drizzle-orm/bun-sqlite';
@@ -23,7 +23,10 @@ if (databasePath !== ':memory:') {
 	mkdirSync(dirname(databasePath), { recursive: true });
 }
 
-const sqlite = new Database(databasePath, {
+// Keep adapter-bun/Rolldown from resolving Bun's builtin at build time.
+const sqliteModuleName = ['bun', 'sqlite'].join(':');
+const { Database } = (await import(sqliteModuleName)) as typeof import('bun:sqlite');
+const sqlite: BunDatabase = new Database(databasePath, {
 	strict: true,
 	create: true
 });

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import 'virtual:uno.css';
 import '../app.css';
 import { Toaster } from 'svelte-sonner';
 import { page } from '$app/stores';

--- a/tests/unit/auth/membership.test.ts
+++ b/tests/unit/auth/membership.test.ts
@@ -1,32 +1,4 @@
-import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
-
-// Stub the settings service so the "no match" precondition is not sensitive to
-// whatever .env.test / DB defaults resolve to at runtime. We pin the configured
-// Plex server URL to a value that clearly does not match the mocked resource's
-// machine id ('unrelated-machine-id') or address, forcing findConfiguredServer
-// to return undefined.
-mock.module('$lib/server/admin/settings.service', () => ({
-	getApiConfigWithSources: () =>
-		Promise.resolve({
-			plex: {
-				serverUrl: {
-					value: 'https://plex.example.com:32400',
-					source: 'db',
-					isLocked: false
-				},
-				token: { value: '', source: 'default', isLocked: false }
-			},
-			openai: {
-				apiKey: { value: '', source: 'default', isLocked: false },
-				baseUrl: {
-					value: 'https://api.openai.com/v1',
-					source: 'default',
-					isLocked: false
-				},
-				model: { value: 'gpt-5-mini', source: 'default', isLocked: false }
-			}
-		})
-}));
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
 
 import { verifyServerMembership } from '$lib/server/auth/membership';
 

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -160,7 +160,7 @@ describe('startPlexLoginRedirect', () => {
 		) as unknown as typeof fetch;
 
 		const originalHref = location.href;
-		let receivedError: string | null = null;
+		let receivedError = '';
 
 		await startPlexLoginRedirect({
 			context: 'landing',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
 		"strict": true,
 		"strictNullChecks": true,
 		"noUncheckedIndexedAccess": true,
-		"moduleResolution": "bundler"
+		"moduleResolution": "bundler",
+		"types": ["node", "bun"]
 	}
 	// Path aliases are handled by https://svelte.dev/docs/kit/configuration#alias
 	// except $lib which is handled by https://svelte.dev/docs/kit/configuration#files

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,14 @@ import { visualizer } from 'rollup-plugin-visualizer';
 import UnoCSS from 'unocss/vite';
 import { defineConfig, type PluginOption } from 'vite';
 
+const rolldownChecks = { pluginTimings: false } as Record<string, boolean>;
+
 export default defineConfig({
+	build: {
+		rollupOptions: {
+			checks: rolldownChecks
+		}
+	},
 	plugins: [
 		UnoCSS(),
 		sveltekit(),


### PR DESCRIPTION
## Summary
- Fix Bun test isolation by removing a leaked settings service mock.
- Add Bun ambient types for standalone TypeScript checks.
- Remove build warnings from UnoCSS, Rolldown plugin timing output, and Bun SQLite resolution.

## Validation
- bun test
- bun run test
- bun run check
- bunx tsc --noEmit --project tsconfig.json
- bun run format:check
- bun run lint
- bun run check:biome
- bun run build