### PR TITLE
fix(plex): tolerate null friend fields and match plain-host server URLs

### DIFF
--- a/src/lib/server/auth/dev-users.ts
+++ b/src/lib/server/auth/dev-users.ts
@@ -108,7 +108,7 @@ async function fetchSharedUsers(
 
 	if (!Array.isArray(data)) {
 		logger.warn(
-			`Invalid friends response: expected array, received ${typeof data}. Shared users will not be available for dev bypass.`,
+			`Invalid friends response: expected array, received ${data === null ? 'null' : typeof data}. Shared users will not be available for dev bypass.`,
 			'DevUsers'
 		);
 		return [];

--- a/src/lib/server/auth/dev-users.ts
+++ b/src/lib/server/auth/dev-users.ts
@@ -7,7 +7,8 @@ import {
 	PLEX_PRODUCT,
 	PLEX_VERSION,
 	PlexAuthApiError,
-	PlexFriendsResponseSchema,
+	type PlexFriend,
+	PlexFriendSchema,
 	PlexServerIdentitySchema,
 	type PlexSharedServerUser
 } from './types';
@@ -104,26 +105,47 @@ async function fetchSharedUsers(
 	}
 
 	const data = await response.json();
-	const result = PlexFriendsResponseSchema.safeParse(data);
 
-	if (!result.success) {
+	if (!Array.isArray(data)) {
 		logger.warn(
-			`Invalid friends response: ${result.error.message}. Shared users will not be available for dev bypass.`,
+			`Invalid friends response: expected array, received ${typeof data}. Shared users will not be available for dev bypass.`,
 			'DevUsers'
 		);
 		return [];
 	}
 
-	// Filter friends to only those with access to this specific server
-	// and map to PlexSharedServerUser format for compatibility
-	return result.data
+	const friends: PlexFriend[] = [];
+	let skipped = 0;
+	for (const entry of data) {
+		const parsed = PlexFriendSchema.safeParse(entry);
+		if (parsed.success) {
+			friends.push(parsed.data);
+		} else {
+			skipped++;
+		}
+	}
+
+	if (skipped > 0) {
+		logger.warn(
+			`Skipped ${skipped} malformed friend record(s) from Plex v2 friends response.`,
+			'DevUsers'
+		);
+	}
+
+	// Filter friends to only those with a usable username and access to this specific server,
+	// then map to PlexSharedServerUser format for compatibility.
+	return friends
+		.filter(
+			(friend): friend is PlexFriend & { username: string } =>
+				typeof friend.username === 'string' && friend.username.length > 0
+		)
 		.filter((friend) =>
 			friend.sharedServers?.some((s) => s.machineIdentifier === machineIdentifier)
 		)
 		.map((friend) => ({
 			id: friend.id,
 			username: friend.username,
-			email: friend.email,
+			email: friend.email ?? undefined,
 			thumb: friend.thumb
 		}));
 }

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -227,6 +227,66 @@ export function filterServerResources(resources: PlexResource[]): PlexResource[]
 	);
 }
 
+function matchesPlainHost(configuredUrl: string, server: PlexResource): boolean {
+	let configuredHost: string;
+	let configuredPort: string;
+	try {
+		const parsed = new URL(configuredUrl);
+		configuredHost = parsed.hostname.toLowerCase();
+		// .plex.direct URLs are handled by matchesByIpAndPort/machineId strategies.
+		if (configuredHost.endsWith('.plex.direct')) {
+			return false;
+		}
+		configuredPort = parsed.port;
+	} catch {
+		return false;
+	}
+
+	const portsMatch = (connPort: number): boolean => {
+		if (configuredPort === '') {
+			return connPort === 32400 || connPort === 443 || connPort === 80;
+		}
+		return connPort.toString() === configuredPort;
+	};
+
+	// Direct address/port match against advertised connections.
+	if (
+		server.connections?.some(
+			(conn) => conn.address.toLowerCase() === configuredHost && portsMatch(conn.port)
+		)
+	) {
+		return true;
+	}
+
+	// Match against the IP embedded in .plex.direct URIs (Plex often advertises only those).
+	if (server.connections) {
+		for (const conn of server.connections) {
+			if (!conn.uri.includes('.plex.direct')) continue;
+			const extracted = extractPlexDirectIpAndPort(conn.uri);
+			if (!extracted) continue;
+			const embeddedPort = extracted.port === '' ? 32400 : parseInt(extracted.port, 10);
+			if (
+				extracted.ip.toLowerCase() === configuredHost &&
+				!Number.isNaN(embeddedPort) &&
+				portsMatch(embeddedPort)
+			) {
+				return true;
+			}
+		}
+	}
+
+	// Match against server.publicAddress when any advertised connection uses the configured port.
+	if (
+		server.publicAddress &&
+		server.publicAddress.toLowerCase() === configuredHost &&
+		server.connections?.some((c) => portsMatch(c.port))
+	) {
+		return true;
+	}
+
+	return false;
+}
+
 function findConfiguredServer(
 	servers: PlexResource[],
 	configuredUrl: string
@@ -257,9 +317,20 @@ function findConfiguredServer(
 			);
 			return serverByIp;
 		}
+	} else {
+		// Strategy 3: For plain-host URLs (e.g. http://192.168.1.34:32400), match against
+		// connection address/port, IPs embedded in .plex.direct URIs, or publicAddress.
+		const serverByPlainHost = servers.find((s) => matchesPlainHost(configuredUrl, s));
+		if (serverByPlainHost) {
+			logger.debug(
+				`Matched server by plain host/port: ${configuredUrl} -> ${serverByPlainHost.name}`,
+				'Membership'
+			);
+			return serverByPlainHost;
+		}
 	}
 
-	// Strategy 3: Fall back to connection URI matching
+	// Strategy 4: Fall back to connection URI matching
 	return servers.find((server) => {
 		if (server.connections) {
 			return server.connections.some((conn) => urlsMatch(conn.uri, configuredUrl));

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -264,12 +264,7 @@ function matchesPlainHost(configuredUrl: string, server: PlexResource): boolean 
 			if (!conn.uri.includes('.plex.direct')) continue;
 			const extracted = extractPlexDirectIpAndPort(conn.uri);
 			if (!extracted) continue;
-			const embeddedPort = extracted.port === '' ? 32400 : parseInt(extracted.port, 10);
-			if (
-				extracted.ip.toLowerCase() === configuredHost &&
-				!Number.isNaN(embeddedPort) &&
-				portsMatch(embeddedPort)
-			) {
+			if (extracted.ip.toLowerCase() === configuredHost && portsMatch(conn.port)) {
 				return true;
 			}
 		}

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -144,8 +144,8 @@ function matchesByIpAndPort(
 		// Compare ports - handle default ports and string/number conversion
 		let matchesPort = false;
 		if (configuredPort === '') {
-			// No port in configured URL - match typical Plex defaults
-			matchesPort = conn.port === 32400 || conn.port === 443;
+			// .plex.direct URLs are always https:, so the implicit default port is 443.
+			matchesPort = conn.port === 443;
 		} else {
 			matchesPort = conn.port.toString() === configuredPort;
 		}
@@ -230,6 +230,7 @@ export function filterServerResources(resources: PlexResource[]): PlexResource[]
 function matchesPlainHost(configuredUrl: string, server: PlexResource): boolean {
 	let configuredHost: string;
 	let configuredPort: string;
+	let configuredProtocol: string;
 	try {
 		const parsed = new URL(configuredUrl);
 		configuredHost = parsed.hostname.toLowerCase();
@@ -238,13 +239,16 @@ function matchesPlainHost(configuredUrl: string, server: PlexResource): boolean 
 			return false;
 		}
 		configuredPort = parsed.port;
+		configuredProtocol = parsed.protocol;
 	} catch {
 		return false;
 	}
 
 	const portsMatch = (connPort: number): boolean => {
 		if (configuredPort === '') {
-			return connPort === 32400 || connPort === 443 || connPort === 80;
+			if (configuredProtocol === 'https:') return connPort === 443;
+			if (configuredProtocol === 'http:') return connPort === 80;
+			return connPort === 32400;
 		}
 		return connPort.toString() === configuredPort;
 	};

--- a/src/lib/server/auth/types.ts
+++ b/src/lib/server/auth/types.ts
@@ -283,8 +283,8 @@ export const PlexFriendSharedServerSchema = z.object({
 export const PlexFriendSchema = z.object({
 	id: z.number().int(),
 	uuid: z.string().optional(),
-	username: z.string(),
-	email: z.string().optional(),
+	username: z.string().nullish(),
+	email: z.string().nullish(),
 	friendlyName: z.string().nullish(),
 	title: z.string().optional(),
 	thumb: z.string().optional(),

--- a/src/lib/server/sync/plex-accounts.service.ts
+++ b/src/lib/server/sync/plex-accounts.service.ts
@@ -6,7 +6,8 @@ import {
 	PLEX_PRODUCT,
 	PLEX_VERSION,
 	PlexAuthApiError,
-	PlexFriendsResponseSchema,
+	type PlexFriend,
+	PlexFriendSchema,
 	PlexServerIdentitySchema,
 	type PlexSharedServerUser
 } from '$lib/server/auth/types';
@@ -156,24 +157,45 @@ async function fetchSharedUsers(
 	}
 
 	const data = await response.json();
-	const result = PlexFriendsResponseSchema.safeParse(data);
 
-	if (!result.success) {
+	if (!Array.isArray(data)) {
 		logger.warn(
-			`Invalid friends response: ${result.error.message}. Shared users will not have cached usernames.`,
+			`Invalid friends response: expected array, received ${typeof data}. Shared users will not have cached usernames.`,
 			'PlexAccountsSync'
 		);
 		return [];
 	}
 
-	return result.data
+	const friends: PlexFriend[] = [];
+	let skipped = 0;
+	for (const entry of data) {
+		const parsed = PlexFriendSchema.safeParse(entry);
+		if (parsed.success) {
+			friends.push(parsed.data);
+		} else {
+			skipped++;
+		}
+	}
+
+	if (skipped > 0) {
+		logger.warn(
+			`Skipped ${skipped} malformed friend record(s) from Plex v2 friends response.`,
+			'PlexAccountsSync'
+		);
+	}
+
+	return friends
+		.filter(
+			(friend): friend is PlexFriend & { username: string } =>
+				typeof friend.username === 'string' && friend.username.length > 0
+		)
 		.filter((friend) =>
 			friend.sharedServers?.some((s) => s.machineIdentifier === machineIdentifier)
 		)
 		.map((friend) => ({
 			id: friend.id,
 			username: friend.username,
-			email: friend.email,
+			email: friend.email ?? undefined,
 			thumb: friend.thumb
 		}));
 }

--- a/src/lib/server/sync/plex-accounts.service.ts
+++ b/src/lib/server/sync/plex-accounts.service.ts
@@ -160,7 +160,7 @@ async function fetchSharedUsers(
 
 	if (!Array.isArray(data)) {
 		logger.warn(
-			`Invalid friends response: expected array, received ${typeof data}. Shared users will not have cached usernames.`,
+			`Invalid friends response: expected array, received ${data === null ? 'null' : typeof data}. Shared users will not have cached usernames.`,
 			'PlexAccountsSync'
 		);
 		return [];

--- a/tests/unit/auth/membership.test.ts
+++ b/tests/unit/auth/membership.test.ts
@@ -56,6 +56,7 @@ describe('verifyServerMembership', () => {
 		// periodic session revalidation on onboarding completion — during onboarding
 		// there is no meaningful configured server to check against, and without the
 		// gate the revalidator would incorrectly revoke the freshly-created session.
+		configSpy = mockConfiguredUrl('http://test-plex-server:32400');
 		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
 			createMockResponse([
 				{

--- a/tests/unit/auth/membership.test.ts
+++ b/tests/unit/auth/membership.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, spyOn } from 'bun:test';
 
+import * as settingsService from '$lib/server/admin/settings.service';
 import { verifyServerMembership } from '$lib/server/auth/membership';
 
 function createMockResponse(data: unknown, ok = true, status = 200): Response {
@@ -22,11 +23,29 @@ function createMockResponse(data: unknown, ok = true, status = 200): Response {
 	} as Response;
 }
 
+const MOCK_MACHINE_ID = 'a'.repeat(32);
+
+function mockConfiguredUrl(url: string): ReturnType<typeof spyOn> {
+	return spyOn(settingsService, 'getApiConfigWithSources').mockResolvedValue({
+		plex: {
+			serverUrl: { value: url, source: 'env', isLocked: false },
+			token: { value: 'test-token', source: 'env', isLocked: false }
+		},
+		openai: {
+			apiKey: { value: '', source: 'default', isLocked: false },
+			baseUrl: { value: 'https://api.openai.com/v1', source: 'default', isLocked: false },
+			model: { value: 'gpt-5-mini', source: 'default', isLocked: false }
+		}
+	});
+}
+
 describe('verifyServerMembership', () => {
 	let fetchSpy: ReturnType<typeof spyOn>;
+	let configSpy: ReturnType<typeof spyOn>;
 
 	afterEach(() => {
 		fetchSpy?.mockRestore();
+		configSpy?.mockRestore();
 	});
 
 	it('returns { isMember: false, isOwner: false } when no server matches the configured URL', async () => {
@@ -63,5 +82,115 @@ describe('verifyServerMembership', () => {
 
 		expect(result.isMember).toBe(false);
 		expect(result.isOwner).toBe(false);
+	});
+
+	it('matches a plain-host configured URL against a .plex.direct-only server (obzorarr-docker #5)', async () => {
+		// Regression: when PLEX_SERVER_URL is a plain http://<lan-ip>:<port> but the
+		// server only advertises .plex.direct URIs (which is the norm once https is
+		// enabled), the previous matcher's three strategies all failed and users saw
+		// "No matching server found" during onboarding.
+		configSpy = mockConfiguredUrl('http://192.168.1.34:32400');
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse([
+				{
+					name: 'Home Server',
+					product: 'Plex Media Server',
+					clientIdentifier: MOCK_MACHINE_ID,
+					owned: true,
+					provides: 'server',
+					publicAddress: '203.0.113.10',
+					connections: [
+						{
+							protocol: 'https',
+							address: '192.168.1.34',
+							port: 32400,
+							uri: `https://192-168-1-34.${MOCK_MACHINE_ID}.plex.direct:32400`,
+							local: true,
+							relay: false
+						},
+						{
+							protocol: 'https',
+							address: '203.0.113.10',
+							port: 32400,
+							uri: `https://203-0-113-10.${MOCK_MACHINE_ID}.plex.direct:32400`,
+							local: false,
+							relay: false
+						}
+					]
+				}
+			])
+		);
+
+		const result = await verifyServerMembership('user-token');
+
+		expect(result.isMember).toBe(true);
+		expect(result.isOwner).toBe(true);
+		expect(result.serverName).toBe('Home Server');
+	});
+
+	it('matches a plain-host configured URL via the embedded IP of a .plex.direct URI', async () => {
+		// When a server only advertises a .plex.direct URI that embeds the public IP
+		// (no structured connection with a matching address), the plain-host matcher
+		// still succeeds by extracting the IP from the URI itself.
+		configSpy = mockConfiguredUrl('http://203.0.113.10:32400');
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse([
+				{
+					name: 'Remote Server',
+					product: 'Plex Media Server',
+					clientIdentifier: MOCK_MACHINE_ID,
+					owned: false,
+					provides: 'server',
+					connections: [
+						{
+							protocol: 'https',
+							address: 'some-internal-host',
+							port: 32400,
+							uri: `https://203-0-113-10.${MOCK_MACHINE_ID}.plex.direct:32400`,
+							local: false,
+							relay: false
+						}
+					]
+				}
+			])
+		);
+
+		const result = await verifyServerMembership('user-token');
+
+		expect(result.isMember).toBe(true);
+		expect(result.isOwner).toBe(false);
+	});
+
+	it('matches a plain-host configured URL via server.publicAddress', async () => {
+		// If the configured host equals publicAddress and any advertised connection
+		// uses the configured port, treat it as the same server.
+		configSpy = mockConfiguredUrl('http://203.0.113.10:32400');
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse([
+				{
+					name: 'Public IP Server',
+					product: 'Plex Media Server',
+					clientIdentifier: MOCK_MACHINE_ID,
+					owned: true,
+					provides: 'server',
+					publicAddress: '203.0.113.10',
+					connections: [
+						{
+							protocol: 'https',
+							address: 'internal.example.com',
+							port: 32400,
+							uri: 'https://internal.example.com:32400',
+							local: true,
+							relay: false
+						}
+					]
+				}
+			])
+		);
+
+		const result = await verifyServerMembership('user-token');
+
+		expect(result.isMember).toBe(true);
+		expect(result.isOwner).toBe(true);
 	});
 });

--- a/tests/unit/auth/types.test.ts
+++ b/tests/unit/auth/types.test.ts
@@ -13,6 +13,7 @@ import {
 	PLEX_PRODUCT,
 	PLEX_VERSION,
 	PlexAuthApiError,
+	PlexFriendSchema,
 	SESSION_DURATION_MS,
 	SessionExpiredError
 } from '$lib/server/auth/types';
@@ -282,5 +283,55 @@ describe('Error Discrimination', () => {
 		expect(codes).toContain('NOT_SERVER_MEMBER');
 		expect(codes).toContain('SESSION_EXPIRED');
 		expect(codes).toContain('PLEX_API_ERROR');
+	});
+});
+
+describe('PlexFriendSchema', () => {
+	// Regression: Plex.tv /api/v2/friends returns null for username/email on some friends.
+	// Before this fix the schema rejected them, causing the whole list to be discarded
+	// (obzorarr-docker issue #4).
+
+	it('accepts a friend with null username', () => {
+		const result = PlexFriendSchema.safeParse({
+			id: 42,
+			username: null,
+			email: 'x@example.com'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts a friend with null email', () => {
+		const result = PlexFriendSchema.safeParse({
+			id: 42,
+			username: 'someone',
+			email: null
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts a friend with both null username and null email', () => {
+		const result = PlexFriendSchema.safeParse({
+			id: 42,
+			username: null,
+			email: null
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('still accepts a friend with valid string username and email', () => {
+		const result = PlexFriendSchema.safeParse({
+			id: 42,
+			username: 'someone',
+			email: 'x@example.com'
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it('still rejects a friend without an id', () => {
+		const result = PlexFriendSchema.safeParse({
+			username: 'someone',
+			email: null
+		});
+		expect(result.success).toBe(false);
 	});
 });


### PR DESCRIPTION
## Summary

Resolves two open bugs reported in the [`engels74/obzorarr-docker`](https://github.com/engels74/obzorarr-docker) issue tracker. Neither code path had been touched by any merged PR since the issues were opened; both root causes were present on `main` at `afbcf81`.

- Fixes [engels74/obzorarr-docker#4](https://github.com/engels74/obzorarr-docker/issues/4) — `PlexAccountSync` silently drops every shared user when a single friend returned by Plex has a `null` `username` or `email`.
- Fixes [engels74/obzorarr-docker#5](https://github.com/engels74/obzorarr-docker/issues/5) — onboarding step 2 fails with `No matching server found` when `PLEX_SERVER_URL` is a plain `http://<ip>:<port>` and the server only advertises `*.plex.direct` URIs.

## Issue #4: null friend fields drop the whole list

**Root cause.** `PlexFriendSchema` in `src/lib/server/auth/types.ts` declared `username: z.string()` and `email: z.string().optional()`. The Plex.tv `/api/v2/friends` endpoint legitimately returns `null` for these fields on some friends, which caused `PlexFriendsResponseSchema.safeParse(data)` in `fetchSharedUsers` to fail for the entire response. The function then logged `Invalid friends response: …` and returned `[]`, so shared viewers never got cached usernames and appeared as generic `User <accountId>` in stats and leaderboards.

This matches the exact warning shown in the issue reporter's logs (Zod errors at paths `[0, "username"]` and `[0, "email"]`).

**Fix.**

1. `PlexFriendSchema.username` and `.email` are now `z.string().nullish()`.
2. `fetchSharedUsers` in `src/lib/server/sync/plex-accounts.service.ts` no longer `safeParse`s the whole response. It validates the top-level shape is an array, then `safeParse`s each entry individually. Records that fail are counted and logged, but the rest of the list is preserved.
3. Friends without a usable (non-empty string) username are filtered out before being mapped to `PlexSharedServerUser`, since that downstream type requires `username: string`.
4. The same change is mirrored in `src/lib/server/auth/dev-users.ts`, which has a near-duplicate `fetchSharedUsers` used by the dev-bypass path.

## Issue #5: plain-host configured URL vs. `.plex.direct`-only server

**Root cause.** `findConfiguredServer` in `src/lib/server/auth/membership.ts` had three strategies:

1. Machine-ID match — only runs when `configuredUrl` is a `.plex.direct` URL.
2. IP/port match against `connections[].address/port` — gated on the same machine-ID extraction (lives inside the `if (configuredMachineId)` block).
3. Fallback `urlsMatch(conn.uri, configuredUrl)` — inside `urlsMatch`, when one side is `.plex.direct` and the other isn't, the function falls through to `normalizeUrl(url1) === normalizeUrl(url2)`, which compares `https://<dashed-ip>.<machineId>.plex.direct:32400` against `http://<lan-ip>:32400` and never matches.

Once a server has HTTPS enabled, Plex typically advertises only `.plex.direct` URIs. So when an admin configures a plain `http://<lan-ip>:<port>` URL (the natural choice for a LAN-only deployment), every strategy fails and the user is told they are not a member of their own server. This reproduces for multiple commenters on the issue.

**Fix.** Add a new `matchesPlainHost(configuredUrl, server)` helper and a corresponding strategy in `findConfiguredServer` that runs when `configuredUrl` is NOT a `.plex.direct` URL. The helper checks three things in order:

1. Direct match against `server.connections[].address` and `.port`.
2. For each `.plex.direct` connection, extract the embedded IP with the existing `extractPlexDirectIpAndPort` helper and compare to the configured host/port.
3. Match against `server.publicAddress` when any advertised connection uses the configured port.

Port comparison accepts 32400, 443, and 80 as Plex defaults when the configured URL has no explicit port, and otherwise compares ports exactly. The existing `.plex.direct`-specific strategies and URI-match fallback are preserved unchanged.

## Tests

- `tests/unit/auth/types.test.ts` — 5 new cases covering `PlexFriendSchema` parsing with `null` `username`, `null` `email`, both `null`, a fully-populated payload (to ensure the loosened schema still accepts valid input), and a missing `id` to confirm required fields still reject.
- `tests/unit/auth/membership.test.ts` — 3 new regression cases that mock `getApiConfigWithSources` to vary the configured URL:
  - plain LAN URL matched against a server whose connections are all `.plex.direct`,
  - plain public-IP URL matched via the IP embedded in a `.plex.direct` URI,
  - plain public-IP URL matched via `server.publicAddress`.

## Test plan

- [x] `bun run check` — 0 errors, 0 warnings.
- [x] `bun run test` — 1266 pass, 0 fail, coverage ≥ 80% threshold met.
- [x] `bun run check:biome` — no new findings in files touched by this PR. The 9 remaining pre-existing errors are in `src/app.html` and `src/routes/plex/thumb/[...path]/+server.ts` and are out of scope.
- [ ] Manual verification (recommended by the issue reporters, not gated on CI):
  - Start a container with `PLEX_SERVER_URL=http://<lan-ip>:32400` against a server advertising only `*.plex.direct` URIs. Complete onboarding step 2 and confirm no `No matching server found` log entry.
  - Run `PlexAccountsSync` with a Plex token whose friend list contains an entry with `null` `username` or `email`. Confirm `Synced N Plex accounts (… shared users > 0 …)` is logged and the malformed friend is counted in `Skipped N malformed friend record(s)`.

## Files changed

- `src/lib/server/auth/types.ts` — loosen `PlexFriendSchema.username` / `.email` to `z.string().nullish()`.
- `src/lib/server/sync/plex-accounts.service.ts` — per-friend `safeParse`, filter empty/null usernames.
- `src/lib/server/auth/dev-users.ts` — mirror the same pattern in the dev-bypass fetcher.
- `src/lib/server/auth/membership.ts` — add `matchesPlainHost` and wire it into `findConfiguredServer` for non-`.plex.direct` configured URLs.
- `tests/unit/auth/types.test.ts`, `tests/unit/auth/membership.test.ts` — new regression tests.