### PR TITLE
fix: resolve QA dogfood findings waves 1-5

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -96,6 +96,7 @@
    ============================================================================= */
 
 /* Theme: Modern Minimal (Default) - Clean blue aesthetic */
+html[data-theme="modern-minimal"],
 .theme-modern-minimal {
 	--font-sans: "Inter", system-ui, sans-serif;
 	--background: 0 0% 8%;
@@ -122,6 +123,7 @@
 }
 
 /* Theme: Supabase - Teal/green brand colors */
+html[data-theme="supabase"],
 .theme-supabase {
 	--font-sans: "Outfit", system-ui, sans-serif;
 	--background: 0 0% 6%;
@@ -148,6 +150,7 @@
 }
 
 /* Theme: Doom 64 - Retro orange/brown gaming aesthetic */
+html[data-theme="doom-64"],
 .theme-doom-64 {
 	--font-sans: "Oxanium", system-ui, sans-serif;
 	--background: 0 0% 9%;
@@ -174,6 +177,7 @@
 }
 
 /* Theme: Amber Minimal - Warm amber/yellow tones */
+html[data-theme="amber-minimal"],
 .theme-amber-minimal {
 	--font-sans: "Inter", system-ui, sans-serif;
 	--background: 0 0% 8%;
@@ -200,6 +204,7 @@
 }
 
 /* Theme: Soviet Red - Classic red aesthetic */
+html[data-theme="soviet-red"],
 .theme-soviet-red {
 	--font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 	--background: 0 0% 6%;
@@ -231,6 +236,7 @@
    ============================================================================= */
 
 /* Theme: Obsidian Premium - Deep blacks with purple/platinum accents */
+html[data-theme="obsidian-premium"],
 .theme-obsidian-premium {
 	--font-sans: "Inter", system-ui, sans-serif;
 	--background: 260 15% 4%;
@@ -285,6 +291,7 @@
 }
 
 /* Theme: Aurora Premium - Teal to cyan/magenta iridescent */
+html[data-theme="aurora-premium"],
 .theme-aurora-premium {
 	--font-sans: "Outfit", system-ui, sans-serif;
 	--background: 200 30% 4%;
@@ -339,6 +346,7 @@
 }
 
 /* Theme: Champagne Premium - Warm golds with rose gold accents */
+html[data-theme="champagne-premium"],
 .theme-champagne-premium {
 	--font-sans: "Inter", system-ui, sans-serif;
 	--background: 35 15% 5%;

--- a/src/app.html
+++ b/src/app.html
@@ -7,7 +7,7 @@
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		%sveltekit.head%
-		<script>
+		<script nonce="%sveltekit.nonce%">
 			(function () {
 				try {
 					var validThemes = ['modern-minimal','supabase','doom-64','amber-minimal','soviet-red','obsidian-premium','aurora-premium','champagne-premium'];
@@ -29,7 +29,7 @@
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>
-		<script>
+		<script nonce="%sveltekit.nonce%">
 			(function () {
 				try {
 					var theme = document.documentElement.getAttribute('data-theme');

--- a/src/app.html
+++ b/src/app.html
@@ -24,10 +24,6 @@
 				} catch (e) {}
 			})();
 		</script>
-		<style>
-			/* Set body class before hydration to prevent FOUC */
-			html[data-theme] body { /* no-op, placeholder to force cascade re-evaluation */ }
-		</style>
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>

--- a/src/app.html
+++ b/src/app.html
@@ -7,8 +7,40 @@
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		%sveltekit.head%
+		<script>
+			(function () {
+				try {
+					var cookies = document.cookie || '';
+					var ui = (cookies.match(/(?:^|;\s*)ui_theme=([^;]+)/) || [])[1];
+					var wrapped = (cookies.match(/(?:^|;\s*)wrapped_theme=([^;]+)/) || [])[1];
+					var isWrapped = location.pathname.indexOf('/wrapped') === 0;
+					var theme = decodeURIComponent(
+						(isWrapped ? wrapped : ui) || ui || 'modern-minimal'
+					);
+					document.documentElement.setAttribute('data-theme', theme);
+					if (isWrapped) {
+						document.documentElement.setAttribute('data-wrapped-route', '1');
+					}
+				} catch (e) {}
+			})();
+		</script>
+		<style>
+			/* Set body class before hydration to prevent FOUC */
+			html[data-theme] body { /* no-op, placeholder to force cascade re-evaluation */ }
+		</style>
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>
+		<script>
+			(function () {
+				try {
+					var theme = document.documentElement.getAttribute('data-theme');
+					var isWrapped =
+						document.documentElement.getAttribute('data-wrapped-route') === '1';
+					if (theme) document.body.classList.add('theme-' + theme);
+					if (isWrapped) document.body.classList.add('wrapped-route');
+				} catch (e) {}
+			})();
+		</script>
 	</body>
 </html>

--- a/src/app.html
+++ b/src/app.html
@@ -10,13 +10,15 @@
 		<script>
 			(function () {
 				try {
+					var validThemes = ['modern-minimal','supabase','doom-64','amber-minimal','soviet-red','obsidian-premium','aurora-premium','champagne-premium'];
 					var cookies = document.cookie || '';
 					var ui = (cookies.match(/(?:^|;\s*)ui_theme=([^;]+)/) || [])[1];
 					var wrapped = (cookies.match(/(?:^|;\s*)wrapped_theme=([^;]+)/) || [])[1];
 					var isWrapped = location.pathname.indexOf('/wrapped') === 0;
-					var theme = decodeURIComponent(
-						(isWrapped ? wrapped : ui) || ui || 'modern-minimal'
-					);
+					var raw = (isWrapped ? wrapped : ui) || ui || '';
+					var theme = 'modern-minimal';
+					try { theme = decodeURIComponent(raw) || 'modern-minimal'; } catch (e) {}
+					if (validThemes.indexOf(theme) === -1) theme = 'modern-minimal';
 					document.documentElement.setAttribute('data-theme', theme);
 					if (isWrapped) {
 						document.documentElement.setAttribute('data-wrapped-route', '1');

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,5 @@
 import type { Handle, HandleServerError } from '@sveltejs/kit';
-import { isRedirect, redirect } from '@sveltejs/kit';
+import { isRedirect } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
@@ -30,6 +30,16 @@ const securityHeadersHandle: Handle = async ({ event, resolve }) => {
 	const response = await resolve(event);
 	return applySecurityHeaders(response, event.request);
 };
+
+function redirectResponse(event: { request: Request }, location: string): Response {
+	return applySecurityHeaders(
+		new Response(null, {
+			status: 303,
+			headers: { Location: location }
+		}),
+		event.request
+	);
+}
 
 const proxyHandle: Handle = async ({ event, resolve }) => {
 	const proto = event.request.headers.get('x-forwarded-proto');
@@ -194,7 +204,7 @@ const onboardingHandle: Handle = async ({ event, resolve }) => {
 
 		if (needsOnboarding) {
 			const currentStep = await getOnboardingStep();
-			redirect(303, `/onboarding/${currentStep}`);
+			return redirectResponse(event, `/onboarding/${currentStep}`);
 		}
 	} catch (error) {
 		// Re-throw redirects - they are expected behavior, not errors
@@ -212,16 +222,9 @@ const onboardingHandle: Handle = async ({ event, resolve }) => {
 };
 
 const authorizationHandle: Handle = async ({ event, resolve }) => {
-	// Check if this is an admin route
 	if (event.url.pathname.startsWith('/admin')) {
-		// Require authentication
-		if (!event.locals.user) {
-			redirect(303, '/');
-		}
-
-		// Require admin privileges
-		if (!event.locals.user.isAdmin) {
-			redirect(303, '/');
+		if (!event.locals.user || !event.locals.user.isAdmin) {
+			return redirectResponse(event, '/');
 		}
 	}
 

--- a/src/lib/components/wrapped/ProgressBar.svelte
+++ b/src/lib/components/wrapped/ProgressBar.svelte
@@ -57,18 +57,18 @@ let { current, total, class: klass = '' }: Props = $props();
 		}
 
 		.segment.completed {
-			background-color: var(--primary, #dc2626);
+			background-color: hsl(var(--primary));
 			opacity: 1;
 		}
 
 		.segment.active {
-			background-color: var(--primary, #dc2626);
+			background-color: hsl(var(--primary));
 			opacity: 1;
 			animation: pulse 2s ease-in-out infinite;
 		}
 
 		.segment.pending {
-			background-color: var(--muted, rgba(255, 255, 255, 0.3));
+			background-color: hsl(var(--muted) / 0.3);
 			opacity: 0.5;
 		}
 

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -235,10 +235,10 @@ $effect(() => {
 									optimisticShareToken = undefined;
 								}
 								await update();
-								optimisticMode = null;
-								optimisticShareToken = undefined;
 							} finally {
 								isUpdating = false;
+								optimisticMode = null;
+								optimisticShareToken = undefined;
 							}
 						};
 					}}

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -38,14 +38,6 @@ let isUpdating = $state(false);
 let optimisticMode = $state<ShareModeType | null>(null);
 let optimisticShareToken = $state<string | null | undefined>(undefined);
 
-// Reset optimistic state when server data updates
-$effect.pre(() => {
-	if (shareSettings?.mode) {
-		optimisticMode = null;
-		optimisticShareToken = undefined;
-	}
-});
-
 const displayMode = $derived(optimisticMode ?? shareSettings?.mode);
 const displayShareToken = $derived(
 	optimisticShareToken === undefined ? shareSettings?.shareToken : optimisticShareToken
@@ -243,13 +235,15 @@ $effect(() => {
 									optimisticShareToken = undefined;
 								}
 								await update();
+								optimisticMode = null;
+								optimisticShareToken = undefined;
 							} finally {
 								isUpdating = false;
 							}
 						};
 					}}
 				>
-					<div class="mode-options">
+					<div class="mode-options" role="radiogroup" aria-labelledby="visibility-label">
 						{#each availableModes as mode}
 							<label class="mode-option" class:active={displayMode === mode}>
 								<input

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -333,13 +333,13 @@ function handleSlideAnimationComplete(): void {}
 
 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
 <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
 <div
 	bind:this={container}
 	class="story-mode {klass}"
 	role="application"
 	aria-label="Story presentation - use arrow keys to navigate"
 	onclick={handleClick}
-	onkeydown={handleKeyDown}
 	ontouchstart={handleTouchStart}
 	ontouchend={handleTouchEnd}
 	tabindex="0"

--- a/src/lib/server/security/csrf-handle.ts
+++ b/src/lib/server/security/csrf-handle.ts
@@ -2,6 +2,7 @@ import type { Handle } from '@sveltejs/kit';
 import { dev } from '$app/environment';
 import { getCsrfConfigWithSource } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
+import { applySecurityHeaders } from './security-headers';
 
 const STATE_CHANGING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
 
@@ -62,10 +63,13 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 			method,
 			path: event.url.pathname
 		});
-		return new Response(JSON.stringify({ error: 'CSRF check failed: missing origin header' }), {
-			status: 403,
-			headers: { 'Content-Type': 'application/json' }
-		});
+		return applySecurityHeaders(
+			new Response(JSON.stringify({ error: 'CSRF check failed: missing origin header' }), {
+				status: 403,
+				headers: { 'Content-Type': 'application/json' }
+			}),
+			event.request
+		);
 	}
 
 	// Compare origins (case-insensitive per URL spec)
@@ -76,10 +80,13 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 			expected: expectedOrigin,
 			received: requestOrigin
 		});
-		return new Response(JSON.stringify({ error: 'CSRF check failed: origin mismatch' }), {
-			status: 403,
-			headers: { 'Content-Type': 'application/json' }
-		});
+		return applySecurityHeaders(
+			new Response(JSON.stringify({ error: 'CSRF check failed: origin mismatch' }), {
+				status: 403,
+				headers: { 'Content-Type': 'application/json' }
+			}),
+			event.request
+		);
 	}
 
 	return resolve(event);

--- a/src/lib/server/security/request-filter.ts
+++ b/src/lib/server/security/request-filter.ts
@@ -1,6 +1,7 @@
 import type { Handle } from '@sveltejs/kit';
 import { logger } from '$lib/server/logging';
 import { isBlockedPath, isBlockedUserAgent } from './request-filter-patterns';
+import { applySecurityHeaders } from './security-headers';
 
 export const requestFilterHandle: Handle = async ({ event, resolve }) => {
 	const path = event.url.pathname;
@@ -9,12 +10,24 @@ export const requestFilterHandle: Handle = async ({ event, resolve }) => {
 
 	if (isBlockedPath(path)) {
 		logger.debug(`Blocked scanner probe: ${path}`, 'Security', { ip });
-		return new Response('Not Found', { status: 404 });
+		return applySecurityHeaders(
+			new Response(JSON.stringify({ error: 'Not Found' }), {
+				status: 404,
+				headers: { 'Content-Type': 'application/json' }
+			}),
+			event.request
+		);
 	}
 
 	if (isBlockedUserAgent(userAgent)) {
 		logger.debug(`Blocked suspicious user-agent: ${userAgent}`, 'Security', { ip });
-		return new Response('Forbidden', { status: 403 });
+		return applySecurityHeaders(
+			new Response(JSON.stringify({ error: 'Forbidden' }), {
+				status: 403,
+				headers: { 'Content-Type': 'application/json' }
+			}),
+			event.request
+		);
 	}
 
 	return resolve(event);

--- a/src/lib/server/security/security-headers.ts
+++ b/src/lib/server/security/security-headers.ts
@@ -1,3 +1,5 @@
+import { dev } from '$app/environment';
+
 const CSP_DIRECTIVES = [
 	"default-src 'self'",
 	"img-src 'self' https://plex.tv https://*.plex.direct data:",
@@ -15,7 +17,9 @@ export function applySecurityHeaders(response: Response, request: Request): Resp
 	response.headers.set('X-Content-Type-Options', 'nosniff');
 	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
 	response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-	response.headers.set('Content-Security-Policy', CSP_DIRECTIVES);
+	if (!dev) {
+		response.headers.set('Content-Security-Policy', CSP_DIRECTIVES);
+	}
 
 	const isHttps =
 		new URL(request.url).protocol === 'https:' ||

--- a/src/lib/server/security/security-headers.ts
+++ b/src/lib/server/security/security-headers.ts
@@ -1,8 +1,21 @@
+const CSP_DIRECTIVES = [
+	"default-src 'self'",
+	"img-src 'self' https://plex.tv https://*.plex.direct data:",
+	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+	"font-src 'self' https://fonts.gstatic.com",
+	"script-src 'self' 'unsafe-inline'",
+	"connect-src 'self' https://plex.tv",
+	"frame-ancestors 'none'",
+	"base-uri 'self'",
+	"form-action 'self'"
+].join('; ');
+
 export function applySecurityHeaders(response: Response, request: Request): Response {
 	response.headers.set('X-Frame-Options', 'DENY');
 	response.headers.set('X-Content-Type-Options', 'nosniff');
 	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
 	response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+	response.headers.set('Content-Security-Policy', CSP_DIRECTIVES);
 
 	const isHttps =
 		new URL(request.url).protocol === 'https:' ||

--- a/src/lib/server/security/security-headers.ts
+++ b/src/lib/server/security/security-headers.ts
@@ -1,25 +1,10 @@
-import { dev } from '$app/environment';
-
-const CSP_DIRECTIVES = [
-	"default-src 'self'",
-	"img-src 'self' https://plex.tv https://*.plex.direct data:",
-	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-	"font-src 'self' https://fonts.gstatic.com",
-	"script-src 'self' 'unsafe-inline'",
-	"connect-src 'self' https://plex.tv",
-	"frame-ancestors 'none'",
-	"base-uri 'self'",
-	"form-action 'self'"
-].join('; ');
-
 export function applySecurityHeaders(response: Response, request: Request): Response {
 	response.headers.set('X-Frame-Options', 'DENY');
 	response.headers.set('X-Content-Type-Options', 'nosniff');
 	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
 	response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-	if (!dev) {
-		response.headers.set('Content-Security-Policy', CSP_DIRECTIVES);
-	}
+	// Content-Security-Policy is managed by SvelteKit's kit.csp (svelte.config.js)
+	// using nonce mode, which eliminates the need for 'unsafe-inline' on script-src.
 
 	const isHttps =
 		new URL(request.url).protocol === 'https:' ||

--- a/src/lib/server/sharing/access-control.ts
+++ b/src/lib/server/sharing/access-control.ts
@@ -104,10 +104,10 @@ export async function checkWrappedAccess(
 			case 'invalid_token':
 				throw new InvalidShareTokenError();
 			case 'not_authenticated':
-				throw new ShareAccessDeniedError('You must be logged in to view this page.');
+				throw new ShareAccessDeniedError('Sign in with your Plex account to view this wrapped.');
 			case 'mode_requires_auth':
 				throw new ShareAccessDeniedError(
-					'You must be a member of this Plex server to view this page.'
+					'This wrapped is visible only to members of this Plex server. Sign in with your Plex account to view.'
 				);
 			default:
 				throw new ShareAccessDeniedError();
@@ -180,10 +180,10 @@ export async function checkServerWrappedAccess(
 	if (!result.allowed) {
 		switch (result.denialReason) {
 			case 'not_authenticated':
-				throw new ShareAccessDeniedError('You must be logged in to view this page.');
+				throw new ShareAccessDeniedError('Sign in with your Plex account to view this wrapped.');
 			case 'mode_requires_auth':
 				throw new ShareAccessDeniedError(
-					'You must be a member of this Plex server to view this page.'
+					'This wrapped is visible only to members of this Plex server. Sign in with your Plex account to view.'
 				);
 			default:
 				throw new ShareAccessDeniedError();

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,10 +1,24 @@
-import { getUITheme } from '$lib/server/admin/settings.service';
+import { getUITheme, getWrappedTheme } from '$lib/server/admin/settings.service';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async () => {
-	const uiTheme = await getUITheme();
+export const load: LayoutServerLoad = async ({ cookies }) => {
+	const [uiTheme, wrappedTheme] = await Promise.all([getUITheme(), getWrappedTheme()]);
+
+	cookies.set('ui_theme', uiTheme, {
+		path: '/',
+		httpOnly: false,
+		sameSite: 'lax',
+		maxAge: 60 * 60 * 24 * 365
+	});
+	cookies.set('wrapped_theme', wrappedTheme, {
+		path: '/',
+		httpOnly: false,
+		sameSite: 'lax',
+		maxAge: 60 * 60 * 24 * 365
+	});
 
 	return {
-		uiTheme
+		uiTheme,
+		wrappedTheme
 	};
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -37,6 +37,9 @@ $effect(() => {
 	// Add the effective theme class
 	document.body.classList.add(themeClass);
 
+	// Keep <html data-theme> (set by pre-paint script) in sync with live changes
+	document.documentElement.setAttribute('data-theme', effectiveTheme);
+
 	// Add/remove wrapped route class for full-viewport theming
 	if (isWrappedRoute) {
 		document.body.classList.add('wrapped-route');

--- a/src/routes/admin/+layout.server.ts
+++ b/src/routes/admin/+layout.server.ts
@@ -2,12 +2,14 @@ import {
 	getCsrfConfigWithSource,
 	isCsrfWarningDismissed
 } from '$lib/server/admin/settings.service';
+import { getUserFullProfile } from '$lib/server/admin/users.service';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
-	const [csrfConfig, csrfWarningDismissed] = await Promise.all([
+	const [csrfConfig, csrfWarningDismissed, profile] = await Promise.all([
 		getCsrfConfigWithSource(),
-		isCsrfWarningDismissed()
+		isCsrfWarningDismissed(),
+		getUserFullProfile(locals.user!.id)
 	]);
 
 	const showCsrfWarning = csrfConfig.origin.source === 'default' && !csrfWarningDismissed;
@@ -16,7 +18,8 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 		adminUser: {
 			id: locals.user!.id,
 			username: locals.user!.username,
-			isAdmin: locals.user!.isAdmin
+			isAdmin: locals.user!.isAdmin,
+			thumb: profile?.thumb ?? null
 		},
 		currentYear: new Date().getFullYear(),
 		csrfWarning: {

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -58,6 +58,7 @@ const isActive = $derived((href: string) => {
 
 // Mobile sidebar state
 let sidebarOpen = $state(false);
+let adminAvatarError = $state(false);
 
 // CSRF warning state - derived from data with local override for immediate dismiss
 let locallyDismissed = $state(false);
@@ -157,13 +158,13 @@ function handleCsrfWarningDismissed() {
 		<div class="sidebar-footer">
 			<div class="user-card">
 				<div class="user-avatar">
-					{#if data.adminUser.thumb}
+					{#if data.adminUser.thumb && !adminAvatarError}
 						<img
 							src={data.adminUser.thumb}
 							alt={data.adminUser.username}
 							class="user-avatar-img"
-							onerror={(e) => {
-								(e.currentTarget as HTMLImageElement).style.display = 'none';
+							onerror={() => {
+								adminAvatarError = true;
 							}}
 						/>
 					{:else}

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -134,7 +134,13 @@ function handleCsrfWarningDismissed() {
 				{#each navItems as item (item.href)}
 					{@const active = isActive(item.href)}
 					<li>
-						<a href={item.href} class="nav-link" class:active onclick={closeSidebar}>
+						<a
+							href={item.href}
+							class="nav-link"
+							class:active
+							aria-current={active ? 'page' : undefined}
+							onclick={closeSidebar}
+						>
 							<span class="nav-icon-wrap" class:active>
 								<item.icon class="nav-icon" />
 							</span>
@@ -151,7 +157,18 @@ function handleCsrfWarningDismissed() {
 		<div class="sidebar-footer">
 			<div class="user-card">
 				<div class="user-avatar">
-					<User class="user-avatar-icon" />
+					{#if data.adminUser.thumb}
+						<img
+							src={data.adminUser.thumb}
+							alt={data.adminUser.username}
+							class="user-avatar-img"
+							onerror={(e) => {
+								(e.currentTarget as HTMLImageElement).style.display = 'none';
+							}}
+						/>
+					{:else}
+						<User class="user-avatar-icon" />
+					{/if}
 				</div>
 				<div class="user-info">
 					<span class="user-name">{data.adminUser.username}</span>
@@ -406,12 +423,20 @@ function handleCsrfWarningDismissed() {
 			background: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--primary) / 0.8) 100%);
 			border-radius: 0.5rem;
 			flex-shrink: 0;
+			overflow: hidden;
 		}
 
 		.user-avatar :global(.user-avatar-icon) {
 			width: 1.125rem;
 			height: 1.125rem;
 			color: hsl(var(--primary-foreground));
+		}
+
+		.user-avatar-img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			display: block;
 		}
 
 		.user-info {

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -60,6 +60,12 @@ const isActive = $derived((href: string) => {
 let sidebarOpen = $state(false);
 let adminAvatarError = $state(false);
 
+// Reset avatar error when thumb URL changes so a new URL gets a fresh load attempt
+$effect(() => {
+	data.adminUser.thumb;
+	adminAvatarError = false;
+});
+
 // CSRF warning state - derived from data with local override for immediate dismiss
 let locallyDismissed = $state(false);
 let showCsrfWarning = $derived(data.csrfWarning.show && !locallyDismissed);

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -373,7 +373,7 @@ $effect(() => {
 							type="button"
 							class="level-toggle {getLevelClass(level)}"
 							class:active={isActive}
-							aria-pressed={isShown}
+							aria-pressed={isActive}
 							onclick={() => toggleLevel(level)}
 						>
 							<span class="level-toggle-check" aria-hidden="true">{isActive ? '✓' : ''}</span>

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -368,11 +368,12 @@ $effect(() => {
 				<div class="level-checkboxes">
 					{#each logLevels as level}
 						{@const isActive = selectedLevels.includes(level)}
+						{@const isShown = selectedLevels.length === 0 || isActive}
 						<button
 							type="button"
 							class="level-toggle {getLevelClass(level)}"
 							class:active={isActive}
-							aria-pressed={isActive}
+							aria-pressed={isShown}
 							onclick={() => toggleLevel(level)}
 						>
 							<span class="level-toggle-check" aria-hidden="true">{isActive ? '✓' : ''}</span>
@@ -412,8 +413,14 @@ $effect(() => {
 				<input
 					type="datetime-local"
 					id="from-date"
-					bind:value={fromDate}
-					onchange={() => applyFilters()}
+					value={fromDate}
+					oninput={(e) => {
+						fromDate = e.currentTarget.value;
+					}}
+					onchange={(e) => {
+						fromDate = e.currentTarget.value;
+						applyFilters();
+					}}
 				/>
 			</div>
 
@@ -423,8 +430,14 @@ $effect(() => {
 				<input
 					type="datetime-local"
 					id="to-date"
-					bind:value={toDate}
-					onchange={() => applyFilters()}
+					value={toDate}
+					oninput={(e) => {
+						toDate = e.currentTarget.value;
+					}}
+					onchange={(e) => {
+						toDate = e.currentTarget.value;
+						applyFilters();
+					}}
 				/>
 			</div>
 		</div>

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -368,7 +368,6 @@ $effect(() => {
 				<div class="level-checkboxes">
 					{#each logLevels as level}
 						{@const isActive = selectedLevels.includes(level)}
-						{@const isShown = selectedLevels.length === 0 || isActive}
 						<button
 							type="button"
 							class="level-toggle {getLevelClass(level)}"

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -1,5 +1,6 @@
 import { fail } from '@sveltejs/kit';
 import { z } from 'zod';
+import { env } from '$env/dynamic/private';
 import {
 	AnonymizationMode,
 	type AnonymizationModeType,
@@ -226,8 +227,12 @@ export const actions: Actions = {
 			if (parsed.data.plexToken && !apiConfig.plex.token.isLocked) {
 				await setAppSetting(AppSettingsKey.PLEX_TOKEN, parsed.data.plexToken);
 			}
-			if (parsed.data.openaiApiKey && !apiConfig.openai.apiKey.isLocked) {
-				await setAppSetting(AppSettingsKey.OPENAI_API_KEY, parsed.data.openaiApiKey);
+			if (!apiConfig.openai.apiKey.isLocked) {
+				if (parsed.data.openaiApiKey) {
+					await setAppSetting(AppSettingsKey.OPENAI_API_KEY, parsed.data.openaiApiKey);
+				} else if (parsed.data.openaiApiKey === '') {
+					await deleteAppSetting(AppSettingsKey.OPENAI_API_KEY);
+				}
 			}
 			if (parsed.data.openaiBaseUrl && !apiConfig.openai.baseUrl.isLocked) {
 				await setAppSetting(AppSettingsKey.OPENAI_BASE_URL, parsed.data.openaiBaseUrl);
@@ -300,7 +305,7 @@ export const actions: Actions = {
 
 	updateWrappedTheme: async ({ request }) => {
 		const formData = await request.formData();
-		const theme = formData.get('theme');
+		const theme = formData.get('wrappedTheme') ?? formData.get('theme');
 
 		const parsed = ThemeSchema.safeParse(theme);
 		if (!parsed.success) {
@@ -649,7 +654,10 @@ export const actions: Actions = {
 		} else {
 			try {
 				await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN);
-				return { success: true, message: 'CSRF origin cleared (using environment variable)' };
+				const message = env.ORIGIN
+					? 'CSRF origin cleared. Application now uses environment variable.'
+					: 'CSRF origin cleared. CSRF protection is currently disabled — set ORIGIN env or re-add an origin.';
+				return { success: true, message };
 			} catch (error) {
 				const message = error instanceof Error ? error.message : 'Failed to clear CSRF origin';
 				return fail(500, { error: message });
@@ -667,7 +675,10 @@ export const actions: Actions = {
 
 		try {
 			await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN);
-			return { success: true, message: 'CSRF origin cleared (using environment variable)' };
+			const message = env.ORIGIN
+				? 'CSRF origin cleared. Application now uses environment variable.'
+				: 'CSRF origin cleared. CSRF protection is currently disabled — set ORIGIN env or re-add an origin.';
+			return { success: true, message };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to clear CSRF origin';
 			return fail(500, { error: message });
@@ -695,7 +706,7 @@ export const actions: Actions = {
 		try {
 			await resetCsrfWarningDismissal();
 			logger.info('CSRF warning re-enabled by admin', 'Security');
-			return { success: true, message: 'CSRF warning will now be shown again' };
+			return { success: true, message: 'CSRF warning re-enabled for this user' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to reset CSRF warning';
 			logger.error(`Failed to reset CSRF warning: ${message}`, 'Security');

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -787,7 +787,7 @@ const logFieldErrors = $derived(
 						{/if}
 					</form>
 
-					{#if !openaiApiKeyLocked && openaiApiKeySource === 'db'}
+					{#if !openaiApiKeyLocked}
 						<form method="POST" action="?/clearOpenaiKey" use:enhance class="panel-form">
 							<div class="panel-actions">
 								<button type="submit" class="btn-destructive">
@@ -865,7 +865,7 @@ const logFieldErrors = $derived(
 								<label class="theme-card" class:selected={selectedWrappedTheme === theme.value}>
 									<input
 										type="radio"
-										name="theme"
+										name="wrappedTheme"
 										value={theme.value}
 										bind:group={selectedWrappedTheme}
 									/>
@@ -1370,9 +1370,14 @@ const logFieldErrors = $derived(
 										action="?/resetCsrfWarning"
 										use:enhance={() => {
 											isResettingCsrfWarning = true;
-											return async ({ update }) => {
+											return async ({ result, update }) => {
 												isResettingCsrfWarning = false;
-												await update();
+												if (result.type === 'success' || result.type === 'failure') {
+													handleFormToast(
+														result.data as { success?: boolean; message?: string; error?: string }
+													);
+												}
+												await update({ reset: false });
 											};
 										}}
 									>

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -27,7 +27,7 @@ const SLIDE_NAMES: Record<SlideType, string> = {
 	'top-shows': 'Top Shows',
 	genres: 'Genre Breakdown',
 	distribution: 'Viewing Distribution',
-	percentile: 'Percentile Ranking',
+	percentile: 'Percentile / Top Contributors',
 	binge: 'Longest Binge',
 	'first-last': 'First & Last Watch',
 	'weekday-patterns': 'Weekday Patterns',
@@ -315,9 +315,18 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 
 							{#if deletingSlideId === item.id}
 								<div class="confirm-delete">
+									<span class="confirm-delete-text">
+										Delete <strong>"{item.title}"</strong> permanently?
+									</span>
 									<form method="POST" action="?/deleteCustom" use:enhance class="delete-form">
 										<input type="hidden" name="id" value={item.id} />
-										<button type="submit" class="confirm-button">Confirm?</button>
+										<button
+											type="submit"
+											class="confirm-button"
+											aria-label={`Confirm delete "${item.title}"`}
+										>
+											Delete
+										</button>
 									</form>
 									<button
 										type="button"
@@ -442,10 +451,19 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 						max="15"
 						required
 					/>
+					{#if customCount < 1 || customCount > 15}
+						<span class="custom-count-error">Custom count must be between 1 and 15.</span>
+					{/if}
 				</div>
 			{/if}
 
-			<button type="submit" class="save-frequency-button"> Save Frequency Settings </button>
+			<button
+				type="submit"
+				class="save-frequency-button"
+				disabled={selectedFrequencyMode === 'custom' && (customCount < 1 || customCount > 15)}
+			>
+				Save Frequency Settings
+			</button>
 		</form>
 	</section>
 
@@ -780,7 +798,18 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 		.confirm-delete {
 			display: flex;
 			align-items: center;
-			gap: 0.375rem;
+			gap: 0.5rem;
+			flex-wrap: wrap;
+		}
+
+		.confirm-delete-text {
+			font-size: 0.75rem;
+			color: hsl(var(--muted-foreground));
+		}
+
+		.confirm-delete-text strong {
+			color: hsl(var(--foreground));
+			font-weight: 600;
 		}
 
 		.confirm-button {
@@ -1261,6 +1290,16 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			outline: none;
 			border-color: hsl(var(--ring));
 			box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
+		}
+
+		.custom-count-error {
+			font-size: 0.75rem;
+			color: hsl(var(--destructive));
+		}
+
+		.save-frequency-button:disabled {
+			opacity: 0.5;
+			cursor: not-allowed;
 		}
 
 		.save-frequency-button {

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -51,7 +51,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 	<header class="page-header">
 		<div class="page-header-row">
 			<div>
-				<h1>User Management</h1>
+				<h1>Users</h1>
 				<p class="subtitle">Manage server users for {data.year}</p>
 				{#if data.availableYears.length === 0}
 					<p class="empty-hint">No watch history yet. Run a sync to populate years.</p>

--- a/src/routes/dashboard/+layout.server.ts
+++ b/src/routes/dashboard/+layout.server.ts
@@ -1,4 +1,5 @@
 import { redirect } from '@sveltejs/kit';
+import { getUserFullProfile } from '$lib/server/admin/users.service';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
@@ -10,10 +11,13 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 		redirect(303, '/admin');
 	}
 
+	const profile = await getUserFullProfile(locals.user.id);
+
 	return {
 		user: {
 			id: locals.user.id,
-			username: locals.user.username
+			username: locals.user.username,
+			thumb: profile?.thumb ?? null
 		},
 		currentYear: new Date().getFullYear()
 	};

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -47,6 +47,12 @@ const isActive = $derived((href: string) => {
 let sidebarOpen = $state(false);
 let avatarError = $state(false);
 
+// Reset avatar error when thumb URL changes so a new URL gets a fresh load attempt
+$effect(() => {
+	data.user.thumb;
+	avatarError = false;
+});
+
 function toggleSidebar() {
 	sidebarOpen = !sidebarOpen;
 }

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -122,7 +122,18 @@ function closeSidebar() {
 		<div class="sidebar-footer">
 			<div class="user-card">
 				<div class="user-avatar">
-					<User class="user-avatar-icon" />
+					{#if data.user.thumb}
+						<img
+							src={data.user.thumb}
+							alt={data.user.username}
+							class="user-avatar-img"
+							onerror={(e) => {
+								(e.currentTarget as HTMLImageElement).style.display = 'none';
+							}}
+						/>
+					{:else}
+						<User class="user-avatar-icon" />
+					{/if}
 				</div>
 				<div class="user-info">
 					<span class="user-name">{data.user.username}</span>
@@ -374,12 +385,20 @@ function closeSidebar() {
 			background: linear-gradient(135deg, hsl(var(--primary)) 0%, hsl(var(--primary) / 0.8) 100%);
 			border-radius: 0.5rem;
 			flex-shrink: 0;
+			overflow: hidden;
 		}
 
 		.user-avatar :global(.user-avatar-icon) {
 			width: 1.125rem;
 			height: 1.125rem;
 			color: hsl(var(--primary-foreground));
+		}
+
+		.user-avatar-img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			display: block;
 		}
 
 		.user-info {

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -45,6 +45,7 @@ const isActive = $derived((href: string) => {
 
 // Mobile sidebar state
 let sidebarOpen = $state(false);
+let avatarError = $state(false);
 
 function toggleSidebar() {
 	sidebarOpen = !sidebarOpen;
@@ -122,13 +123,13 @@ function closeSidebar() {
 		<div class="sidebar-footer">
 			<div class="user-card">
 				<div class="user-avatar">
-					{#if data.user.thumb}
+					{#if data.user.thumb && !avatarError}
 						<img
 							src={data.user.thumb}
 							alt={data.user.username}
 							class="user-avatar-img"
-							onerror={(e) => {
-								(e.currentTarget as HTMLImageElement).style.display = 'none';
+							onerror={() => {
+								avatarError = true;
 							}}
 						/>
 					{:else}

--- a/src/routes/dashboard/settings/+page.server.ts
+++ b/src/routes/dashboard/settings/+page.server.ts
@@ -45,6 +45,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	return {
 		user: {
 			id: userProfile?.id ?? userId,
+			plexId: userProfile?.plexId ?? locals.user!.plexId ?? null,
 			username: userProfile?.username ?? locals.user!.username,
 			email: userProfile?.email ?? null,
 			thumb: userProfile?.thumb ?? null,

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -452,8 +452,15 @@ function getLogoModeDescription(): string {
 							</span>
 						</div>
 
+						{#if data.user.plexId}
+							<div class="detail-row">
+								<span class="detail-label">Plex ID</span>
+								<span class="detail-value mono">{data.user.plexId}</span>
+							</div>
+						{/if}
+
 						<div class="detail-row">
-							<span class="detail-label">User ID</span>
+							<span class="detail-label">Account ID</span>
 							<span class="detail-value mono">{data.user.id}</span>
 						</div>
 					</div>

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -637,7 +637,14 @@ function getThemeColors(themeValue: string) {
 		/* Hidden submit */
 		.hidden-submit {
 			position: absolute;
-			left: -9999px;
+			width: 1px;
+			height: 1px;
+			padding: 0;
+			margin: -1px;
+			overflow: hidden;
+			clip: rect(0, 0, 0, 0);
+			white-space: nowrap;
+			border: 0;
 		}
 
 		/* ==========================================================================

--- a/src/routes/plex/thumb/[...path]/+server.ts
+++ b/src/routes/plex/thumb/[...path]/+server.ts
@@ -22,7 +22,7 @@ function isAllowedPath(path: string): boolean {
 // Intentionally unauthenticated: shared/public wrapped pages render thumbnails
 // via getThumbUrl() without a user session. Path validation (ALLOWED_PATH_PATTERNS)
 // restricts access to Plex library metadata thumbnails only.
-export const GET: RequestHandler = async ({ params }) => {
+export const GET: RequestHandler = async ({ params, request }) => {
 	const { path } = params;
 
 	if (!path) {
@@ -33,7 +33,6 @@ export const GET: RequestHandler = async ({ params }) => {
 		error(400, { message: 'Invalid thumbnail path' });
 	}
 
-	// Get merged config (database takes priority over environment)
 	const config = await getPlexConfig();
 
 	if (!config.serverUrl) {
@@ -43,10 +42,27 @@ export const GET: RequestHandler = async ({ params }) => {
 	const plexUrl = new URL(`/${path}`, config.serverUrl);
 
 	try {
+		const upstreamHeaders: Record<string, string> = getPlexHeaders(config.token);
+		const ifNoneMatch = request.headers.get('if-none-match');
+		const ifModSince = request.headers.get('if-modified-since');
+		if (ifNoneMatch) upstreamHeaders['If-None-Match'] = ifNoneMatch;
+		if (ifModSince) upstreamHeaders['If-Modified-Since'] = ifModSince;
+
 		const response = await fetch(plexUrl.toString(), {
 			method: 'GET',
-			headers: getPlexHeaders(config.token)
+			headers: upstreamHeaders
 		});
+
+		if (response.status === 304) {
+			const notModHeaders: Record<string, string> = {
+				'Cache-Control': `public, max-age=${CACHE_MAX_AGE}, immutable`
+			};
+			const etag = response.headers.get('etag');
+			const lastMod = response.headers.get('last-modified');
+			if (etag) notModHeaders['ETag'] = etag;
+			if (lastMod) notModHeaders['Last-Modified'] = lastMod;
+			return new Response(null, { status: 304, headers: notModHeaders });
+		}
 
 		if (!response.ok) {
 			if (response.status === 404) {
@@ -56,19 +72,25 @@ export const GET: RequestHandler = async ({ params }) => {
 			console.error(
 				`[Plex Thumb] Error fetching thumbnail: ${response.status} ${response.statusText}`
 			);
-			error(502, { message: 'Failed to fetch thumbnail from Plex' });
+			error(502, { message: 'Thumbnail unavailable' });
 		}
 
 		const imageData = await response.arrayBuffer();
 		const contentType = response.headers.get('content-type') || 'image/jpeg';
+		const etag = response.headers.get('etag');
+		const lastMod = response.headers.get('last-modified');
+
+		const headers: Record<string, string> = {
+			'Content-Type': contentType,
+			'Cache-Control': `public, max-age=${CACHE_MAX_AGE}, immutable`,
+			'Content-Length': String(imageData.byteLength)
+		};
+		if (etag) headers['ETag'] = etag;
+		if (lastMod) headers['Last-Modified'] = lastMod;
 
 		return new Response(imageData, {
 			status: 200,
-			headers: {
-				'Content-Type': contentType,
-				'Cache-Control': `public, max-age=${CACHE_MAX_AGE}, immutable`,
-				'Content-Length': String(imageData.byteLength)
-			}
+			headers
 		});
 	} catch (err) {
 		if (err instanceof Error && 'status' in err) {
@@ -76,6 +98,6 @@ export const GET: RequestHandler = async ({ params }) => {
 		}
 
 		console.error('[Plex Thumb] Network error:', err);
-		error(502, { message: 'Unable to connect to Plex server' });
+		error(502, { message: 'Thumbnail unavailable' });
 	}
 };

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -6,6 +6,20 @@ const config = {
 	preprocess: vitePreprocess(),
 
 	kit: {
+		csp: {
+			mode: 'nonce',
+			directives: {
+				'default-src': ['self'],
+				'img-src': ['self', 'https://plex.tv', 'https://*.plex.direct', 'data:'],
+				'style-src': ['self', 'unsafe-inline', 'https://fonts.googleapis.com'],
+				'font-src': ['self', 'https://fonts.gstatic.com'],
+				'script-src': ['self'],
+				'connect-src': ['self', 'https://plex.tv'],
+				'frame-ancestors': ['none'],
+				'base-uri': ['self'],
+				'form-action': ['self']
+			}
+		},
 		adapter: adapter({
 			out: 'build',
 			precompress: true

--- a/tests/unit/sharing/access-control.test.ts
+++ b/tests/unit/sharing/access-control.test.ts
@@ -274,7 +274,7 @@ describe('Sharing Access Control', () => {
 				} catch (error) {
 					expect(error).toBeInstanceOf(ShareAccessDeniedError);
 					expect((error as ShareAccessDeniedError).message).toBe(
-						'You must be logged in to view this page.'
+						'Sign in with your Plex account to view this wrapped.'
 					);
 				}
 			});
@@ -383,7 +383,9 @@ describe('Sharing Access Control', () => {
 					expect.unreachable('Should have thrown');
 				} catch (error) {
 					expect(error).toBeInstanceOf(ShareAccessDeniedError);
-					expect((error as ShareAccessDeniedError).message).toContain('member of this Plex server');
+					expect((error as ShareAccessDeniedError).message).toContain(
+						'members of this Plex server'
+					);
 				}
 			});
 
@@ -398,7 +400,7 @@ describe('Sharing Access Control', () => {
 					expect.unreachable('Should have thrown');
 				} catch (error) {
 					expect(error).toBeInstanceOf(ShareAccessDeniedError);
-					expect((error as ShareAccessDeniedError).message).toContain('logged in');
+					expect((error as ShareAccessDeniedError).message).toContain('Sign in');
 				}
 			});
 
@@ -824,7 +826,7 @@ describe('Sharing Access Control', () => {
 					expect.unreachable('Should have thrown');
 				} catch (error) {
 					expect(error).toBeInstanceOf(ShareAccessDeniedError);
-					expect((error as ShareAccessDeniedError).message).toContain('logged in');
+					expect((error as ShareAccessDeniedError).message).toContain('Sign in');
 				}
 			});
 


### PR DESCRIPTION
## Summary

Resolves ~25 actionable findings from the 5-wave E2E dogfood QA of Obzorarr. Changes span security hardening, wrapped-presentation bugs, admin UI polish, thumbnail proxy caching, dashboard/sidebar parity, and onboarding accessibility.

## Changes

### Security headers
- CSRF and request-filter handlers now wrap their early-return 403/404 responses with `applySecurityHeaders()` and emit JSON bodies for consistency with the rate-limit handler.
- Onboarding and authorization handles return explicit 303 `Response` objects instead of throwing `redirect()`, so `securityHeadersHandle` can wrap them.
- Adds a Content-Security-Policy directive tailored to the app (allows Plex thumbs via `https://plex.tv` / `https://*.plex.direct` and Google Fonts, denies `frame-ancestors`).

### Wrapped presentation
- `ProgressBar` now uses `hsl(var(--primary))` instead of a raw triplet that was always falling through to the `#dc2626` red fallback.
- Percentile slot relabelled to `Percentile / Top Contributors` to reflect both server-wide and per-user renderings.
- Private-oauth denial messages now explain server-membership requirement and prompt Plex sign-in.
- `ShareModal` radio group gets `role="radiogroup"` and drops the flicker-causing optimistic-reset `$effect.pre`.
- `StoryMode` root div no longer double-binds `onkeydown` (window listener remains).

### Admin
- OpenAI API key clear button visible whenever not locked; empty-string save now deletes the setting.
- CSRF origin clear toast reflects whether `ORIGIN` env is actually present.
- Re-enabling CSRF warning now surfaces a toast.
- Wrapped theme radio uses a distinct `name` to avoid collision with UI theme.
- Inline pre-hydration script reads `ui_theme`/`wrapped_theme` cookies to eliminate FOUC.
- Active admin nav links announce `aria-current="page"`.
- Admin Users page h1 matches sidebar label.
- Logs page datetime filters are reactive; level filter buttons report `aria-pressed` correctly when all levels are shown.

### Slides
- Fun fact custom count shows an inline error and disables Save when out of range.
- Custom slide delete confirmation shows the slide title.

### Thumbnail proxy
- Forwards `ETag` / `Last-Modified` from upstream and passes through `If-None-Match` / `If-Modified-Since` to support 304s.
- Replaced upstream-disclosure 502 message with generic `Thumbnail unavailable`.

### Dashboard / Sidebar
- Dashboard settings now shows both `Plex ID` and `Account ID`.
- Dashboard and admin sidebars render the Plex avatar thumbnail (with user-icon fallback on missing/broken URLs).

### Onboarding
- Replaced `left: -9999px` hidden-submit CSS with an accessible `clip: rect(0,0,0,0)` sr-only pattern.

### Tests
- Updated 4 access-control assertions to match the improved denial copy.

## Out of scope (deferred or not applicable)

- `X-XSS-Protection` absence, HSTS-conditional-on-HTTPS, and raw-`../` path behaviour are intentional (OWASP / framework behaviour).
- `/api/user/lookup` 404 spam: no caller or endpoint exists in the current tree.
- Speculative onboarding wizard Next/Previous staleness: could not be reproduced; code path is reactive as written.
- Sync history pagination: already implemented with full pagination controls.

## Test plan

- [x] `bun run check` — 0 errors, 0 warnings
- [x] `bun test` — 1258 pass, 0 fail
- [ ] Manual: `curl -sI -X POST /admin -H 'Origin: http://evil.com'` includes `content-security-policy` and friends
- [ ] Manual: `/wrapped/<year>` on Modern Minimal theme shows blue ProgressBar (not red fallback)
- [ ] Manual: `/admin/settings` — clear OpenAI key, re-enable CSRF warning, toggle wrapped theme radio
- [ ] Manual: `/dashboard/settings` shows both Plex ID and Account ID; sidebar avatar renders
- [ ] Manual: Reload Plex thumbnails → subsequent requests return 304