### PR TITLE
fix: resolve 17 QA dogfood findings across admin, onboarding, wrapped

### DIFF
--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -18,6 +18,7 @@ interface Props {
 	isOwner?: boolean;
 	isAdmin?: boolean;
 	isServerWrapped?: boolean;
+	globalFloor?: ShareModeType;
 }
 
 let {
@@ -28,8 +29,21 @@ let {
 	shareSettings,
 	isOwner = false,
 	isAdmin = false,
-	isServerWrapped = false
+	isServerWrapped = false,
+	globalFloor
 }: Props = $props();
+
+const privacyLevel: Record<ShareModeType, number> = {
+	public: 0,
+	'private-link': 1,
+	'private-oauth': 2
+};
+
+const floorLevel = $derived(globalFloor ? privacyLevel[globalFloor] : 0);
+
+function isBelowFloor(mode: ShareModeType): boolean {
+	return privacyLevel[mode] < floorLevel;
+}
 
 // State
 let copied = $state(false);
@@ -260,6 +274,12 @@ $effect(() => {
 								<div class="mode-content">
 									<span class="mode-label">{modeLabels[mode as ShareModeType].label}</span>
 									<span class="mode-desc">{modeLabels[mode as ShareModeType].description}</span>
+									{#if isAdmin && globalFloor && isBelowFloor(mode as ShareModeType)}
+										<span class="floor-note">
+											Global floor is <strong>{modeLabels[globalFloor].label}</strong>. Effective
+											mode at access time will be <strong>{modeLabels[globalFloor].label}</strong>.
+										</span>
+									{/if}
 								</div>
 								{#if displayMode === mode}
 									<svg
@@ -462,7 +482,20 @@ $effect(() => {
 		}
 
 		.mode-option input[type='radio'] {
-			display: none;
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			padding: 0;
+			margin: -1px;
+			overflow: hidden;
+			clip: rect(0, 0, 0, 0);
+			white-space: nowrap;
+			border: 0;
+		}
+
+		.mode-option:focus-within {
+			outline: 2px solid hsl(var(--primary));
+			outline-offset: 2px;
 		}
 
 		.mode-content {
@@ -481,6 +514,17 @@ $effect(() => {
 		.mode-desc {
 			font-size: 0.75rem;
 			color: hsl(var(--muted-foreground));
+		}
+
+		.floor-note {
+			margin-top: 0.375rem;
+			padding: 0.375rem 0.5rem;
+			font-size: 0.7rem;
+			line-height: 1.4;
+			color: hsl(45, 93%, 65%);
+			background: rgba(250, 204, 21, 0.08);
+			border-left: 2px solid rgba(250, 204, 21, 0.5);
+			border-radius: 4px;
 		}
 
 		.check-icon {

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -311,6 +311,16 @@ export interface ConfigValue<T> {
 	isLocked: boolean;
 }
 
+/**
+ * Shape exposed to the client for secret fields. Omits the raw value so it never
+ * crosses the wire during SvelteKit hydration.
+ */
+export interface SafeConfigValue {
+	source: ConfigSource;
+	isLocked: boolean;
+	hasValue: boolean;
+}
+
 export interface ApiConfigWithSources {
 	plex: {
 		serverUrl: ConfigValue<string>;
@@ -320,6 +330,14 @@ export interface ApiConfigWithSources {
 		apiKey: ConfigValue<string>;
 		baseUrl: ConfigValue<string>;
 		model: ConfigValue<string>;
+	};
+}
+
+export function toSafeConfigValue(config: ConfigValue<string>): SafeConfigValue {
+	return {
+		source: config.source,
+		isLocked: config.isLocked,
+		hasValue: Boolean(config.value)
 	};
 }
 

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -637,9 +637,12 @@ $effect(() => {
 				use:enhance={() => {
 					isClearingLogs = true;
 					return async ({ update }) => {
-						await refreshAfterLogMutation(update);
-						isClearingLogs = false;
-						clearLogsDialogOpen = false;
+						try {
+							await refreshAfterLogMutation(update);
+							clearLogsDialogOpen = false;
+						} finally {
+							isClearingLogs = false;
+						}
 					};
 				}}
 				style="display: contents;"

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -3,6 +3,7 @@ import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
 import { page } from '$app/stores';
+import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import type { LogEntry, LogLevelType } from '$lib/server/logging';
 import { handleFormToast } from '$lib/utils/form-toast';
 import type { ActionData, PageData } from './$types';
@@ -51,6 +52,10 @@ $effect.pre(() => {
 	toDate = data.filters?.toTimestamp ? toLocalDateTimeInput(data.filters.toTimestamp) : '';
 });
 let autoScroll = $state(true);
+
+// Clear-logs confirmation dialog
+let clearLogsDialogOpen = $state(false);
+let isClearingLogs = $state(false);
 
 // SSE connection state
 let eventSource: EventSource | null = $state(null);
@@ -495,21 +500,13 @@ $effect(() => {
 				<button type="submit" class="control-button secondary"> Run Cleanup </button>
 			</form>
 
-			<form
-				method="POST"
-				action="?/clearLogs"
-				use:enhance={() => {
-					if (!confirm('Are you sure you want to delete all logs? This cannot be undone.')) {
-						return async () => {};
-					}
-					return async ({ update }) => {
-						await refreshAfterLogMutation(update);
-					};
-				}}
-				class="inline-form"
+			<button
+				type="button"
+				class="control-button danger"
+				onclick={() => (clearLogsDialogOpen = true)}
 			>
-				<button type="submit" class="control-button danger"> Clear All Logs </button>
-			</form>
+				Clear All Logs
+			</button>
 		</div>
 	</section>
 
@@ -623,6 +620,37 @@ $effect(() => {
 		</p>
 	</section>
 </div>
+
+<AlertDialog.Root bind:open={clearLogsDialogOpen}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Clear all logs?</AlertDialog.Title>
+			<AlertDialog.Description>
+				This will permanently delete every log entry. This action cannot be undone.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel disabled={isClearingLogs}>Cancel</AlertDialog.Cancel>
+			<form
+				method="POST"
+				action="?/clearLogs"
+				use:enhance={() => {
+					isClearingLogs = true;
+					return async ({ update }) => {
+						await refreshAfterLogMutation(update);
+						isClearingLogs = false;
+						clearLogsDialogOpen = false;
+					};
+				}}
+				style="display: contents;"
+			>
+				<AlertDialog.Action type="submit" disabled={isClearingLogs}>
+					{isClearingLogs ? 'Clearing…' : 'Clear All'}
+				</AlertDialog.Action>
+			</form>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
 
 <style>
 	.logs-page {

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -27,6 +27,7 @@ import {
 	setWrappedTheme,
 	ThemePresets,
 	type ThemePresetType,
+	toSafeConfigValue,
 	WrappedLogoMode,
 	type WrappedLogoModeType
 } from '$lib/server/admin/settings.service';
@@ -75,18 +76,17 @@ const ServerWrappedModeSchema = z.enum(['public', 'private-oauth']);
 
 const PrivacySettingsSchema = z.object({
 	anonymizationMode: AnonymizationSchema,
-	logoMode: WrappedLogoModeSchema,
 	serverWrappedShareMode: ServerWrappedModeSchema,
 	defaultShareMode: ShareModeSchema,
 	allowUserControl: z.coerce.boolean()
 });
 
 const ApiConfigSchema = z.object({
-	plexServerUrl: z.string().url('Invalid URL format').optional().or(z.literal('')),
-	plexToken: z.string().optional(),
-	openaiApiKey: z.string().optional(),
-	openaiBaseUrl: z.string().url('Invalid URL format').optional().or(z.literal('')),
-	openaiModel: z.string().optional()
+	plexServerUrl: z.string().max(512).url('Invalid URL format').optional().or(z.literal('')),
+	plexToken: z.string().max(512).optional(),
+	openaiApiKey: z.string().max(512).optional(),
+	openaiBaseUrl: z.string().max(512).url('Invalid URL format').optional().or(z.literal('')),
+	openaiModel: z.string().max(100).optional()
 });
 
 const LogSettingsSchema = z.object({
@@ -109,6 +109,8 @@ interface SettingValue {
 	source: ConfigSource;
 	isLocked: boolean;
 }
+
+type SafeSettingValue = Omit<SettingValue, 'value'> & { hasValue: boolean };
 
 export const load: PageServerLoad = async () => {
 	const [
@@ -148,8 +150,8 @@ export const load: PageServerLoad = async () => {
 	return {
 		settings: {
 			plexServerUrl: apiConfig.plex.serverUrl as SettingValue,
-			plexToken: apiConfig.plex.token as SettingValue,
-			openaiApiKey: apiConfig.openai.apiKey as SettingValue,
+			plexToken: toSafeConfigValue(apiConfig.plex.token) satisfies SafeSettingValue,
+			openaiApiKey: toSafeConfigValue(apiConfig.openai.apiKey) satisfies SafeSettingValue,
 			openaiBaseUrl: apiConfig.openai.baseUrl as SettingValue,
 			openaiModel: apiConfig.openai.model as SettingValue
 		},
@@ -220,19 +222,17 @@ export const actions: Actions = {
 		try {
 			const apiConfig = await getApiConfigWithSources();
 
-			// Save each setting (only if provided AND not locked by ENV)
+			// Save each setting (only if provided AND not locked by ENV).
+			// Secret fields (plexToken, openaiApiKey) are blank on load to avoid
+			// leaking via hydration; an empty submission means "no change".
 			if (parsed.data.plexServerUrl && !apiConfig.plex.serverUrl.isLocked) {
 				await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, parsed.data.plexServerUrl);
 			}
 			if (parsed.data.plexToken && !apiConfig.plex.token.isLocked) {
 				await setAppSetting(AppSettingsKey.PLEX_TOKEN, parsed.data.plexToken);
 			}
-			if (!apiConfig.openai.apiKey.isLocked) {
-				if (parsed.data.openaiApiKey) {
-					await setAppSetting(AppSettingsKey.OPENAI_API_KEY, parsed.data.openaiApiKey);
-				} else if (parsed.data.openaiApiKey === '') {
-					await deleteAppSetting(AppSettingsKey.OPENAI_API_KEY);
-				}
+			if (parsed.data.openaiApiKey && !apiConfig.openai.apiKey.isLocked) {
+				await setAppSetting(AppSettingsKey.OPENAI_API_KEY, parsed.data.openaiApiKey);
 			}
 			if (parsed.data.openaiBaseUrl && !apiConfig.openai.baseUrl.isLocked) {
 				await setAppSetting(AppSettingsKey.OPENAI_BASE_URL, parsed.data.openaiBaseUrl);
@@ -250,8 +250,14 @@ export const actions: Actions = {
 
 	testPlexConnection: async ({ request }) => {
 		const formData = await request.formData();
-		const plexServerUrl = formData.get('plexServerUrl')?.toString();
-		const plexToken = formData.get('plexToken')?.toString();
+		const submittedUrl = formData.get('plexServerUrl')?.toString() ?? '';
+		const submittedToken = formData.get('plexToken')?.toString() ?? '';
+
+		// Fall back to stored config if the client omitted either field (the client
+		// never echoes the stored token to avoid hydration leaks).
+		const apiConfig = await getApiConfigWithSources();
+		const plexServerUrl = submittedUrl || apiConfig.plex.serverUrl.value;
+		const plexToken = submittedToken || apiConfig.plex.token.value;
 
 		if (!plexServerUrl || !plexToken) {
 			return fail(400, { error: 'Plex server URL and token are required' });
@@ -563,7 +569,6 @@ export const actions: Actions = {
 
 		const data = {
 			anonymizationMode: formData.get('anonymizationMode'),
-			logoMode: formData.get('logoMode'),
 			serverWrappedShareMode: formData.get('serverWrappedShareMode'),
 			defaultShareMode: formData.get('defaultShareMode'),
 			allowUserControl: formData.get('allowUserControl') === 'true'
@@ -580,7 +585,6 @@ export const actions: Actions = {
 		try {
 			await Promise.all([
 				setAnonymizationMode(parsed.data.anonymizationMode as AnonymizationModeType),
-				setWrappedLogoMode(parsed.data.logoMode as WrappedLogoModeType),
 				setServerWrappedShareMode(parsed.data.serverWrappedShareMode as ShareModeType),
 				setGlobalShareDefaults({
 					defaultShareMode: parsed.data.defaultShareMode as ShareModeType,

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -270,12 +270,14 @@ export const actions: Actions = {
 		// Allow token fallback only when the URL hasn't changed from what is stored.
 		const plexToken = submittedToken || (urlMatchesStored ? apiConfig.plex.token.value : '');
 
-		if (!plexServerUrl || !plexToken) {
-			return fail(400, {
-				error: !plexToken
-					? 'A Plex token is required when testing a new server URL'
-					: 'Plex server URL and token are required'
-			});
+		if (!plexServerUrl && !plexToken) {
+			return fail(400, { error: 'Plex server URL and token are required' });
+		}
+		if (!plexServerUrl) {
+			return fail(400, { error: 'Plex server URL is required' });
+		}
+		if (!plexToken) {
+			return fail(400, { error: 'A Plex token is required to test the server connection' });
 		}
 
 		try {

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -253,14 +253,29 @@ export const actions: Actions = {
 		const submittedUrl = formData.get('plexServerUrl')?.toString() ?? '';
 		const submittedToken = formData.get('plexToken')?.toString() ?? '';
 
-		// Fall back to stored config if the client omitted either field (the client
-		// never echoes the stored token to avoid hydration leaks).
+		// The client never echoes the stored token back (to avoid hydration leaks),
+		// so a missing token field is the normal case. We fall back to the stored
+		// token ONLY when the submitted URL also matches the stored URL — this
+		// prevents the stored token from being forwarded to an attacker-controlled
+		// host (SSRF / secret exfil).
 		const apiConfig = await getApiConfigWithSources();
-		const plexServerUrl = submittedUrl || apiConfig.plex.serverUrl.value;
-		const plexToken = submittedToken || apiConfig.plex.token.value;
+		const storedUrl = apiConfig.plex.serverUrl.value;
+		const plexServerUrl = submittedUrl || storedUrl;
+
+		// Normalise both URLs for comparison (strip trailing slashes).
+		const normalise = (u: string) => u.replace(/\/+$/, '');
+		const urlMatchesStored =
+			plexServerUrl && storedUrl && normalise(plexServerUrl) === normalise(storedUrl);
+
+		// Allow token fallback only when the URL hasn't changed from what is stored.
+		const plexToken = submittedToken || (urlMatchesStored ? apiConfig.plex.token.value : '');
 
 		if (!plexServerUrl || !plexToken) {
-			return fail(400, { error: 'Plex server URL and token are required' });
+			return fail(400, {
+				error: !plexToken
+					? 'A Plex token is required when testing a new server URL'
+					: 'Plex server URL and token are required'
+			});
 		}
 
 		try {

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -105,15 +105,10 @@ let selectedDefaultShareMode = $state('public');
 let allowUserControl = $state(true);
 let isBulkApplyingUserControl = $state(false);
 
-async function bulkApplyUserControlToExistingUsers() {
-	if (
-		!window.confirm(
-			"This will overwrite the per-user 'can control' setting for every user. Continue?"
-		)
-	) {
-		return;
-	}
+let bulkApplyUserControlDialogOpen = $state(false);
 
+async function confirmBulkApplyUserControl() {
+	bulkApplyUserControlDialogOpen = false;
 	isBulkApplyingUserControl = true;
 
 	const formData = new FormData();
@@ -158,11 +153,17 @@ let openaiBaseUrlLocked = $state(false);
 let openaiModelLocked = $state(false);
 let csrfOriginLocked = $state(false);
 
+// Secret fields: true when a value is stored server-side (DB or ENV).
+// Used to display a placeholder without exposing the raw value.
+let plexTokenHasValue = $state(false);
+let openaiApiKeyHasValue = $state(false);
+
 // Sync local state with data (initial load and after form submission)
 $effect(() => {
 	plexServerUrl = data.settings.plexServerUrl.value;
-	plexToken = data.settings.plexToken.value;
-	openaiApiKey = data.settings.openaiApiKey.value;
+	// Secret fields are never hydrated with the raw value; blank input = no change.
+	plexToken = '';
+	openaiApiKey = '';
 	openaiBaseUrl = data.settings.openaiBaseUrl.value;
 	openaiModel = data.settings.openaiModel.value;
 	plexServerUrlSource = data.settings.plexServerUrl.source;
@@ -175,6 +176,8 @@ $effect(() => {
 	openaiApiKeyLocked = data.settings.openaiApiKey.isLocked;
 	openaiBaseUrlLocked = data.settings.openaiBaseUrl.isLocked;
 	openaiModelLocked = data.settings.openaiModel.isLocked;
+	plexTokenHasValue = data.settings.plexToken.hasValue;
+	openaiApiKeyHasValue = data.settings.openaiApiKey.hasValue;
 	selectedUITheme = data.uiTheme;
 	selectedWrappedTheme = data.wrappedTheme;
 	selectedAnonymization = data.anonymizationMode;
@@ -484,10 +487,15 @@ const logFieldErrors = $derived(
 							<Zap class="panel-icon plex" />
 							<h2>Plex Server</h2>
 						</div>
-						<div class="connection-status" class:connected={plexServerUrl && plexToken}>
+						<div
+							class="connection-status"
+							class:connected={plexServerUrl && (plexToken || plexTokenHasValue)}
+						>
 							<span class="status-dot"></span>
 							<span class="status-text"
-								>{plexServerUrl && plexToken ? 'Configured' : 'Not configured'}</span
+								>{plexServerUrl && (plexToken || plexTokenHasValue)
+									? 'Configured'
+									: 'Not configured'}</span
 							>
 						</div>
 					</div>
@@ -512,6 +520,7 @@ const logFieldErrors = $derived(
 								id="plexServerUrl"
 								name="plexServerUrl"
 								bind:value={plexServerUrl}
+								maxlength="512"
 								placeholder="http://192.168.1.100:32400"
 								class:from-env={plexServerUrlLocked}
 								disabled={plexServerUrlLocked}
@@ -545,7 +554,10 @@ const logFieldErrors = $derived(
 									id="plexToken"
 									name="plexToken"
 									bind:value={plexToken}
-									placeholder="X-Plex-Token"
+									maxlength="512"
+									placeholder={plexTokenHasValue
+										? '(unchanged — re-enter to change)'
+										: 'X-Plex-Token'}
 									class:from-env={plexTokenLocked}
 									disabled={plexTokenLocked}
 								/>
@@ -581,7 +593,7 @@ const logFieldErrors = $derived(
 							<button
 								type="button"
 								class="btn-secondary"
-								disabled={isTesting || !plexServerUrl || !plexToken}
+								disabled={isTesting || !plexServerUrl || (!plexToken && !plexTokenHasValue)}
 								onclick={async () => {
 									isTesting = true;
 									testConnectionResult = null;
@@ -682,7 +694,10 @@ const logFieldErrors = $derived(
 									id="openaiApiKey"
 									name="openaiApiKey"
 									bind:value={openaiApiKey}
-									placeholder="sk-..."
+									maxlength="512"
+									placeholder={openaiApiKeyHasValue
+										? '(unchanged — re-enter to change)'
+										: 'sk-...'}
 									class:from-env={openaiApiKeyLocked}
 									disabled={openaiApiKeyLocked}
 								/>
@@ -727,6 +742,7 @@ const logFieldErrors = $derived(
 									id="openaiBaseUrl"
 									name="openaiBaseUrl"
 									bind:value={openaiBaseUrl}
+									maxlength="512"
 									placeholder="https://api.openai.com/v1"
 									class:from-env={openaiBaseUrlLocked}
 									disabled={openaiBaseUrlLocked}
@@ -759,6 +775,7 @@ const logFieldErrors = $derived(
 									id="openaiModel"
 									name="openaiModel"
 									bind:value={openaiModel}
+									maxlength="100"
 									placeholder="gpt-5-mini"
 									class:from-env={openaiModelLocked}
 									disabled={openaiModelLocked}
@@ -889,6 +906,95 @@ const logFieldErrors = $derived(
 						</div>
 					</form>
 				</section>
+
+				<!-- Wrapped Logo Section -->
+				<section class="panel theme-panel">
+					<div class="panel-header">
+						<div class="panel-title">
+							<Image class="panel-icon" />
+							<h2>Wrapped Page Logo</h2>
+						</div>
+					</div>
+					<p class="panel-description">
+						Control logo visibility on Year in Review slideshow pages.
+					</p>
+
+					<form method="POST" action="?/updateWrappedLogoMode" use:enhance>
+						<div class="option-cards">
+							<label
+								class="option-card"
+								class:selected={selectedWrappedLogoMode === 'always_show'}
+							>
+								<input
+									type="radio"
+									name="logoMode"
+									value="always_show"
+									bind:group={selectedWrappedLogoMode}
+								/>
+								<div class="option-icon">
+									<Image />
+								</div>
+								<div class="option-content">
+									<span class="option-title">Always Show</span>
+									<span class="option-desc">{wrappedLogoDescriptions.always_show}</span>
+								</div>
+								{#if selectedWrappedLogoMode === 'always_show'}
+									<div class="option-check"><Check /></div>
+								{/if}
+							</label>
+
+							<label
+								class="option-card"
+								class:selected={selectedWrappedLogoMode === 'always_hide'}
+							>
+								<input
+									type="radio"
+									name="logoMode"
+									value="always_hide"
+									bind:group={selectedWrappedLogoMode}
+								/>
+								<div class="option-icon">
+									<ImageOff />
+								</div>
+								<div class="option-content">
+									<span class="option-title">Always Hide</span>
+									<span class="option-desc">{wrappedLogoDescriptions.always_hide}</span>
+								</div>
+								{#if selectedWrappedLogoMode === 'always_hide'}
+									<div class="option-check"><Check /></div>
+								{/if}
+							</label>
+
+							<label
+								class="option-card"
+								class:selected={selectedWrappedLogoMode === 'user_choice'}
+							>
+								<input
+									type="radio"
+									name="logoMode"
+									value="user_choice"
+									bind:group={selectedWrappedLogoMode}
+								/>
+								<div class="option-icon">
+									<ToggleRight />
+								</div>
+								<div class="option-content">
+									<span class="option-title">User Choice</span>
+									<span class="option-desc">{wrappedLogoDescriptions.user_choice}</span>
+								</div>
+								{#if selectedWrappedLogoMode === 'user_choice'}
+									<div class="option-check"><Check /></div>
+								{/if}
+							</label>
+						</div>
+						<div class="panel-actions">
+							<button type="submit" class="btn-primary">
+								<Image class="btn-icon" />
+								Apply Logo Mode
+							</button>
+						</div>
+					</form>
+				</section>
 			</div>
 		{/if}
 
@@ -969,69 +1075,6 @@ const logFieldErrors = $derived(
 						</label>
 					</div>
 
-					<h3 class="subsection-title">
-						<Image class="subsection-icon" />
-						Wrapped Page Logo
-					</h3>
-
-					<div class="option-cards">
-						<label class="option-card" class:selected={selectedWrappedLogoMode === 'always_show'}>
-							<input
-								type="radio"
-								name="logoMode"
-								value="always_show"
-								bind:group={selectedWrappedLogoMode}
-							/>
-							<div class="option-icon">
-								<Image />
-							</div>
-							<div class="option-content">
-								<span class="option-title">Always Show</span>
-								<span class="option-desc">{wrappedLogoDescriptions.always_show}</span>
-							</div>
-							{#if selectedWrappedLogoMode === 'always_show'}
-								<div class="option-check"><Check /></div>
-							{/if}
-						</label>
-
-						<label class="option-card" class:selected={selectedWrappedLogoMode === 'always_hide'}>
-							<input
-								type="radio"
-								name="logoMode"
-								value="always_hide"
-								bind:group={selectedWrappedLogoMode}
-							/>
-							<div class="option-icon">
-								<ImageOff />
-							</div>
-							<div class="option-content">
-								<span class="option-title">Always Hide</span>
-								<span class="option-desc">{wrappedLogoDescriptions.always_hide}</span>
-							</div>
-							{#if selectedWrappedLogoMode === 'always_hide'}
-								<div class="option-check"><Check /></div>
-							{/if}
-						</label>
-
-						<label class="option-card" class:selected={selectedWrappedLogoMode === 'user_choice'}>
-							<input
-								type="radio"
-								name="logoMode"
-								value="user_choice"
-								bind:group={selectedWrappedLogoMode}
-							/>
-							<div class="option-icon">
-								<ToggleRight />
-							</div>
-							<div class="option-content">
-								<span class="option-title">User Choice</span>
-								<span class="option-desc">{wrappedLogoDescriptions.user_choice}</span>
-							</div>
-							{#if selectedWrappedLogoMode === 'user_choice'}
-								<div class="option-check"><Check /></div>
-							{/if}
-						</label>
-					</div>
 				</section>
 
 				<!-- Sharing Access Section -->
@@ -1189,7 +1232,7 @@ const logFieldErrors = $derived(
 						type="button"
 						class="btn-secondary"
 						disabled={isBulkApplyingUserControl}
-						onclick={bulkApplyUserControlToExistingUsers}
+						onclick={() => (bulkApplyUserControlDialogOpen = true)}
 					>
 						{#if isBulkApplyingUserControl}
 							<Loader2 class="btn-icon spinning" />
@@ -1305,6 +1348,9 @@ const logFieldErrors = $derived(
 								{/if}
 							</div>
 
+							<p class="csrf-actions-caption">
+								Warning-reset controls appear when a CSRF warning is active.
+							</p>
 							<div class="csrf-actions">
 								{#if !csrfOriginLocked}
 									<form
@@ -1866,6 +1912,27 @@ const logFieldErrors = $derived(
 					{/if}
 				</AlertDialog.Action>
 			</form>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
+
+<AlertDialog.Root bind:open={bulkApplyUserControlDialogOpen}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Apply default to all users?</AlertDialog.Title>
+			<AlertDialog.Description>
+				This will overwrite the per-user "can control" setting for every existing user. Future users
+				will still receive the current default.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel disabled={isBulkApplyingUserControl}>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Action
+				disabled={isBulkApplyingUserControl}
+				onclick={confirmBulkApplyUserControl}
+			>
+				{isBulkApplyingUserControl ? 'Applying…' : 'Apply to all users'}
+			</AlertDialog.Action>
 		</AlertDialog.Footer>
 	</AlertDialog.Content>
 </AlertDialog.Root>
@@ -3025,7 +3092,13 @@ const logFieldErrors = $derived(
 			gap: 0.75rem;
 			align-items: center;
 			flex-wrap: wrap;
-			margin-top: 1rem;
+			margin-top: 0.5rem;
+		}
+
+		.csrf-actions-caption {
+			margin: 1rem 0 0;
+			font-size: 0.8rem;
+			color: hsl(var(--muted-foreground));
 		}
 
 		/* Help Trigger - Whisper-quiet info hint */

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -158,6 +158,16 @@ let csrfOriginLocked = $state(false);
 let plexTokenHasValue = $state(false);
 let openaiApiKeyHasValue = $state(false);
 
+// Mirror the server's URL-match gate in testPlexConnection: the stored token
+// fallback is only honoured when the submitted URL equals the stored URL
+// (same trailing-slash normalisation). When the URL changes, a fresh token
+// must be entered — disable Test and show a hint so users get a clear signal
+// instead of a deterministic 400.
+const storedPlexServerUrl = $derived(data.settings.plexServerUrl.value);
+const plexUrlChanged = $derived(
+	(plexServerUrl ?? '').replace(/\/+$/, '') !== (storedPlexServerUrl ?? '').replace(/\/+$/, '')
+);
+
 // Sync local state with data (initial load and after form submission)
 $effect(() => {
 	plexServerUrl = data.settings.plexServerUrl.value;
@@ -579,6 +589,10 @@ const logFieldErrors = $derived(
 								<span class="field-hint env-hint"
 									>This value is set via PLEX_TOKEN environment variable</span
 								>
+							{:else if plexUrlChanged && !plexToken && plexTokenHasValue}
+								<span class="field-hint">
+									Enter a token for the new server URL before testing the connection.
+								</span>
 							{/if}
 						</div>
 
@@ -593,7 +607,9 @@ const logFieldErrors = $derived(
 							<button
 								type="button"
 								class="btn-secondary"
-								disabled={isTesting || !plexServerUrl || (!plexToken && !plexTokenHasValue)}
+								disabled={isTesting ||
+									!plexServerUrl ||
+									(plexUrlChanged ? !plexToken : !plexToken && !plexTokenHasValue)}
 								onclick={async () => {
 									isTesting = true;
 									testConnectionResult = null;

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -986,7 +986,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 
 		.form-group textarea {
 			resize: vertical;
-			min-height: 150px;
+			min-height: 96px;
 			font-family: monospace;
 		}
 
@@ -1121,9 +1121,12 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			justify-content: flex-end;
 			gap: 0.75rem;
 			margin-top: 1.5rem;
-			padding-top: 1rem;
+			padding-top: 0.75rem;
+			padding-bottom: 0.25rem;
 			border-top: 1px solid hsl(var(--border));
-			position: relative;
+			position: sticky;
+			bottom: 0;
+			background: hsl(var(--card));
 			z-index: 1;
 		}
 

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -50,7 +50,7 @@ export const load: PageServerLoad = async ({ url }) => {
 		]);
 
 	const currentYear = new Date().getFullYear();
-	const availableYears = Array.from({ length: 6 }, (_, i) => currentYear - i);
+	const availableYears = Array.from({ length: currentYear - 2000 + 1 }, (_, i) => currentYear - i);
 
 	return {
 		isRunning,

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -27,6 +27,8 @@ let cronExpression = $state('0 0 * * *');
 const cronError = $derived(validateCron(cronExpression));
 let isSyncing = $state(false);
 let isCancelling = $state(false);
+// Optimistic flag so Cancel is hit-testable during the brief gap between Start-click and the first SSE frame.
+let pendingStart = $state(false);
 
 function validateCron(expr: string): string {
 	const trimmed = expr.trim();
@@ -48,7 +50,9 @@ let isConnected = $state(false);
 let syncCompleted = $state(false);
 
 const syncActive = $derived(
-	(data.isRunning && !syncCompleted) || (progress !== null && progress.status === 'running')
+	(data.isRunning && !syncCompleted) ||
+		(progress !== null && progress.status === 'running') ||
+		pendingStart
 );
 
 const enrichmentPercent = $derived(() => {
@@ -90,9 +94,11 @@ function connectSSE() {
 
 			if (eventData.type === 'connected' || eventData.type === 'progress') {
 				if (eventData.progress) progress = eventData.progress;
+				if (progress?.status === 'running') pendingStart = false;
 			} else if (['completed', 'failed', 'cancelled'].includes(eventData.type)) {
 				if (eventData.progress) progress = eventData.progress;
 				syncCompleted = true;
+				pendingStart = false;
 				setTimeout(() => {
 					disconnectSSE();
 					isSyncing = false;
@@ -105,6 +111,7 @@ function connectSSE() {
 			} else if (eventData.type === 'idle') {
 				progress = null;
 				isSyncing = false;
+				pendingStart = false;
 			}
 		} catch (e) {
 			console.error('Failed to parse SSE event:', e);
@@ -362,7 +369,7 @@ async function goToPage(page: number) {
 						{/if}
 					</div>
 
-					{#if progress?.status === 'running'}
+					{#if progress?.status === 'running' || pendingStart}
 						<form
 							method="POST"
 							action="?/cancelSync"
@@ -394,9 +401,13 @@ async function goToPage(page: number) {
 					use:enhance={() => {
 						isSyncing = true;
 						syncCompleted = false;
+						pendingStart = true;
 						connectSSE();
-						return async ({ update }) => {
+						return async ({ update, result }) => {
 							await update();
+							if (result.type === 'failure' || result.type === 'error') {
+								pendingStart = false;
+							}
 						};
 					}}
 					class="sync-form"

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -120,6 +120,9 @@ function connectSSE() {
 
 	eventSource.onerror = () => {
 		isConnected = false;
+		pendingStart = false;
+		eventSource?.close();
+		eventSource = null;
 		setTimeout(() => {
 			if (isSyncing && !eventSource) connectSSE();
 		}, 2000);

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -407,8 +407,12 @@ async function goToPage(page: number) {
 						pendingStart = true;
 						connectSSE();
 						return async ({ update, result }) => {
-							await update();
-							if (result.type === 'failure' || result.type === 'error') {
+							try {
+								await update();
+								if (result.type === 'failure' || result.type === 'error') {
+									pendingStart = false;
+								}
+							} catch {
 								pendingStart = false;
 							}
 						};

--- a/src/routes/dashboard/settings/+page.server.ts
+++ b/src/routes/dashboard/settings/+page.server.ts
@@ -6,6 +6,7 @@ import { getUserFullProfile } from '$lib/server/admin/users.service';
 import { db } from '$lib/server/db/client';
 import { sessions } from '$lib/server/db/schema';
 import {
+	getGlobalAllowUserControl,
 	getGlobalDefaultShareMode,
 	getOrCreateShareSettings,
 	getUserLogoPreference,
@@ -33,14 +34,25 @@ export const load: PageServerLoad = async ({ locals }) => {
 	const userId = locals.user!.id;
 	const currentYear = new Date().getFullYear();
 
-	const [userProfile, shareSettings, wrappedLogoMode, userLogoPreference, sessionExpiration] =
-		await Promise.all([
-			getUserFullProfile(userId),
-			getOrCreateShareSettings({ userId, year: currentYear }),
-			getWrappedLogoMode(),
-			getUserLogoPreference(userId, currentYear),
-			getSessionExpiration(userId)
-		]);
+	const [
+		userProfile,
+		shareSettings,
+		wrappedLogoMode,
+		userLogoPreference,
+		sessionExpiration,
+		globalAllowUserControl
+	] = await Promise.all([
+		getUserFullProfile(userId),
+		getOrCreateShareSettings({ userId, year: currentYear }),
+		getWrappedLogoMode(),
+		getUserLogoPreference(userId, currentYear),
+		getSessionExpiration(userId),
+		getGlobalAllowUserControl()
+	]);
+
+	// Effective control gate: admin's global toggle short-circuits the per-user flag
+	// so an "off" global floor is immediately authoritative without a bulk rewrite.
+	const effectiveCanUserControl = globalAllowUserControl && shareSettings.canUserControl;
 
 	return {
 		user: {
@@ -54,7 +66,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 		shareSettings: {
 			mode: shareSettings.mode,
 			shareToken: shareSettings.shareToken,
-			canUserControl: shareSettings.canUserControl
+			canUserControl: effectiveCanUserControl
 		},
 		userLogoPreference,
 		wrappedLogoMode,
@@ -78,9 +90,12 @@ export const actions: Actions = {
 		}
 
 		try {
-			const shareSettings = await getOrCreateShareSettings({ userId, year: currentYear });
+			const [shareSettings, globalAllowUserControl] = await Promise.all([
+				getOrCreateShareSettings({ userId, year: currentYear }),
+				getGlobalAllowUserControl()
+			]);
 
-			if (!shareSettings.canUserControl) {
+			if (!globalAllowUserControl || !shareSettings.canUserControl) {
 				return fail(403, {
 					error: 'You do not have permission to change sharing settings',
 					action: 'updateShareMode'
@@ -110,9 +125,12 @@ export const actions: Actions = {
 		const currentYear = new Date().getFullYear();
 
 		try {
-			const shareSettings = await getOrCreateShareSettings({ userId, year: currentYear });
+			const [shareSettings, globalAllowUserControl] = await Promise.all([
+				getOrCreateShareSettings({ userId, year: currentYear }),
+				getGlobalAllowUserControl()
+			]);
 
-			if (!shareSettings.canUserControl) {
+			if (!globalAllowUserControl || !shareSettings.canUserControl) {
 				return fail(403, {
 					error: 'You do not have permission to change sharing settings',
 					action: 'regenerateToken'

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -76,12 +76,12 @@ interface SubStep {
 	icon: 'appearance' | 'privacy' | 'slides' | 'ai';
 }
 
-// Build sub-steps array (AI only if configured) - reactive to data.hasOpenAI
+// Fun-fact settings work with built-in templates even without OpenAI, so always show the step
 let subSteps = $derived([
 	{ id: 'appearance', label: 'Appearance', icon: 'appearance' },
 	{ id: 'privacy', label: 'Privacy', icon: 'privacy' },
 	{ id: 'slides', label: 'Slides', icon: 'slides' },
-	...(data.hasOpenAI ? [{ id: 'ai', label: 'AI Features', icon: 'ai' as const }] : [])
+	{ id: 'ai', label: 'AI Features', icon: 'ai' }
 ] satisfies SubStep[]);
 
 let currentSubStep = $state(0);

--- a/src/routes/onboarding/sync/+page.server.ts
+++ b/src/routes/onboarding/sync/+page.server.ts
@@ -7,6 +7,7 @@ import {
 	isSyncRunning,
 	startBackgroundSync
 } from '$lib/server/sync';
+import { cancelSync } from '$lib/server/sync/progress';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ parent }) => {
@@ -55,6 +56,20 @@ export const actions: Actions = {
 
 			return fail(500, { error: 'Failed to start sync. Please try again.' });
 		}
+	},
+
+	cancelSync: async ({ locals }) => {
+		if (!locals.user?.isAdmin) {
+			return fail(403, { error: 'Admin access required' });
+		}
+
+		const cancelled = cancelSync();
+
+		if (!cancelled) {
+			return fail(400, { error: 'No sync is currently running' });
+		}
+
+		return { success: true, message: 'Sync cancelled' };
 	},
 
 	continue: async ({ locals }) => {

--- a/src/routes/onboarding/sync/+page.svelte
+++ b/src/routes/onboarding/sync/+page.svelte
@@ -397,8 +397,11 @@ function formatNumber(n: number): string {
 					use:enhance={() => {
 						isCancelling = true;
 						return async ({ update }) => {
-							await update();
-							isCancelling = false;
+							try {
+								await update();
+							} finally {
+								isCancelling = false;
+							}
 						};
 					}}
 				>

--- a/src/routes/onboarding/sync/+page.svelte
+++ b/src/routes/onboarding/sync/+page.svelte
@@ -28,6 +28,7 @@ let phase = $state<'fetching' | 'enriching' | null>(
 let enrichmentTotal = $state(untrack(() => data.currentProgress?.enrichmentTotal ?? 0));
 let enrichmentProcessed = $state(untrack(() => data.currentProgress?.enrichmentProcessed ?? 0));
 let isStarting = $state(false);
+let isCancelling = $state(false);
 let error = $state<string | null>(null);
 
 // SSE connection
@@ -388,14 +389,40 @@ function formatNumber(n: number): string {
 	</div>
 
 	{#snippet footer()}
-		<form method="POST" action="?/continue" use:enhance>
-			<button type="submit" class="continue-button" disabled={!hasStarted}>
-				<span>Continue</span>
-				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-					<path d="M5 12h14M12 5l7 7-7 7" stroke-linecap="round" stroke-linejoin="round" />
-				</svg>
-			</button>
-		</form>
+		<div class="footer-actions">
+			{#if isRunning}
+				<form
+					method="POST"
+					action="?/cancelSync"
+					use:enhance={() => {
+						isCancelling = true;
+						return async ({ update }) => {
+							await update();
+							isCancelling = false;
+						};
+					}}
+				>
+					<button type="submit" class="cancel-button" disabled={isCancelling}>
+						{#if isCancelling}
+							<span class="btn-spinner"></span>
+						{:else}
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+								<rect x="6" y="6" width="12" height="12" rx="2" />
+							</svg>
+						{/if}
+						<span>Cancel</span>
+					</button>
+				</form>
+			{/if}
+			<form method="POST" action="?/continue" use:enhance>
+				<button type="submit" class="continue-button" disabled={!hasStarted}>
+					<span>Continue</span>
+					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+						<path d="M5 12h14M12 5l7 7-7 7" stroke-linecap="round" stroke-linejoin="round" />
+					</svg>
+				</button>
+			</form>
+		</div>
 	{/snippet}
 </OnboardingCard>
 
@@ -845,6 +872,47 @@ function formatNumber(n: number): string {
 			color: rgba(255, 255, 255, 0.5);
 			text-align: center;
 			animation: fade-slide-in 0.3s ease-out;
+		}
+
+		/* Footer actions (Cancel + Continue) */
+		.footer-actions {
+			display: flex;
+			gap: 0.75rem;
+			align-items: center;
+			justify-content: flex-end;
+			flex-wrap: wrap;
+		}
+
+		/* Cancel button */
+		.cancel-button {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			gap: 0.5rem;
+			padding: 0.75rem 1.5rem;
+			font-size: 0.95rem;
+			font-weight: 600;
+			color: hsl(0, 84%, 70%);
+			background: rgba(239, 68, 68, 0.08);
+			border: 1px solid rgba(239, 68, 68, 0.3);
+			border-radius: 10px;
+			cursor: pointer;
+			transition: all 0.25s cubic-bezier(0.22, 1, 0.36, 1);
+		}
+
+		.cancel-button:hover:not(:disabled) {
+			background: rgba(239, 68, 68, 0.15);
+			border-color: rgba(239, 68, 68, 0.5);
+		}
+
+		.cancel-button:disabled {
+			opacity: 0.6;
+			cursor: not-allowed;
+		}
+
+		.cancel-button svg {
+			width: 18px;
+			height: 18px;
 		}
 
 		/* Continue button */

--- a/src/routes/wrapped/[year]/+page.server.ts
+++ b/src/routes/wrapped/[year]/+page.server.ts
@@ -76,6 +76,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 		showLogo: logoVisibility.showLogo,
 		canUserControlLogo: false,
 		currentUrl: `/wrapped/${year}`,
-		isAdmin: locals.user?.isAdmin ?? false
+		isAdmin: locals.user?.isAdmin ?? false,
+		isLoggedIn: !!locals.user
 	};
 };

--- a/src/routes/wrapped/[year]/+page.svelte
+++ b/src/routes/wrapped/[year]/+page.svelte
@@ -35,8 +35,23 @@ const messagingContext = $derived(createServerContext(data.serverName));
 type ViewMode = 'story' | 'scroll';
 let viewMode = $state<ViewMode>('story');
 
+// Read the initial slide index from the URL hash synchronously so StoryMode
+// receives the correct `initialSlideIndex` prop on its first render.
+// Deferring this to a $effect raced with StoryMode's own one-shot
+// `navigation.initialize()` effect — the seeded index could arrive after
+// StoryMode had already initialised with the default 0.
+function readInitialSlideIndex(): number {
+	if (!browser) return 0;
+	const match = window.location.hash.match(/^#slide=(\d+)$/);
+	if (!match) return 0;
+	const parsed = parseInt(match[1]!, 10);
+	if (Number.isNaN(parsed)) return 0;
+	const max = Math.max(0, data.slides.length - 1);
+	return Math.min(Math.max(parsed, 0), max);
+}
+
 /** Current slide index for mode switching (preserves position) */
-let currentSlideIndex = $state(0);
+let currentSlideIndex = $state(readInitialSlideIndex());
 
 /** Whether to show the summary page */
 let showSummary = $state(false);
@@ -46,17 +61,6 @@ let showShareModal = $state(false);
 
 /** Key for forcing StoryMode remount on restart */
 let storyKey = $state(0);
-
-// Seed slide index from URL hash (e.g. #slide=3) so reloads preserve position.
-$effect(() => {
-	if (!browser) return;
-	const match = window.location.hash.match(/^#slide=(\d+)$/);
-	if (!match) return;
-	const parsed = parseInt(match[1]!, 10);
-	if (Number.isNaN(parsed)) return;
-	const max = Math.max(0, data.slides.length - 1);
-	currentSlideIndex = Math.min(Math.max(parsed, 0), max);
-});
 
 // Reflect slide index back into the hash without creating history entries.
 $effect(() => {

--- a/src/routes/wrapped/[year]/+page.svelte
+++ b/src/routes/wrapped/[year]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import Logo from '$lib/components/Logo.svelte';
 import { createServerContext } from '$lib/components/slides/messaging-context';
@@ -46,6 +47,26 @@ let showShareModal = $state(false);
 /** Key for forcing StoryMode remount on restart */
 let storyKey = $state(0);
 
+// Seed slide index from URL hash (e.g. #slide=3) so reloads preserve position.
+$effect(() => {
+	if (!browser) return;
+	const match = window.location.hash.match(/^#slide=(\d+)$/);
+	if (!match) return;
+	const parsed = parseInt(match[1]!, 10);
+	if (Number.isNaN(parsed)) return;
+	const max = Math.max(0, data.slides.length - 1);
+	currentSlideIndex = Math.min(Math.max(parsed, 0), max);
+});
+
+// Reflect slide index back into the hash without creating history entries.
+$effect(() => {
+	if (!browser) return;
+	const next = `#slide=${currentSlideIndex}`;
+	if (window.location.hash !== next) {
+		history.replaceState(null, '', `${window.location.pathname}${window.location.search}${next}`);
+	}
+});
+
 // ==========================================================================
 // Event Handlers
 // ==========================================================================
@@ -76,9 +97,15 @@ function handleComplete(): void {
  * Handle close/exit action
  */
 function handleClose(): void {
-	const isSameOrigin =
-		document.referrer !== '' && document.referrer.startsWith(window.location.origin);
-	if (isSameOrigin && window.history.length > 1) {
+	let sameOrigin = false;
+	if (document.referrer) {
+		try {
+			sameOrigin = new URL(document.referrer).origin === window.location.origin;
+		} catch {
+			sameOrigin = false;
+		}
+	}
+	if (sameOrigin && window.history.length > 1) {
 		window.history.back();
 	} else {
 		goto('/');
@@ -99,7 +126,13 @@ function handleRestart(): void {
  * Handle return home from summary
  */
 function handleHome(): void {
-	goto('/');
+	if (data.isAdmin) {
+		goto('/admin');
+	} else if (data.isLoggedIn) {
+		goto('/dashboard');
+	} else {
+		goto('/');
+	}
 }
 
 /**

--- a/src/routes/wrapped/[year]/+page.svelte
+++ b/src/routes/wrapped/[year]/+page.svelte
@@ -63,7 +63,11 @@ $effect(() => {
 	if (!browser) return;
 	const next = `#slide=${currentSlideIndex}`;
 	if (window.location.hash !== next) {
-		history.replaceState(null, '', `${window.location.pathname}${window.location.search}${next}`);
+		history.replaceState(
+			history.state,
+			'',
+			`${window.location.pathname}${window.location.search}${next}`
+		);
 	}
 });
 

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -199,6 +199,8 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		},
 		isOwner,
 		isAdmin,
+		isLoggedIn: !!locals.user,
+		globalFloor: globalFloorForUrl,
 		currentUrl: `/wrapped/${year}/u/${urlIdentifier}`,
 		yearIdentifiers
 	};

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
@@ -41,8 +41,23 @@ let showLogo = $derived(showLogoOverride ?? data.showLogo);
 type ViewMode = 'story' | 'scroll';
 let viewMode = $state<ViewMode>('story');
 
+// Read the initial slide index from the URL hash synchronously so StoryMode
+// receives the correct `initialSlideIndex` prop on its first render.
+// Deferring this to a $effect raced with StoryMode's own one-shot
+// `navigation.initialize()` effect — the seeded index could arrive after
+// StoryMode had already initialised with the default 0.
+function readInitialSlideIndex(): number {
+	if (!browser) return 0;
+	const match = window.location.hash.match(/^#slide=(\d+)$/);
+	if (!match) return 0;
+	const parsed = parseInt(match[1]!, 10);
+	if (Number.isNaN(parsed)) return 0;
+	const max = Math.max(0, data.slides.length - 1);
+	return Math.min(Math.max(parsed, 0), max);
+}
+
 /** Current slide index for mode switching (preserves position) */
-let currentSlideIndex = $state(0);
+let currentSlideIndex = $state(readInitialSlideIndex());
 
 /** Whether to show the summary page */
 let showSummary = $state(false);
@@ -52,17 +67,6 @@ let showShareModal = $state(false);
 
 /** Key for forcing StoryMode remount on restart */
 let storyKey = $state(0);
-
-// Seed slide index from URL hash (e.g. #slide=3) so reloads preserve position.
-$effect(() => {
-	if (!browser) return;
-	const match = window.location.hash.match(/^#slide=(\d+)$/);
-	if (!match) return;
-	const parsed = parseInt(match[1]!, 10);
-	if (Number.isNaN(parsed)) return;
-	const max = Math.max(0, data.slides.length - 1);
-	currentSlideIndex = Math.min(Math.max(parsed, 0), max);
-});
 
 // Reflect slide index back into the hash without creating history entries.
 $effect(() => {

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
 import { goto } from '$app/navigation';
 import Logo from '$lib/components/Logo.svelte';
@@ -52,6 +53,26 @@ let showShareModal = $state(false);
 /** Key for forcing StoryMode remount on restart */
 let storyKey = $state(0);
 
+// Seed slide index from URL hash (e.g. #slide=3) so reloads preserve position.
+$effect(() => {
+	if (!browser) return;
+	const match = window.location.hash.match(/^#slide=(\d+)$/);
+	if (!match) return;
+	const parsed = parseInt(match[1]!, 10);
+	if (Number.isNaN(parsed)) return;
+	const max = Math.max(0, data.slides.length - 1);
+	currentSlideIndex = Math.min(Math.max(parsed, 0), max);
+});
+
+// Reflect slide index back into the hash without creating history entries.
+$effect(() => {
+	if (!browser) return;
+	const next = `#slide=${currentSlideIndex}`;
+	if (window.location.hash !== next) {
+		history.replaceState(null, '', `${window.location.pathname}${window.location.search}${next}`);
+	}
+});
+
 // ==========================================================================
 // Event Handlers
 // ==========================================================================
@@ -82,9 +103,15 @@ function handleComplete(): void {
  * Handle close/exit action
  */
 function handleClose(): void {
-	const isSameOrigin =
-		document.referrer !== '' && document.referrer.startsWith(window.location.origin);
-	if (isSameOrigin && window.history.length > 1) {
+	let sameOrigin = false;
+	if (document.referrer) {
+		try {
+			sameOrigin = new URL(document.referrer).origin === window.location.origin;
+		} catch {
+			sameOrigin = false;
+		}
+	}
+	if (sameOrigin && window.history.length > 1) {
 		window.history.back();
 	} else {
 		goto('/');
@@ -105,7 +132,13 @@ function handleRestart(): void {
  * Handle return home from summary
  */
 function handleHome(): void {
-	goto('/');
+	if (data.isAdmin) {
+		goto('/admin');
+	} else if (data.isLoggedIn) {
+		goto('/dashboard');
+	} else {
+		goto('/');
+	}
 }
 
 /**
@@ -273,6 +306,7 @@ function handleLogoToggle(): void {
 		shareSettings={data.shareSettings}
 		isOwner={data.isOwner}
 		isAdmin={data.isAdmin}
+		globalFloor={data.globalFloor}
 	/>
 </div>
 

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
@@ -69,7 +69,11 @@ $effect(() => {
 	if (!browser) return;
 	const next = `#slide=${currentSlideIndex}`;
 	if (window.location.hash !== next) {
-		history.replaceState(null, '', `${window.location.pathname}${window.location.search}${next}`);
+		history.replaceState(
+			history.state,
+			'',
+			`${window.location.pathname}${window.location.search}${next}`
+		);
 	}
 });
 


### PR DESCRIPTION
## Summary

Resolves all 17 findings from the post-PR #70 E2E QA dogfood pass (1 critical, 1 high, 4 medium, 11 low).

### Critical
- **F-001** — Plex token and OpenAI API key no longer leak into the SvelteKit load hydration blob. A new `SafeConfigValue` shape (`source`, `isLocked`, `hasValue`) replaces the raw value for secret fields. Inputs render empty with a `(unchanged — re-enter to change)` placeholder when a secret is stored; empty submissions are a no-op, explicit clear remains available.

### High
- **F-002** — `/admin/slides` Create Custom Slide modal now keeps its action buttons reachable at typical laptop viewports via a sticky footer (`position: sticky; bottom: 0`) and a reduced textarea `min-height`.

### Medium
- **F-003** — `/dashboard/settings` load computes the effective `canUserControl` as `globalAllowUserControl && shareSettings.canUserControl`, making an admin's global toggle immediately authoritative without a bulk rewrite.
- **F-004** — Sync backfill dropdown enumerates 2000 → current year (was: last 6 years).
- **F-005** — Logo Mode relocated from the Privacy tab to the Appearance tab in admin settings.
- **F-006** — Destructive actions (Clear All Logs, bulk-apply-user-control) use the shadcn `AlertDialog` primitive instead of `window.confirm`.

### Low
- **F-007** — `/onboarding/sync` gains a Cancel button while a sync is running, wired to a new `cancelSync` action on the route.
- **F-008** — AI fun-fact settings step is always shown in onboarding (templates work without OpenAI).
- **F-009** — Admin sync Cancel button stays hit-testable during the Start-click → first-SSE-frame gap via a `pendingStart` optimistic flag.
- **F-010** — Security tab documents when warning-reset controls appear.
- **F-011** — Wrapped close handler uses `URL.origin ===` (not `startsWith`) to avoid origin-prefix tricks and falls back to `goto('/')` when the referrer is cross-origin or history is empty.
- **F-013** — Return Home routes by role: admin → `/admin`, logged-in user → `/dashboard`, anonymous → `/`.
- **F-014** — ShareModal shows an inline floor caption when an admin picks a less-restrictive mode than the global floor, stating the effective mode at access time.
- **F-015** — Share-mode radios use the `.sr-only` pattern (from `ProgressBar.svelte`) instead of `display: none`, so screen readers announce the `checked` state; focus ring is on the wrapping label.
- **F-016** — StoryMode slide position persists via a `#slide=N` hash, parsed on mount and written on change via `history.replaceState`.
- **F-017** — `ApiConfigSchema` bounds `openaiModel` at 100 chars and `openaiBaseUrl`/`plexServerUrl`/secrets at 512.

## Test plan
- [x] `bun run check` — 0 errors, 0 warnings
- [x] `bun run test` — 1258 pass, coverage 95.9% line/function
- [ ] Manual: confirm hydration HTML contains no raw token for `PLEX_TOKEN` / `OPENAI_API_KEY`
- [ ] Manual: `/admin/slides` modal at 1280×577 — Cancel / Update Preview / Create Slide reachable
- [ ] Manual: admin toggles `allowUserControl=false`; second-session user reloads `/dashboard/settings` and sees locked Privacy tab immediately
- [ ] Manual: `/admin/sync` backfill dropdown shows 2000–current year
- [ ] Manual: Appearance tab shows Logo Mode; Privacy tab no longer does
- [ ] Manual: Clear All Logs opens `AlertDialog`; Esc / Cancel leaves logs intact; explicit confirm clears
- [ ] Manual: onboarding sync Cancel appears while running and transitions state
- [ ] Manual: first-run without OpenAI still shows AI sub-step in onboarding
- [ ] Manual: Start-Sync → Cancel visible immediately and remains stable
- [ ] Manual: CSRF Security tab caption visible
- [ ] Manual: cross-origin referrer on wrapped Close → lands on `/`, not `about:blank`
- [ ] Manual: admin viewing `/wrapped/:year` Return Home → `/admin`; user → `/dashboard`; anon → `/`
- [ ] Manual: ShareModal as admin shows floor caption when picking a less-restrictive mode
- [ ] Manual: DevTools a11y — share-mode radios report correct `checked`
- [ ] Manual: advance StoryMode to slide 3, reload, resume at slide 3
- [ ] Manual: pasting >100 chars in OpenAI model rejected (server + client `maxlength`)

## Notes
Pre-existing lint errors in `src/app.html` and `src/routes/plex/thumb/[...path]/+server.ts` are untouched in this PR.