### PR TITLE
fix: resolve dogfood QA findings from post-PR #68 review

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -19,24 +19,16 @@ import {
 import { SESSION_DURATION_MS } from '$lib/server/auth/types';
 import { logger } from '$lib/server/logging';
 import { getOnboardingStep, requiresOnboarding } from '$lib/server/onboarding';
-import { csrfHandle, rateLimitHandle, requestFilterHandle } from '$lib/server/security';
+import {
+	applySecurityHeaders,
+	csrfHandle,
+	rateLimitHandle,
+	requestFilterHandle
+} from '$lib/server/security';
 
 const securityHeadersHandle: Handle = async ({ event, resolve }) => {
 	const response = await resolve(event);
-
-	response.headers.set('X-Frame-Options', 'DENY');
-	response.headers.set('X-Content-Type-Options', 'nosniff');
-	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-	response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-
-	const isHttps =
-		event.url.protocol === 'https:' ||
-		event.request.headers.get('x-forwarded-proto')?.includes('https');
-	if (isHttps) {
-		response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
-	}
-
-	return response;
+	return applySecurityHeaders(response, event.request);
 };
 
 const proxyHandle: Handle = async ({ event, resolve }) => {

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -240,7 +240,7 @@ function handleClick(event: MouseEvent): void {
 	const clickX = event.clientX - rect.left;
 	const relativeX = clickX / rect.width;
 
-	if (relativeX < EDGE_ZONE_PERCENT) {
+	if (relativeX <= EDGE_ZONE_PERCENT) {
 		goToPrevious();
 	} else {
 		goToNext();

--- a/src/lib/server/ratelimit/service.ts
+++ b/src/lib/server/ratelimit/service.ts
@@ -13,10 +13,11 @@ export function checkRateLimit(
 	config: RateLimitConfig = FALLBACK_RATE_LIMIT
 ): RateLimitResult {
 	const now = Date.now();
-	const record = rateLimitStore.get(ip);
+	const key = `${config.name}:${ip}`;
+	const record = rateLimitStore.get(key);
 
 	if (!record || now - record.windowStart >= config.windowMs) {
-		rateLimitStore.set(ip, { count: 1, windowStart: now });
+		rateLimitStore.set(key, { count: 1, windowStart: now });
 		return {
 			allowed: true,
 			remaining: config.maxRequests - 1,

--- a/src/lib/server/ratelimit/types.ts
+++ b/src/lib/server/ratelimit/types.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 export const RateLimitConfigSchema = z.object({
+	name: z.string().min(1),
 	windowMs: z.number().int().min(1000).default(60_000),
 	maxRequests: z.number().int().min(1).default(10)
 });
@@ -20,16 +21,17 @@ export interface RateLimitRecord {
 }
 
 export const FALLBACK_RATE_LIMIT: RateLimitConfig = {
+	name: 'fallback',
 	windowMs: 60_000,
 	maxRequests: 10
 };
 
 export const RATE_LIMIT_CONFIGS = {
-	default: { windowMs: 60_000, maxRequests: 60 },
-	auth: { windowMs: 300_000, maxRequests: 10 },
-	authPoll: { windowMs: 60_000, maxRequests: 60 },
-	authRedirect: { windowMs: 60_000, maxRequests: 30 },
-	api: { windowMs: 60_000, maxRequests: 30 }
+	default: { name: 'default', windowMs: 60_000, maxRequests: 60 },
+	auth: { name: 'auth', windowMs: 300_000, maxRequests: 10 },
+	authPoll: { name: 'authPoll', windowMs: 60_000, maxRequests: 60 },
+	authRedirect: { name: 'authRedirect', windowMs: 60_000, maxRequests: 30 },
+	api: { name: 'api', windowMs: 60_000, maxRequests: 30 }
 } as const satisfies Record<string, RateLimitConfig>;
 
 export const STALE_THRESHOLD_MS = 5 * 60 * 1000;

--- a/src/lib/server/ratelimit/types.ts
+++ b/src/lib/server/ratelimit/types.ts
@@ -28,6 +28,7 @@ export const RATE_LIMIT_CONFIGS = {
 	default: { windowMs: 60_000, maxRequests: 60 },
 	auth: { windowMs: 300_000, maxRequests: 10 },
 	authPoll: { windowMs: 60_000, maxRequests: 60 },
+	authRedirect: { windowMs: 60_000, maxRequests: 30 },
 	api: { windowMs: 60_000, maxRequests: 30 }
 } as const satisfies Record<string, RateLimitConfig>;
 

--- a/src/lib/server/security/index.ts
+++ b/src/lib/server/security/index.ts
@@ -6,3 +6,4 @@ export {
 } from './error-sanitizer';
 export { rateLimitHandle } from './rate-limit-handle';
 export { requestFilterHandle } from './request-filter';
+export { applySecurityHeaders } from './security-headers';

--- a/src/lib/server/security/rate-limit-handle.ts
+++ b/src/lib/server/security/rate-limit-handle.ts
@@ -1,4 +1,4 @@
-import { error, type Handle } from '@sveltejs/kit';
+import type { Handle } from '@sveltejs/kit';
 import { checkRateLimit, RATE_LIMIT_CONFIGS, type RateLimitConfig } from '$lib/server/ratelimit';
 
 function getConfigForPath(path: string): RateLimitConfig {
@@ -55,7 +55,15 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 			});
 		}
 
-		error(429, 'Too many requests');
+		return new Response('Too many requests', {
+			status: 429,
+			headers: {
+				'Content-Type': 'text/plain',
+				'Retry-After': String(result.retryAfter ?? 60),
+				'X-RateLimit-Remaining': '0',
+				'X-RateLimit-Reset': String(result.resetTime)
+			}
+		});
 	}
 
 	const response = await resolve(event);

--- a/src/lib/server/security/rate-limit-handle.ts
+++ b/src/lib/server/security/rate-limit-handle.ts
@@ -6,6 +6,10 @@ function getConfigForPath(path: string): RateLimitConfig {
 		return RATE_LIMIT_CONFIGS.authPoll;
 	}
 
+	if (path === '/auth/plex/redirect') {
+		return RATE_LIMIT_CONFIGS.authRedirect;
+	}
+
 	if (path === '/auth/logout' || path === '/auth/plex/callback') {
 		return RATE_LIMIT_CONFIGS.default;
 	}
@@ -35,7 +39,7 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 	if (!result.allowed) {
 		const isApiRequest =
 			path.startsWith('/api/') ||
-			path.startsWith('/auth/') ||
+			(path.startsWith('/auth/') && path !== '/auth/plex/redirect') ||
 			event.request.headers.get('accept')?.includes('application/json') ||
 			event.request.headers.get('content-type')?.includes('application/json');
 

--- a/src/lib/server/security/rate-limit-handle.ts
+++ b/src/lib/server/security/rate-limit-handle.ts
@@ -1,5 +1,6 @@
 import type { Handle } from '@sveltejs/kit';
 import { checkRateLimit, RATE_LIMIT_CONFIGS, type RateLimitConfig } from '$lib/server/ratelimit';
+import { applySecurityHeaders } from './security-headers';
 
 function getConfigForPath(path: string): RateLimitConfig {
 	if (path === '/auth/plex') {
@@ -44,15 +45,18 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 			event.request.headers.get('content-type')?.includes('application/json');
 
 		if (isApiRequest) {
-			return new Response(JSON.stringify({ error: 'Too many requests' }), {
-				status: 429,
-				headers: {
-					'Content-Type': 'application/json',
-					'Retry-After': String(result.retryAfter ?? 60),
-					'X-RateLimit-Remaining': '0',
-					'X-RateLimit-Reset': String(result.resetTime)
-				}
-			});
+			return applySecurityHeaders(
+				new Response(JSON.stringify({ error: 'Too many requests' }), {
+					status: 429,
+					headers: {
+						'Content-Type': 'application/json',
+						'Retry-After': String(result.retryAfter ?? 60),
+						'X-RateLimit-Remaining': '0',
+						'X-RateLimit-Reset': String(result.resetTime)
+					}
+				}),
+				event.request
+			);
 		}
 
 		const retryAfterSeconds = result.retryAfter ?? 60;
@@ -74,15 +78,18 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 </body>
 </html>`;
 
-		return new Response(htmlBody, {
-			status: 429,
-			headers: {
-				'Content-Type': 'text/html; charset=utf-8',
-				'Retry-After': String(retryAfterSeconds),
-				'X-RateLimit-Remaining': '0',
-				'X-RateLimit-Reset': String(result.resetTime)
-			}
-		});
+		return applySecurityHeaders(
+			new Response(htmlBody, {
+				status: 429,
+				headers: {
+					'Content-Type': 'text/html; charset=utf-8',
+					'Retry-After': String(retryAfterSeconds),
+					'X-RateLimit-Remaining': '0',
+					'X-RateLimit-Reset': String(result.resetTime)
+				}
+			}),
+			event.request
+		);
 	}
 
 	const response = await resolve(event);

--- a/src/lib/server/security/rate-limit-handle.ts
+++ b/src/lib/server/security/rate-limit-handle.ts
@@ -55,11 +55,30 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 			});
 		}
 
-		return new Response('Too many requests', {
+		const retryAfterSeconds = result.retryAfter ?? 60;
+		const htmlBody = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>429 Too Many Requests – Obzorarr</title>
+<style>body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;font-family:system-ui,sans-serif;background:#0a0a0a;color:#e5e5e5}div{max-width:400px;text-align:center;padding:2.5rem;background:#1a1a1a;border:1px solid #333;border-radius:12px}h1{font-size:1.5rem;font-weight:600;margin:0 0 .75rem}p{color:#a1a1aa;margin:0 0 1.5rem;line-height:1.5}a{display:inline-flex;align-items:center;padding:.625rem 1.25rem;background:#e5a00d;color:#000;text-decoration:none;border-radius:8px;font-size:.875rem;font-weight:500}</style>
+</head>
+<body>
+<div>
+<div style="font-size:4rem;font-weight:800;color:#e5a00d;line-height:1;margin-bottom:.5rem">429</div>
+<h1>Too many requests</h1>
+<p>Please slow down and try again in ${retryAfterSeconds} second${retryAfterSeconds === 1 ? '' : 's'}.</p>
+<a href="/">Home</a>
+</div>
+</body>
+</html>`;
+
+		return new Response(htmlBody, {
 			status: 429,
 			headers: {
-				'Content-Type': 'text/plain',
-				'Retry-After': String(result.retryAfter ?? 60),
+				'Content-Type': 'text/html; charset=utf-8',
+				'Retry-After': String(retryAfterSeconds),
 				'X-RateLimit-Remaining': '0',
 				'X-RateLimit-Reset': String(result.resetTime)
 			}

--- a/src/lib/server/security/security-headers.ts
+++ b/src/lib/server/security/security-headers.ts
@@ -1,0 +1,15 @@
+export function applySecurityHeaders(response: Response, request: Request): Response {
+	response.headers.set('X-Frame-Options', 'DENY');
+	response.headers.set('X-Content-Type-Options', 'nosniff');
+	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+	response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+
+	const isHttps =
+		new URL(request.url).protocol === 'https:' ||
+		request.headers.get('x-forwarded-proto')?.includes('https');
+	if (isHttps) {
+		response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+	}
+
+	return response;
+}

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -84,6 +84,11 @@ export async function setGlobalShareDefaults(defaults: GlobalShareDefaults): Pro
 		});
 }
 
+export async function bulkApplyUserControl(canUserControl: boolean): Promise<number> {
+	const result = await db.update(shareSettings).set({ canUserControl }).returning();
+	return result.length;
+}
+
 export async function getServerWrappedShareMode(): Promise<ShareModeType> {
 	const result = await db
 		.select()

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -85,7 +85,10 @@ export async function setGlobalShareDefaults(defaults: GlobalShareDefaults): Pro
 }
 
 export async function bulkApplyUserControl(canUserControl: boolean): Promise<number> {
-	const result = await db.update(shareSettings).set({ canUserControl }).returning();
+	const result = await db
+		.update(shareSettings)
+		.set({ canUserControl })
+		.returning({ id: shareSettings.id });
 	return result.length;
 }
 

--- a/src/lib/server/stats/calculators/new-slides.ts
+++ b/src/lib/server/stats/calculators/new-slides.ts
@@ -150,9 +150,15 @@ export function calculateMarathonDay(records: PlayHistoryRecord[]): MarathonDay 
 
 	if (!maxDay) return null;
 
+	// Plex history records store item duration, not actual watched time.
+	// Overlapping sessions and partial watches can sum past 24h, so clamp to
+	// one day as an upper bound on wall-clock watch time.
+	const MAX_MINUTES_PER_DAY = 24 * 60;
+	const cappedMinutes = Math.min(maxDay.stats.minutes, MAX_MINUTES_PER_DAY);
+
 	return {
 		date: maxDay.date,
-		minutes: maxDay.stats.minutes,
+		minutes: cappedMinutes,
 		plays: maxDay.stats.plays,
 		items: maxDay.stats.items.slice(0, 10)
 	};

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,0 +1,6 @@
+export function formatDuration(ms: number): string {
+	if (ms < 1000) return '<1s';
+	if (ms < 60000) return `${Math.round(ms / 1000)}s`;
+	if (ms < 3600000) return `${Math.round(ms / 60000)}m`;
+	return `${Math.round(ms / 3600000)}h`;
+}

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,6 +1,6 @@
 export function formatDuration(ms: number): string {
 	if (ms < 1000) return '<1s';
-	if (ms < 60000) return `${Math.round(ms / 1000)}s`;
-	if (ms < 3600000) return `${Math.round(ms / 60000)}m`;
-	return `${Math.round(ms / 3600000)}h`;
+	if (ms < 60000) return `${Math.floor(ms / 1000)}s`;
+	if (ms < 3600000) return `${Math.floor(ms / 60000)}m`;
+	return `${Math.floor(ms / 3600000)}h`;
 }

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+import { goto } from '$app/navigation';
+import { page } from '$app/stores';
+
+const status = $derived($page.status);
+const message = $derived($page.error?.message ?? '');
+
+const title = $derived.by(() => {
+	if (status === 404) return 'Page not found';
+	if (status === 403) return 'Access denied';
+	if (status === 429) return 'Too many requests';
+	if (status >= 500) return 'Something went wrong';
+	return 'Error';
+});
+
+const description = $derived.by(() => {
+	if (message) return message;
+	if (status === 404) return "We couldn't find the page you were looking for.";
+	if (status === 403) return "You don't have permission to view this page.";
+	if (status === 429) return 'Please slow down and try again in a moment.';
+	if (status >= 500) return 'An unexpected error occurred on the server.';
+	return 'An unexpected error occurred.';
+});
+
+function goHome(): void {
+	goto('/');
+}
+
+function goBack(): void {
+	if (typeof window !== 'undefined' && window.history.length > 1) {
+		window.history.back();
+	} else {
+		goto('/');
+	}
+}
+</script>
+
+<svelte:head>
+	<title>{title} - Obzorarr</title>
+</svelte:head>
+
+<div class="error-page">
+	<div class="error-card">
+		<div class="status-code">{status}</div>
+		<h1>{title}</h1>
+		<p>{description}</p>
+		<div class="actions">
+			<button type="button" class="btn secondary" onclick={goBack}>Go back</button>
+			<button type="button" class="btn primary" onclick={goHome}>Home</button>
+		</div>
+	</div>
+</div>
+
+<style>
+	.error-page {
+		min-height: 100vh;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 2rem;
+		background: hsl(var(--background));
+	}
+
+	.error-card {
+		max-width: 480px;
+		width: 100%;
+		text-align: center;
+		background: hsl(var(--card));
+		border: 1px solid hsl(var(--border));
+		border-radius: var(--radius);
+		padding: 2.5rem 2rem;
+	}
+
+	.status-code {
+		font-size: 4rem;
+		font-weight: 800;
+		color: hsl(var(--primary));
+		line-height: 1;
+		margin-bottom: 0.5rem;
+	}
+
+	h1 {
+		font-size: 1.5rem;
+		font-weight: 600;
+		margin: 0 0 0.75rem;
+		color: hsl(var(--foreground));
+	}
+
+	p {
+		color: hsl(var(--muted-foreground));
+		margin: 0 0 2rem;
+		line-height: 1.5;
+	}
+
+	.actions {
+		display: flex;
+		gap: 0.75rem;
+		justify-content: center;
+		flex-wrap: wrap;
+	}
+
+	.btn {
+		padding: 0.625rem 1.25rem;
+		border-radius: var(--radius);
+		font-size: 0.875rem;
+		font-weight: 500;
+		cursor: pointer;
+		border: 1px solid hsl(var(--border));
+		transition: opacity 0.15s ease;
+	}
+
+	.btn:hover {
+		opacity: 0.85;
+	}
+
+	.btn.primary {
+		background: hsl(var(--primary));
+		color: hsl(var(--primary-foreground));
+		border-color: hsl(var(--primary));
+	}
+
+	.btn.secondary {
+		background: hsl(var(--muted));
+		color: hsl(var(--foreground));
+	}
+</style>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -22,10 +22,6 @@ const description = $derived.by(() => {
 	return 'An unexpected error occurred.';
 });
 
-function goHome(): void {
-	goto('/');
-}
-
 function goBack(): void {
 	if (typeof window !== 'undefined' && window.history.length > 1) {
 		window.history.back();
@@ -46,7 +42,7 @@ function goBack(): void {
 		<p>{description}</p>
 		<div class="actions">
 			<button type="button" class="btn secondary" onclick={goBack}>Go back</button>
-			<button type="button" class="btn primary" onclick={goHome}>Home</button>
+			<a href="/" class="btn primary">Home</a>
 		</div>
 	</div>
 </div>
@@ -107,6 +103,11 @@ function goBack(): void {
 		cursor: pointer;
 		border: 1px solid hsl(var(--border));
 		transition: opacity 0.15s ease;
+		text-decoration: none;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		line-height: 1;
 	}
 
 	.btn:hover {

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -8,9 +8,8 @@ import type { Actions, PageServerLoad } from './$types';
 const UsernameSchema = z.object({
 	username: z
 		.string()
-		.min(1, 'Username is required')
-		.max(100, 'Username is too long')
 		.transform((val) => val.trim())
+		.pipe(z.string().min(1, 'Username is required').max(100, 'Username is too long'))
 });
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -24,11 +23,14 @@ export const load: PageServerLoad = async ({ locals }) => {
 };
 
 export const actions: Actions = {
-	lookupUser: async ({ request, getClientAddress }) => {
+	lookupUser: async ({ request, getClientAddress, setHeaders }) => {
 		const ip = getClientAddress();
 
 		const rateLimitResult = checkRateLimit(ip);
 		if (!rateLimitResult.allowed) {
+			if (rateLimitResult.retryAfter != null) {
+				setHeaders({ 'Retry-After': rateLimitResult.retryAfter.toString() });
+			}
 			return fail(429, {
 				error: 'Too many requests. Please try again later.',
 				retryAfter: rateLimitResult.retryAfter,

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -32,7 +32,10 @@ export const load: PageServerLoad = async () => {
 					startedAt: lastSync.startedAt.toISOString(),
 					completedAt: lastSync.completedAt?.toISOString() ?? null,
 					recordsProcessed: lastSync.recordsProcessed,
-					status: lastSync.status
+					status: lastSync.status,
+					durationMs: lastSync.completedAt
+						? lastSync.completedAt.getTime() - lastSync.startedAt.getTime()
+						: null
 				}
 			: null,
 		schedulerStatus: schedulerStatus

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -15,6 +15,7 @@ import Settings from '@lucide/svelte/icons/settings';
 import SlidersHorizontal from '@lucide/svelte/icons/sliders-horizontal';
 import Star from '@lucide/svelte/icons/star';
 import Users from '@lucide/svelte/icons/users';
+import { formatDuration } from '$lib/utils/format';
 import type { PageData } from './$types';
 
 /**
@@ -195,6 +196,13 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 						<span class="sync-value highlight"
 							>{data.lastSync.recordsProcessed.toLocaleString()}</span
 						>
+					</div>
+				{/if}
+
+				{#if data.lastSync?.durationMs !== null && data.lastSync?.durationMs !== undefined}
+					<div class="sync-row">
+						<span class="sync-label">Duration</span>
+						<span class="sync-value">{formatDuration(data.lastSync.durationMs)}</span>
 					</div>
 				{/if}
 

--- a/src/routes/admin/logs/+page.server.ts
+++ b/src/routes/admin/logs/+page.server.ts
@@ -126,7 +126,11 @@ export const actions: Actions = {
 	clearLogs: async () => {
 		try {
 			const count = await deleteAllLogs();
-			return { success: true, message: `Deleted ${count} log entries` };
+			const message =
+				count === 0
+					? 'No log entries to delete'
+					: `Deleted ${count} log ${count === 1 ? 'entry' : 'entries'}`;
+			return { success: true, message };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to clear logs';
 			return fail(500, { error: message });
@@ -136,10 +140,12 @@ export const actions: Actions = {
 	runCleanup: async () => {
 		try {
 			const result = await triggerRetentionCleanup();
-			return {
-				success: true,
-				message: `Cleanup completed: ${result.byAge} deleted by age, ${result.byCount} deleted by count`
-			};
+			const total = result.byAge + result.byCount;
+			const message =
+				total === 0
+					? 'Cleanup completed: no log entries needed to be removed'
+					: `Cleanup completed: removed ${total} log ${total === 1 ? 'entry' : 'entries'} (${result.byAge} by age, ${result.byCount} by count)`;
+			return { success: true, message };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to run cleanup';
 			return fail(500, { error: message });

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -367,13 +367,16 @@ $effect(() => {
 				<span class="filter-label">Log Level</span>
 				<div class="level-checkboxes">
 					{#each logLevels as level}
+						{@const isActive = selectedLevels.includes(level)}
 						<button
 							type="button"
 							class="level-toggle {getLevelClass(level)}"
-							class:active={selectedLevels.includes(level)}
+							class:active={isActive}
+							aria-pressed={isActive}
 							onclick={() => toggleLevel(level)}
 						>
-							{level}
+							<span class="level-toggle-check" aria-hidden="true">{isActive ? '✓' : ''}</span>
+							<span class="level-toggle-label">{level}</span>
 							<span class="level-count">({visibleLevelCounts[level]})</span>
 						</button>
 					{/each}
@@ -748,19 +751,49 @@ $effect(() => {
 		}
 
 		.level-toggle {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.375rem;
 			padding: 0.375rem 0.75rem;
 			font-size: 0.75rem;
 			font-weight: 500;
-			background: hsl(var(--muted));
+			background: hsl(var(--muted) / 0.4);
 			color: hsl(var(--muted-foreground));
-			border: 1px solid hsl(var(--border));
+			border: 1px dashed hsl(var(--border));
 			border-radius: var(--radius);
 			cursor: pointer;
+			opacity: 0.7;
 			transition: all 0.15s ease;
 		}
 
 		.level-toggle:hover {
-			background: hsl(var(--muted) / 0.8);
+			background: hsl(var(--muted) / 0.7);
+			opacity: 1;
+		}
+
+		.level-toggle.active {
+			opacity: 1;
+			font-weight: 600;
+			border-style: solid;
+		}
+
+		.level-toggle-check {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			width: 0.875rem;
+			height: 0.875rem;
+			font-size: 0.75rem;
+			font-weight: 700;
+			line-height: 1;
+		}
+
+		.level-toggle:not(.active) .level-toggle-check {
+			opacity: 0.25;
+		}
+
+		.level-toggle:not(.active) .level-toggle-check::before {
+			content: '○';
 		}
 
 		.level-toggle.active.level-error {

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -40,6 +40,7 @@ import {
 	setLogRetentionDays
 } from '$lib/server/logging';
 import {
+	bulkApplyUserControl,
 	getGlobalAllowUserControl,
 	getGlobalDefaultShareMode,
 	getServerWrappedShareMode,
@@ -169,7 +170,7 @@ export const load: PageServerLoad = async () => {
 				.toLowerCase()
 				.replace(/\b\w/g, (c) => c.toUpperCase())
 		})),
-		availableYears: availableYears.length > 0 ? availableYears : [currentYear],
+		availableYears,
 		currentYear,
 		logSettings: {
 			retentionDays: logRetentionDays,
@@ -505,6 +506,20 @@ export const actions: Actions = {
 		}
 	},
 
+	bulkApplyUserControl: async ({ request }) => {
+		const formData = await request.formData();
+		const canUserControl = formData.get('canUserControl') === 'true';
+
+		try {
+			const count = await bulkApplyUserControl(canUserControl);
+			return { success: true, message: `Updated ${count} user share records` };
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : 'Failed to apply default to existing users';
+			return fail(500, { error: message });
+		}
+	},
+
 	updateServerWrappedMode: async ({ request }) => {
 		const formData = await request.formData();
 		const mode = formData.get('serverWrappedShareMode');
@@ -643,6 +658,23 @@ export const actions: Actions = {
 			return { success: true, message: 'CSRF origin cleared (using environment variable)' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to clear CSRF origin';
+			return fail(500, { error: message });
+		}
+	},
+
+	clearOpenaiKey: async () => {
+		const apiConfig = await getApiConfigWithSources();
+		if (apiConfig.openai.apiKey.isLocked) {
+			return fail(400, {
+				error: 'OpenAI API key is set via environment variable and cannot be cleared here'
+			});
+		}
+
+		try {
+			await deleteAppSetting(AppSettingsKey.OPENAI_API_KEY);
+			return { success: true, message: 'OpenAI API key cleared' };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Failed to clear OpenAI API key';
 			return fail(500, { error: message });
 		}
 	},

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -65,6 +65,10 @@ const GlobalDefaultsSchema = z.object({
 	defaultShareMode: ShareModeSchema,
 	allowUserControl: z.coerce.boolean()
 });
+const BulkUserControlSchema = z.object({
+	canUserControl: z.enum(['true', 'false']).transform((v) => v === 'true')
+});
+
 // Server-wide wrapped only supports public and private-oauth (not private-link)
 const ServerWrappedModeSchema = z.enum(['public', 'private-oauth']);
 
@@ -508,10 +512,18 @@ export const actions: Actions = {
 
 	bulkApplyUserControl: async ({ request }) => {
 		const formData = await request.formData();
-		const canUserControl = formData.get('canUserControl') === 'true';
+
+		const parsed = BulkUserControlSchema.safeParse({
+			canUserControl: formData.get('canUserControl')
+		});
+		if (!parsed.success) {
+			return fail(400, {
+				error: 'Invalid input: canUserControl must be "true" or "false"'
+			});
+		}
 
 		try {
-			const count = await bulkApplyUserControl(canUserControl);
+			const count = await bulkApplyUserControl(parsed.data.canUserControl);
 			return { success: true, message: `Updated ${count} user share records` };
 		} catch (error) {
 			const message =

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -132,6 +132,8 @@ async function bulkApplyUserControlToExistingUsers() {
 			handleFormToast({
 				error: (result.data as { error?: string })?.error ?? 'Failed to apply default.'
 			});
+		} else if (result.type === 'error') {
+			handleFormToast({ error: result.error?.message ?? 'Failed to apply default.' });
 		}
 	} catch (error) {
 		const message = error instanceof Error ? error.message : 'Failed to apply default.';

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -118,7 +118,7 @@ async function bulkApplyUserControlToExistingUsers() {
 	isBulkApplyingUserControl = true;
 
 	const formData = new FormData();
-	formData.append('canUserControl', data.globalDefaults.allowUserControl.toString());
+	formData.append('canUserControl', allowUserControl.toString());
 
 	try {
 		const response = await fetch('?/bulkApplyUserControl', {

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -45,7 +45,6 @@ import { page } from '$app/stores';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import * as Tabs from '$lib/components/ui/tabs';
 import * as Tooltip from '$lib/components/ui/tooltip';
-import { toast } from '$lib/services/toast';
 import { handleFormToast } from '$lib/utils/form-toast';
 import type { ActionData, PageData } from './$types';
 
@@ -1313,13 +1312,7 @@ const logFieldErrors = $derived(
 											isSavingCsrf = true;
 											return async ({ result, update }) => {
 												isSavingCsrf = false;
-												if (result.type === 'failure') {
-													const error = (result.data as { error?: string })?.error;
-													toast.error(error ?? 'Failed to update CSRF origin');
-													await update({ reset: false });
-												} else {
-													await update();
-												}
+												await update({ reset: result.type !== 'failure' });
 											};
 										}}
 									>

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -40,10 +40,12 @@ import VenetianMask from '@lucide/svelte/icons/venetian-mask';
 import X from '@lucide/svelte/icons/x';
 import Zap from '@lucide/svelte/icons/zap';
 import { deserialize, enhance } from '$app/forms';
+import { goto } from '$app/navigation';
 import { page } from '$app/stores';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import * as Tabs from '$lib/components/ui/tabs';
 import * as Tooltip from '$lib/components/ui/tooltip';
+import { toast } from '$lib/services/toast';
 import { handleFormToast } from '$lib/utils/form-toast';
 import type { ActionData, PageData } from './$types';
 
@@ -61,6 +63,13 @@ $effect(() => {
 		activeTab = urlTab as TabValue;
 	}
 });
+
+function selectTab(value: TabValue) {
+	activeTab = value;
+	const url = new URL($page.url);
+	url.searchParams.set('tab', value);
+	goto(url, { replaceState: true, noScroll: true, keepFocus: true });
+}
 
 /**
  * Admin Settings Page - Command Center Design
@@ -95,6 +104,43 @@ let logDebugEnabled = $state(false);
 let selectedServerWrappedMode = $state('public');
 let selectedDefaultShareMode = $state('public');
 let allowUserControl = $state(true);
+let isBulkApplyingUserControl = $state(false);
+
+async function bulkApplyUserControlToExistingUsers() {
+	if (
+		!window.confirm(
+			"This will overwrite the per-user 'can control' setting for every user. Continue?"
+		)
+	) {
+		return;
+	}
+
+	isBulkApplyingUserControl = true;
+
+	const formData = new FormData();
+	formData.append('canUserControl', data.globalDefaults.allowUserControl.toString());
+
+	try {
+		const response = await fetch('?/bulkApplyUserControl', {
+			method: 'POST',
+			body: formData
+		});
+		const result = deserialize(await response.text());
+
+		if (result.type === 'success' && result.data) {
+			handleFormToast(result.data as { success: boolean; message: string });
+		} else if (result.type === 'failure') {
+			handleFormToast({
+				error: (result.data as { error?: string })?.error ?? 'Failed to apply default.'
+			});
+		}
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'Failed to apply default.';
+		handleFormToast({ error: message });
+	} finally {
+		isBulkApplyingUserControl = false;
+	}
+}
 
 // Track sources for display
 let plexServerUrlSource = $state<'env' | 'db' | 'default'>('default');
@@ -417,7 +463,7 @@ const logFieldErrors = $derived(
 				type="button"
 				class="tab-button"
 				class:active={activeTab === tab.value}
-				onclick={() => (activeTab = tab.value)}
+				onclick={() => selectTab(tab.value)}
 			>
 				<tab.icon class="tab-icon" />
 				<span class="tab-label">{tab.label}</span>
@@ -739,6 +785,17 @@ const logFieldErrors = $derived(
 							</div>
 						{/if}
 					</form>
+
+					{#if !openaiApiKeyLocked && openaiApiKeySource === 'db'}
+						<form method="POST" action="?/clearOpenaiKey" use:enhance class="panel-form">
+							<div class="panel-actions">
+								<button type="submit" class="btn-destructive">
+									<X class="btn-icon" />
+									Clear OpenAI API Key
+								</button>
+							</div>
+						</form>
+					{/if}
 				</section>
 			</div>
 		{/if}
@@ -1126,6 +1183,21 @@ const logFieldErrors = $derived(
 						</p>
 					</div>
 					<input type="hidden" name="allowUserControl" value={allowUserControl.toString()} />
+
+					<button
+						type="button"
+						class="btn-secondary"
+						disabled={isBulkApplyingUserControl}
+						onclick={bulkApplyUserControlToExistingUsers}
+					>
+						{#if isBulkApplyingUserControl}
+							<Loader2 class="btn-icon spinning" />
+							Applying...
+						{:else}
+							<Users class="btn-icon" />
+							Apply current default to all existing users
+						{/if}
+					</button>
 				</section>
 
 				<!-- Sticky Save Button -->
@@ -1239,9 +1311,15 @@ const logFieldErrors = $derived(
 										action="?/updateCsrfOrigin"
 										use:enhance={() => {
 											isSavingCsrf = true;
-											return async ({ update }) => {
+											return async ({ result, update }) => {
 												isSavingCsrf = false;
-												await update();
+												if (result.type === 'failure') {
+													const error = (result.data as { error?: string })?.error;
+													toast.error(error ?? 'Failed to update CSRF origin');
+													await update({ reset: false });
+												} else {
+													await update();
+												}
 											};
 										}}
 									>

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -3,6 +3,7 @@ import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
 import { handleFormToast } from '$lib/utils/form-toast';
+import { formatDuration as formatDurationMs } from '$lib/utils/format';
 import type { ActionData, PageData } from './$types';
 
 interface SyncProgress {
@@ -165,11 +166,7 @@ function formatRelativeTime(isoDate: string | null): string {
 function formatDuration(start: string, end: string | null, status?: string): string {
 	if (status === 'running') return 'In progress';
 	if (!end) return '—';
-	const diffMs = new Date(end).getTime() - new Date(start).getTime();
-	if (diffMs < 1000) return '<1s';
-	if (diffMs < 60000) return `${Math.round(diffMs / 1000)}s`;
-	if (diffMs < 3600000) return `${Math.round(diffMs / 60000)}m`;
-	return `${Math.round(diffMs / 3600000)}h`;
+	return formatDurationMs(new Date(end).getTime() - new Date(start).getTime());
 }
 
 const cronPresets = [

--- a/src/routes/admin/users/+page.server.ts
+++ b/src/routes/admin/users/+page.server.ts
@@ -40,7 +40,7 @@ export const load: PageServerLoad = async ({ url }) => {
 			canUserControl: u.canUserControl
 		})),
 		year,
-		availableYears: availableYears.length > 0 ? availableYears : [year]
+		availableYears
 	};
 };
 

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -53,8 +53,11 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 			<div>
 				<h1>User Management</h1>
 				<p class="subtitle">Manage server users for {data.year}</p>
+				{#if data.availableYears.length === 0}
+					<p class="empty-hint">No watch history yet. Run a sync to populate years.</p>
+				{/if}
 			</div>
-			{#if data.availableYears.length >= 1}
+			{#if data.availableYears.length > 0}
 				<form method="GET" class="year-form">
 					<select
 						name="year"
@@ -222,6 +225,12 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 		.subtitle {
 			color: hsl(var(--muted-foreground));
 			margin: 0;
+		}
+
+		.empty-hint {
+			color: hsl(var(--muted-foreground));
+			font-size: 0.875rem;
+			margin: 0.5rem 0 0;
 		}
 
 		.page-header-row {

--- a/src/routes/auth/plex/redirect/+page.server.ts
+++ b/src/routes/auth/plex/redirect/+page.server.ts
@@ -1,9 +1,17 @@
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, request, url }) => {
 	if (locals.user) {
 		redirect(303, locals.user.isAdmin ? '/admin' : '/dashboard');
+	}
+
+	const referer = request.headers.get('referer');
+	const fromPlex = referer?.startsWith('https://app.plex.tv') ?? false;
+	const fromSameOrigin = referer?.startsWith(url.origin) ?? false;
+
+	if (!fromPlex && !fromSameOrigin) {
+		redirect(303, '/');
 	}
 
 	return {};

--- a/src/routes/auth/plex/redirect/+page.server.ts
+++ b/src/routes/auth/plex/redirect/+page.server.ts
@@ -10,7 +10,8 @@ export const load: PageServerLoad = async ({ locals, request, url }) => {
 	const fromPlex = referer?.startsWith('https://app.plex.tv') ?? false;
 	const fromSameOrigin = referer?.startsWith(url.origin) ?? false;
 
-	if (!fromPlex && !fromSameOrigin) {
+	// Allow missing/empty referer; sessionStorage PIN check on the client is the real gate.
+	if (referer && !fromPlex && !fromSameOrigin) {
 		redirect(303, '/');
 	}
 

--- a/src/routes/auth/plex/redirect/+page.server.ts
+++ b/src/routes/auth/plex/redirect/+page.server.ts
@@ -7,8 +7,16 @@ export const load: PageServerLoad = async ({ locals, request, url }) => {
 	}
 
 	const referer = request.headers.get('referer');
-	const fromPlex = referer?.startsWith('https://app.plex.tv') ?? false;
-	const fromSameOrigin = referer?.startsWith(url.origin) ?? false;
+	let refererOrigin: string | null = null;
+	if (referer) {
+		try {
+			refererOrigin = new URL(referer).origin.toLowerCase();
+		} catch {
+			refererOrigin = null;
+		}
+	}
+	const fromPlex = refererOrigin === 'https://app.plex.tv';
+	const fromSameOrigin = refererOrigin === url.origin.toLowerCase();
 
 	// Allow missing/empty referer; sessionStorage PIN check on the client is the real gate.
 	if (referer && !fromPlex && !fromSameOrigin) {

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -3,7 +3,6 @@ import { enhance } from '$app/forms';
 import { page } from '$app/stores';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import * as Tabs from '$lib/components/ui/tabs';
-import { toast } from '$lib/services/toast';
 import { handleFormToast } from '$lib/utils/form-toast';
 import type { ActionData, PageData } from './$types';
 
@@ -171,16 +170,7 @@ function getLogoModeDescription(): string {
 						use:enhance={() => {
 							isUpdating = true;
 							return async ({ result, update }) => {
-								if (result.type === 'failure') {
-									const errMsg =
-										typeof result.data?.error === 'string'
-											? result.data.error
-											: 'Failed to update share settings';
-									toast.error(errMsg);
-									await update({ reset: false });
-								} else {
-									await update();
-								}
+								await update({ reset: result.type !== 'failure' });
 								isUpdating = false;
 							};
 						}}

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -3,6 +3,7 @@ import { enhance } from '$app/forms';
 import { page } from '$app/stores';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import * as Tabs from '$lib/components/ui/tabs';
+import { toast } from '$lib/services/toast';
 import { handleFormToast } from '$lib/utils/form-toast';
 import type { ActionData, PageData } from './$types';
 
@@ -169,8 +170,17 @@ function getLogoModeDescription(): string {
 						action="?/updateShareMode"
 						use:enhance={() => {
 							isUpdating = true;
-							return async ({ update }) => {
-								await update();
+							return async ({ result, update }) => {
+								if (result.type === 'failure') {
+									const errMsg =
+										typeof result.data?.error === 'string'
+											? result.data.error
+											: 'Failed to update share settings';
+									toast.error(errMsg);
+									await update({ reset: false });
+								} else {
+									await update();
+								}
 								isUpdating = false;
 							};
 						}}

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -16,14 +16,18 @@ import {
 	getAnonymizationMode,
 	getFunFactFrequency,
 	getUITheme,
+	getWrappedLogoMode,
 	getWrappedTheme,
 	hasOpenAIEnvConfig,
 	setAnonymizationMode,
 	setFunFactFrequency,
 	setUITheme,
+	setWrappedLogoMode,
 	setWrappedTheme,
 	ThemePresets,
-	type ThemePresetType
+	type ThemePresetType,
+	WrappedLogoMode,
+	type WrappedLogoModeType
 } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
 import { OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
@@ -66,6 +70,11 @@ const SettingsSchema = z.object({
 		AnonymizationMode.ANONYMOUS,
 		AnonymizationMode.HYBRID
 	]),
+	logoMode: z.enum([
+		WrappedLogoMode.ALWAYS_SHOW,
+		WrappedLogoMode.ALWAYS_HIDE,
+		WrappedLogoMode.USER_CHOICE
+	]),
 	defaultShareMode: z.enum([ShareMode.PUBLIC, ShareMode.PRIVATE_OAUTH, ShareMode.PRIVATE_LINK]),
 	allowUserControl: z.coerce.boolean(),
 
@@ -98,6 +107,7 @@ export const load: PageServerLoad = async ({ parent }) => {
 		uiTheme,
 		wrappedTheme,
 		anonymizationMode,
+		wrappedLogoMode,
 		defaultShareMode,
 		allowUserControl,
 		slideConfigs,
@@ -106,6 +116,7 @@ export const load: PageServerLoad = async ({ parent }) => {
 		getUITheme(),
 		getWrappedTheme(),
 		getAnonymizationMode(),
+		getWrappedLogoMode(),
 		getGlobalDefaultShareMode(),
 		getGlobalAllowUserControl(),
 		getAllSlideConfigs(),
@@ -178,12 +189,31 @@ export const load: PageServerLoad = async ({ parent }) => {
 		{ value: FunFactFrequency.MANY, label: 'Many', description: '6-10 facts' }
 	];
 
+	const wrappedLogoOptions = [
+		{
+			value: WrappedLogoMode.ALWAYS_SHOW,
+			label: 'Always Show',
+			description: 'Logo always visible on wrapped pages'
+		},
+		{
+			value: WrappedLogoMode.ALWAYS_HIDE,
+			label: 'Always Hide',
+			description: 'Logo hidden on all wrapped pages'
+		},
+		{
+			value: WrappedLogoMode.USER_CHOICE,
+			label: 'User Choice',
+			description: 'Users can toggle logo visibility'
+		}
+	];
+
 	return {
 		...parentData,
 		settings: {
 			uiTheme,
 			wrappedTheme,
 			anonymizationMode,
+			wrappedLogoMode,
 			defaultShareMode,
 			allowUserControl
 		},
@@ -191,6 +221,7 @@ export const load: PageServerLoad = async ({ parent }) => {
 		themeOptions,
 		anonymizationOptions,
 		shareModeOptions,
+		wrappedLogoOptions,
 		hasOpenAI,
 		funFactConfig,
 		funFactOptions
@@ -242,6 +273,7 @@ export const actions: Actions = {
 				uiTheme: formData.get('uiTheme'),
 				wrappedTheme: formData.get('wrappedTheme'),
 				anonymizationMode: formData.get('anonymizationMode'),
+				logoMode: formData.get('logoMode'),
 				defaultShareMode: formData.get('defaultShareMode'),
 				allowUserControl: formData.get('allowUserControl'),
 				enabledSlides: formData.get('enabledSlides'),
@@ -266,6 +298,7 @@ export const actions: Actions = {
 
 				// Privacy
 				setAnonymizationMode(data.anonymizationMode as AnonymizationModeType),
+				setWrappedLogoMode(data.logoMode as WrappedLogoModeType),
 				setGlobalShareDefaults({
 					defaultShareMode: data.defaultShareMode as ShareModeType,
 					allowUserControl: data.allowUserControl

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -18,6 +18,7 @@ let { data, form }: { data: PageData; form: ActionData } = $props();
 let uiTheme = $state(untrack(() => data.settings.uiTheme));
 let wrappedTheme = $state(untrack(() => data.settings.wrappedTheme));
 let anonymizationMode = $state(untrack(() => data.settings.anonymizationMode));
+let wrappedLogoMode = $state(untrack(() => data.settings.wrappedLogoMode));
 let defaultShareMode = $state(untrack(() => data.settings.defaultShareMode));
 let allowUserControl = $state(untrack(() => data.settings.allowUserControl));
 let enableFunFacts = $state(untrack(() => data.funFactConfig.count > 0));
@@ -220,6 +221,7 @@ function getThemeColors(themeValue: string) {
 				<input type="hidden" name="uiTheme" value={uiTheme} />
 				<input type="hidden" name="wrappedTheme" value={wrappedTheme} />
 				<input type="hidden" name="anonymizationMode" value={anonymizationMode} />
+				<input type="hidden" name="logoMode" value={wrappedLogoMode} />
 				<input type="hidden" name="defaultShareMode" value={defaultShareMode} />
 				<input type="hidden" name="allowUserControl" value={allowUserControl} />
 				<input type="hidden" name="enabledSlides" value={enabledSlidesString} />
@@ -324,6 +326,33 @@ function getThemeColors(themeValue: string) {
 												value={option.value}
 												checked={anonymizationMode === option.value}
 												onchange={() => (anonymizationMode = option.value)}
+											/>
+											<div class="radio-card-content">
+												<div class="radio-indicator">
+													<div class="radio-dot"></div>
+												</div>
+												<div class="radio-text">
+													<span class="radio-label">{option.label}</span>
+													<span class="radio-description">{option.description}</span>
+												</div>
+											</div>
+										</label>
+									{/each}
+								</div>
+							</div>
+
+							<div class="setting-group">
+								<span class="setting-label">Wrapped Page Logo</span>
+								<p class="setting-description">Control logo visibility on wrapped pages</p>
+								<div class="radio-cards">
+									{#each data.wrappedLogoOptions as option}
+										<label class="radio-card" class:selected={wrappedLogoMode === option.value}>
+											<input
+												type="radio"
+												name="wrappedLogoModeRadio"
+												value={option.value}
+												checked={wrappedLogoMode === option.value}
+												onchange={() => (wrappedLogoMode = option.value)}
 											/>
 											<div class="radio-card-content">
 												<div class="radio-indicator">

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -76,18 +76,18 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 
 			// Verify year matches the token's year
 			if (tokenResult.year !== year) {
-				error(404, 'Wrapped not found');
+				error(404, 'This share link is invalid, expired, or has been revoked.');
 			}
 		} catch (err) {
 			if (err instanceof InvalidShareTokenError) {
-				error(404, 'Wrapped not found');
+				error(404, 'This share link is invalid, expired, or has been revoked.');
 			}
 			throw err;
 		}
 	} else {
 		const parsedId = parseInt(identifier, 10);
 		if (Number.isNaN(parsedId) || parsedId <= 0) {
-			error(404, 'Invalid identifier');
+			error(404, "We couldn't find a Wrapped page for that link.");
 		}
 		userId = parsedId;
 
@@ -102,7 +102,7 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 				error(403, err.message);
 			}
 			if (err instanceof InvalidShareTokenError) {
-				error(404, 'Wrapped not found');
+				error(404, 'This share link is invalid, expired, or has been revoked.');
 			}
 			throw err;
 		}


### PR DESCRIPTION
## Summary

Addresses 20 actionable findings surfaced by the dogfood E2E QA pass after PR #68. Changes are surgical and grouped by severity; all type checks pass (`bun run check` clean).

## Major

- **Retroactive `allow_user_control` apply.** New explicit button on `/admin/settings` to apply the global default to existing per-user share records. No silent backfill.
- **Privacy floor toast.** `/dashboard/settings` now surfaces a toast when the server rejects a chosen share mode; previously the UI reset silently.

## Medium

- **Marathon-day cap at 24h.** `calculateMarathonDay()` now clamps per-day totals to 1440 minutes so overlapping/duplicated history records cannot produce >24h days.
- **OAuth redirect rate limit.** New `authRedirect` bucket (30/min) for `/auth/plex/redirect` instead of the stricter generic `auth` bucket. The page also redirects visitors home when there is no active OAuth flow.
- **Log level filter indicator.** Level toggles now render an inline check/ring glyph plus `aria-pressed` so active filters are obvious at a glance.

## Minor

- Friendly error page at `src/routes/+error.svelte` covering 404/403/429/5xx.
- New `$lib/utils/format.ts` exporting `formatDuration`, extracted from `admin/sync` and now shown on the admin dashboard's sync widget.
- Wrapped logo visibility mode is configurable during onboarding.
- Admin year selectors show an empty-state hint when no watch history exists instead of a lone current-year option.
- OpenAI API key can be cleared from `/admin/settings`.
- CSRF origin validation failures now raise an explicit toast.
- Settings page active tab is written back to the URL so it is bookmarkable.
- Log cleanup reports the exact number of entries removed.

## Low

- Share-token 404 wording now explains expiry/invalidation rather than saying "not found".
- `lookupUser` rate-limited failures set `Retry-After`.
- Username validation runs after `.trim()`, so whitespace-only input is rejected.
- Story-mode left-edge tap zone uses `<=` so the first pixel no longer skips to the next slide.

## Deferred

- W4-F5 Story Mode position regression — code path looks correct on inspection; needs a concrete repro before a targeted fix.
- `plexAccounts` mapping investigation (dogfood §5 item #8) — out of scope for this plan.
- W1.1-F4 JSON parse warning — real origin is not `plex-oauth.ts`; needs a browser-side stack trace to retarget.

## Test plan

- [ ] `bun run check` passes locally (0 errors / 0 warnings).
- [ ] Manually toggle "allow user control" global default, click the apply button, confirm per-user state updates and toast reports count.
- [ ] Attempt a share-mode change that exceeds the global floor as a non-admin user; confirm toast surfaces.
- [ ] Visit `/auth/plex/redirect` directly (no flow); confirm redirect to `/`.
- [ ] Onboarding flow: verify wrapped logo mode control appears in the privacy sub-step and persists.
- [ ] Open the wrapped page, tap the left edge pixel-by-pixel, confirm the boundary triggers "previous" reliably.
- [ ] Hit a nonexistent route (e.g. `/admin/data`), confirm the new error page renders.
- [ ] Trigger a 429 on the landing-page username lookup, confirm `Retry-After` header on the response.