### PR TITLE
Fix comprehensive E2E QA findings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -68,6 +68,7 @@
 			"!**/.svelte-kit",
 			"!**/node_modules",
 			"!**/data",
+			"!**/dogfood-output",
 			"!**/drizzle",
 			"!**/*.db",
 			"!**/bun.lock"

--- a/drizzle/0004_quiet_mode_source.sql
+++ b/drizzle/0004_quiet_mode_source.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `share_settings` ADD `mode_source` text DEFAULT 'explicit' NOT NULL;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,794 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1ead892c-77cf-433f-b668-973bccf97336",
+  "prevId": "74e8cc59-1370-42ae-8008-9075507083e0",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cached_stats": {
+      "name": "cached_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stats_type": {
+          "name": "stats_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stats_json": {
+          "name": "stats_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cached_stats_lookup": {
+          "name": "idx_cached_stats_lookup",
+          "columns": [
+            "user_id",
+            "year",
+            "stats_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_slides": {
+      "name": "custom_slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "logs": {
+      "name": "logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_logs_timestamp": {
+          "name": "idx_logs_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "idx_logs_level": {
+          "name": "idx_logs_level",
+          "columns": [
+            "level"
+          ],
+          "isUnique": false
+        },
+        "idx_logs_level_timestamp": {
+          "name": "idx_logs_level_timestamp",
+          "columns": [
+            "level",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metadata_cache": {
+      "name": "metadata_cache",
+      "columns": {
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetch_failed": {
+          "name": "fetch_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "play_history": {
+      "name": "play_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "history_key": {
+          "name": "history_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_section_id": {
+          "name": "library_section_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_title": {
+          "name": "grandparent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_rating_key": {
+          "name": "grandparent_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_thumb": {
+          "name": "grandparent_thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_title": {
+          "name": "parent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "play_history_history_key_unique": {
+          "name": "play_history_history_key_unique",
+          "columns": [
+            "history_key"
+          ],
+          "isUnique": true
+        },
+        "idx_play_history_rating_key": {
+          "name": "idx_play_history_rating_key",
+          "columns": [
+            "rating_key"
+          ],
+          "isUnique": false
+        },
+        "idx_play_history_account_id": {
+          "name": "idx_play_history_account_id",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "idx_play_history_viewed_at": {
+          "name": "idx_play_history_viewed_at",
+          "columns": [
+            "viewed_at"
+          ],
+          "isUnique": false
+        },
+        "idx_play_history_account_viewed": {
+          "name": "idx_play_history_account_viewed",
+          "columns": [
+            "account_id",
+            "viewed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plex_accounts": {
+      "name": "plex_accounts",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_id": {
+          "name": "plex_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_token": {
+          "name": "plex_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_settings": {
+      "name": "share_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "mode_source": {
+          "name": "mode_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'explicit'"
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "can_user_control": {
+          "name": "can_user_control",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_logo": {
+          "name": "show_logo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "share_settings_share_token_unique": {
+          "name": "share_settings_share_token_unique",
+          "columns": [
+            "share_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_config": {
+      "name": "slide_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slide_type": {
+          "name": "slide_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_status": {
+      "name": "sync_status",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "records_processed": {
+          "name": "records_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "plex_id": {
+          "name": "plex_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_plex_id_unique": {
+          "name": "users_plex_id_unique",
+          "columns": [
+            "plex_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1767046608447,
       "tag": "0003_charming_prima",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1776268800000,
+      "tag": "0004_quiet_mode_source",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -2,12 +2,12 @@
  * Shared client-side helpers for the Plex OAuth login flow.
  *
  * Two entry points share PIN-fetch and polling plumbing:
- *  - `startPlexLoginPopup`   — opens Plex.tv in a popup, polls for the auth token
- *    in the background, and finalises by exchanging the token at /auth/plex/callback.
+ *  - `startPlexLoginPopup`   — opens Plex.tv in a popup, polls until the server
+ *    creates an Obzorarr session, then returns the logged-in user.
  *  - `startPlexLoginRedirect` — same-tab navigation to Plex.tv with `forwardUrl`
  *    pointing back at /auth/plex/redirect; the redirect page then polls and
- *    completes the callback. Designed for headless / E2E automation that
- *    cannot reliably orchestrate popups.
+ *    receives the completed session. Designed for headless / E2E automation
+ *    that cannot reliably orchestrate popups.
  */
 
 export const PIN_STORAGE_KEY = 'obzorarr_plex_pin';
@@ -22,6 +22,11 @@ export interface PlexLoginUser {
 	plexId?: number;
 	username?: string;
 	isAdmin: boolean;
+}
+
+interface CompletedLoginResponse {
+	user: PlexLoginUser;
+	redirectTo?: string;
 }
 
 interface PopupWindowHandle {
@@ -182,31 +187,15 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 						return;
 					}
 
-					const result = (await pollResponse.json()) as { pending: true } | { authToken: string };
+					const result = (await pollResponse.json()) as { pending: true } | CompletedLoginResponse;
 					if (finished) return;
 
-					if ('authToken' in result && result.authToken) {
+					if ('user' in result && result.user) {
 						callbackInProgress = true;
 						cleanup();
 
 						try {
-							const callbackResponse = await fetch('/auth/plex/callback', {
-								method: 'POST',
-								headers: { 'Content-Type': 'application/json' },
-								body: JSON.stringify({ authToken: result.authToken })
-							});
-
-							if (!callbackResponse.ok) {
-								const errData = (await callbackResponse.json().catch(() => ({}))) as {
-									message?: string;
-								};
-								throw new Error(errData.message || 'Login failed');
-							}
-
-							const userData = (await callbackResponse.json()) as {
-								user: PlexLoginUser;
-							};
-							await opts.onSuccess(userData.user);
+							await opts.onSuccess(result.user);
 							succeeded = true;
 						} catch (err) {
 							if (cancelled || succeeded || timedOut || pinExpired) return;

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -183,7 +183,13 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 							pinExpired = true;
 							cleanup();
 							opts.onError('Authentication expired. Please try again.');
+							return;
 						}
+						const errData = (await pollResponse.json().catch(() => ({}))) as {
+							message?: string;
+						};
+						cleanup();
+						opts.onError(errData.message || 'Login failed. Please try again.');
 						return;
 					}
 

--- a/src/lib/components/wrapped/ProgressBar.svelte
+++ b/src/lib/components/wrapped/ProgressBar.svelte
@@ -9,9 +9,6 @@ interface Props {
 }
 
 let { current, total, class: klass = '' }: Props = $props();
-
-// Calculate progress percentage for continuous bar fallback
-const progressPercent = $derived(total > 0 ? ((current + 1) / total) * 100 : 0);
 </script>
 
 <div
@@ -82,6 +79,16 @@ const progressPercent = $derived(total > 0 ? ((current + 1) / total) * 100 : 0);
 			}
 			50% {
 				opacity: 0.7;
+			}
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+			.segment {
+				transition: none;
+			}
+
+			.segment.active {
+				animation: none;
 			}
 		}
 

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -47,7 +47,9 @@ $effect.pre(() => {
 });
 
 const displayMode = $derived(optimisticMode ?? shareSettings?.mode);
-const displayShareToken = $derived(optimisticShareToken ?? shareSettings?.shareToken);
+const displayShareToken = $derived(
+	optimisticShareToken === undefined ? shareSettings?.shareToken : optimisticShareToken
+);
 
 // Computed URL based on mode
 const shareUrl = $derived.by(() => {

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -13,6 +13,7 @@ interface Props {
 	open?: boolean;
 	onOpenChange?: (open: boolean) => void;
 	currentUrl: string;
+	canonicalUrl?: string;
 	shareSettings?: ShareSettings;
 	isOwner?: boolean;
 	isAdmin?: boolean;
@@ -23,6 +24,7 @@ let {
 	open = $bindable(false),
 	onOpenChange,
 	currentUrl,
+	canonicalUrl,
 	shareSettings,
 	isOwner = false,
 	isAdmin = false,
@@ -34,36 +36,40 @@ let copied = $state(false);
 let copyTimeout: ReturnType<typeof setTimeout> | undefined;
 let isUpdating = $state(false);
 let optimisticMode = $state<ShareModeType | null>(null);
+let optimisticShareToken = $state<string | null | undefined>(undefined);
 
 // Reset optimistic state when server data updates
 $effect.pre(() => {
 	if (shareSettings?.mode) {
 		optimisticMode = null;
+		optimisticShareToken = undefined;
 	}
 });
 
 const displayMode = $derived(optimisticMode ?? shareSettings?.mode);
+const displayShareToken = $derived(optimisticShareToken ?? shareSettings?.shareToken);
 
 // Computed URL based on mode
 const shareUrl = $derived.by(() => {
 	const origin = typeof window !== 'undefined' ? window.location.origin : '';
+	const baseUrl = canonicalUrl ?? currentUrl;
 
-	if (!shareSettings) return `${origin}${currentUrl}`;
+	if (!shareSettings) return `${origin}${baseUrl}`;
 
-	if (shareSettings.mode === 'private-link' && shareSettings.shareToken) {
-		// Replace user ID with token in URL for private-link mode
-		const parts = currentUrl.split('/u/');
+	if (displayMode === 'private-link' && displayShareToken) {
+		const parts = baseUrl.split('/u/');
 		if (parts.length === 2) {
-			return `${origin}${parts[0]}/u/${shareSettings.shareToken}`;
+			return `${origin}${parts[0]}/u/${displayShareToken}`;
 		}
 	}
-	return `${origin}${currentUrl}`;
+	return `${origin}${baseUrl}`;
 });
 
 // Can show share mode controls
 const canControlShare = $derived(
-	isOwner && (shareSettings?.canUserControl || isAdmin) && !isServerWrapped
+	(isOwner || isAdmin) && (shareSettings?.canUserControl || isAdmin) && !isServerWrapped
 );
+const canRegenerateToken = $derived(canControlShare && displayMode === 'private-link');
 
 // Available modes based on permissions
 const availableModes = $derived.by(() => {
@@ -115,6 +121,27 @@ async function copyUrl(): Promise<void> {
 function handleOpenChange(value: boolean): void {
 	open = value;
 	onOpenChange?.(value);
+}
+
+function applyShareActionData(data: unknown): void {
+	const actionData = data as
+		| {
+				shareSettings?: Partial<ShareSettings>;
+				shareToken?: string | null;
+		  }
+		| undefined;
+
+	if (actionData?.shareSettings?.mode) {
+		optimisticMode = actionData.shareSettings.mode;
+	}
+
+	if (actionData?.shareSettings && 'shareToken' in actionData.shareSettings) {
+		optimisticShareToken = actionData.shareSettings.shareToken;
+	}
+
+	if (actionData && 'shareToken' in actionData) {
+		optimisticShareToken = actionData.shareToken;
+	}
 }
 
 // Cleanup on unmount
@@ -205,12 +232,17 @@ $effect(() => {
 					action="?/updateShareMode"
 					use:enhance={() => {
 						isUpdating = true;
-						return async ({ update }) => {
+						return async ({ result, update }) => {
 							try {
+								if (result.type === 'success') {
+									applyShareActionData(result.data);
+								} else {
+									optimisticMode = null;
+									optimisticShareToken = undefined;
+								}
 								await update();
 							} finally {
 								isUpdating = false;
-								optimisticMode = null;
 							}
 						};
 					}}
@@ -255,14 +287,17 @@ $effect(() => {
 				</form>
 
 				<!-- Regenerate Token (admin only, private-link mode) -->
-				{#if isAdmin && displayMode === 'private-link'}
+				{#if canRegenerateToken}
 					<form
 						method="POST"
 						action="?/regenerateToken"
 						use:enhance={() => {
 							isUpdating = true;
-							return async ({ update }) => {
+							return async ({ result, update }) => {
 								try {
+									if (result.type === 'success') {
+										applyShareActionData(result.data);
+									}
 									await update();
 								} finally {
 									isUpdating = false;

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -15,6 +15,8 @@ interface Props {
 	stats: UserStats | ServerStats;
 	slides: SlideRenderConfig[];
 	customSlides?: Map<number, CustomSlide>;
+	initialSlideIndex?: number;
+	onSlideChange?: (slideIndex: number) => void;
 	onComplete?: () => void;
 	onClose?: () => void;
 	class?: string;
@@ -25,6 +27,8 @@ let {
 	stats,
 	slides,
 	customSlides,
+	initialSlideIndex = 0,
+	onSlideChange,
 	onComplete,
 	onClose,
 	class: klass = '',
@@ -36,9 +40,16 @@ const SWIPE_THRESHOLD = 50;
 const ANIMATION_DURATION = 450;
 
 const navigation = createSlideState();
+let initialized = $state(false);
+let initializedSlideCount = $state(0);
 
 $effect(() => {
-	navigation.initialize(slides.length);
+	if (!initialized || initializedSlideCount !== slides.length) {
+		navigation.initialize(slides.length, initialSlideIndex);
+		initialized = true;
+		initializedSlideCount = slides.length;
+		onSlideChange?.(navigation.currentSlide);
+	}
 });
 
 let touchStartX = $state(0);
@@ -72,6 +83,10 @@ $effect(() => {
 const currentSlide = $derived(slides[navigation.currentSlide]);
 const previousSlide = $derived(previousSlideIndex >= 0 ? slides[previousSlideIndex] : null);
 
+function emitSlideChange(): void {
+	onSlideChange?.(navigation.currentSlide);
+}
+
 function goToNext(): void {
 	if (isTransitioning || !navigation.canGoNext) {
 		// If on last slide and trying to go next, call onComplete
@@ -86,6 +101,7 @@ function goToNext(): void {
 	isTransitioning = true;
 
 	navigation.goToNext();
+	emitSlideChange();
 	animateTransition('forward');
 }
 
@@ -97,6 +113,7 @@ function goToPrevious(): void {
 	isTransitioning = true;
 
 	navigation.goToPrevious();
+	emitSlideChange();
 	animateTransition('backward');
 }
 
@@ -291,6 +308,7 @@ function handleKeyDown(event: KeyboardEvent): void {
 				showPreviousSlide = true;
 				isTransitioning = true;
 				navigation.goToFirst();
+				emitSlideChange();
 				animateTransition('backward');
 			}
 			break;
@@ -301,6 +319,7 @@ function handleKeyDown(event: KeyboardEvent): void {
 				showPreviousSlide = true;
 				isTransitioning = true;
 				navigation.goToLast();
+				emitSlideChange();
 				animateTransition('forward');
 			}
 			break;
@@ -575,6 +594,14 @@ function handleSlideAnimationComplete(): void {}
 			.navigation-hint {
 				animation: none;
 				opacity: 0.8;
+			}
+
+			.close-button {
+				transition: none;
+			}
+
+			.close-button:hover {
+				transform: none;
 			}
 		}
 </style>

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -2,7 +2,7 @@
 import { animate, stagger } from 'motion';
 import { prefersReducedMotion } from 'svelte/motion';
 import type { ServerStats, UserStats } from '$lib/stats/types';
-import { isServerStats, isUserStats } from '$lib/stats/types';
+import { hasWatchHistory, isServerStats, isUserStats } from '$lib/stats/types';
 import { DELAY_PRESETS, SPRING_PRESETS, STAGGER_PRESETS } from '$lib/utils/animation-presets';
 
 interface Props {
@@ -18,7 +18,7 @@ interface Props {
 let { stats, year, username, onRestart, onHome, onShare, class: klass = '' }: Props = $props();
 
 // Computed stats
-const isPersonal = $derived(isUserStats(stats));
+const hasHistory = $derived(hasWatchHistory(stats));
 const hours = $derived(Math.floor(stats.totalWatchTimeMinutes / 60));
 const topMovie = $derived(stats.topMovies[0]?.title ?? null);
 const topShow = $derived(stats.topShows[0]?.title ?? null);
@@ -121,10 +121,17 @@ $effect(() => {
 				{year} Server Wrapped
 			{/if}
 		</h1>
-		<p class="subtitle">Your Year in Review</p>
+		<p class="subtitle">
+			{#if hasHistory}
+				Your Year in Review
+			{:else}
+				No viewing history for this year yet
+			{/if}
+		</p>
 	</div>
 
-	<div bind:this={statsGrid} class="stats-grid">
+	{#if hasHistory}
+		<div bind:this={statsGrid} class="stats-grid">
 		<!-- Total Watch Time -->
 		<div bind:this={statCards[0]} class="stat-card highlight">
 			<span class="stat-icon">&#128249;</span>
@@ -189,6 +196,11 @@ $effect(() => {
 			</div>
 		{/if}
 	</div>
+	{:else}
+		<div bind:this={statsGrid} class="empty-summary">
+			<p>No viewing history for this year yet.</p>
+		</div>
+	{/if}
 
 	<div bind:this={buttonsRow} class="actions">
 		<button type="button" class="btn btn-secondary" onclick={onRestart}>
@@ -329,6 +341,18 @@ $effect(() => {
 			width: 100%;
 			margin-bottom: 2.5rem;
 			z-index: 1;
+		}
+
+		.empty-summary {
+			z-index: 1;
+			margin-bottom: 2.5rem;
+			padding: 1.5rem;
+			color: hsl(var(--muted-foreground));
+			text-align: center;
+		}
+
+		.empty-summary p {
+			margin: 0;
 		}
 
 		.stat-card {

--- a/src/lib/server/admin/users.service.ts
+++ b/src/lib/server/admin/users.service.ts
@@ -2,7 +2,12 @@ import { and, between, eq, sql } from 'drizzle-orm';
 import { db } from '$lib/server/db/client';
 import { playHistory, shareSettings, users } from '$lib/server/db/schema';
 import { generateShareToken, getGlobalDefaultShareMode } from '$lib/server/sharing/service';
-import { ShareMode, type ShareModeType } from '$lib/server/sharing/types';
+import {
+	ShareMode,
+	ShareModeSource,
+	type ShareModeSourceType,
+	type ShareModeType
+} from '$lib/server/sharing/types';
 
 export interface UserWithStats {
 	id: number;
@@ -14,6 +19,7 @@ export interface UserWithStats {
 	createdAt: Date | null;
 	totalWatchTimeMinutes: number;
 	shareMode: ShareModeType | null;
+	shareModeSource: ShareModeSourceType | null;
 	canUserControl: boolean;
 }
 
@@ -64,10 +70,14 @@ export async function getAllUsersWithStats(year: number): Promise<UserWithStats[
 		watchTimeMap.set(wt.accountId, wt.totalDuration);
 	}
 
-	const shareSettingsMap = new Map<number, { mode: ShareModeType; canUserControl: boolean }>();
+	const shareSettingsMap = new Map<
+		number,
+		{ mode: ShareModeType; modeSource: ShareModeSourceType; canUserControl: boolean }
+	>();
 	for (const ss of shareSettingsByUser) {
 		shareSettingsMap.set(ss.userId, {
 			mode: ss.mode as ShareModeType,
+			modeSource: (ss.modeSource ?? ShareModeSource.EXPLICIT) as ShareModeSourceType,
 			canUserControl: ss.canUserControl ?? false
 		});
 	}
@@ -91,6 +101,7 @@ export async function getAllUsersWithStats(year: number): Promise<UserWithStats[
 			createdAt: user.createdAt,
 			totalWatchTimeMinutes: Math.round(watchTimeSeconds / 60),
 			shareMode: settings?.mode ?? null,
+			shareModeSource: settings?.modeSource ?? null,
 			canUserControl: settings?.canUserControl ?? false
 		};
 	});
@@ -150,6 +161,7 @@ export async function updateUserSharePermission(
 			userId,
 			year,
 			mode: defaultMode,
+			modeSource: ShareModeSource.DEFAULT,
 			shareToken,
 			canUserControl
 		});

--- a/src/lib/server/auth/login-completion.ts
+++ b/src/lib/server/auth/login-completion.ts
@@ -1,0 +1,132 @@
+import type { Cookies } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import { getApiConfigWithSources } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { users } from '$lib/server/db/schema';
+import { requiresOnboarding } from '$lib/server/onboarding';
+import { requireServerMembership, verifyServerOwnership } from './membership';
+import { checkPinStatus, getPlexUserInfo } from './plex-oauth';
+import { createSession } from './session';
+import { NotServerMemberError, SESSION_DURATION_MS } from './types';
+
+const COOKIE_OPTIONS = {
+	path: '/',
+	httpOnly: true,
+	secure: process.env.NODE_ENV === 'production',
+	sameSite: 'lax' as const,
+	maxAge: Math.floor(SESSION_DURATION_MS / 1000)
+};
+
+export interface CompletedLoginUser {
+	id: number;
+	plexId: number;
+	username: string;
+	isAdmin: boolean;
+}
+
+export interface CompletedLogin {
+	user: CompletedLoginUser;
+	redirectTo: '/admin' | '/dashboard';
+}
+
+export type PinLoginResult = { pending: true } | CompletedLogin;
+
+export async function createSessionFromPlexToken(
+	authToken: string,
+	cookies: Cookies
+): Promise<CompletedLogin> {
+	const plexUser = await getPlexUserInfo(authToken);
+
+	const isOnboarding = await requiresOnboarding();
+	const apiConfig = await getApiConfigWithSources();
+	const hasServerConfigured = !!apiConfig.plex.serverUrl.value;
+
+	let isAdmin = false;
+	let accountId: number;
+
+	if (isOnboarding && !hasServerConfigured) {
+		const ownership = await verifyServerOwnership(authToken);
+
+		if (!ownership.isOwner) {
+			throw new NotServerMemberError('You must own a Plex server to configure Obzorarr.');
+		}
+
+		isAdmin = true;
+		accountId = 1;
+	} else {
+		const membership = await requireServerMembership(authToken);
+
+		isAdmin = membership.isOwner;
+		accountId = membership.isOwner ? 1 : plexUser.id;
+	}
+
+	const existingUser = await db.query.users.findFirst({
+		where: eq(users.plexId, plexUser.id)
+	});
+
+	let userId: number;
+
+	if (existingUser) {
+		await db
+			.update(users)
+			.set({
+				username: plexUser.username,
+				email: plexUser.email,
+				thumb: plexUser.thumb ?? null,
+				isAdmin,
+				accountId
+			})
+			.where(eq(users.id, existingUser.id));
+
+		userId = existingUser.id;
+	} else {
+		const result = await db
+			.insert(users)
+			.values({
+				plexId: plexUser.id,
+				accountId,
+				username: plexUser.username,
+				email: plexUser.email,
+				thumb: plexUser.thumb ?? null,
+				isAdmin
+			})
+			.returning({ id: users.id });
+
+		const insertedUser = result[0];
+		if (!insertedUser) {
+			throw new Error('Failed to create user');
+		}
+		userId = insertedUser.id;
+	}
+
+	const sessionId = await createSession({
+		userId,
+		plexToken: authToken,
+		isAdmin
+	});
+
+	cookies.set('session', sessionId, COOKIE_OPTIONS);
+
+	return {
+		user: {
+			id: userId,
+			plexId: plexUser.id,
+			username: plexUser.username,
+			isAdmin
+		},
+		redirectTo: isAdmin ? '/admin' : '/dashboard'
+	};
+}
+
+export async function completePlexPinLogin(
+	pinId: number,
+	cookies: Cookies
+): Promise<PinLoginResult> {
+	const pinStatus = await checkPinStatus(pinId);
+
+	if (!pinStatus.authToken) {
+		return { pending: true };
+	}
+
+	return createSessionFromPlexToken(pinStatus.authToken, cookies);
+}

--- a/src/lib/server/auth/logout.ts
+++ b/src/lib/server/auth/logout.ts
@@ -1,13 +1,12 @@
-import { redirect } from '@sveltejs/kit';
-import { invalidateSession } from '$lib/server/auth/session';
+import type { Cookies } from '@sveltejs/kit';
 import { logger } from '$lib/server/logging';
-import type { RequestHandler } from './$types';
+import { invalidateSession } from './session';
 
 const COOKIE_OPTIONS = {
 	path: '/'
 };
 
-export const GET: RequestHandler = async ({ cookies }) => {
+export async function logout(cookies: Cookies): Promise<void> {
 	const sessionId = cookies.get('session');
 
 	if (sessionId) {
@@ -19,6 +18,4 @@ export const GET: RequestHandler = async ({ cookies }) => {
 	}
 
 	cookies.delete('session', COOKIE_OPTIONS);
-
-	redirect(303, '/');
-};
+}

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -69,6 +69,7 @@ export const shareSettings = sqliteTable('share_settings', {
 	userId: integer('user_id').notNull(),
 	year: integer('year').notNull(),
 	mode: text('mode').notNull().default('public'),
+	modeSource: text('mode_source').notNull().default('explicit'),
 	shareToken: text('share_token').unique(),
 	canUserControl: integer('can_user_control', { mode: 'boolean' }).default(false),
 	showLogo: integer('show_logo', { mode: 'boolean' })

--- a/src/lib/server/logo/service.ts
+++ b/src/lib/server/logo/service.ts
@@ -6,6 +6,12 @@ import {
 } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { shareSettings } from '$lib/server/db/schema';
+import {
+	generateShareToken,
+	getGlobalAllowUserControl,
+	getGlobalDefaultShareMode
+} from '$lib/server/sharing/service';
+import { ShareMode, ShareModeSource } from '$lib/server/sharing/types';
 
 export interface LogoVisibilityResult {
 	showLogo: boolean;
@@ -82,10 +88,16 @@ export async function setUserLogoPreference(
 			.set({ showLogo })
 			.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)));
 	} else {
+		const defaultMode = await getGlobalDefaultShareMode();
+		const allowUserControl = await getGlobalAllowUserControl();
+		const shareToken = defaultMode === ShareMode.PRIVATE_LINK ? generateShareToken() : null;
 		await db.insert(shareSettings).values({
 			userId,
 			year,
-			mode: 'public',
+			mode: defaultMode,
+			modeSource: ShareModeSource.DEFAULT,
+			shareToken,
+			canUserControl: allowUserControl,
 			showLogo
 		});
 	}

--- a/src/lib/server/security/request-filter-patterns.ts
+++ b/src/lib/server/security/request-filter-patterns.ts
@@ -1,0 +1,42 @@
+const BLOCKED_PATH_PATTERNS = [
+	/^\/\.env/i,
+	/^\/\.git/i,
+	/^\/\.svn/i,
+	/^\/\.htaccess/i,
+	/^\/wp-/i,
+	/^\/wordpress/i,
+	/^\/xmlrpc\.php/i,
+	/^\/phpmyadmin/i,
+	/^\/adminer/i,
+	/^\/admin\.php/i,
+	/^\/config\.php/i,
+	/^\/setup\.php/i,
+	/^\/install\.php/i,
+	/^\/actuator/i,
+	/^\/debug\//i,
+	/^\/console/i,
+	/^\/manager/i,
+	/^\/phpinfo/i,
+	/^\/cgi-bin/i
+];
+
+const BLOCKED_USER_AGENT_PATTERNS = [
+	/zgrab/i,
+	/nuclei/i,
+	/nmap/i,
+	/nikto/i,
+	/sqlmap/i,
+	/masscan/i,
+	/gobuster/i,
+	/dirbuster/i,
+	/wpscan/i,
+	/acunetix/i
+];
+
+export function isBlockedPath(path: string): boolean {
+	return BLOCKED_PATH_PATTERNS.some((pattern) => pattern.test(path));
+}
+
+export function isBlockedUserAgent(userAgent: string): boolean {
+	return BLOCKED_USER_AGENT_PATTERNS.some((pattern) => pattern.test(userAgent));
+}

--- a/src/lib/server/security/request-filter.ts
+++ b/src/lib/server/security/request-filter.ts
@@ -1,48 +1,6 @@
 import type { Handle } from '@sveltejs/kit';
 import { logger } from '$lib/server/logging';
-
-const BLOCKED_PATH_PATTERNS = [
-	/^\/\.env/i,
-	/^\/\.git/i,
-	/^\/\.svn/i,
-	/^\/\.htaccess/i,
-	/^\/wp-/i,
-	/^\/wordpress/i,
-	/^\/xmlrpc\.php/i,
-	/^\/phpmyadmin/i,
-	/^\/adminer/i,
-	/^\/admin\.php/i,
-	/^\/config\.php/i,
-	/^\/setup\.php/i,
-	/^\/install\.php/i,
-	/^\/actuator/i,
-	/^\/debug\//i,
-	/^\/console/i,
-	/^\/manager/i,
-	/^\/phpinfo/i,
-	/^\/cgi-bin/i
-];
-
-const BLOCKED_USER_AGENT_PATTERNS = [
-	/zgrab/i,
-	/nuclei/i,
-	/nmap/i,
-	/nikto/i,
-	/sqlmap/i,
-	/masscan/i,
-	/gobuster/i,
-	/dirbuster/i,
-	/wpscan/i,
-	/acunetix/i
-];
-
-function isBlockedPath(path: string): boolean {
-	return BLOCKED_PATH_PATTERNS.some((pattern) => pattern.test(path));
-}
-
-function isBlockedUserAgent(userAgent: string): boolean {
-	return BLOCKED_USER_AGENT_PATTERNS.some((pattern) => pattern.test(userAgent));
-}
+import { isBlockedPath, isBlockedUserAgent } from './request-filter-patterns';
 
 export const requestFilterHandle: Handle = async ({ event, resolve }) => {
 	const path = event.url.pathname;

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { db } from '$lib/server/db/client';
 import { appSettings, shareSettings } from '$lib/server/db/schema';
 import {
@@ -128,7 +128,33 @@ export async function getShareSettings(
 		return null;
 	}
 
-	return toShareSettings(record, await getGlobalDefaultShareMode());
+	const globalDefault = await getGlobalDefaultShareMode();
+	const settings = toShareSettings(record, globalDefault);
+
+	if (settings.mode !== ShareMode.PRIVATE_LINK || settings.shareToken) {
+		return settings;
+	}
+
+	const generatedToken = generateShareToken();
+
+	await db
+		.update(shareSettings)
+		.set({ shareToken: generatedToken })
+		.where(
+			and(
+				eq(shareSettings.userId, record.userId),
+				eq(shareSettings.year, record.year),
+				isNull(shareSettings.shareToken)
+			)
+		);
+
+	const refreshed = await db
+		.select({ shareToken: shareSettings.shareToken })
+		.from(shareSettings)
+		.where(and(eq(shareSettings.userId, record.userId), eq(shareSettings.year, record.year)))
+		.limit(1);
+
+	return { ...settings, shareToken: refreshed[0]?.shareToken ?? generatedToken };
 }
 
 function toShareSettings(record: ShareSettingsRecord, globalDefault: ShareModeType): ShareSettings {

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -9,12 +9,16 @@ import {
 	ShareError,
 	ShareMode,
 	ShareModeSchema,
+	ShareModeSource,
+	type ShareModeSourceType,
 	type ShareModeType,
 	type ShareSettings,
 	ShareSettingsKey,
 	ShareSettingsNotFoundError,
 	type UpdateShareSettings
 } from './types';
+
+type ShareSettingsRecord = typeof shareSettings.$inferSelect;
 
 export function generateShareToken(): string {
 	return crypto.randomUUID();
@@ -124,10 +128,20 @@ export async function getShareSettings(
 		return null;
 	}
 
+	return toShareSettings(record, await getGlobalDefaultShareMode());
+}
+
+function toShareSettings(record: ShareSettingsRecord, globalDefault: ShareModeType): ShareSettings {
+	const storedMode = record.mode as ShareModeType;
+	const modeSource = (record.modeSource ?? ShareModeSource.EXPLICIT) as ShareModeSourceType;
+	const mode = modeSource === ShareModeSource.DEFAULT ? globalDefault : storedMode;
+
 	return {
 		userId: record.userId,
 		year: record.year,
-		mode: record.mode as ShareModeType,
+		mode,
+		storedMode,
+		modeSource,
 		shareToken: record.shareToken,
 		canUserControl: record.canUserControl ?? false
 	};
@@ -138,15 +152,9 @@ export async function getOrCreateShareSettings(
 ): Promise<ShareSettings> {
 	const { userId, year, createIfMissing = true } = options;
 
-	// Always get current global setting - ensures admin toggle has immediate effect
-	const allowUserControl = await getGlobalAllowUserControl();
-
 	const existing = await getShareSettings(userId, year);
 	if (existing) {
-		return {
-			...existing,
-			canUserControl: allowUserControl
-		};
+		return existing;
 	}
 
 	if (!createIfMissing) {
@@ -154,6 +162,7 @@ export async function getOrCreateShareSettings(
 	}
 
 	const defaultMode = await getGlobalDefaultShareMode();
+	const allowUserControl = await getGlobalAllowUserControl();
 	const shareToken = defaultMode === ShareMode.PRIVATE_LINK ? generateShareToken() : null;
 
 	const result = await db
@@ -162,6 +171,7 @@ export async function getOrCreateShareSettings(
 			userId,
 			year,
 			mode: defaultMode,
+			modeSource: ShareModeSource.DEFAULT,
 			shareToken,
 			canUserControl: allowUserControl
 		})
@@ -172,13 +182,7 @@ export async function getOrCreateShareSettings(
 		throw new ShareError('Failed to create share settings', 'CREATE_FAILED');
 	}
 
-	return {
-		userId: record.userId,
-		year: record.year,
-		mode: record.mode as ShareModeType,
-		shareToken: record.shareToken,
-		canUserControl: record.canUserControl ?? false
-	};
+	return toShareSettings(record, defaultMode);
 }
 
 export async function updateShareSettings(
@@ -212,6 +216,7 @@ export async function updateShareSettings(
 
 	if (updates.mode !== undefined) {
 		updateValues.mode = updates.mode;
+		updateValues.modeSource = ShareModeSource.EXPLICIT;
 
 		if (updates.mode === ShareMode.PRIVATE_LINK && !existing.shareToken) {
 			updateValues.shareToken = generateShareToken();
@@ -299,13 +304,7 @@ export async function getShareSettingsByToken(token: string): Promise<ShareSetti
 		return null;
 	}
 
-	return {
-		userId: record.userId,
-		year: record.year,
-		mode: record.mode as ShareModeType,
-		shareToken: record.shareToken,
-		canUserControl: record.canUserControl ?? false
-	};
+	return toShareSettings(record, await getGlobalDefaultShareMode());
 }
 
 export async function deleteShareSettings(userId: number, year: number): Promise<void> {
@@ -316,14 +315,9 @@ export async function deleteShareSettings(userId: number, year: number): Promise
 
 export async function getAllUserShareSettings(userId: number): Promise<ShareSettings[]> {
 	const results = await db.select().from(shareSettings).where(eq(shareSettings.userId, userId));
+	const globalDefault = await getGlobalDefaultShareMode();
 
-	return results.map((record) => ({
-		userId: record.userId,
-		year: record.year,
-		mode: record.mode as ShareModeType,
-		shareToken: record.shareToken,
-		canUserControl: record.canUserControl ?? false
-	}));
+	return results.map((record) => toShareSettings(record, globalDefault));
 }
 
 export async function updateUserLogoPreference(
@@ -347,6 +341,7 @@ export async function updateUserLogoPreference(
 			userId,
 			year,
 			mode: defaultMode,
+			modeSource: ShareModeSource.DEFAULT,
 			shareToken,
 			canUserControl: allowUserControl,
 			showLogo

--- a/src/lib/server/sharing/types.ts
+++ b/src/lib/server/sharing/types.ts
@@ -10,6 +10,13 @@ export const ShareSettingsKey = {
 	SERVER_WRAPPED_SHARE_MODE: 'server_wrapped_share_mode'
 } as const;
 
+export const ShareModeSource = {
+	DEFAULT: 'default',
+	EXPLICIT: 'explicit'
+} as const;
+
+export type ShareModeSourceType = (typeof ShareModeSource)[keyof typeof ShareModeSource];
+
 export const ShareModePrivacyLevel = {
 	[ShareMode.PUBLIC]: 0,
 	[ShareMode.PRIVATE_LINK]: 1,
@@ -68,11 +75,14 @@ export class ShareSettingsNotFoundError extends ShareError {
 }
 
 export const ShareModeSchema = z.enum(['public', 'private-oauth', 'private-link']);
+export const ShareModeSourceSchema = z.enum(['default', 'explicit']);
 
 export const ShareSettingsSchema = z.object({
 	userId: z.number().int().positive(),
 	year: z.number().int().min(2000).max(2100),
 	mode: ShareModeSchema.default('public'),
+	storedMode: ShareModeSchema.default('public'),
+	modeSource: ShareModeSourceSchema.default('explicit'),
 	shareToken: z.string().nullable().optional(),
 	canUserControl: z.boolean().default(false)
 });

--- a/src/lib/stats/types.ts
+++ b/src/lib/stats/types.ts
@@ -170,3 +170,7 @@ export function isUserStats(stats: Stats): stats is UserStats {
 export function isServerStats(stats: Stats): stats is ServerStats {
 	return 'totalUsers' in stats && 'topViewers' in stats;
 }
+
+export function hasWatchHistory(stats: Stats): boolean {
+	return stats.totalPlays > 0 || stats.totalWatchTimeMinutes > 0;
+}

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
-import { goto } from '$app/navigation';
+import { goto, invalidateAll } from '$app/navigation';
 import { page } from '$app/stores';
 import type { LogEntry, LogLevelType } from '$lib/server/logging';
 import { handleFormToast } from '$lib/utils/form-toast';
@@ -75,6 +75,24 @@ const filteredStreamedLogs = $derived(
 
 // Combined logs (filtered streamed + server-filtered)
 const allLogs = $derived([...filteredStreamedLogs, ...data.logs]);
+
+const visibleLevelCounts = $derived.by(() => {
+	const counts: Record<LogLevelType, number> = { DEBUG: 0, INFO: 0, WARN: 0, ERROR: 0 };
+	for (const log of allLogs) {
+		counts[log.level] += 1;
+	}
+	return counts;
+});
+
+const visibleSources = $derived.by(() => {
+	const sources = new Set(data.sources);
+	for (const log of filteredStreamedLogs) {
+		if (log.source) sources.add(log.source);
+	}
+	return Array.from(sources).sort();
+});
+
+const visibleTotalCount = $derived(allLogs.length);
 
 // Available log levels
 const logLevels: LogLevelType[] = ['DEBUG', 'INFO', 'WARN', 'ERROR'];
@@ -260,6 +278,17 @@ function toggleAutoScroll() {
 	}
 }
 
+async function refreshAfterLogMutation(update: () => Promise<void>): Promise<void> {
+	streamedLogs = [];
+	lastSeenStreamId = 0;
+	await update();
+	await invalidateAll();
+	if (autoScroll) {
+		disconnectSSE();
+		connectSSE();
+	}
+}
+
 // Copy log entry to clipboard
 function copyLog(log: LogEntry) {
 	const text = `[${new Date(log.timestamp).toISOString()}] [${log.level}] [${log.source ?? 'App'}] ${log.message}`;
@@ -308,19 +337,19 @@ $effect(() => {
 	<!-- Stats Section -->
 	<section class="stats-section">
 		<div class="stat-card">
-			<span class="stat-value">{data.totalCount.toLocaleString()}</span>
+			<span class="stat-value">{visibleTotalCount.toLocaleString()}</span>
 			<span class="stat-label">Total Logs</span>
 		</div>
 		<div class="stat-card level-info">
-			<span class="stat-value">{data.levelCounts.INFO.toLocaleString()}</span>
+			<span class="stat-value">{visibleLevelCounts.INFO.toLocaleString()}</span>
 			<span class="stat-label">Info</span>
 		</div>
 		<div class="stat-card level-warn">
-			<span class="stat-value">{data.levelCounts.WARN.toLocaleString()}</span>
+			<span class="stat-value">{visibleLevelCounts.WARN.toLocaleString()}</span>
 			<span class="stat-label">Warnings</span>
 		</div>
 		<div class="stat-card level-error">
-			<span class="stat-value">{data.levelCounts.ERROR.toLocaleString()}</span>
+			<span class="stat-value">{visibleLevelCounts.ERROR.toLocaleString()}</span>
 			<span class="stat-label">Errors</span>
 		</div>
 	</section>
@@ -345,7 +374,7 @@ $effect(() => {
 							onclick={() => toggleLevel(level)}
 						>
 							{level}
-							<span class="level-count">({data.levelCounts[level]})</span>
+							<span class="level-count">({visibleLevelCounts[level]})</span>
 						</button>
 					{/each}
 				</div>
@@ -368,7 +397,7 @@ $effect(() => {
 				<label class="filter-label" for="source">Source</label>
 				<select id="source" value={selectedSource} onchange={handleSourceChange}>
 					<option value="">All sources</option>
-					{#each data.sources as source}
+					{#each visibleSources as source}
 						<option value={source}>{source}</option>
 					{/each}
 				</select>
@@ -438,7 +467,16 @@ $effect(() => {
 		</div>
 
 		<div class="controls-right">
-			<form method="POST" action="?/runCleanup" use:enhance class="inline-form">
+			<form
+				method="POST"
+				action="?/runCleanup"
+				use:enhance={() => {
+					return async ({ update }) => {
+						await refreshAfterLogMutation(update);
+					};
+				}}
+				class="inline-form"
+			>
 				<button type="submit" class="control-button secondary"> Run Cleanup </button>
 			</form>
 
@@ -450,7 +488,7 @@ $effect(() => {
 						return async () => {};
 					}
 					return async ({ update }) => {
-						await update();
+						await refreshAfterLogMutation(update);
 					};
 				}}
 				class="inline-form"
@@ -465,7 +503,7 @@ $effect(() => {
 		<div class="logs-header">
 			<h2>Log Entries</h2>
 			<span class="logs-count">
-				Showing {allLogs.length} of {(data.totalCount + filteredStreamedLogs.length).toLocaleString()}
+				Showing {allLogs.length} of {visibleTotalCount.toLocaleString()}
 			</span>
 		</div>
 

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -338,19 +338,19 @@ $effect(() => {
 	<section class="stats-section">
 		<div class="stat-card">
 			<span class="stat-value">{visibleTotalCount.toLocaleString()}</span>
-			<span class="stat-label">Total Logs</span>
+			<span class="stat-label">Visible Logs</span>
 		</div>
 		<div class="stat-card level-info">
 			<span class="stat-value">{visibleLevelCounts.INFO.toLocaleString()}</span>
-			<span class="stat-label">Info</span>
+			<span class="stat-label">Visible Info</span>
 		</div>
 		<div class="stat-card level-warn">
 			<span class="stat-value">{visibleLevelCounts.WARN.toLocaleString()}</span>
-			<span class="stat-label">Warnings</span>
+			<span class="stat-label">Visible Warnings</span>
 		</div>
 		<div class="stat-card level-error">
 			<span class="stat-value">{visibleLevelCounts.ERROR.toLocaleString()}</span>
-			<span class="stat-label">Errors</span>
+			<span class="stat-label">Visible Errors</span>
 		</div>
 	</section>
 
@@ -503,7 +503,7 @@ $effect(() => {
 		<div class="logs-header">
 			<h2>Log Entries</h2>
 			<span class="logs-count">
-				Showing {allLogs.length} of {visibleTotalCount.toLocaleString()}
+				Showing {visibleTotalCount.toLocaleString()} visible log entries
 			</span>
 		</div>
 

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -84,6 +84,7 @@ let selectedWrappedTheme = $state('');
 let selectedAnonymization = $state('');
 let selectedWrappedLogoMode = $state('');
 let isTesting = $state(false);
+let testConnectionResult = $state<{ type: 'success' | 'error'; message: string } | null>(null);
 
 // Logging settings state
 let logRetentionDays = $state(7);
@@ -185,6 +186,7 @@ let pendingCacheYear = $state<number | undefined>(undefined);
 let pendingCacheCount = $state(0);
 let loadingCount = $state(false);
 let isClearing = $state(false);
+let cacheCountResult = $state<{ label: string; count: number } | null>(null);
 
 // Play history clearing dialog state
 let historyDialogOpen = $state(false);
@@ -192,6 +194,7 @@ let pendingHistoryYear = $state<number | undefined>(undefined);
 let pendingHistoryCount = $state(0);
 let loadingHistoryCount = $state(false);
 let isClearingHistory = $state(false);
+let historyCountResult = $state<{ label: string; count: number } | null>(null);
 
 // Open cache clearing confirmation dialog
 async function showCacheConfirmation(year?: number) {
@@ -217,6 +220,35 @@ async function showCacheConfirmation(year?: number) {
 		}
 	} catch (error) {
 		console.error('Failed to get cache count:', error);
+	} finally {
+		loadingCount = false;
+	}
+}
+
+async function getCacheCount(year?: number) {
+	loadingCount = true;
+	pendingCacheYear = year;
+	cacheCountResult = null;
+
+	const formData = new FormData();
+	if (year !== undefined) {
+		formData.append('year', year.toString());
+	}
+
+	try {
+		const response = await fetch('?/getCacheCount', {
+			method: 'POST',
+			body: formData
+		});
+		const result = deserialize(await response.text());
+
+		if (result.type === 'success' && result.data) {
+			const data = result.data as { success: boolean; count: number; year?: number };
+			cacheCountResult = {
+				label: year !== undefined ? `${year} cache` : 'All cache',
+				count: data.count
+			};
+		}
 	} finally {
 		loadingCount = false;
 	}
@@ -263,6 +295,35 @@ async function showHistoryConfirmation(year?: number) {
 	}
 }
 
+async function getHistoryCount(year?: number) {
+	loadingHistoryCount = true;
+	pendingHistoryYear = year;
+	historyCountResult = null;
+
+	const formData = new FormData();
+	if (year !== undefined) {
+		formData.append('year', year.toString());
+	}
+
+	try {
+		const response = await fetch('?/getPlayHistoryCount', {
+			method: 'POST',
+			body: formData
+		});
+		const result = deserialize(await response.text());
+
+		if (result.type === 'success' && result.data) {
+			const data = result.data as { success: boolean; count: number; year?: number };
+			historyCountResult = {
+				label: year !== undefined ? `${year} history` : 'All history',
+				count: data.count
+			};
+		}
+	} finally {
+		loadingHistoryCount = false;
+	}
+}
+
 function handleHistoryCleared() {
 	historyDialogOpen = false;
 	pendingHistoryYear = undefined;
@@ -274,6 +335,10 @@ function getHistoryConfirmationMessage(): string {
 		return `This will permanently delete ${pendingHistoryCount} play history record${pendingHistoryCount !== 1 ? 's' : ''} for ${pendingHistoryYear}.`;
 	}
 	return `This will permanently delete ${pendingHistoryCount} play history record${pendingHistoryCount !== 1 ? 's' : ''} across all years.`;
+}
+
+function formatRecordCount(count: number): string {
+	return `${count.toLocaleString()} record${count === 1 ? '' : 's'}`;
 }
 
 // Tab configuration with icons
@@ -309,6 +374,12 @@ function detectCurrentUrl() {
 		csrfOriginValue = window.location.origin;
 	}
 }
+
+const logFieldErrors = $derived(
+	form && 'fieldErrors' in form
+		? (form.fieldErrors as Record<string, string[] | undefined>)
+		: undefined
+);
 </script>
 
 <div class="settings-command-center">
@@ -452,6 +523,7 @@ function detectCurrentUrl() {
 								disabled={isTesting || !plexServerUrl || !plexToken}
 								onclick={async () => {
 									isTesting = true;
+									testConnectionResult = null;
 									const formData = new FormData();
 									formData.set('plexServerUrl', plexServerUrl);
 									formData.set('plexToken', plexToken);
@@ -462,20 +534,28 @@ function detectCurrentUrl() {
 										});
 										const result = deserialize(await response.text());
 										if (result.type === 'success' || result.type === 'failure') {
-											handleFormToast(result.data);
+											const data = result.data as { success?: boolean; message?: string; error?: string };
+											handleFormToast(data);
+											testConnectionResult = data.error
+												? { type: 'error', message: data.error }
+												: {
+														type: 'success',
+														message: data.message ?? 'Plex connection succeeded'
+													};
 										} else if (result.type === 'error') {
-											handleFormToast({
-												error: result.error?.message ?? 'An error occurred while testing connection'
-											});
+											const message =
+												result.error?.message ?? 'An error occurred while testing connection';
+											handleFormToast({ error: message });
+											testConnectionResult = { type: 'error', message };
 										} else {
-											handleFormToast({
-												error: 'Unexpected response from server'
-											});
+											const message = 'Unexpected response from server';
+											handleFormToast({ error: message });
+											testConnectionResult = { type: 'error', message };
 										}
 									} catch {
-										handleFormToast({
-											error: 'Failed to test connection. Please check your network and try again.'
-										});
+										const message = 'Failed to test connection. Please check your network and try again.';
+										handleFormToast({ error: message });
+										testConnectionResult = { type: 'error', message };
 									} finally {
 										isTesting = false;
 									}
@@ -496,6 +576,11 @@ function detectCurrentUrl() {
 								<span class="info-text"
 									>All Plex settings are managed via environment variables</span
 								>
+							</div>
+						{/if}
+						{#if testConnectionResult}
+							<div class="inline-result" class:error={testConnectionResult.type === 'error'}>
+								{testConnectionResult.message}
 							</div>
 						{/if}
 					</form>
@@ -1318,6 +1403,19 @@ function detectCurrentUrl() {
 							<button
 								type="button"
 								class="btn-secondary"
+								onclick={() => getCacheCount(year)}
+								disabled={loadingCount}
+							>
+								{#if loadingCount && pendingCacheYear === year}
+									<Loader2 class="btn-icon spinning" />
+								{:else}
+									<Database class="btn-icon" />
+								{/if}
+								Get {year} Count
+							</button>
+							<button
+								type="button"
+								class="btn-secondary"
 								onclick={() => showCacheConfirmation(year)}
 								disabled={loadingCount}
 							>
@@ -1332,6 +1430,19 @@ function detectCurrentUrl() {
 						<button
 							type="button"
 							class="btn-secondary btn-all"
+							onclick={() => getCacheCount()}
+							disabled={loadingCount}
+						>
+							{#if loadingCount && pendingCacheYear === undefined}
+								<Loader2 class="btn-icon spinning" />
+							{:else}
+								<Database class="btn-icon" />
+							{/if}
+							Get All Cache Count
+						</button>
+						<button
+							type="button"
+							class="btn-secondary btn-all"
 							onclick={() => showCacheConfirmation()}
 							disabled={loadingCount}
 						>
@@ -1343,6 +1454,11 @@ function detectCurrentUrl() {
 							Clear All Cache
 						</button>
 					</div>
+					{#if cacheCountResult}
+						<p class="count-result">
+							{cacheCountResult.label}: {formatRecordCount(cacheCountResult.count)}
+						</p>
+					{/if}
 				</section>
 
 				<!-- Danger Zone -->
@@ -1377,6 +1493,19 @@ function detectCurrentUrl() {
 						{#each data.availableYears as year}
 							<button
 								type="button"
+								class="btn-secondary"
+								onclick={() => getHistoryCount(year)}
+								disabled={loadingHistoryCount}
+							>
+								{#if loadingHistoryCount && pendingHistoryYear === year}
+									<Loader2 class="btn-icon spinning" />
+								{:else}
+									<Database class="btn-icon" />
+								{/if}
+								Get {year} Count
+							</button>
+							<button
+								type="button"
 								class="btn-danger"
 								onclick={() => showHistoryConfirmation(year)}
 								disabled={loadingHistoryCount}
@@ -1391,6 +1520,19 @@ function detectCurrentUrl() {
 						{/each}
 						<button
 							type="button"
+							class="btn-secondary btn-all"
+							onclick={() => getHistoryCount()}
+							disabled={loadingHistoryCount}
+						>
+							{#if loadingHistoryCount && pendingHistoryYear === undefined}
+								<Loader2 class="btn-icon spinning" />
+							{:else}
+								<Database class="btn-icon" />
+							{/if}
+							Get All History Count
+						</button>
+						<button
+							type="button"
 							class="btn-danger btn-all"
 							onclick={() => showHistoryConfirmation()}
 							disabled={loadingHistoryCount}
@@ -1403,6 +1545,11 @@ function detectCurrentUrl() {
 							Delete All History
 						</button>
 					</div>
+					{#if historyCountResult}
+						<p class="count-result">
+							{historyCountResult.label}: {formatRecordCount(historyCountResult.count)}
+						</p>
+					{/if}
 				</section>
 			</div>
 		{/if}
@@ -1443,6 +1590,9 @@ function detectCurrentUrl() {
 									/>
 									<span class="input-suffix">days</span>
 								</div>
+								{#if logFieldErrors?.retentionDays?.[0]}
+									<span class="field-error">{logFieldErrors.retentionDays[0]}</span>
+								{/if}
 								<span class="field-hint">Auto-delete logs older than this (1-365)</span>
 							</div>
 
@@ -1461,10 +1611,13 @@ function detectCurrentUrl() {
 										bind:value={logMaxCount}
 										min="1000"
 										max="1000000"
-										step="1000"
+										step="1"
 									/>
 									<span class="input-suffix">logs</span>
 								</div>
+								{#if logFieldErrors?.maxCount?.[0]}
+									<span class="field-error">{logFieldErrors.maxCount[0]}</span>
+								{/if}
 								<span class="field-hint">Maximum logs to retain</span>
 							</div>
 						</div>
@@ -1923,6 +2076,13 @@ function detectCurrentUrl() {
 			margin-top: 0.375rem;
 		}
 
+		.field-error {
+			display: block;
+			font-size: 0.75rem;
+			color: hsl(var(--destructive));
+			margin-top: 0.375rem;
+		}
+
 		.source-badge {
 			font-size: 0.625rem;
 			font-weight: 600;
@@ -1988,6 +2148,23 @@ function detectCurrentUrl() {
 			font-size: 0.8125rem;
 			color: hsl(210 60% 60%);
 			font-style: italic;
+		}
+
+		.inline-result,
+		.count-result {
+			margin-top: 1rem;
+			padding: 0.75rem 1rem;
+			border: 1px solid hsl(140 50% 35% / 0.45);
+			border-radius: 8px;
+			background: hsl(140 50% 30% / 0.12);
+			color: hsl(140 50% 70%);
+			font-size: 0.875rem;
+		}
+
+		.inline-result.error {
+			border-color: hsl(var(--destructive) / 0.45);
+			background: hsl(var(--destructive) / 0.1);
+			color: hsl(var(--destructive));
 		}
 
 		.input-with-action {

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -249,6 +249,9 @@ async function getCacheCount(year?: number) {
 				count: data.count
 			};
 		}
+	} catch (error) {
+		console.error('Failed to get cache count:', error);
+		handleFormToast({ error: 'Failed to get cache count. Please try again.' });
 	} finally {
 		loadingCount = false;
 	}
@@ -319,6 +322,9 @@ async function getHistoryCount(year?: number) {
 				count: data.count
 			};
 		}
+	} catch (error) {
+		console.error('Failed to get history count:', error);
+		handleFormToast({ error: 'Failed to get play history count. Please try again.' });
 	} finally {
 		loadingHistoryCount = false;
 	}

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -248,6 +248,10 @@ async function getCacheCount(year?: number) {
 				label: year !== undefined ? `${year} cache` : 'All cache',
 				count: data.count
 			};
+		} else if (result.type === 'failure') {
+			handleFormToast({
+				error: (result.data as { error?: string })?.error ?? 'Failed to get cache count.'
+			});
 		}
 	} catch (error) {
 		console.error('Failed to get cache count:', error);
@@ -321,6 +325,10 @@ async function getHistoryCount(year?: number) {
 				label: year !== undefined ? `${year} history` : 'All history',
 				count: data.count
 			};
+		} else if (result.type === 'failure') {
+			handleFormToast({
+				error: (result.data as { error?: string })?.error ?? 'Failed to get play history count.'
+			});
 		}
 	} catch (error) {
 		console.error('Failed to get history count:', error);

--- a/src/routes/admin/slides/+page.server.ts
+++ b/src/routes/admin/slides/+page.server.ts
@@ -341,7 +341,12 @@ export const actions: Actions = {
 
 		try {
 			await setFunFactFrequency(mode as FunFactFrequencyType, customCount);
-			return { success: true };
+			const funFactFrequency = await getFunFactFrequency();
+			return {
+				success: true,
+				message: 'Fun fact frequency updated',
+				funFactFrequency
+			};
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update frequency';
 			return fail(500, { error: message });

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -380,40 +380,53 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			Control how many fun facts appear interspersed throughout the wrapped presentation.
 		</p>
 
-		<form method="POST" action="?/setFunFactFrequency" use:enhance>
+		<form
+			method="POST"
+			action="?/setFunFactFrequency"
+			use:enhance={() => {
+				return async ({ result, update }) => {
+					if (result.type === 'success' && result.data?.funFactFrequency) {
+						const frequency = result.data.funFactFrequency as typeof data.funFactFrequency;
+						selectedFrequencyMode = frequency.mode;
+						customCount = frequency.count;
+					}
+					await update();
+				};
+			}}
+		>
 			<!-- svelte-ignore a11y_click_events_have_key_events -->
 			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			<div class="frequency-options" onclick={(e) => e.stopPropagation()}>
 				<label class="frequency-option">
 					<input type="radio" name="mode" value="few" bind:group={selectedFrequencyMode} />
-					<span class="frequency-label">
-						<span class="frequency-name">Few</span>
-						<span class="frequency-desc">1-2 fun facts</span>
-					</span>
+						<span class="frequency-label">
+							<span class="frequency-name">Few</span>
+							<span class="frequency-desc">2 fun facts</span>
+						</span>
 				</label>
 
 				<label class="frequency-option">
 					<input type="radio" name="mode" value="normal" bind:group={selectedFrequencyMode} />
-					<span class="frequency-label">
-						<span class="frequency-name">Normal</span>
-						<span class="frequency-desc">3-5 fun facts</span>
-					</span>
+						<span class="frequency-label">
+							<span class="frequency-name">Normal</span>
+							<span class="frequency-desc">4 fun facts</span>
+						</span>
 				</label>
 
 				<label class="frequency-option">
 					<input type="radio" name="mode" value="many" bind:group={selectedFrequencyMode} />
-					<span class="frequency-label">
-						<span class="frequency-name">Many</span>
-						<span class="frequency-desc">6-10 fun facts</span>
-					</span>
+						<span class="frequency-label">
+							<span class="frequency-name">Many</span>
+							<span class="frequency-desc">8 fun facts</span>
+						</span>
 				</label>
 
 				<label class="frequency-option">
 					<input type="radio" name="mode" value="custom" bind:group={selectedFrequencyMode} />
-					<span class="frequency-label">
-						<span class="frequency-name">Custom</span>
-						<span class="frequency-desc">Specific number</span>
-					</span>
+						<span class="frequency-label">
+							<span class="frequency-name">Custom</span>
+							<span class="frequency-desc">1-15 fun facts</span>
+						</span>
 				</label>
 			</div>
 

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -1,5 +1,6 @@
 import { fail } from '@sveltejs/kit';
 import { z } from 'zod';
+import { AppSettingsKey, getAppSetting, setAppSetting } from '$lib/server/admin/settings.service';
 import { cancelSync } from '$lib/server/sync/progress';
 import {
 	getSchedulerStatus,
@@ -7,6 +8,7 @@ import {
 	resumeSyncScheduler,
 	setupSyncScheduler,
 	startBackgroundSync,
+	stopSyncScheduler,
 	updateSchedulerCron
 } from '$lib/server/sync/scheduler';
 import {
@@ -37,13 +39,15 @@ export const load: PageServerLoad = async ({ url }) => {
 	const pageParam = url.searchParams.get('page');
 	const page = Math.max(1, parseInt(pageParam ?? '1', 10) || 1);
 
-	const [isRunning, lastSync, paginatedHistory, schedulerStatus, historyCount] = await Promise.all([
-		isSyncRunning(),
-		getLastSuccessfulSync(),
-		getSyncHistory({ page, pageSize: HISTORY_PAGE_SIZE }),
-		getSchedulerStatus(),
-		getPlayHistoryCount()
-	]);
+	const [isRunning, lastSync, paginatedHistory, schedulerStatus, historyCount, storedCron] =
+		await Promise.all([
+			isSyncRunning(),
+			getLastSuccessfulSync(),
+			getSyncHistory({ page, pageSize: HISTORY_PAGE_SIZE }),
+			getSchedulerStatus(),
+			getPlayHistoryCount(),
+			getAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION)
+		]);
 
 	const currentYear = new Date().getFullYear();
 	const availableYears = Array.from({ length: 6 }, (_, i) => currentYear - i);
@@ -79,7 +83,7 @@ export const load: PageServerLoad = async ({ url }) => {
 			isPaused: schedulerStatus.isPaused,
 			nextRun: schedulerStatus.nextRun?.toISOString() ?? null,
 			previousRun: schedulerStatus.previousRun?.toISOString() ?? null,
-			cronExpression: schedulerStatus.cronExpression
+			cronExpression: schedulerStatus.cronExpression ?? storedCron
 		},
 		historyCount,
 		availableYears
@@ -147,6 +151,7 @@ export const actions: Actions = {
 
 		try {
 			updateSchedulerCron(parsed.data);
+			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data);
 			return { success: true, message: 'Schedule updated successfully' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update schedule';
@@ -174,6 +179,16 @@ export const actions: Actions = {
 		}
 	},
 
+	stopScheduler: async () => {
+		try {
+			stopSyncScheduler();
+			return { success: true, message: 'Scheduler stopped' };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Failed to stop scheduler';
+			return fail(500, { error: message });
+		}
+	},
+
 	initScheduler: async ({ request }) => {
 		const formData = await request.formData();
 		const cronExpression = formData.get('cronExpression');
@@ -192,6 +207,7 @@ export const actions: Actions = {
 				cronExpression: parsed.data,
 				startImmediately: true
 			});
+			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data);
 			return { success: true, message: 'Scheduler initialized' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to initialize scheduler';

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -150,8 +150,8 @@ export const actions: Actions = {
 		}
 
 		try {
-			updateSchedulerCron(parsed.data);
 			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data);
+			updateSchedulerCron(parsed.data);
 			return { success: true, message: 'Schedule updated successfully' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update schedule';
@@ -203,11 +203,11 @@ export const actions: Actions = {
 		}
 
 		try {
+			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data);
 			setupSyncScheduler({
 				cronExpression: parsed.data,
 				startImmediately: true
 			});
-			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data);
 			return { success: true, message: 'Scheduler initialized' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to initialize scheduler';

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -150,8 +150,8 @@ export const actions: Actions = {
 		}
 
 		try {
-			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data);
 			updateSchedulerCron(parsed.data);
+			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data);
 			return { success: true, message: 'Schedule updated successfully' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update schedule';
@@ -203,11 +203,11 @@ export const actions: Actions = {
 		}
 
 		try {
-			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data);
 			setupSyncScheduler({
 				cronExpression: parsed.data,
 				startImmediately: true
 			});
+			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data);
 			return { success: true, message: 'Scheduler initialized' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to initialize scheduler';

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -162,7 +162,8 @@ function formatRelativeTime(isoDate: string | null): string {
 	return date.toLocaleDateString();
 }
 
-function formatDuration(start: string, end: string | null): string {
+function formatDuration(start: string, end: string | null, status?: string): string {
+	if (status === 'running') return 'In progress';
 	if (!end) return '—';
 	const diffMs = new Date(end).getTime() - new Date(start).getTime();
 	if (diffMs < 1000) return '<1s';
@@ -525,6 +526,16 @@ async function goToPage(page: number) {
 							</button>
 						</form>
 					{/if}
+					{#if data.schedulerStatus.isRunning || data.schedulerStatus.isPaused}
+						<form method="POST" action="?/stopScheduler" use:enhance>
+							<button type="submit" class="control-btn stop">
+								<svg viewBox="0 0 24 24" fill="currentColor">
+									<rect x="6" y="6" width="12" height="12" rx="2" />
+								</svg>
+								Stop
+							</button>
+						</form>
+					{/if}
 				</div>
 
 				<form method="POST" action="?/updateSchedule" use:enhance class="cron-config">
@@ -630,9 +641,14 @@ async function goToPage(page: number) {
 						</div>
 
 						<div class="history-stats">
-							<span class="stat-duration">{formatDuration(sync.startedAt, sync.completedAt)}</span>
+							<span class="stat-duration"
+								>{formatDuration(sync.startedAt, sync.completedAt, sync.status)}</span
+							>
 							<span class="stat-records"
-								>{sync.recordsProcessed.toLocaleString()} <small>records</small></span
+								>{sync.status === 'running' && progress
+									? progress.recordsProcessed.toLocaleString()
+									: sync.recordsProcessed.toLocaleString()}
+								<small>records</small></span
 							>
 						</div>
 
@@ -1408,6 +1424,16 @@ async function goToPage(page: number) {
 
 		.control-btn.init:hover {
 			opacity: 0.9;
+		}
+
+		.control-btn.stop {
+			background: hsl(var(--muted));
+			border: 1px solid hsl(var(--border));
+			color: hsl(var(--foreground));
+		}
+
+		.control-btn.stop:hover {
+			background: hsl(var(--muted) / 0.8);
 		}
 
 		.cron-config {

--- a/src/routes/admin/users/+page.server.ts
+++ b/src/routes/admin/users/+page.server.ts
@@ -36,6 +36,7 @@ export const load: PageServerLoad = async ({ url }) => {
 			isAdmin: u.isAdmin,
 			totalWatchTimeMinutes: u.totalWatchTimeMinutes,
 			shareMode: u.shareMode,
+			shareModeSource: u.shareModeSource,
 			canUserControl: u.canUserControl
 		})),
 		year,

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -31,7 +31,9 @@ function formatWatchTime(minutes: number): string {
 }
 
 // Get share mode display label
-function getShareModeLabel(mode: string | null): string {
+function getShareModeLabel(mode: string | null, source: string | null): string {
+	if (source === 'default') return 'Default';
+
 	switch (mode) {
 		case 'public':
 			return 'Public';
@@ -52,11 +54,12 @@ function getShareModeLabel(mode: string | null): string {
 				<h1>User Management</h1>
 				<p class="subtitle">Manage server users for {data.year}</p>
 			</div>
-			{#if data.availableYears.length > 1}
+			{#if data.availableYears.length >= 1}
 				<form method="GET" class="year-form">
 					<select
 						name="year"
 						class="year-selector"
+						disabled={data.availableYears.length === 1}
 						onchange={(e) => e.currentTarget.form?.requestSubmit()}
 					>
 						{#each data.availableYears as yr}
@@ -95,18 +98,20 @@ function getShareModeLabel(mode: string | null): string {
 							<tr>
 								<td>
 									<div class="user-cell">
-										{#if user.thumb}
-											<img src={user.thumb} alt="" class="user-avatar" />
-										{:else}
-											<span class="user-avatar placeholder">&#9787;</span>
-										{/if}
+										<a href="/wrapped/{data.year}/u/{user.id}" class="user-avatar-link">
+											{#if user.thumb}
+												<img src={user.thumb} alt="" class="user-avatar" />
+											{:else}
+												<span class="user-avatar placeholder">&#9787;</span>
+											{/if}
+										</a>
 										<div class="user-info">
-											<span class="user-name">
+											<a href="/wrapped/{data.year}/u/{user.id}" class="user-name">
 												{user.username}
 												{#if user.isAdmin}
 													<span class="admin-badge">Admin</span>
 												{/if}
-											</span>
+											</a>
 											{#if user.email}
 												<span class="user-email">{user.email}</span>
 											{/if}
@@ -119,11 +124,13 @@ function getShareModeLabel(mode: string | null): string {
 								<td>
 									<span
 										class="share-mode"
-										class:public={user.shareMode === 'public'}
-										class:oauth={user.shareMode === 'private-oauth'}
-										class:link={user.shareMode === 'private-link'}
+										class:public={user.shareModeSource !== 'default' && user.shareMode === 'public'}
+										class:oauth={user.shareModeSource !== 'default' &&
+											user.shareMode === 'private-oauth'}
+										class:link={user.shareModeSource !== 'default' &&
+											user.shareMode === 'private-link'}
 									>
-										{getShareModeLabel(user.shareMode)}
+										{getShareModeLabel(user.shareMode, user.shareModeSource)}
 									</span>
 								</td>
 								<td>
@@ -244,6 +251,11 @@ function getShareModeLabel(mode: string | null): string {
 			box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
 		}
 
+		.year-selector:disabled {
+			cursor: default;
+			opacity: 0.75;
+		}
+
 		.section {
 			background: hsl(var(--card));
 			border: 1px solid hsl(var(--border));
@@ -318,6 +330,11 @@ function getShareModeLabel(mode: string | null): string {
 			gap: 0.75rem;
 		}
 
+		.user-avatar-link,
+		.user-name {
+			text-decoration: none;
+		}
+
 		.user-avatar {
 			width: 36px;
 			height: 36px;
@@ -345,6 +362,10 @@ function getShareModeLabel(mode: string | null): string {
 			display: flex;
 			align-items: center;
 			gap: 0.5rem;
+		}
+
+		.user-name:hover {
+			color: hsl(var(--primary));
 		}
 
 		.user-email {

--- a/src/routes/auth/logout/+page.server.ts
+++ b/src/routes/auth/logout/+page.server.ts
@@ -1,26 +1,15 @@
 import { redirect } from '@sveltejs/kit';
-import { invalidateSession } from '$lib/server/auth/session';
-import { logger } from '$lib/server/logging';
-import type { Actions } from './$types';
+import { logout } from '$lib/server/auth/logout';
+import type { Actions, PageServerLoad } from './$types';
 
-const COOKIE_OPTIONS = {
-	path: '/'
+export const load: PageServerLoad = async ({ cookies }) => {
+	await logout(cookies);
+	throw redirect(303, '/');
 };
 
 export const actions: Actions = {
 	default: async ({ cookies }) => {
-		const sessionId = cookies.get('session');
-
-		if (sessionId) {
-			try {
-				await invalidateSession(sessionId);
-			} catch (err) {
-				logger.error('Error invalidating session', 'Logout', { error: String(err) });
-			}
-		}
-
-		cookies.delete('session', COOKIE_OPTIONS);
-
-		redirect(303, '/');
+		await logout(cookies);
+		throw redirect(303, '/');
 	}
 };

--- a/src/routes/auth/logout/+page.svelte
+++ b/src/routes/auth/logout/+page.svelte
@@ -1,0 +1,1 @@
+<p>Signing out...</p>

--- a/src/routes/auth/plex/+server.ts
+++ b/src/routes/auth/plex/+server.ts
@@ -1,6 +1,7 @@
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
-import { checkPinStatus, getPinInfo } from '$lib/server/auth/plex-oauth';
+import { completePlexPinLogin } from '$lib/server/auth/login-completion';
+import { getPinInfo } from '$lib/server/auth/plex-oauth';
 import { PinExpiredError, PlexAuthApiError } from '$lib/server/auth/types';
 import type { RequestHandler } from './$types';
 
@@ -29,7 +30,7 @@ export const GET: RequestHandler = async ({ url }) => {
 	}
 };
 
-export const POST: RequestHandler = async ({ request }) => {
+export const POST: RequestHandler = async ({ request, cookies }) => {
 	let body: unknown;
 	try {
 		body = await request.json();
@@ -47,13 +48,7 @@ export const POST: RequestHandler = async ({ request }) => {
 	const { pinId } = parseResult.data;
 
 	try {
-		const pinStatus = await checkPinStatus(pinId);
-
-		if (pinStatus.authToken) {
-			return json({ authToken: pinStatus.authToken });
-		}
-
-		return json({ pending: true });
+		return json(await completePlexPinLogin(pinId, cookies));
 	} catch (err) {
 		if (err instanceof PinExpiredError) {
 			error(401, {
@@ -62,13 +57,13 @@ export const POST: RequestHandler = async ({ request }) => {
 		}
 
 		if (err instanceof PlexAuthApiError) {
-			console.error('Plex OAuth error:', err.message);
+			console.error('Plex OAuth error during PIN poll');
 			error(502, {
 				message: 'Unable to connect to Plex. Please try again.'
 			});
 		}
 
-		console.error('Unexpected error in PIN poll:', err);
+		console.error('Unexpected error in PIN poll');
 		error(500, {
 			message: 'An unexpected error occurred.'
 		});

--- a/src/routes/auth/plex/+server.ts
+++ b/src/routes/auth/plex/+server.ts
@@ -2,7 +2,7 @@ import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
 import { completePlexPinLogin } from '$lib/server/auth/login-completion';
 import { getPinInfo } from '$lib/server/auth/plex-oauth';
-import { PinExpiredError, PlexAuthApiError } from '$lib/server/auth/types';
+import { NotServerMemberError, PinExpiredError, PlexAuthApiError } from '$lib/server/auth/types';
 import type { RequestHandler } from './$types';
 
 const PollRequestSchema = z.object({
@@ -60,6 +60,12 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 			console.error('Plex OAuth error during PIN poll');
 			error(502, {
 				message: 'Unable to connect to Plex. Please try again.'
+			});
+		}
+
+		if (err instanceof NotServerMemberError) {
+			error(403, {
+				message: err.message
 			});
 		}
 

--- a/src/routes/auth/plex/callback/+server.ts
+++ b/src/routes/auth/plex/callback/+server.ts
@@ -1,31 +1,12 @@
 import { error, json } from '@sveltejs/kit';
-import { eq } from 'drizzle-orm';
 import { z } from 'zod';
-import { getApiConfigWithSources } from '$lib/server/admin/settings.service';
-import { requireServerMembership, verifyServerOwnership } from '$lib/server/auth/membership';
-import { getPlexUserInfo } from '$lib/server/auth/plex-oauth';
-import { createSession } from '$lib/server/auth/session';
-import {
-	NotServerMemberError,
-	PlexAuthApiError,
-	SESSION_DURATION_MS
-} from '$lib/server/auth/types';
-import { db } from '$lib/server/db/client';
-import { users } from '$lib/server/db/schema';
-import { requiresOnboarding } from '$lib/server/onboarding';
+import { createSessionFromPlexToken } from '$lib/server/auth/login-completion';
+import { NotServerMemberError, PlexAuthApiError } from '$lib/server/auth/types';
 import type { RequestHandler } from './$types';
 
 const CallbackRequestSchema = z.object({
 	authToken: z.string().min(1, 'Auth token is required')
 });
-
-const COOKIE_OPTIONS = {
-	path: '/',
-	httpOnly: true,
-	secure: process.env.NODE_ENV === 'production',
-	sameSite: 'lax' as const,
-	maxAge: Math.floor(SESSION_DURATION_MS / 1000)
-};
 
 export const POST: RequestHandler = async ({ request, cookies }) => {
 	let body: unknown;
@@ -45,86 +26,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 	const { authToken } = parseResult.data;
 
 	try {
-		const plexUser = await getPlexUserInfo(authToken);
-
-		const isOnboarding = await requiresOnboarding();
-		const apiConfig = await getApiConfigWithSources();
-		const hasServerConfigured = !!apiConfig.plex.serverUrl.value;
-
-		let isAdmin = false;
-		let accountId: number;
-
-		if (isOnboarding && !hasServerConfigured) {
-			const ownership = await verifyServerOwnership(authToken);
-
-			if (!ownership.isOwner) {
-				throw new NotServerMemberError('You must own a Plex server to configure Obzorarr.');
-			}
-
-			isAdmin = true;
-			accountId = 1;
-		} else {
-			const membership = await requireServerMembership(authToken);
-
-			isAdmin = membership.isOwner;
-			accountId = membership.isOwner ? 1 : plexUser.id;
-		}
-
-		const existingUser = await db.query.users.findFirst({
-			where: eq(users.plexId, plexUser.id)
-		});
-
-		let userId: number;
-
-		if (existingUser) {
-			await db
-				.update(users)
-				.set({
-					username: plexUser.username,
-					email: plexUser.email,
-					thumb: plexUser.thumb ?? null,
-					isAdmin,
-					accountId
-				})
-				.where(eq(users.id, existingUser.id));
-
-			userId = existingUser.id;
-		} else {
-			const result = await db
-				.insert(users)
-				.values({
-					plexId: plexUser.id,
-					accountId,
-					username: plexUser.username,
-					email: plexUser.email,
-					thumb: plexUser.thumb ?? null,
-					isAdmin
-				})
-				.returning({ id: users.id });
-
-			const insertedUser = result[0];
-			if (!insertedUser) {
-				throw new Error('Failed to create user');
-			}
-			userId = insertedUser.id;
-		}
-
-		const sessionId = await createSession({
-			userId,
-			plexToken: authToken,
-			isAdmin
-		});
-
-		cookies.set('session', sessionId, COOKIE_OPTIONS);
-
-		return json({
-			user: {
-				id: userId,
-				plexId: plexUser.id,
-				username: plexUser.username,
-				isAdmin
-			}
-		});
+		return json(await createSessionFromPlexToken(authToken, cookies));
 	} catch (err) {
 		if (err instanceof NotServerMemberError) {
 			error(403, {
@@ -133,7 +35,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 		}
 
 		if (err instanceof PlexAuthApiError) {
-			console.error('Plex API error:', err.message);
+			console.error('Plex API error during OAuth callback');
 
 			if (err.statusCode === 401) {
 				error(401, {
@@ -146,7 +48,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 			});
 		}
 
-		console.error('Unexpected error in OAuth callback:', err);
+		console.error('Unexpected error in OAuth callback');
 		error(500, {
 			message: 'An unexpected error occurred.'
 		});

--- a/src/routes/auth/plex/redirect/+page.svelte
+++ b/src/routes/auth/plex/redirect/+page.svelte
@@ -46,30 +46,13 @@ onMount(async () => {
 	}
 
 	try {
-		const authToken = await pollForToken(pinData.pinId);
+		const loginResult = await pollForLogin(pinData.pinId);
 
-		if (!authToken) {
+		if (!loginResult) {
 			status = 'cancelled';
 			sessionStorage.removeItem(PIN_STORAGE_KEY);
 			return;
 		}
-
-		const callbackResponse = await fetch('/auth/plex/callback', {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ authToken })
-		});
-
-		if (!callbackResponse.ok) {
-			const errData = await callbackResponse.json().catch(() => ({}));
-			throw new Error(
-				(errData as { message?: string }).message || 'Failed to complete authentication'
-			);
-		}
-
-		const userData = (await callbackResponse.json()) as {
-			user: { isAdmin: boolean };
-		};
 		sessionStorage.removeItem(PIN_STORAGE_KEY);
 
 		status = 'success';
@@ -77,9 +60,7 @@ onMount(async () => {
 		const targetUrl =
 			pinData.context === 'onboarding'
 				? '/onboarding/plex'
-				: userData.user.isAdmin
-					? '/admin'
-					: '/dashboard';
+				: (loginResult.redirectTo ?? (loginResult.user.isAdmin ? '/admin' : '/dashboard'));
 
 		window.location.href = targetUrl;
 	} catch (err) {
@@ -89,7 +70,9 @@ onMount(async () => {
 	}
 });
 
-async function pollForToken(pinId: number): Promise<string | null> {
+async function pollForLogin(
+	pinId: number
+): Promise<{ user: { isAdmin: boolean }; redirectTo?: string } | null> {
 	for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
 		if (attempt > 0) await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
 
@@ -106,10 +89,12 @@ async function pollForToken(pinId: number): Promise<string | null> {
 			throw new Error('Failed to check authentication status');
 		}
 
-		const result = (await response.json()) as { pending: true } | { authToken: string };
+		const result = (await response.json()) as
+			| { pending: true }
+			| { user: { isAdmin: boolean }; redirectTo?: string };
 
-		if ('authToken' in result && result.authToken) {
-			return result.authToken;
+		if ('user' in result && result.user) {
+			return result;
 		}
 	}
 

--- a/src/routes/auth/plex/redirect/+page.svelte
+++ b/src/routes/auth/plex/redirect/+page.svelte
@@ -86,7 +86,8 @@ async function pollForLogin(
 			if (response.status === 401) {
 				return null;
 			}
-			throw new Error('Failed to check authentication status');
+			const errData = (await response.json().catch(() => ({}))) as { message?: string };
+			throw new Error(errData.message || 'Failed to check authentication status');
 		}
 
 		const result = (await response.json()) as

--- a/src/routes/wrapped/[year]/+page.svelte
+++ b/src/routes/wrapped/[year]/+page.svelte
@@ -148,6 +148,8 @@ function handleShare(): void {
 				stats={data.stats}
 				slides={data.slides}
 				customSlides={data.customSlidesMap}
+				initialSlideIndex={currentSlideIndex}
+				onSlideChange={(index) => (currentSlideIndex = index)}
 				onComplete={handleComplete}
 				onClose={handleClose}
 				{messagingContext}

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -33,7 +33,28 @@ import {
 } from '$lib/server/slides';
 import { calculateUserStats } from '$lib/server/stats/engine';
 import { triggerLiveSyncIfNeeded } from '$lib/server/sync/live-sync';
+import { hasWatchHistory } from '$lib/stats/types';
 import type { Actions, PageServerLoad } from './$types';
+
+async function resolveUserIdFromIdentifier(
+	identifier: string,
+	year: number
+): Promise<number | null> {
+	if (isValidTokenFormat(identifier)) {
+		try {
+			const tokenResult = await checkTokenAccess(identifier);
+			return tokenResult.year === year ? tokenResult.userId : null;
+		} catch (err) {
+			if (err instanceof InvalidShareTokenError) {
+				return null;
+			}
+			throw err;
+		}
+	}
+
+	const userId = parseInt(identifier, 10);
+	return Number.isNaN(userId) || userId <= 0 ? null : userId;
+}
 
 export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	const year = parseInt(params.year, 10);
@@ -96,6 +117,7 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 
 	const statsAccountId = user.accountId ?? user.plexId;
 	const stats = await calculateUserStats(statsAccountId, year);
+	const userHasWatchHistory = hasWatchHistory(stats);
 
 	let yearIdentifiers: Record<number, string | number> | undefined;
 
@@ -133,10 +155,12 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 
 	const frequencyConfig = await getFunFactFrequency();
 	let funFacts: Awaited<ReturnType<typeof generateFunFacts>> = [];
-	try {
-		funFacts = await generateFunFacts(stats, { count: frequencyConfig.count });
-	} catch (err) {
-		console.warn('Failed to generate fun facts:', err);
+	if (userHasWatchHistory) {
+		try {
+			funFacts = await generateFunFacts(stats, { count: frequencyConfig.count });
+		} catch (err) {
+			console.warn('Failed to generate fun facts:', err);
+		}
 	}
 
 	const slides = intersperseFunFacts(baseSlides, funFacts);
@@ -165,8 +189,11 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		serverName: null,
 		showLogo: logoVisibility.showLogo,
 		canUserControlLogo: logoVisibility.canUserControl,
+		hasWatchHistory: userHasWatchHistory,
 		shareSettings: {
 			mode: shareSettings.mode,
+			storedMode: shareSettings.storedMode,
+			modeSource: shareSettings.modeSource,
 			shareToken: shareSettings.shareToken,
 			canUserControl: shareSettings.canUserControl || isAdmin
 		},
@@ -211,8 +238,8 @@ export const actions: Actions = {
 			return fail(400, { error: 'Invalid year' });
 		}
 
-		const userId = parseInt(params.identifier, 10);
-		if (Number.isNaN(userId) || userId <= 0) {
+		const userId = await resolveUserIdFromIdentifier(params.identifier, year);
+		if (!userId) {
 			return fail(400, { error: 'Invalid user identifier' });
 		}
 
@@ -239,8 +266,10 @@ export const actions: Actions = {
 				success: true,
 				shareSettings: {
 					mode: updated.mode,
+					storedMode: updated.storedMode,
+					modeSource: updated.modeSource,
 					shareToken: updated.shareToken,
-					canUserControl: updated.canUserControl
+					canUserControl: updated.canUserControl || locals.user.isAdmin
 				}
 			};
 		} catch (err) {
@@ -253,8 +282,8 @@ export const actions: Actions = {
 	},
 
 	regenerateToken: async ({ params, locals }) => {
-		if (!locals.user?.isAdmin) {
-			return fail(403, { error: 'Admin access required' });
+		if (!locals.user) {
+			return fail(401, { error: 'Authentication required' });
 		}
 
 		const year = parseInt(params.year, 10);
@@ -262,14 +291,38 @@ export const actions: Actions = {
 			return fail(400, { error: 'Invalid year' });
 		}
 
-		const userId = parseInt(params.identifier, 10);
-		if (Number.isNaN(userId) || userId <= 0) {
+		const userId = await resolveUserIdFromIdentifier(params.identifier, year);
+		if (!userId) {
 			return fail(400, { error: 'Invalid user identifier' });
 		}
 
 		try {
+			if (locals.user.id !== userId && !locals.user.isAdmin) {
+				return fail(403, { error: 'Not authorized to change share settings' });
+			}
+
+			const settings = await getOrCreateShareSettings({ userId, year });
+			const canControl = settings.canUserControl || locals.user.isAdmin;
+			if (!canControl) {
+				return fail(403, { error: 'You do not have permission to change share settings.' });
+			}
+
+			if (settings.mode !== ShareMode.PRIVATE_LINK) {
+				return fail(400, { error: 'Can only regenerate token for private-link mode' });
+			}
+
 			const newToken = await regenerateShareToken(userId, year);
-			return { success: true, shareToken: newToken };
+			return {
+				success: true,
+				shareToken: newToken,
+				shareSettings: {
+					mode: settings.mode,
+					storedMode: settings.storedMode,
+					modeSource: settings.modeSource,
+					shareToken: newToken,
+					canUserControl: canControl
+				}
+			};
 		} catch (err) {
 			const message = err instanceof Error ? err.message : 'Failed to regenerate token';
 			return fail(500, { error: message });

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
@@ -190,7 +190,12 @@ function handleLogoToggle(): void {
 				</button>
 			</form>
 		{/if}
-		<ModeToggle mode={viewMode} onModeChange={handleModeChange} />
+		{#if data.isOwner || data.isAdmin}
+			<button type="button" class="share-toggle" onclick={handleShare}>Share</button>
+		{/if}
+		{#if data.hasWatchHistory}
+			<ModeToggle mode={viewMode} onModeChange={handleModeChange} />
+		{/if}
 	</div>
 
 	<!-- User Header -->
@@ -218,12 +223,30 @@ function handleLogoToggle(): void {
 			onHome={handleHome}
 			onShare={handleShare}
 		/>
+	{:else if !data.hasWatchHistory}
+		<section class="empty-wrapped-state">
+			<div class="empty-content">
+				<p class="empty-eyebrow">{data.year} Wrapped</p>
+				<h2>No viewing history for {data.year} yet</h2>
+				<p>
+					Once {data.username} has Plex activity for the year, their Wrapped will appear here.
+				</p>
+				<div class="empty-actions">
+					<button type="button" class="empty-btn secondary" onclick={handleHome}>Home</button>
+					{#if data.isOwner || data.isAdmin}
+						<button type="button" class="empty-btn primary" onclick={handleShare}>Share</button>
+					{/if}
+				</div>
+			</div>
+		</section>
 	{:else if viewMode === 'story'}
 		{#key storyKey}
 			<StoryMode
 				stats={data.stats}
 				slides={data.slides}
 				customSlides={data.customSlidesMap}
+				initialSlideIndex={currentSlideIndex}
+				onSlideChange={(index) => (currentSlideIndex = index)}
 				onComplete={handleComplete}
 				onClose={handleClose}
 				{messagingContext}
@@ -246,6 +269,7 @@ function handleLogoToggle(): void {
 		bind:open={showShareModal}
 		onOpenChange={(v) => (showShareModal = v)}
 		currentUrl={data.currentUrl}
+		canonicalUrl={`/wrapped/${data.year}/u/${data.userId}`}
 		shareSettings={data.shareSettings}
 		isOwner={data.isOwner}
 		isAdmin={data.isAdmin}
@@ -287,13 +311,14 @@ function handleLogoToggle(): void {
 			align-items: center;
 		}
 
-		.logo-toggle {
+		.logo-toggle,
+		.share-toggle {
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			width: 2rem;
+			min-width: 2rem;
 			height: 2rem;
-			padding: 0;
+			padding: 0 0.65rem;
 			border: none;
 			border-radius: 0.375rem;
 			background: var(--card);
@@ -305,7 +330,18 @@ function handleLogoToggle(): void {
 				background 0.2s;
 		}
 
-		.logo-toggle:hover {
+		.logo-toggle {
+			width: 2rem;
+			padding: 0;
+		}
+
+		.share-toggle {
+			font-size: 0.8125rem;
+			font-weight: 600;
+		}
+
+		.logo-toggle:hover,
+		.share-toggle:hover {
 			opacity: 1;
 			background: var(--muted);
 		}
@@ -328,5 +364,75 @@ function handleLogoToggle(): void {
 			color: var(--foreground);
 			opacity: 0.8;
 			margin: 0;
+		}
+
+		.empty-wrapped-state {
+			min-height: 100vh;
+			min-height: 100dvh;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			padding: 6rem 1.5rem 3rem;
+			color: var(--foreground);
+		}
+
+		.empty-content {
+			width: min(100%, 36rem);
+			text-align: center;
+		}
+
+		.empty-eyebrow {
+			margin: 0 0 0.75rem;
+			font-size: 0.8125rem;
+			font-weight: 700;
+			letter-spacing: 0.12em;
+			text-transform: uppercase;
+			color: var(--muted-foreground);
+		}
+
+		.empty-content h2 {
+			margin: 0 0 1rem;
+			font-size: clamp(2rem, 8vw, 3.5rem);
+			line-height: 1;
+		}
+
+		.empty-content p {
+			margin: 0 auto;
+			max-width: 30rem;
+			color: var(--muted-foreground);
+			line-height: 1.6;
+		}
+
+		.empty-actions {
+			display: flex;
+			justify-content: center;
+			gap: 0.75rem;
+			margin-top: 1.75rem;
+			flex-wrap: wrap;
+		}
+
+		.empty-btn {
+			border: none;
+			border-radius: 8px;
+			padding: 0.75rem 1.1rem;
+			font-weight: 700;
+			cursor: pointer;
+		}
+
+		.empty-btn.primary {
+			background: hsl(var(--primary));
+			color: hsl(var(--primary-foreground));
+		}
+
+		.empty-btn.secondary {
+			background: var(--card);
+			color: var(--foreground);
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+			.logo-toggle,
+			.share-toggle {
+				transition: none;
+			}
 		}
 </style>

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -97,6 +97,7 @@ sqlite.exec(`
 		user_id INTEGER NOT NULL,
 		year INTEGER NOT NULL,
 		mode TEXT NOT NULL DEFAULT 'public',
+		mode_source TEXT NOT NULL DEFAULT 'explicit',
 		share_token TEXT UNIQUE,
 		can_user_control INTEGER DEFAULT 0,
 		show_logo INTEGER

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -203,6 +203,7 @@ describe('startPlexLoginPopup', () => {
 		};
 
 		let pollCalls = 0;
+		let callbackCalls = 0;
 		let rejectFirstPoll: (err: Error) => void = () => {};
 		const firstPoll = new Promise<Response>((_, reject) => {
 			rejectFirstPoll = reject;
@@ -220,6 +221,7 @@ describe('startPlexLoginPopup', () => {
 			}
 
 			if (url === '/auth/plex/callback') {
+				callbackCalls += 1;
 				return new Response(JSON.stringify({ error: 'callback should stay server-only' }), {
 					status: 200,
 					headers: { 'Content-Type': 'application/json' }
@@ -262,5 +264,6 @@ describe('startPlexLoginPopup', () => {
 		expect(onSuccess).toHaveBeenCalledTimes(1);
 		expect(onError).not.toHaveBeenCalled();
 		expect(onPopupBlocked).not.toHaveBeenCalled();
+		expect(callbackCalls).toBe(0);
 	});
 });

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -182,7 +182,7 @@ describe('startPlexLoginPopup', () => {
 		globalThis.fetch = originalFetch;
 	});
 
-	it('ignores stale poll failures once callback exchange has started', async () => {
+	it('ignores stale poll failures once login completion has started', async () => {
 		const intervalCallbacks: Array<() => Promise<void>> = [];
 		let resolveIntervalRegistered: () => void = () => {};
 		const intervalRegistered = new Promise<void>((resolve) => {
@@ -207,30 +207,23 @@ describe('startPlexLoginPopup', () => {
 		const firstPoll = new Promise<Response>((_, reject) => {
 			rejectFirstPoll = reject;
 		});
-		let resolveCallbackRequested: () => void = () => {};
-		const callbackRequested = new Promise<void>((resolve) => {
-			resolveCallbackRequested = resolve;
-		});
-		let resolveCallback: (response: Response) => void = () => {};
-		const callbackExchange = new Promise<Response>((resolve) => {
-			resolveCallback = resolve;
-		});
-
 		globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
 			const url = typeof input === 'string' ? input : input.toString();
 
 			if (url === '/auth/plex' && init?.method === 'POST') {
 				pollCalls += 1;
 				if (pollCalls === 1) return firstPoll;
-				return new Response(JSON.stringify({ authToken: 'plex-token' }), {
+				return new Response(JSON.stringify({ user: { id: 1, username: 'plex', isAdmin: true } }), {
 					status: 200,
 					headers: { 'Content-Type': 'application/json' }
 				});
 			}
 
 			if (url === '/auth/plex/callback') {
-				resolveCallbackRequested();
-				return callbackExchange;
+				return new Response(JSON.stringify({ error: 'callback should stay server-only' }), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' }
+				});
 			}
 
 			return new Response(
@@ -259,18 +252,11 @@ describe('startPlexLoginPopup', () => {
 		const poll = intervalCallbacks[0] as () => Promise<void>;
 		const staleTick = poll();
 		const successTick = poll();
-		await callbackRequested;
 
 		rejectFirstPoll(new Error('Network dropped'));
 		await staleTick;
 		expect(onError).not.toHaveBeenCalled();
 
-		resolveCallback(
-			new Response(JSON.stringify({ user: { id: 1, username: 'plex', isAdmin: true } }), {
-				status: 200,
-				headers: { 'Content-Type': 'application/json' }
-			})
-		);
 		await successTick;
 
 		expect(onSuccess).toHaveBeenCalledTimes(1);

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -266,4 +266,120 @@ describe('startPlexLoginPopup', () => {
 		expect(onPopupBlocked).not.toHaveBeenCalled();
 		expect(callbackCalls).toBe(0);
 	});
+
+	it('surfaces server message and stops polling on 403 (NotServerMemberError)', async () => {
+		let resolveIntervalRegistered: () => void = () => {};
+		const intervalRegistered = new Promise<void>((resolve) => {
+			resolveIntervalRegistered = resolve;
+		});
+		const intervalCallbacks: Array<() => Promise<void>> = [];
+		const timers = createTimerMocks((callback) => {
+			intervalCallbacks.push(callback);
+			resolveIntervalRegistered();
+		});
+
+		const popup: MockPopupWindow = { closed: false, close: mock(() => {}) };
+		const browserWindow: MockWindow = {
+			location: { origin: 'https://obzorarr.example', href: 'https://obzorarr.example/' },
+			open: mock(() => popup) as unknown as MockWindow['open']
+		};
+
+		globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === 'string' ? input : input.toString();
+			if (url === '/auth/plex' && init?.method === 'POST') {
+				return new Response(
+					JSON.stringify({ message: 'You are not a member of this Plex server.' }),
+					{ status: 403, headers: { 'Content-Type': 'application/json' } }
+				);
+			}
+			return new Response(
+				JSON.stringify({ pinId: 42, authUrl: 'https://app.plex.tv/auth#?code=ABCD' }),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } }
+			);
+		}) as unknown as typeof fetch;
+
+		const onSuccess = mock(async () => {});
+		const onError = mock(() => {});
+		const onPopupBlocked = mock(() => {});
+
+		startPlexLoginPopup({
+			context: 'landing',
+			onSuccess,
+			onError,
+			onPopupBlocked,
+			window: browserWindow,
+			timers
+		});
+		await intervalRegistered;
+
+		const poll = intervalCallbacks[0] as () => Promise<void>;
+		await poll();
+
+		expect(onError).toHaveBeenCalledTimes(1);
+		expect((onError.mock.calls[0] as string[])[0]).toBe(
+			'You are not a member of this Plex server.'
+		);
+		expect(onSuccess).not.toHaveBeenCalled();
+
+		await poll();
+		expect(onError).toHaveBeenCalledTimes(1);
+	});
+
+	it('surfaces server message and stops polling on 502 (PlexAuthApiError)', async () => {
+		let resolveIntervalRegistered: () => void = () => {};
+		const intervalRegistered = new Promise<void>((resolve) => {
+			resolveIntervalRegistered = resolve;
+		});
+		const intervalCallbacks: Array<() => Promise<void>> = [];
+		const timers = createTimerMocks((callback) => {
+			intervalCallbacks.push(callback);
+			resolveIntervalRegistered();
+		});
+
+		const popup: MockPopupWindow = { closed: false, close: mock(() => {}) };
+		const browserWindow: MockWindow = {
+			location: { origin: 'https://obzorarr.example', href: 'https://obzorarr.example/' },
+			open: mock(() => popup) as unknown as MockWindow['open']
+		};
+
+		globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === 'string' ? input : input.toString();
+			if (url === '/auth/plex' && init?.method === 'POST') {
+				return new Response(
+					JSON.stringify({ message: 'Unable to connect to Plex. Please try again.' }),
+					{ status: 502, headers: { 'Content-Type': 'application/json' } }
+				);
+			}
+			return new Response(
+				JSON.stringify({ pinId: 42, authUrl: 'https://app.plex.tv/auth#?code=ABCD' }),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } }
+			);
+		}) as unknown as typeof fetch;
+
+		const onSuccess = mock(async () => {});
+		const onError = mock(() => {});
+		const onPopupBlocked = mock(() => {});
+
+		startPlexLoginPopup({
+			context: 'landing',
+			onSuccess,
+			onError,
+			onPopupBlocked,
+			window: browserWindow,
+			timers
+		});
+		await intervalRegistered;
+
+		const poll = intervalCallbacks[0] as () => Promise<void>;
+		await poll();
+
+		expect(onError).toHaveBeenCalledTimes(1);
+		expect((onError.mock.calls[0] as string[])[0]).toBe(
+			'Unable to connect to Plex. Please try again.'
+		);
+		expect(onSuccess).not.toHaveBeenCalled();
+
+		await poll();
+		expect(onError).toHaveBeenCalledTimes(1);
+	});
 });

--- a/tests/unit/security/request-filter-patterns.test.ts
+++ b/tests/unit/security/request-filter-patterns.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'bun:test';
+import { isBlockedPath, isBlockedUserAgent } from '$lib/server/security/request-filter-patterns';
+
+describe('request filter patterns', () => {
+	it('blocks scanner paths without exposing filesystem details', () => {
+		expect(isBlockedPath('/.env')).toBe(true);
+		expect(isBlockedPath('/.git/config')).toBe(true);
+		expect(isBlockedPath('/wp-admin')).toBe(true);
+		expect(isBlockedPath('/admin')).toBe(false);
+	});
+
+	it('blocks known scanner user agents', () => {
+		expect(isBlockedUserAgent('Mozilla/5.0 nuclei')).toBe(true);
+		expect(isBlockedUserAgent('sqlmap/1.8')).toBe(true);
+		expect(isBlockedUserAgent('Mozilla/5.0 Safari/605.1.15')).toBe(false);
+	});
+});

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -199,6 +199,33 @@ describe('Sharing Service', () => {
 				const settings = await getShareSettings(userId, year);
 				expect(settings?.shareToken).toBe(token);
 			});
+
+			it('repairs missing token when default-sourced settings become private-link', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: true
+				});
+
+				await db.insert(shareSettings).values({
+					userId,
+					year,
+					mode: ShareMode.PUBLIC,
+					modeSource: ShareModeSource.DEFAULT,
+					shareToken: null,
+					canUserControl: true
+				});
+
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: true
+				});
+
+				const settings = await getShareSettings(userId, year);
+				expect(settings?.mode).toBe(ShareMode.PRIVATE_LINK);
+				expect(settings?.shareToken).not.toBeNull();
+				expect(isValidTokenFormat(settings!.shareToken!)).toBe(true);
+				expect((await getShareSettings(userId, year))?.shareToken).toBe(settings?.shareToken);
+			});
 		});
 
 		describe('getOrCreateShareSettings', () => {

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -20,6 +20,7 @@ import {
 import {
 	PermissionExceededError,
 	ShareMode,
+	ShareModeSource,
 	ShareSettingsKey,
 	ShareSettingsNotFoundError
 } from '$lib/server/sharing/types';
@@ -212,6 +213,8 @@ describe('Sharing Service', () => {
 				expect(settings.userId).toBe(userId);
 				expect(settings.year).toBe(year);
 				expect(settings.mode).toBe(ShareMode.PRIVATE_OAUTH);
+				expect(settings.storedMode).toBe(ShareMode.PRIVATE_OAUTH);
+				expect(settings.modeSource).toBe(ShareModeSource.DEFAULT);
 				expect(settings.canUserControl).toBe(true);
 				expect(settings.shareToken).toBeNull();
 			});
@@ -225,6 +228,7 @@ describe('Sharing Service', () => {
 				const settings = await getOrCreateShareSettings({ userId, year });
 
 				expect(settings.mode).toBe(ShareMode.PRIVATE_LINK);
+				expect(settings.modeSource).toBe(ShareModeSource.DEFAULT);
 				expect(settings.shareToken).not.toBeNull();
 				expect(isValidTokenFormat(settings.shareToken!)).toBe(true);
 			});
@@ -243,11 +247,11 @@ describe('Sharing Service', () => {
 
 				// Mode and token should be preserved from database
 				expect(settings.mode).toBe(ShareMode.PRIVATE_LINK);
+				expect(settings.modeSource).toBe(ShareModeSource.EXPLICIT);
 				expect(settings.shareToken).toBe(existingToken);
 			});
 
-			it('uses current global allowUserControl for existing settings', async () => {
-				// Create settings with canUserControl: false in database
+			it('preserves stored canUserControl for existing settings', async () => {
 				await db.insert(shareSettings).values({
 					userId,
 					year,
@@ -256,25 +260,44 @@ describe('Sharing Service', () => {
 					canUserControl: false
 				});
 
-				// Set global allowUserControl to true
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PUBLIC,
 					allowUserControl: true
 				});
 
-				// canUserControl should reflect global setting, not stored value
 				const settings = await getOrCreateShareSettings({ userId, year });
-				expect(settings.canUserControl).toBe(true);
+				expect(settings.canUserControl).toBe(false);
 
-				// Now disable global allowUserControl
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PUBLIC,
 					allowUserControl: false
 				});
 
-				// canUserControl should now be false
 				const settings2 = await getOrCreateShareSettings({ userId, year });
 				expect(settings2.canUserControl).toBe(false);
+			});
+
+			it('keeps default-sourced mode effective from global defaults without changing control', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: true
+				});
+
+				const settings = await getOrCreateShareSettings({ userId, year });
+				expect(settings.mode).toBe(ShareMode.PUBLIC);
+				expect(settings.modeSource).toBe(ShareModeSource.DEFAULT);
+				expect(settings.canUserControl).toBe(true);
+
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_OAUTH,
+					allowUserControl: false
+				});
+
+				const updated = await getOrCreateShareSettings({ userId, year });
+				expect(updated.mode).toBe(ShareMode.PRIVATE_OAUTH);
+				expect(updated.storedMode).toBe(ShareMode.PUBLIC);
+				expect(updated.modeSource).toBe(ShareModeSource.DEFAULT);
+				expect(updated.canUserControl).toBe(true);
 			});
 
 			it('throws when createIfMissing is false and settings do not exist', async () => {
@@ -311,6 +334,7 @@ describe('Sharing Service', () => {
 				);
 
 				expect(updated.mode).toBe(ShareMode.PRIVATE_OAUTH);
+				expect(updated.modeSource).toBe(ShareModeSource.EXPLICIT);
 			});
 
 			it('allows admin to set private-link mode', async () => {
@@ -352,11 +376,7 @@ describe('Sharing Service', () => {
 			});
 
 			it('denies user without canUserControl', async () => {
-				// Disable user control globally (canUserControl is derived from global setting)
-				await setGlobalShareDefaults({
-					defaultShareMode: ShareMode.PUBLIC,
-					allowUserControl: false
-				});
+				await updateShareSettings(userId, year, { canUserControl: false }, true);
 
 				await expect(
 					updateShareSettings(userId, year, { mode: ShareMode.PRIVATE_OAUTH }, false)

--- a/tests/unit/stats/types.test.ts
+++ b/tests/unit/stats/types.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it } from 'bun:test';
 import type { ServerStats, UserStats } from '$lib/server/stats/types';
-import { isServerStats, isUserStats } from '$lib/server/stats/types';
+import { hasWatchHistory, isServerStats, isUserStats } from '$lib/server/stats/types';
 
 // =============================================================================
 // Test Helpers
@@ -130,5 +130,22 @@ describe('isServerStats', () => {
 		const userStats = createMockUserStats();
 		// UserStats has userId and percentileRank, not totalUsers and topViewers
 		expect(isServerStats(userStats)).toBe(false);
+	});
+});
+
+describe('hasWatchHistory', () => {
+	it('returns true when plays or watch time exist', () => {
+		expect(hasWatchHistory(createMockUserStats({ totalPlays: 1, totalWatchTimeMinutes: 0 }))).toBe(
+			true
+		);
+		expect(
+			hasWatchHistory(createMockServerStats({ totalPlays: 0, totalWatchTimeMinutes: 30 }))
+		).toBe(true);
+	});
+
+	it('returns false when both plays and watch time are empty', () => {
+		expect(hasWatchHistory(createMockUserStats({ totalPlays: 0, totalWatchTimeMinutes: 0 }))).toBe(
+			false
+		);
 	});
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,16 @@ function devRequestFilter(): PluginOption {
 		name: 'obzorarr-dev-request-filter',
 		configureServer(server) {
 			server.middlewares.use((req, res, next) => {
-				const path = new URL(req.url ?? '/', 'http://localhost').pathname;
+				let path: string;
+
+				try {
+					path = new URL(req.url ?? '/', 'http://localhost').pathname;
+				} catch {
+					res.statusCode = 400;
+					res.end('Bad Request');
+					return;
+				}
+
 				const userAgent = req.headers['user-agent'];
 				const userAgentValue = Array.isArray(userAgent) ? userAgent.join(' ') : (userAgent ?? '');
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,39 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 import UnoCSS from 'unocss/vite';
 import { defineConfig, type PluginOption } from 'vite';
+import {
+	isBlockedPath,
+	isBlockedUserAgent
+} from './src/lib/server/security/request-filter-patterns';
 
 const rolldownChecks = { pluginTimings: false } as Record<string, boolean>;
+
+function devRequestFilter(): PluginOption {
+	return {
+		name: 'obzorarr-dev-request-filter',
+		configureServer(server) {
+			server.middlewares.use((req, res, next) => {
+				const path = new URL(req.url ?? '/', 'http://localhost').pathname;
+				const userAgent = req.headers['user-agent'];
+				const userAgentValue = Array.isArray(userAgent) ? userAgent.join(' ') : (userAgent ?? '');
+
+				if (isBlockedPath(path)) {
+					res.statusCode = 404;
+					res.end('Not Found');
+					return;
+				}
+
+				if (isBlockedUserAgent(userAgentValue)) {
+					res.statusCode = 403;
+					res.end('Forbidden');
+					return;
+				}
+
+				next();
+			});
+		}
+	};
+}
 
 export default defineConfig({
 	build: {
@@ -13,6 +44,7 @@ export default defineConfig({
 	},
 	plugins: [
 		UnoCSS(),
+		devRequestFilter(),
 		sveltekit(),
 		process.env.ANALYZE
 			? visualizer({


### PR DESCRIPTION
## Summary

This pull request resolves the confirmed comprehensive E2E QA findings across authentication, sharing semantics, admin workflows, wrapped presentation behavior, and dev security hardening.

Key changes include:

- Move Plex OAuth PIN completion fully server-side so the browser never receives Plex auth tokens.
- Replace the direct logout endpoint ambiguity with a page route backed by a shared server logout helper.
- Add `share_settings.mode_source` with a Drizzle migration and preserve default versus explicit share-mode semantics.
- Preserve per-user sharing control settings instead of re-deriving existing rows from global defaults.
- Improve admin users, settings, sync, logs, and slides flows for the reported persistence and UI state issues.
- Preserve wrapped Story/Scroll position, respect reduced-motion progress behavior, add persistent personal share controls, and handle zero-history personal wraps with a clear empty state.
- Reuse request-filter matchers in production hooks and Vite dev middleware so scanner paths and blocked user agents receive generic responses.
- Exclude generated `dogfood-output` artifacts from Biome formatting so captured QA evidence and browser state files are not rewritten.

## Notable implementation details

- `/auth/plex` POST now returns either `{ pending: true }` or a completed login payload with `{ user, redirectTo }`; it no longer serializes Plex auth tokens.
- `/auth/plex/callback` remains as a backward-compatible server endpoint but delegates to the same server-only login completion helper.
- Share settings now expose effective mode, stored mode, and mode source, allowing the UI to show `Default` while access checks still use the effective global default.
- Personal wrapped share actions resolve both numeric user identifiers and valid private-link tokens, so owner/admin controls continue to work when accessed via a token URL.
- Fun facts are suppressed for zero-history personal stats to avoid misleading presentation content.

## Database migration

- Adds `drizzle/0004_quiet_mode_source.sql` to add `share_settings.mode_source` with default `explicit`.
- Existing share-setting rows are treated as explicit overrides, preserving current behavior for already-created rows.

## Validation

The following commands passed locally:

```bash
bun run check
bun test --env-file=.env.test
bun run format:check
```

Latest test result: `1255 pass, 0 fail`.

## Follow-up verification recommended

- Run the focused browser E2E rerun for OAuth redirect/popup login, direct logout, admin settings, sync/logs/slides, wrapped sharing, reduced motion, zero-history wrapped, and suspicious dev paths.
- Apply the new migration in the target environment before validating share settings in an existing database.
