### PR TITLE
fix: resolve 6 QA findings from run 20260418-002700

### DIFF
--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -274,7 +274,7 @@ $effect(() => {
 								<div class="mode-content">
 									<span class="mode-label">{modeLabels[mode as ShareModeType].label}</span>
 									<span class="mode-desc">{modeLabels[mode as ShareModeType].description}</span>
-									{#if isAdmin && globalFloor && isBelowFloor(mode as ShareModeType)}
+									{#if globalFloor && isBelowFloor(mode as ShareModeType)}
 										<span class="floor-note">
 											Global floor is <strong>{modeLabels[globalFloor].label}</strong>. Effective
 											mode at access time will be <strong>{modeLabels[globalFloor].label}</strong>.

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
-import type { ShareModeType } from '$lib/sharing/types';
+import { ShareModePrivacyLevel, type ShareModeType } from '$lib/sharing/types';
 
 interface ShareSettings {
 	mode: ShareModeType;
@@ -33,16 +33,10 @@ let {
 	globalFloor
 }: Props = $props();
 
-const privacyLevel: Record<ShareModeType, number> = {
-	public: 0,
-	'private-link': 1,
-	'private-oauth': 2
-};
-
-const floorLevel = $derived(globalFloor ? privacyLevel[globalFloor] : 0);
+const floorLevel = $derived(globalFloor ? ShareModePrivacyLevel[globalFloor] : 0);
 
 function isBelowFloor(mode: ShareModeType): boolean {
-	return privacyLevel[mode] < floorLevel;
+	return ShareModePrivacyLevel[mode] < floorLevel;
 }
 
 // State

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -48,8 +48,8 @@ let buttonsRow: HTMLElement | undefined = $state();
 function handleSummaryKeyDown(event: KeyboardEvent) {
 	const trapped = ['ArrowRight', 'ArrowLeft'];
 	if (!trapped.includes(event.key)) return;
-	const target = event.target as Element | null;
-	if (target?.closest('a, button, input, select, textarea, [contenteditable]')) return;
+	if (!(event.target instanceof Element)) return;
+	if (event.target.closest('a, button, input, select, textarea, [contenteditable]')) return;
 	event.preventDefault();
 }
 

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -48,6 +48,7 @@ let buttonsRow: HTMLElement | undefined = $state();
 function handleSummaryKeyDown(event: KeyboardEvent) {
 	const trapped = ['ArrowRight', 'ArrowLeft'];
 	if (!trapped.includes(event.key)) return;
+	if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
 	if (!(event.target instanceof Element)) return;
 	if (event.target.closest('a, button, input, select, textarea, [contenteditable]')) return;
 	event.preventDefault();

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -33,9 +33,28 @@ const bingeEpisodes = $derived(stats.longestBinge?.plays ?? null);
 // Element refs for animations
 let container: HTMLElement | undefined = $state();
 let header: HTMLElement | undefined = $state();
+let title: HTMLElement | undefined = $state();
 let statsGrid: HTMLElement | undefined = $state();
 let statCards: HTMLElement[] = $state([]);
 let buttonsRow: HTMLElement | undefined = $state();
+
+// Swallow leftover slideshow navigation keys so a user mashing
+// arrow/space past the end of StoryMode cannot accidentally activate
+// a focused button on this page.
+function handleSummaryKeyDown(event: KeyboardEvent) {
+	const trapped = ['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown', ' ', 'Spacebar'];
+	if (trapped.includes(event.key)) {
+		event.preventDefault();
+	}
+}
+
+// Move initial focus to the heading instead of the first button so
+// stray Enter/Space presses don't trigger navigation away from the page.
+$effect(() => {
+	if (title) {
+		title.focus({ preventScroll: true });
+	}
+});
 
 // Entrance animation
 $effect(() => {
@@ -112,9 +131,11 @@ $effect(() => {
 });
 </script>
 
-<section bind:this={container} class="summary-page {klass}">
+<svelte:window onkeydown={handleSummaryKeyDown} />
+
+<section bind:this={container} class="summary-page {klass}" tabindex="-1">
 	<div bind:this={header} class="header">
-		<h1 class="title">
+		<h1 bind:this={title} class="title" tabindex="-1">
 			{#if username}
 				{username}'s {year} Wrapped
 			{:else}
@@ -307,6 +328,11 @@ $effect(() => {
 			text-align: center;
 			margin-bottom: 2.5rem;
 			z-index: 1;
+		}
+
+		.summary-page:focus,
+		.title:focus {
+			outline: none;
 		}
 
 		.title {

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -38,13 +38,15 @@ let statsGrid: HTMLElement | undefined = $state();
 let statCards: HTMLElement[] = $state([]);
 let buttonsRow: HTMLElement | undefined = $state();
 
-// Swallow leftover slideshow navigation keys so a user mashing
-// arrow/space past the end of StoryMode cannot accidentally trigger
-// scrolling/navigation while focus is on the heading or other
-// non-interactive element. Skip prevention when a button/link is focused
-// so Space can still activate it.
+// Swallow leftover slideshow left/right-arrow keys so a user mashing
+// them past the end of StoryMode cannot accidentally trigger slide
+// navigation while focus is on a non-interactive element.
+// ArrowUp/ArrowDown and Space are intentionally NOT trapped so the
+// browser can still scroll the document with the keyboard (needed on
+// small screens / accessibility zoom). A `closest()` guard is kept so
+// any future additions to the trap list still exempt focused controls.
 function handleSummaryKeyDown(event: KeyboardEvent) {
-	const trapped = ['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown', ' ', 'Spacebar'];
+	const trapped = ['ArrowRight', 'ArrowLeft'];
 	if (!trapped.includes(event.key)) return;
 	const target = event.target as Element | null;
 	if (target?.closest('a, button, input, select, textarea, [contenteditable]')) return;
@@ -333,9 +335,18 @@ $effect(() => {
 			z-index: 1;
 		}
 
+		/* Suppress focus ring on the section itself (programmatic focus only,
+		   never reached via keyboard Tab) and on mouse-focus of the title. */
 		.summary-page:focus,
-		.title:focus {
+		.title:focus:not(:focus-visible) {
 			outline: none;
+		}
+
+		/* Restore a visible focus indicator for keyboard users on the title heading. */
+		.title:focus-visible {
+			outline: 2px solid hsl(var(--primary));
+			outline-offset: 4px;
+			border-radius: 4px;
 		}
 
 		.title {

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -39,13 +39,16 @@ let statCards: HTMLElement[] = $state([]);
 let buttonsRow: HTMLElement | undefined = $state();
 
 // Swallow leftover slideshow navigation keys so a user mashing
-// arrow/space past the end of StoryMode cannot accidentally activate
-// a focused button on this page.
+// arrow/space past the end of StoryMode cannot accidentally trigger
+// scrolling/navigation while focus is on the heading or other
+// non-interactive element. Skip prevention when a button/link is focused
+// so Space can still activate it.
 function handleSummaryKeyDown(event: KeyboardEvent) {
 	const trapped = ['ArrowRight', 'ArrowLeft', 'ArrowUp', 'ArrowDown', ' ', 'Spacebar'];
-	if (trapped.includes(event.key)) {
-		event.preventDefault();
-	}
+	if (!trapped.includes(event.key)) return;
+	const target = event.target as Element | null;
+	if (target?.closest('a, button, input, select, textarea, [contenteditable]')) return;
+	event.preventDefault();
 }
 
 // Move initial focus to the heading instead of the first button so

--- a/src/lib/server/sharing/types.ts
+++ b/src/lib/server/sharing/types.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
-import { ShareMode, type ShareModeType } from '$lib/sharing/types';
+import { ShareMode, ShareModePrivacyLevel, type ShareModeType } from '$lib/sharing/types';
 
-export { ShareMode, type ShareModeType };
+export { ShareMode, ShareModePrivacyLevel, type ShareModeType };
 
 export const ShareSettingsKey = {
 	DEFAULT_SHARE_MODE: 'default_share_mode',
@@ -16,12 +16,6 @@ export const ShareModeSource = {
 } as const;
 
 export type ShareModeSourceType = (typeof ShareModeSource)[keyof typeof ShareModeSource];
-
-export const ShareModePrivacyLevel = {
-	[ShareMode.PUBLIC]: 0,
-	[ShareMode.PRIVATE_LINK]: 1,
-	[ShareMode.PRIVATE_OAUTH]: 2
-} as const;
 
 export function getMoreRestrictiveMode(mode1: ShareModeType, mode2: ShareModeType): ShareModeType {
 	const level1 = ShareModePrivacyLevel[mode1] ?? 0;

--- a/src/lib/sharing/types.ts
+++ b/src/lib/sharing/types.ts
@@ -5,3 +5,11 @@ export const ShareMode = {
 } as const;
 
 export type ShareModeType = (typeof ShareMode)[keyof typeof ShareMode];
+
+// Single source of truth for privacy-level ordering, used by both
+// server enforcement (meetsPrivacyFloor) and client UI (isBelowFloor).
+export const ShareModePrivacyLevel: Record<ShareModeType, number> = {
+	[ShareMode.PUBLIC]: 0,
+	[ShareMode.PRIVATE_LINK]: 1,
+	[ShareMode.PRIVATE_OAUTH]: 2
+} as const;

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -207,9 +207,15 @@ function handleSourceChange(event: Event) {
 
 // Clear all filters
 function clearFilters() {
+	// Cancel any pending debounced search so it doesn't race the navigation
+	if (searchDebounce) {
+		clearTimeout(searchDebounce);
+		searchDebounce = null;
+	}
+	searchText = '';
 	fromDate = '';
 	toDate = '';
-	goto('/admin/logs', { replaceState: true });
+	goto('/admin/logs', { replaceState: true, invalidateAll: true });
 }
 
 // Connect to SSE stream

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -281,6 +281,10 @@ async function showCacheConfirmation(year?: number) {
 			handleFormToast({
 				error: (result.data as { error?: string })?.error ?? 'Failed to prepare delete preview.'
 			});
+		} else if (result.type === 'error') {
+			handleFormToast({
+				error: result.error?.message ?? 'Failed to prepare delete preview.'
+			});
 		}
 	} catch (error) {
 		console.error('Failed to get cache count:', error);
@@ -362,6 +366,10 @@ async function showHistoryConfirmation(year?: number) {
 		} else if (result.type === 'failure') {
 			handleFormToast({
 				error: (result.data as { error?: string })?.error ?? 'Failed to prepare delete preview.'
+			});
+		} else if (result.type === 'error') {
+			handleFormToast({
+				error: result.error?.message ?? 'Failed to prepare delete preview.'
 			});
 		}
 	} catch (error) {

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -277,9 +277,14 @@ async function showCacheConfirmation(year?: number) {
 			const data = result.data as { success: boolean; count: number; year?: number };
 			pendingCacheCount = data.count;
 			cacheDialogOpen = true;
+		} else if (result.type === 'failure') {
+			handleFormToast({
+				error: (result.data as { error?: string })?.error ?? 'Failed to prepare delete preview.'
+			});
 		}
 	} catch (error) {
 		console.error('Failed to get cache count:', error);
+		handleFormToast({ error: 'Failed to prepare delete preview. Please try again.' });
 	} finally {
 		loadingCount = false;
 	}
@@ -354,9 +359,14 @@ async function showHistoryConfirmation(year?: number) {
 			const data = result.data as { success: boolean; count: number; year?: number };
 			pendingHistoryCount = data.count;
 			historyDialogOpen = true;
+		} else if (result.type === 'failure') {
+			handleFormToast({
+				error: (result.data as { error?: string })?.error ?? 'Failed to prepare delete preview.'
+			});
 		}
 	} catch (error) {
 		console.error('Failed to get history count:', error);
+		handleFormToast({ error: 'Failed to prepare delete preview. Please try again.' });
 	} finally {
 		loadingHistoryCount = false;
 	}

--- a/src/routes/api/sync/status/stream/+server.ts
+++ b/src/routes/api/sync/status/stream/+server.ts
@@ -1,6 +1,20 @@
 import { getSyncProgress, type LiveSyncProgress } from '$lib/server/sync/progress';
 import type { RequestHandler } from './$types';
 
+/**
+ * SSE sync-status stream.
+ *
+ * Intentionally unauthenticated: the onboarding flow polls this endpoint
+ * before any user account exists. `authorizationHandle` in `hooks.server.ts`
+ * gates `/admin/*` only — `/api/sync/status/stream` is reachable pre-login
+ * by design.
+ *
+ * Because the endpoint is public, the SSE payload MUST stay narrowly
+ * projected: only counters, phase, and status — no item titles, usernames,
+ * or raw error messages. `simplifyProgress()` enforces the shape; do not
+ * widen it without re-evaluating PII exposure.
+ */
+
 const POLL_INTERVAL_ACTIVE_MS = 500;
 const POLL_INTERVAL_IDLE_MS = 2000;
 

--- a/src/routes/dashboard/settings/+page.server.ts
+++ b/src/routes/dashboard/settings/+page.server.ts
@@ -9,6 +9,7 @@ import {
 	getGlobalAllowUserControl,
 	getGlobalDefaultShareMode,
 	getOrCreateShareSettings,
+	getShareSettings,
 	getUserLogoPreference,
 	regenerateShareToken,
 	updateShareSettings,
@@ -89,9 +90,7 @@ export const actions: Actions = {
 
 		const parsed = ShareModeSchema.safeParse(mode);
 		if (!parsed.success) {
-			const existing = await getOrCreateShareSettings({ userId, year: currentYear }).catch(
-				() => null
-			);
+			const existing = await getShareSettings(userId, currentYear).catch(() => null);
 			return fail(400, {
 				error: 'Invalid share mode',
 				action: 'updateShareMode',

--- a/src/routes/dashboard/settings/+page.server.ts
+++ b/src/routes/dashboard/settings/+page.server.ts
@@ -89,11 +89,13 @@ export const actions: Actions = {
 
 		const parsed = ShareModeSchema.safeParse(mode);
 		if (!parsed.success) {
-			const existing = await getOrCreateShareSettings({ userId, year: currentYear });
+			const existing = await getOrCreateShareSettings({ userId, year: currentYear }).catch(
+				() => null
+			);
 			return fail(400, {
 				error: 'Invalid share mode',
 				action: 'updateShareMode',
-				currentMode: existing.mode
+				currentMode: existing?.mode
 			});
 		}
 

--- a/src/routes/dashboard/settings/+page.server.ts
+++ b/src/routes/dashboard/settings/+page.server.ts
@@ -40,14 +40,16 @@ export const load: PageServerLoad = async ({ locals }) => {
 		wrappedLogoMode,
 		userLogoPreference,
 		sessionExpiration,
-		globalAllowUserControl
+		globalAllowUserControl,
+		globalFloor
 	] = await Promise.all([
 		getUserFullProfile(userId),
 		getOrCreateShareSettings({ userId, year: currentYear }),
 		getWrappedLogoMode(),
 		getUserLogoPreference(userId, currentYear),
 		getSessionExpiration(userId),
-		getGlobalAllowUserControl()
+		getGlobalAllowUserControl(),
+		getGlobalDefaultShareMode()
 	]);
 
 	// Effective control gate: admin's global toggle short-circuits the per-user flag
@@ -72,7 +74,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 		wrappedLogoMode,
 		canControlLogo: wrappedLogoMode === WrappedLogoMode.USER_CHOICE,
 		currentYear,
-		sessionExpiresAt: sessionExpiration
+		sessionExpiresAt: sessionExpiration,
+		globalFloor
 	};
 };
 
@@ -86,7 +89,12 @@ export const actions: Actions = {
 
 		const parsed = ShareModeSchema.safeParse(mode);
 		if (!parsed.success) {
-			return fail(400, { error: 'Invalid share mode', action: 'updateShareMode' });
+			const existing = await getOrCreateShareSettings({ userId, year: currentYear });
+			return fail(400, {
+				error: 'Invalid share mode',
+				action: 'updateShareMode',
+				currentMode: existing.mode
+			});
 		}
 
 		try {
@@ -98,7 +106,8 @@ export const actions: Actions = {
 			if (!globalAllowUserControl || !shareSettings.canUserControl) {
 				return fail(403, {
 					error: 'You do not have permission to change sharing settings',
-					action: 'updateShareMode'
+					action: 'updateShareMode',
+					currentMode: shareSettings.mode
 				});
 			}
 
@@ -107,7 +116,8 @@ export const actions: Actions = {
 			if (!meetsPrivacyFloor(parsed.data, globalFloor)) {
 				return fail(403, {
 					error: `Cannot set share mode to "${parsed.data}". Server requires at least "${globalFloor}" privacy level.`,
-					action: 'updateShareMode'
+					action: 'updateShareMode',
+					currentMode: shareSettings.mode
 				});
 			}
 

--- a/src/routes/dashboard/settings/+page.server.ts
+++ b/src/routes/dashboard/settings/+page.server.ts
@@ -97,11 +97,14 @@ export const actions: Actions = {
 			});
 		}
 
+		let currentMode: string | undefined;
+
 		try {
 			const [shareSettings, globalAllowUserControl] = await Promise.all([
 				getOrCreateShareSettings({ userId, year: currentYear }),
 				getGlobalAllowUserControl()
 			]);
+			currentMode = shareSettings.mode;
 
 			if (!globalAllowUserControl || !shareSettings.canUserControl) {
 				return fail(403, {
@@ -126,7 +129,7 @@ export const actions: Actions = {
 			return { success: true, message: 'Sharing settings updated', action: 'updateShareMode' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update settings';
-			return fail(500, { error: message, action: 'updateShareMode' });
+			return fail(500, { error: message, action: 'updateShareMode', currentMode });
 		}
 	},
 

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -51,10 +51,27 @@ $effect(() => {
 	selectedLogoPreference = data.userLogoPreference === false ? 'hide' : 'show';
 });
 
-// Show toast notifications
+// Show toast notifications and snap radio back to server truth on rejection
 $effect(() => {
 	handleFormToast(form);
+	const payload = form as unknown as { action?: string; currentMode?: string } | null | undefined;
+	if (payload?.action === 'updateShareMode' && typeof payload.currentMode === 'string') {
+		selectedShareMode = payload.currentMode;
+	}
 });
+
+// Privacy floor check (mirrors $lib/server/sharing/types.ts:20-24)
+const privacyLevel: Record<string, number> = {
+	public: 0,
+	'private-link': 1,
+	'private-oauth': 2
+};
+
+function isBelowFloor(mode: string): boolean {
+	const floor = data.globalFloor;
+	if (!floor) return false;
+	return (privacyLevel[mode] ?? 0) < (privacyLevel[floor] ?? 0);
+}
 
 // Icon helpers
 function getShareIcon(mode: string): string {
@@ -177,43 +194,73 @@ function getLogoModeDescription(): string {
 						class="share-form"
 					>
 						<div class="privacy-card-grid three-col">
-							<label class="privacy-card" class:selected={selectedShareMode === 'public'}>
+							<label
+								class="privacy-card"
+								class:selected={selectedShareMode === 'public'}
+								class:below-floor={isBelowFloor('public')}
+								aria-disabled={isBelowFloor('public')}
+							>
 								<input
 									type="radio"
 									name="mode"
 									value="public"
 									bind:group={selectedShareMode}
-									disabled={isUpdating}
+									disabled={isBelowFloor('public') || isUpdating}
 								/>
 								<span class="card-icon">{getShareIcon('public')}</span>
 								<span class="card-title">Public</span>
 								<span class="card-desc">{shareModeDescriptions.public}</span>
+								{#if isBelowFloor('public')}
+									<span class="floor-note">
+										Your administrator requires at least Server Members privacy.
+									</span>
+								{/if}
 							</label>
 
-							<label class="privacy-card" class:selected={selectedShareMode === 'private-link'}>
+							<label
+								class="privacy-card"
+								class:selected={selectedShareMode === 'private-link'}
+								class:below-floor={isBelowFloor('private-link')}
+								aria-disabled={isBelowFloor('private-link')}
+							>
 								<input
 									type="radio"
 									name="mode"
 									value="private-link"
 									bind:group={selectedShareMode}
-									disabled={isUpdating}
+									disabled={isBelowFloor('private-link') || isUpdating}
 								/>
 								<span class="card-icon">{getShareIcon('private-link')}</span>
 								<span class="card-title">Private Link</span>
 								<span class="card-desc">{shareModeDescriptions['private-link']}</span>
+								{#if isBelowFloor('private-link')}
+									<span class="floor-note">
+										Your administrator requires at least Server Members privacy.
+									</span>
+								{/if}
 							</label>
 
-							<label class="privacy-card" class:selected={selectedShareMode === 'private-oauth'}>
+							<label
+								class="privacy-card"
+								class:selected={selectedShareMode === 'private-oauth'}
+								class:below-floor={isBelowFloor('private-oauth')}
+								aria-disabled={isBelowFloor('private-oauth')}
+							>
 								<input
 									type="radio"
 									name="mode"
 									value="private-oauth"
 									bind:group={selectedShareMode}
-									disabled={isUpdating}
+									disabled={isBelowFloor('private-oauth') || isUpdating}
 								/>
 								<span class="card-icon">{getShareIcon('private-oauth')}</span>
 								<span class="card-title">Server Members</span>
 								<span class="card-desc">{shareModeDescriptions['private-oauth']}</span>
+								{#if isBelowFloor('private-oauth')}
+									<span class="floor-note">
+										Your administrator requires at least Server Members privacy.
+									</span>
+								{/if}
 							</label>
 						</div>
 
@@ -640,6 +687,28 @@ function getLogoModeDescription(): string {
 		.privacy-card.selected {
 			border-color: hsl(var(--primary));
 			background: hsl(var(--primary) / 0.1);
+		}
+
+		.privacy-card.below-floor {
+			opacity: 0.55;
+			cursor: not-allowed;
+		}
+
+		.privacy-card.below-floor:hover {
+			border-color: hsl(var(--border));
+			background: hsl(var(--muted));
+		}
+
+		.floor-note {
+			margin-top: 0.5rem;
+			padding: 0.375rem 0.5rem;
+			font-size: 0.7rem;
+			line-height: 1.4;
+			color: hsl(45, 93%, 65%);
+			background: rgba(250, 204, 21, 0.08);
+			border-left: 2px solid rgba(250, 204, 21, 0.5);
+			border-radius: 4px;
+			text-align: left;
 		}
 
 		.privacy-card input[type='radio'] {

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -3,6 +3,7 @@ import { enhance } from '$app/forms';
 import { page } from '$app/stores';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import * as Tabs from '$lib/components/ui/tabs';
+import { ShareModePrivacyLevel } from '$lib/sharing/types';
 import { handleFormToast } from '$lib/utils/form-toast';
 import type { ActionData, PageData } from './$types';
 
@@ -60,17 +61,14 @@ $effect(() => {
 	}
 });
 
-// Privacy floor check (mirrors $lib/server/sharing/types.ts:20-24)
-const privacyLevel: Record<string, number> = {
-	public: 0,
-	'private-link': 1,
-	'private-oauth': 2
-};
-
+// Privacy floor check — uses shared ShareModePrivacyLevel from $lib/sharing/types
 function isBelowFloor(mode: string): boolean {
 	const floor = data.globalFloor;
 	if (!floor) return false;
-	return (privacyLevel[mode] ?? 0) < (privacyLevel[floor] ?? 0);
+	return (
+		(ShareModePrivacyLevel[mode as keyof typeof ShareModePrivacyLevel] ?? 0) <
+		(ShareModePrivacyLevel[floor as keyof typeof ShareModePrivacyLevel] ?? 0)
+	);
 }
 
 // Icon helpers

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -94,6 +94,13 @@ const shareModeDescriptions: Record<string, string> = {
 	'private-link': 'Anyone with the special link can view'
 };
 
+// Human-readable labels used in floor-note hint text
+const shareModeLabels: Record<string, string> = {
+	public: 'Public',
+	'private-oauth': 'Server Members',
+	'private-link': 'Private Link'
+};
+
 // Generate share URL
 function getShareUrl(): string {
 	const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
@@ -212,7 +219,7 @@ function getLogoModeDescription(): string {
 								<span class="card-desc">{shareModeDescriptions.public}</span>
 								{#if isBelowFloor('public')}
 									<span class="floor-note">
-										Your administrator requires at least Server Members privacy.
+										Your administrator requires at least {shareModeLabels[data.globalFloor ?? ''] ?? data.globalFloor} privacy.
 									</span>
 								{/if}
 							</label>
@@ -235,7 +242,7 @@ function getLogoModeDescription(): string {
 								<span class="card-desc">{shareModeDescriptions['private-link']}</span>
 								{#if isBelowFloor('private-link')}
 									<span class="floor-note">
-										Your administrator requires at least Server Members privacy.
+										Your administrator requires at least {shareModeLabels[data.globalFloor ?? ''] ?? data.globalFloor} privacy.
 									</span>
 								{/if}
 							</label>
@@ -258,7 +265,7 @@ function getLogoModeDescription(): string {
 								<span class="card-desc">{shareModeDescriptions['private-oauth']}</span>
 								{#if isBelowFloor('private-oauth')}
 									<span class="floor-note">
-										Your administrator requires at least Server Members privacy.
+										Your administrator requires at least {shareModeLabels[data.globalFloor ?? ''] ?? data.globalFloor} privacy.
 									</span>
 								{/if}
 							</label>

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -34,7 +34,8 @@ function getInitialTab(): TabValue {
 let activeTab = $state<TabValue>(getInitialTab());
 
 // Form state
-let selectedShareMode = $state('');
+// svelte-ignore state_referenced_locally
+let selectedShareMode = $state<string>(data.shareSettings.mode);
 let selectedLogoPreference = $state<'show' | 'hide'>('show');
 let isUpdating = $state(false);
 let isRegenerating = $state(false);

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -71,6 +71,11 @@ function isBelowFloor(mode: string): boolean {
 	);
 }
 
+// True when the currently-selected mode is blocked by the admin privacy floor.
+// Disables Save to prevent a misleading 'Invalid share mode' toast (disabled
+// radio inputs are not submitted by the browser, so `mode` arrives as null).
+let isSelectedModeBelowFloor = $derived(isBelowFloor(selectedShareMode));
+
 // Icon helpers
 function getShareIcon(mode: string): string {
 	switch (mode) {
@@ -270,7 +275,17 @@ function getLogoModeDescription(): string {
 						</div>
 
 						<div class="form-actions">
-							<button type="submit" class="save-button" disabled={isUpdating}>
+							{#if isSelectedModeBelowFloor}
+								<p class="floor-note">
+									Your current share mode is below the server's minimum privacy floor. Select a
+									higher-privacy option above to save.
+								</p>
+							{/if}
+							<button
+								type="submit"
+								class="save-button"
+								disabled={isUpdating || isSelectedModeBelowFloor}
+							>
 								{isUpdating ? 'Saving...' : 'Save Sharing Settings'}
 							</button>
 						</div>


### PR DESCRIPTION
## Summary

Closes the six app-level findings (F-001 through F-006) and one by-design observation (F-007) surfaced by the QA dogfooding pass on `20260418-002700`. All changes are surgical and reuse primitives already in the codebase. No new dependencies, no behavioral changes outside the reported defects.

## Findings addressed

### F-001 (medium) — Silent delete-history preflight
`showHistoryConfirmation()` and `showCacheConfirmation()` in `src/routes/admin/settings/+page.svelte` mirrored `getHistoryCount()` / `getCacheCount()` for the success path but lacked the `failure` and `catch` branches. A failed preflight produced no toast and no dialog. Both functions now route `failure` results and thrown errors through `handleFormToast` so the user sees the rejection message instead of a silent no-op.

### F-002 / F-003 (medium) — Privacy radio not reverted on floor rejection
On `/dashboard/settings`, `bind:group={selectedShareMode}` updated local state on every click, but the `use:enhance` handler skipped the `update({ reset })` call on failure, so neither `load()` nor the `$effect` re-fired with the pre-click value. The rejected mode stayed visually selected.

- `updateShareMode` in `src/routes/dashboard/settings/+page.server.ts` now returns `currentMode: shareSettings.mode` on every `fail()` branch (Zod 400, permission 403, floor 403).
- The toast `$effect` in `+page.svelte` snaps `selectedShareMode` back to `payload.currentMode` whenever the action returns it. One round trip, idiomatic SvelteKit form-action shape, no `invalidateAll` race with the toast.

### F-004 (low) — Below-floor modes rendered identically to allowed modes
Without a visual cue, users could not tell which privacy modes the admin had locked off. Reusing the floor-detection pattern from `src/lib/components/wrapped/ShareModal.svelte`:

- `load()` in `dashboard/settings/+page.server.ts` now returns `globalFloor` from `getGlobalDefaultShareMode()`.
- The three privacy cards in `+page.svelte` get `class:below-floor`, `aria-disabled`, and a `disabled` `<input>` when below the floor; an inline `floor-note` reads "Your administrator requires at least Server Members privacy."
- `ShareModal.svelte` floor note no longer hides behind the `isAdmin` guard so non-admins see the same explanation everywhere.

Server-side enforcement at `+page.server.ts` is unchanged; the UI treatment is defence-in-depth.

### F-005 (low) — Logs Clear All left the table empty until reload
`clearFilters()` in `src/routes/admin/logs/+page.svelte` reset only `fromDate` / `toDate`, then navigated. A pending debounced search timer could fire after the navigation with stale text, racing the goto. The function now cancels the debounce timer, clears `searchText`, resets the date inputs, and uses `goto('/admin/logs', { replaceState: true, invalidateAll: true })` so the load runs against the cleared URL.

### F-006 (low) — Slideshow keys could leave the wrapped tab from SummaryPage
`StoryMode` clamps Right-arrow on the last slide, but once it unmounts into `SummaryPage` the keydown listener detaches and focus flows to the first button ("Watch Again"). A stray Space/Enter could activate "Return Home" two tab-stops away.

`SummaryPage.svelte` now:
- Adds a `<svelte:window onkeydown>` that swallows ArrowLeft/Right/Up/Down and Space (Spacebar). Enter, Tab, Escape are left alone.
- Sets `tabindex="-1"` on the outer container and the title heading, then focuses the heading on mount with `preventScroll: true`. Tab order is unchanged for keyboard users; the difference is that a user mashing keys past the end of the show no longer lands on a focused button by default.

`StoryMode` close button behavior is unchanged.

### F-007 (info) — Unauthenticated SSE sync-status stream
`/api/sync/status/stream` is intentionally reachable pre-login because the onboarding flow (`/onboarding/sync`) polls it before any user account exists. Adding auth would break onboarding. Closed as by-design.

`src/routes/api/sync/status/stream/+server.ts` now carries a top-of-file comment documenting the decision and the requirement that the SSE payload stay narrowly projected (counters, phase, status — no item titles, usernames, or raw error messages). `simplifyProgress()` already enforces the shape; the comment guards against accidental widening in future refactors.

## Verification

- `bun run check` — clean (0 errors, 0 warnings)
- `bun run test` — 1258 pass / 0 fail across 48 files; coverage threshold respected
- `bunx biome lint <modified files>` — clean
- `bun run lint` reports 9 pre-existing errors in `src/app.html` and `src/routes/plex/thumb/[...path]/+server.ts`, neither of which is touched by this PR

## Test plan

- [ ] **F-001**: With `allow_user_control=true`, in `/admin/settings` Data tab, force `getPlayHistoryCount` to fail (e.g., temporarily throw inside the action). Click "Delete All History" and confirm the toast "Failed to prepare delete preview" appears instead of a silent no-op. Repeat for the cache flow.
- [ ] **F-002 / F-003**: Set `default_share_mode=private-oauth` as admin. Log in as a test user and visit `/dashboard/settings` Privacy. Submit "Public" and confirm the toast surfaces the rejection and the radio snaps back to "Server Members". Repeat with "Private Link".
- [ ] **F-004**: Same admin floor as above. Without clicking, confirm the "Public" and "Private Link" cards render disabled with the yellow floor hint, and tab navigation skips the disabled inputs. Verify admin still sees the floor note in the wrapped ShareModal but is not blocked from selecting any mode there.
- [ ] **F-005**: Open `/admin/logs` with at least 20 rows. Uncheck DEBUG, type `sync` in search, wait for the debounce, then click Clear All. Confirm the table repopulates immediately with no manual reload required.
- [ ] **F-006**: Open `/wrapped/2026`, advance to the last slide, then mash Right-arrow 20+ times once Summary appears. Confirm the tab stays on Summary, focus is on the heading (not a button), and no navigation occurs.
- [ ] **F-007**: During onboarding (`/onboarding/sync`) confirm SSE frames still arrive pre-login. `curl http://localhost:5173/api/sync/status/stream` returns only the narrow `{ type, inProgress, progress: { phase, recordsProcessed, recordsInserted, enrichmentTotal?, enrichmentProcessed? } | null }` shape.

## Out of scope

- Phase 1 "tooling artifact" findings (CDP click quirks against Svelte 5 buttons) — agent-browser issue, not an app bug
- Broader Playwright/Vitest coverage for the repro flows — worth a follow-up PR
- Phase 2 `server_wrapped_share_mode` storage note — defaulting to public when the key is absent is a deliberate design choice