### PR TITLE
Fix CSRF onboarding footer submission

### DIFF
--- a/src/routes/onboarding/csrf/+page.svelte
+++ b/src/routes/onboarding/csrf/+page.svelte
@@ -111,13 +111,6 @@ $effect(() => {
 function useDetectedOrigin() {
 	csrfOriginInput = data.detection.detectedOrigin;
 }
-
-function submitButtonForm(event: MouseEvent) {
-	const submitter = event.currentTarget as HTMLButtonElement;
-	if (!submitter.form || typeof submitter.form.requestSubmit !== 'function') return;
-	event.preventDefault();
-	submitter.form.requestSubmit(submitter);
-}
 </script>
 
 <OnboardingCard title="Security Settings" subtitle="Configure CSRF protection for your application">
@@ -391,7 +384,7 @@ function submitButtonForm(event: MouseEvent) {
 	{#snippet footer()}
 		<div class="button-group">
 			<form method="POST" action="?/skipCsrf" class="skip-form">
-				<button type="submit" class="skip-btn" formnovalidate onclick={submitButtonForm}>
+				<button type="submit" class="skip-btn" formnovalidate>
 					{data.csrfConfig.isLocked ? 'Continue' : 'Skip'}
 				</button>
 			</form>
@@ -402,7 +395,6 @@ function submitButtonForm(event: MouseEvent) {
 						type="submit"
 						class="save-btn"
 						disabled={!csrfOriginInput || testResult !== 'success'}
-						onclick={submitButtonForm}
 					>
 						Save & Continue
 					</button>

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -13,6 +13,7 @@ import { actions } from '../../../src/routes/onboarding/csrf/+page.server';
 const ORIGIN = 'http://localhost:5173';
 type SaveOriginAction = NonNullable<typeof actions.saveOrigin>;
 type SkipCsrfAction = NonNullable<typeof actions.skipCsrf>;
+type TestOriginAction = NonNullable<typeof actions.testOrigin>;
 
 function createFormRequest(csrfOrigin: string, origin = ORIGIN): Request {
 	const formData = new FormData();
@@ -28,6 +29,11 @@ function createFormRequest(csrfOrigin: string, origin = ORIGIN): Request {
 async function runSaveOrigin(request: Request) {
 	const saveOrigin = actions.saveOrigin as SaveOriginAction;
 	return saveOrigin({ request } as Parameters<SaveOriginAction>[0]);
+}
+
+async function runTestOrigin(request: Request) {
+	const testOrigin = actions.testOrigin as TestOriginAction;
+	return testOrigin({ request } as Parameters<TestOriginAction>[0]);
 }
 
 async function runSkipCsrf(request: Request) {
@@ -50,6 +56,56 @@ async function expectRedirect(run: () => Promise<unknown>, location: string) {
 describe('onboarding CSRF actions', () => {
 	beforeEach(async () => {
 		await db.delete(appSettings);
+	});
+
+	it('test origin succeeds when the submitted origin matches the browser origin', async () => {
+		const result = await runTestOrigin(createFormRequest(ORIGIN));
+
+		expect(result).toEqual({ testSuccess: true, testedOrigin: ORIGIN });
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
+	it('test origin rejects invalid URLs without advancing onboarding', async () => {
+		const result = await runTestOrigin(createFormRequest('not-a-url'));
+
+		expect(result).toEqual({
+			status: 400,
+			data: { testError: 'Invalid URL format' }
+		});
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
+	it('test origin rejects requests without a browser origin', async () => {
+		const formData = new FormData();
+		formData.set('csrfOrigin', ORIGIN);
+
+		const request = new Request(`${ORIGIN}/onboarding/csrf`, {
+			method: 'POST',
+			body: formData
+		});
+
+		const result = await runTestOrigin(request);
+
+		expect(result).toEqual({
+			status: 400,
+			data: {
+				testError: 'Could not detect browser origin. Ensure you are accessing via HTTP/HTTPS.'
+			}
+		});
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
+	it('test origin rejects mismatches without advancing onboarding', async () => {
+		const result = await runTestOrigin(createFormRequest('https://example.com'));
+
+		expect(result).toEqual({
+			status: 400,
+			data: {
+				testError:
+					'Origin mismatch: browser sends "http://localhost:5173" but you configured "https://example.com"'
+			}
+		});
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
 	});
 
 	it('saves a matching CSRF origin, advances to Plex, and redirects', async () => {

--- a/tests/unit/onboarding/csrf-page-source.test.ts
+++ b/tests/unit/onboarding/csrf-page-source.test.ts
@@ -17,29 +17,34 @@ async function readPageSource(): Promise<string> {
 	return Bun.file(pageSourcePath).text();
 }
 
-function findPostForm(source: string, action: string): string {
+function findPostForm(source: string, action: string, className: string): string {
 	const escapedAction = escapeRegExp(action);
+	const escapedClassName = escapeRegExp(className);
 	const formPattern = new RegExp(
-		`<form\\b(?=[^>]*\\bmethod="POST")(?=[^>]*\\baction="${escapedAction}")[^>]*>[\\s\\S]*?<\\/form>`
+		`<form\\b(?=[^>]*\\bmethod="POST")(?=[^>]*\\baction="${escapedAction}")(?=[^>]*\\bclass="[^"]*\\b${escapedClassName}\\b[^"]*")[^>]*>[\\s\\S]*?<\\/form>`
 	);
 
 	return source.match(formPattern)?.[0] ?? '';
 }
 
+function expectNoClickBridge(formSource: string): void {
+	expect(formSource).not.toMatch(/\bonclick\s*=|\bon:click\b/);
+}
+
 describe('onboarding CSRF page source', () => {
 	it('does not reintroduce custom submit bridging for native footer forms', async () => {
 		const source = await readPageSource();
-		const skipForm = findPostForm(source, '?/skipCsrf');
-		const saveForm = findPostForm(source, '?/saveOrigin');
+		const skipForm = findPostForm(source, '?/skipCsrf', 'skip-form');
+		const saveForm = findPostForm(source, '?/saveOrigin', 'save-form');
 
-		expect(skipForm).not.toContain('onclick=');
-		expect(saveForm).not.toContain('onclick=');
+		expectNoClickBridge(skipForm);
+		expectNoClickBridge(saveForm);
 	});
 
 	it('keeps native skip and save form actions in the footer', async () => {
 		const source = await readPageSource();
-		const skipForm = findPostForm(source, '?/skipCsrf');
-		const saveForm = findPostForm(source, '?/saveOrigin');
+		const skipForm = findPostForm(source, '?/skipCsrf', 'skip-form');
+		const saveForm = findPostForm(source, '?/saveOrigin', 'save-form');
 
 		expect(skipForm).toContain('type="submit"');
 		expect(skipForm).toContain('formnovalidate');

--- a/tests/unit/onboarding/csrf-page-source.test.ts
+++ b/tests/unit/onboarding/csrf-page-source.test.ts
@@ -1,25 +1,48 @@
 import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
 
-const pageSourcePath = 'src/routes/onboarding/csrf/+page.svelte';
+const pageSourcePath = join(
+	import.meta.dir,
+	'..',
+	'..',
+	'..',
+	'src/routes/onboarding/csrf/+page.svelte'
+);
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 async function readPageSource(): Promise<string> {
 	return Bun.file(pageSourcePath).text();
 }
 
+function findPostForm(source: string, action: string): string {
+	const escapedAction = escapeRegExp(action);
+	const formPattern = new RegExp(
+		`<form\\b(?=[^>]*\\bmethod="POST")(?=[^>]*\\baction="${escapedAction}")[^>]*>[\\s\\S]*?<\\/form>`
+	);
+
+	return source.match(formPattern)?.[0] ?? '';
+}
+
 describe('onboarding CSRF page source', () => {
 	it('does not reintroduce custom submit bridging for native footer forms', async () => {
 		const source = await readPageSource();
+		const skipForm = findPostForm(source, '?/skipCsrf');
+		const saveForm = findPostForm(source, '?/saveOrigin');
 
-		expect(source).not.toContain('requestSubmit');
-		expect(source).not.toContain('submitButtonForm');
-		expect(source).not.toContain('onclick={submitButtonForm}');
+		expect(skipForm).not.toContain('onclick=');
+		expect(saveForm).not.toContain('onclick=');
 	});
 
 	it('keeps native skip and save form actions in the footer', async () => {
 		const source = await readPageSource();
+		const skipForm = findPostForm(source, '?/skipCsrf');
+		const saveForm = findPostForm(source, '?/saveOrigin');
 
-		expect(source).toContain('<form method="POST" action="?/skipCsrf"');
-		expect(source).toContain('<form method="POST" action="?/saveOrigin"');
-		expect(source).toContain('formnovalidate');
+		expect(skipForm).toContain('type="submit"');
+		expect(skipForm).toContain('formnovalidate');
+		expect(saveForm).toContain('type="submit"');
 	});
 });

--- a/tests/unit/onboarding/csrf-page-source.test.ts
+++ b/tests/unit/onboarding/csrf-page-source.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test';
+
+const pageSourcePath = 'src/routes/onboarding/csrf/+page.svelte';
+
+async function readPageSource(): Promise<string> {
+	return Bun.file(pageSourcePath).text();
+}
+
+describe('onboarding CSRF page source', () => {
+	it('does not reintroduce custom submit bridging for native footer forms', async () => {
+		const source = await readPageSource();
+
+		expect(source).not.toContain('requestSubmit');
+		expect(source).not.toContain('submitButtonForm');
+		expect(source).not.toContain('onclick={submitButtonForm}');
+	});
+
+	it('keeps native skip and save form actions in the footer', async () => {
+		const source = await readPageSource();
+
+		expect(source).toContain('<form method="POST" action="?/skipCsrf"');
+		expect(source).toContain('<form method="POST" action="?/saveOrigin"');
+		expect(source).toContain('formnovalidate');
+	});
+});


### PR DESCRIPTION
## Summary

This pull request fixes the CSRF onboarding footer controls by removing the custom submit bridge that was layered on top of native submit buttons. The CSRF step now relies on the existing native forms for both `Skip` and `Save & Continue`, allowing SvelteKit form redirects to complete normally.

The previous implementation used `preventDefault()` and `requestSubmit()` from a click handler on buttons that were already inside native POST forms. Browser QA showed that this shared client-side path could prevent both footer actions from reaching their server actions, leaving onboarding stuck on `/onboarding/csrf` even after the origin was verified.

## Changes

- Removed the `submitButtonForm` helper and footer button click handlers from the CSRF onboarding page.
- Preserved the separate native POST forms for `?/skipCsrf` and `?/saveOrigin`.
- Preserved `formnovalidate` on `Skip` so invalid URL input cannot block skipping CSRF setup.
- Preserved the existing `Save & Continue` guard requiring a non-empty origin and successful origin test.
- Added `testOrigin` unit coverage for matching origins, invalid URLs, missing browser origin headers, and origin mismatch handling.
- Added a source-level regression test that fails if the custom submit bridge or `requestSubmit` pattern is reintroduced.

## Verification

- `bun test tests/unit/onboarding/csrf-actions.test.ts tests/unit/onboarding/csrf-page-source.test.ts`
- `bun run check`
- `bun run format:check`
- `git diff --check`

Additional isolated browser verification was performed with two separate `gpt-5.4` medium agent-browser workers:

- Save flow: `/` redirected to `/onboarding/csrf`, `Test URL` verified the detected origin, `Save & Continue` posted to `?/saveOrigin`, and the browser landed on `/onboarding/plex` with no browser errors.
- Skip flow: `/` redirected to `/onboarding/csrf`, the origin field was changed to `not-a-url`, `Skip` posted to `?/skipCsrf`, and the browser landed on `/onboarding/plex` with no browser errors.

## Notes

This intentionally does not add Playwright or Vitest browser-mode dependencies. The added source-level regression test is a lightweight guard for the exact recurrence pattern while preserving the current Bun-only test stack.