### PR TITLE
Refactor code quality workflow into tiered jobs

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  prek:
+  pre-commit:
     name: Pre-commit Checks
     runs-on: ubuntu-latest
     permissions:
@@ -50,3 +50,47 @@ jobs:
           extra-args: --all-files --hook-stage manual
         env:
           SKIP: no-commit-to-branch
+
+  type-check:
+    name: Type Checking
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run Svelte and TypeScript checks
+        run: bun run check
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    needs: type-check
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run tests
+        run: bun run test

--- a/tests/unit/auth/dev-users.test.ts
+++ b/tests/unit/auth/dev-users.test.ts
@@ -8,26 +8,11 @@
  * and the plex-oauth module to test the pure logic (caching, user lookup, etc.)
  */
 
-import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
 // =============================================================================
 // Mock Setup
 // =============================================================================
-
-// Mock the plex-oauth module's getPlexUserInfo function
-const mockGetPlexUserInfo = mock(() =>
-	Promise.resolve({
-		id: 12345,
-		uuid: 'owner-uuid',
-		username: 'ServerOwner',
-		email: 'owner@example.com',
-		thumb: 'https://plex.tv/users/owner/avatar'
-	})
-);
-
-mock.module('$lib/server/auth/plex-oauth', () => ({
-	getPlexUserInfo: mockGetPlexUserInfo
-}));
 
 // Note: We don't mock the logger to avoid contaminating the module cache
 // for other test files that test the actual logger implementation
@@ -82,7 +67,6 @@ function createMockFriendsResponse(
 	};
 }
 
-// Import after mocks are set up
 import {
 	clearUsersCache,
 	getRandomNonOwnerUser,
@@ -92,6 +76,7 @@ import {
 	getUserByUsername,
 	resolveUserIdentifier
 } from '$lib/server/auth/dev-users';
+import * as plexOAuth from '$lib/server/auth/plex-oauth';
 
 // =============================================================================
 // Test Suites
@@ -99,12 +84,20 @@ import {
 
 describe('dev-users module', () => {
 	let fetchMock: ReturnType<typeof spyOn>;
+	let mockGetPlexUserInfo: ReturnType<typeof spyOn>;
 
 	beforeEach(() => {
 		// Clear cache before each test
 		clearUsersCache();
-		// Reset mock calls
-		mockGetPlexUserInfo.mockClear();
+		mockGetPlexUserInfo = spyOn(plexOAuth, 'getPlexUserInfo').mockImplementation(() =>
+			Promise.resolve({
+				id: 12345,
+				uuid: 'owner-uuid',
+				username: 'ServerOwner',
+				email: 'owner@example.com',
+				thumb: 'https://plex.tv/users/owner/avatar'
+			})
+		);
 	});
 
 	afterEach(() => {
@@ -112,6 +105,7 @@ describe('dev-users module', () => {
 		if (fetchMock) {
 			fetchMock.mockRestore();
 		}
+		mockGetPlexUserInfo.mockRestore();
 	});
 
 	// Shared mock data

--- a/tests/unit/auth/revalidation.test.ts
+++ b/tests/unit/auth/revalidation.test.ts
@@ -1,19 +1,6 @@
-import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
-const mockVerifyServerMembership = mock(() =>
-	Promise.resolve({ isMember: true, isOwner: false, serverName: 'TestServer' })
-);
-
-mock.module('$lib/server/auth/membership', () => ({
-	verifyServerMembership: mockVerifyServerMembership
-}));
-
-const mockRequiresOnboarding = mock(() => Promise.resolve(false));
-
-mock.module('$lib/server/onboarding', () => ({
-	requiresOnboarding: mockRequiresOnboarding
-}));
-
+import * as membership from '$lib/server/auth/membership';
 import {
 	clearRevalidationEntry,
 	needsRevalidation,
@@ -22,17 +9,28 @@ import {
 	shouldRevalidateSession
 } from '$lib/server/auth/revalidation';
 import { PlexAuthApiError } from '$lib/server/auth/types';
+import * as onboarding from '$lib/server/onboarding';
 
 const SESSION_ID = 'test-session';
 const PLEX_TOKEN = 'test-token';
 
 describe('revalidation module', () => {
+	let mockVerifyServerMembership: ReturnType<typeof spyOn>;
+	let mockRequiresOnboarding: ReturnType<typeof spyOn>;
+
 	beforeEach(() => {
-		mockVerifyServerMembership.mockClear();
-		mockVerifyServerMembership.mockImplementation(() =>
-			Promise.resolve({ isMember: true, isOwner: false, serverName: 'TestServer' })
+		mockVerifyServerMembership = spyOn(membership, 'verifyServerMembership').mockImplementation(
+			() => Promise.resolve({ isMember: true, isOwner: false, serverName: 'TestServer' })
+		);
+		mockRequiresOnboarding = spyOn(onboarding, 'requiresOnboarding').mockImplementation(() =>
+			Promise.resolve(false)
 		);
 		clearRevalidationEntry(SESSION_ID);
+	});
+
+	afterEach(() => {
+		mockVerifyServerMembership.mockRestore();
+		mockRequiresOnboarding.mockRestore();
 	});
 
 	describe('needsRevalidation', () => {


### PR DESCRIPTION
## Summary
- Split code quality CI into pre-commit, type-check, and test jobs.
- Added explicit job dependencies so failures block later stages.
- Preserved the Renovate-only Biome migration behavior in the pre-commit stage.

## Verification
- bunx prek run check-yaml --files .github/workflows/code-quality.yml
- git diff --check
- bun run check
- bun run test