### PR TITLE
Fix onboarding CSRF navigation

### DIFF
--- a/src/routes/onboarding/csrf/+page.svelte
+++ b/src/routes/onboarding/csrf/+page.svelte
@@ -385,7 +385,6 @@ function useDetectedOrigin() {
 	{#snippet footer()}
 		<form method="POST" action="?/saveOrigin" class="button-group" onsubmit={() => (isSubmitting = true)}>
 			<input type="hidden" name="csrfOrigin" value={csrfOriginInput ?? ''} />
-			<input type="hidden" name="validated" value={testResult === 'success' ? 'true' : 'false'} />
 			<button
 				type="submit"
 				class="skip-btn"

--- a/src/routes/onboarding/csrf/+page.svelte
+++ b/src/routes/onboarding/csrf/+page.svelte
@@ -2,7 +2,7 @@
 import ExternalLink from '@lucide/svelte/icons/external-link';
 import type { ActionResult } from '@sveltejs/kit';
 import { animate, stagger } from 'motion';
-import { deserialize, enhance } from '$app/forms';
+import { deserialize } from '$app/forms';
 import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
 import type { ActionData, PageData } from './$types';
 
@@ -251,7 +251,6 @@ function useDetectedOrigin() {
 						placeholder="https://your-domain.com"
 						class="origin-input"
 						class:error={form?.error}
-						form="csrf-form"
 					/>
 					{#if csrfOriginInput !== data.detection.detectedOrigin}
 						<button type="button" class="use-detected-btn" onclick={useDetectedOrigin}>
@@ -384,54 +383,31 @@ function useDetectedOrigin() {
 	</div>
 
 	{#snippet footer()}
-		<div class="button-group">
-			<form
-				method="POST"
-				action="?/skipCsrf"
-				use:enhance={() => {
-					isSubmitting = true;
-					return async ({ update }) => {
-						await update();
-						isSubmitting = false;
-					};
-				}}
+		<form method="POST" action="?/saveOrigin" class="button-group" onsubmit={() => (isSubmitting = true)}>
+			<input type="hidden" name="csrfOrigin" value={csrfOriginInput ?? ''} />
+			<input type="hidden" name="validated" value={testResult === 'success' ? 'true' : 'false'} />
+			<button
+				type="submit"
+				class="skip-btn"
+				disabled={isSubmitting}
+				formaction="?/skipCsrf"
+				formnovalidate
 			>
-				<button type="submit" class="skip-btn" disabled={isSubmitting}>
-					{data.csrfConfig.isLocked ? 'Continue' : 'Skip'}
-				</button>
-			</form>
-
+				{data.csrfConfig.isLocked ? 'Continue' : 'Skip'}
+			</button>
 			{#if !data.csrfConfig.isLocked}
-				<form
-					id="csrf-form"
-					method="POST"
-					action="?/saveOrigin"
-					use:enhance={() => {
-						isSubmitting = true;
-						return async ({ update }) => {
-							await update();
-							isSubmitting = false;
-						};
-					}}
+				<button
+					type="submit"
+					class="save-btn"
+					disabled={isSubmitting || !csrfOriginInput || testResult !== 'success'}
 				>
-					<input
-						type="hidden"
-						name="validated"
-						value={testResult === 'success' ? 'true' : 'false'}
-					/>
-					<button
-						type="submit"
-						class="save-btn"
-						disabled={isSubmitting || !csrfOriginInput || testResult !== 'success'}
-					>
-						{#if isSubmitting}
-							<span class="spinner"></span>
-						{/if}
-						Save & Continue
-					</button>
-				</form>
+					{#if isSubmitting}
+						<span class="spinner"></span>
+					{/if}
+					Save & Continue
+				</button>
 			{/if}
-		</div>
+		</form>
 	{/snippet}
 </OnboardingCard>
 

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { isRedirect } from '@sveltejs/kit';
+import {
+	AppSettingsKey,
+	deleteAppSetting,
+	getAppSetting
+} from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import { getOnboardingStep, OnboardingSteps } from '$lib/server/onboarding';
+import { actions } from '../../../src/routes/onboarding/csrf/+page.server';
+
+const ORIGIN = 'http://localhost:5173';
+type SaveOriginAction = NonNullable<typeof actions.saveOrigin>;
+type SkipCsrfAction = NonNullable<typeof actions.skipCsrf>;
+
+function createFormRequest(csrfOrigin: string, origin = ORIGIN): Request {
+	const formData = new FormData();
+	formData.set('csrfOrigin', csrfOrigin);
+
+	return new Request(`${ORIGIN}/onboarding/csrf`, {
+		method: 'POST',
+		headers: { origin },
+		body: formData
+	});
+}
+
+async function runSaveOrigin(request: Request) {
+	const saveOrigin = actions.saveOrigin as SaveOriginAction;
+	return saveOrigin({ request } as Parameters<SaveOriginAction>[0]);
+}
+
+async function runSkipCsrf(request: Request) {
+	const skipCsrf = actions.skipCsrf as SkipCsrfAction;
+	return skipCsrf({ request } as Parameters<SkipCsrfAction>[0]);
+}
+
+async function expectRedirect(run: () => Promise<unknown>, location: string) {
+	try {
+		await run();
+		throw new Error('Expected action to redirect');
+	} catch (error) {
+		expect(isRedirect(error)).toBe(true);
+		if (!isRedirect(error)) throw error;
+		expect(error.status).toBe(303);
+		expect(error.location).toBe(location);
+	}
+}
+
+describe('onboarding CSRF actions', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+	});
+
+	it('saves a matching CSRF origin, advances to Plex, and redirects', async () => {
+		await expectRedirect(() => runSaveOrigin(createFormRequest(ORIGIN)), '/onboarding/plex');
+
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.PLEX);
+	});
+
+	it('does not advance when the origin URL is invalid', async () => {
+		const result = await runSaveOrigin(createFormRequest('not-a-url'));
+
+		expect(result).toEqual({
+			status: 400,
+			data: { error: 'Invalid URL format' }
+		});
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
+	it('does not advance when the submitted origin differs from the browser origin', async () => {
+		const result = await runSaveOrigin(createFormRequest('https://example.com'));
+
+		expect(result).toEqual({
+			status: 400,
+			data: {
+				error:
+					'Origin mismatch: browser sends "http://localhost:5173" but you configured "https://example.com"'
+			}
+		});
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
+	it('skips CSRF setup, advances to Plex, and redirects', async () => {
+		await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN);
+
+		await expectRedirect(() => runSkipCsrf(createFormRequest('not-a-url')), '/onboarding/plex');
+
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.PLEX);
+	});
+});


### PR DESCRIPTION
## Summary
- Replace the CSRF onboarding footer's enhanced split forms with a native POST form so Save and Skip reliably follow SvelteKit redirects.
- Add focused unit coverage for valid save, invalid origin, origin mismatch, and skip behavior.

## Verification
- bun test tests/unit/onboarding/csrf-actions.test.ts
- bun run check
- bun run format:check
- bun test
- Browser smoke tested Save and Skip advancing to /onboarding/plex