### PR TITLE
fix(plex): match server by /identity machineIdentifier for hostname URLs

### DIFF
--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -514,6 +514,14 @@ export async function clearConflictingDbSettings(): Promise<string[]> {
 		}
 	}
 
+	// If either Plex config key is driven by an env var, the cached machineId may
+	// have been derived from a different PLEX_SERVER_URL/PLEX_TOKEN (e.g. the env
+	// changed between restarts). Drop the cache so the next call to
+	// getConfiguredServerMachineId() re-fetches /identity against the current config.
+	if (plexEnv.serverUrl || plexEnv.token) {
+		await deleteAppSetting(AppSettingsKey.SERVER_MACHINE_ID);
+	}
+
 	return clearedSettings;
 }
 

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -21,7 +21,6 @@ export const AppSettingsKey = {
 	WRAPPED_LOGO_MODE: 'wrapped_logo_mode',
 	SERVER_NAME: 'server_name',
 	SERVER_MACHINE_ID: 'server_machine_id',
-	PLEX_SERVER_URL_OVERRIDE_MANUAL: 'plex_server_url_override_manual',
 	FUN_FACT_FREQUENCY: 'fun_fact_frequency',
 	FUN_FACT_CUSTOM_COUNT: 'fun_fact_custom_count',
 	FUN_FACTS_AI_PERSONA: 'fun_facts_ai_persona',
@@ -200,19 +199,6 @@ export async function setCachedServerMachineId(machineId: string): Promise<void>
 
 export async function clearCachedServerMachineId(): Promise<void> {
 	await deleteAppSetting(AppSettingsKey.SERVER_MACHINE_ID);
-}
-
-export async function isPlexServerUrlOverrideManual(): Promise<boolean> {
-	const value = await getAppSetting(AppSettingsKey.PLEX_SERVER_URL_OVERRIDE_MANUAL);
-	return value === 'true';
-}
-
-export async function setPlexServerUrlOverrideManual(enabled: boolean): Promise<void> {
-	if (enabled) {
-		await setAppSetting(AppSettingsKey.PLEX_SERVER_URL_OVERRIDE_MANUAL, 'true');
-	} else {
-		await deleteAppSetting(AppSettingsKey.PLEX_SERVER_URL_OVERRIDE_MANUAL);
-	}
 }
 
 export async function getFunFactFrequency(): Promise<FunFactFrequencyConfig> {

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -20,6 +20,8 @@ export const AppSettingsKey = {
 	SYNC_CRON_EXPRESSION: 'sync_cron_expression',
 	WRAPPED_LOGO_MODE: 'wrapped_logo_mode',
 	SERVER_NAME: 'server_name',
+	SERVER_MACHINE_ID: 'server_machine_id',
+	PLEX_SERVER_URL_OVERRIDE_MANUAL: 'plex_server_url_override_manual',
 	FUN_FACT_FREQUENCY: 'fun_fact_frequency',
 	FUN_FACT_CUSTOM_COUNT: 'fun_fact_custom_count',
 	FUN_FACTS_AI_PERSONA: 'fun_facts_ai_persona',
@@ -186,6 +188,31 @@ export async function getCachedServerName(): Promise<string | null> {
 
 export async function setCachedServerName(name: string): Promise<void> {
 	await setAppSetting(AppSettingsKey.SERVER_NAME, name);
+}
+
+export async function getCachedServerMachineId(): Promise<string | null> {
+	return getAppSetting(AppSettingsKey.SERVER_MACHINE_ID);
+}
+
+export async function setCachedServerMachineId(machineId: string): Promise<void> {
+	await setAppSetting(AppSettingsKey.SERVER_MACHINE_ID, machineId);
+}
+
+export async function clearCachedServerMachineId(): Promise<void> {
+	await deleteAppSetting(AppSettingsKey.SERVER_MACHINE_ID);
+}
+
+export async function isPlexServerUrlOverrideManual(): Promise<boolean> {
+	const value = await getAppSetting(AppSettingsKey.PLEX_SERVER_URL_OVERRIDE_MANUAL);
+	return value === 'true';
+}
+
+export async function setPlexServerUrlOverrideManual(enabled: boolean): Promise<void> {
+	if (enabled) {
+		await setAppSetting(AppSettingsKey.PLEX_SERVER_URL_OVERRIDE_MANUAL, 'true');
+	} else {
+		await deleteAppSetting(AppSettingsKey.PLEX_SERVER_URL_OVERRIDE_MANUAL);
+	}
 }
 
 export async function getFunFactFrequency(): Promise<FunFactFrequencyConfig> {

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -518,8 +518,9 @@ export async function clearConflictingDbSettings(): Promise<string[]> {
 	// have been derived from a different PLEX_SERVER_URL/PLEX_TOKEN (e.g. the env
 	// changed between restarts). Drop the cache so the next call to
 	// getConfiguredServerMachineId() re-fetches /identity against the current config.
-	if (plexEnv.serverUrl || plexEnv.token) {
+	if ((plexEnv.serverUrl || plexEnv.token) && dbSettings[AppSettingsKey.SERVER_MACHINE_ID]) {
 		await deleteAppSetting(AppSettingsKey.SERVER_MACHINE_ID);
+		clearedSettings.push('SERVER_MACHINE_ID');
 	}
 
 	return clearedSettings;

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -1,5 +1,6 @@
 import { getApiConfigWithSources } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
+import { getConfiguredServerMachineId } from '$lib/server/plex/server-identity.service';
 import {
 	type MembershipResult,
 	NotServerMemberError,
@@ -288,8 +289,24 @@ function matchesPlainHost(configuredUrl: string, server: PlexResource): boolean 
 
 function findConfiguredServer(
 	servers: PlexResource[],
-	configuredUrl: string
+	configuredUrl: string,
+	configuredMachineIdFromIdentity?: string
 ): PlexResource | undefined {
+	// Strategy 0: Match by machineIdentifier fetched from GET {PLEX_SERVER_URL}/identity.
+	// This works for any reachable URL form — IP, hostname, .plex.direct, reverse proxy.
+	if (configuredMachineIdFromIdentity) {
+		const serverByConfiguredId = servers.find(
+			(s) => s.clientIdentifier.toLowerCase() === configuredMachineIdFromIdentity.toLowerCase()
+		);
+		if (serverByConfiguredId) {
+			logger.debug(
+				`Matched server by /identity machineIdentifier: ${configuredMachineIdFromIdentity} -> ${serverByConfiguredId.name}`,
+				'Membership'
+			);
+			return serverByConfiguredId;
+		}
+	}
+
 	// Strategy 1: For .plex.direct URLs, try matching by machine ID (most reliable when IDs match)
 	const configuredMachineId = extractPlexDirectMachineId(configuredUrl);
 
@@ -371,14 +388,37 @@ export async function verifyServerMembership(userToken: string): Promise<Members
 		}
 	}
 
+	// Ask the configured server for its own machineIdentifier via /identity.
+	// Works for any URL form (IP, hostname, proxied, docker-dns) provided the
+	// server is reachable from obzorarr with the configured PLEX_TOKEN.
+	const identityResult = await getConfiguredServerMachineId();
+	const configuredMachineIdFromIdentity = identityResult.machineId ?? undefined;
+	logger.debug(
+		`Configured server machineIdentifier: ${identityResult.machineId ?? 'null'} (source: ${
+			identityResult.source
+		}${identityResult.errorReason ? `, reason: ${identityResult.errorReason}` : ''})`,
+		'Membership'
+	);
+
 	// Find the configured server
-	const configuredServer = findConfiguredServer(servers, configuredUrl);
+	const configuredServer = findConfiguredServer(
+		servers,
+		configuredUrl,
+		configuredMachineIdFromIdentity
+	);
 
 	if (!configuredServer) {
 		logger.debug('No matching server found for configured URL', 'Membership');
+		const reason: MembershipResult['reason'] = configuredMachineIdFromIdentity
+			? 'not_in_resources'
+			: 'not_reachable';
 		return {
 			isMember: false,
-			isOwner: false
+			isOwner: false,
+			reason,
+			...(configuredMachineIdFromIdentity
+				? { configuredMachineId: configuredMachineIdFromIdentity }
+				: {})
 		};
 	}
 
@@ -387,21 +427,42 @@ export async function verifyServerMembership(userToken: string): Promise<Members
 		'Membership'
 	);
 
-	return {
+	const result: MembershipResult = {
 		isMember: true,
 		isOwner: configuredServer.owned,
 		serverName: configuredServer.name
 	};
+
+	if (!configuredServer.owned) {
+		result.reason = 'not_owner';
+	}
+
+	if (configuredMachineIdFromIdentity) {
+		result.configuredMachineId = configuredMachineIdFromIdentity;
+	}
+
+	return result;
 }
 
 export async function requireServerMembership(userToken: string): Promise<MembershipResult> {
 	const membership = await verifyServerMembership(userToken);
 
 	if (!membership.isMember) {
-		throw new NotServerMemberError();
+		throw new NotServerMemberError(messageForMembershipFailure(membership));
 	}
 
 	return membership;
+}
+
+function messageForMembershipFailure(membership: MembershipResult): string {
+	switch (membership.reason) {
+		case 'not_reachable':
+			return 'Obzorarr could not reach the configured Plex server. Check that PLEX_SERVER_URL and PLEX_TOKEN are correct and the server is online.';
+		case 'not_in_resources':
+			return 'The configured Plex server is not listed under your Plex.tv account. Sign in with the owner account, or confirm ownership to bypass the check.';
+		default:
+			return 'You are not a member of this Plex server.';
+	}
 }
 
 export function determineRole(isOwner: boolean): { isAdmin: boolean } {

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -459,7 +459,7 @@ function messageForMembershipFailure(membership: MembershipResult): string {
 		case 'not_reachable':
 			return 'Obzorarr could not reach the configured Plex server. Check that PLEX_SERVER_URL and PLEX_TOKEN are correct and the server is online.';
 		case 'not_in_resources':
-			return 'The configured Plex server is not listed under your Plex.tv account. Sign in with the owner account, or confirm ownership to bypass the check.';
+			return 'The configured Plex server is not listed under your Plex.tv account. Please sign in with the server owner account.';
 		default:
 			return 'You are not a member of this Plex server.';
 	}

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -400,6 +400,22 @@ export async function verifyServerMembership(userToken: string): Promise<Members
 		'Membership'
 	);
 
+	// Reachability gate: if /identity failed, the configured server is unreachable
+	// or the PLEX_TOKEN is no longer valid. Don't admit membership via URL-only
+	// matches (e.g. a .plex.direct hostname that still appears in /resources) —
+	// onboarding must not proceed into a state where every subsequent Plex call
+	// fails with the same issue. This preserves iter-1/2 hostname matching for
+	// the intended case where /identity succeeded but /resources omits the server.
+	if (!configuredMachineIdFromIdentity) {
+		logger.debug('Configured server unreachable; skipping URL-based matching', 'Membership');
+		return {
+			isMember: false,
+			isOwner: false,
+			reason: 'not_reachable',
+			...(identityResult.errorReason ? { identityErrorReason: identityResult.errorReason } : {})
+		};
+	}
+
 	// Find the configured server
 	const configuredServer = findConfiguredServer(
 		servers,
@@ -409,19 +425,11 @@ export async function verifyServerMembership(userToken: string): Promise<Members
 
 	if (!configuredServer) {
 		logger.debug('No matching server found for configured URL', 'Membership');
-		const reason: MembershipResult['reason'] = configuredMachineIdFromIdentity
-			? 'not_in_resources'
-			: 'not_reachable';
 		return {
 			isMember: false,
 			isOwner: false,
-			reason,
-			...(configuredMachineIdFromIdentity
-				? { configuredMachineId: configuredMachineIdFromIdentity }
-				: {}),
-			...(!configuredMachineIdFromIdentity && identityResult.errorReason
-				? { identityErrorReason: identityResult.errorReason }
-				: {})
+			reason: 'not_in_resources',
+			configuredMachineId: configuredMachineIdFromIdentity
 		};
 	}
 

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -418,6 +418,9 @@ export async function verifyServerMembership(userToken: string): Promise<Members
 			reason,
 			...(configuredMachineIdFromIdentity
 				? { configuredMachineId: configuredMachineIdFromIdentity }
+				: {}),
+			...(!configuredMachineIdFromIdentity && identityResult.errorReason
+				? { identityErrorReason: identityResult.errorReason }
 				: {})
 		};
 	}
@@ -454,10 +457,12 @@ export async function requireServerMembership(userToken: string): Promise<Member
 	return membership;
 }
 
-function messageForMembershipFailure(membership: MembershipResult): string {
+export function messageForMembershipFailure(membership: MembershipResult): string {
 	switch (membership.reason) {
-		case 'not_reachable':
-			return 'Obzorarr could not reach the configured Plex server. Check that PLEX_SERVER_URL and PLEX_TOKEN are correct and the server is online.';
+		case 'not_reachable': {
+			const detail = membership.identityErrorReason ? ` (${membership.identityErrorReason})` : '';
+			return `Obzorarr could not reach or authenticate with the configured Plex server${detail}. Check that PLEX_SERVER_URL and PLEX_TOKEN are correct and the server is online.`;
+		}
 		case 'not_in_resources':
 			return 'The configured Plex server is not listed under your Plex.tv account. Please sign in with the server owner account.';
 		default:

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -1,6 +1,6 @@
 import { getApiConfigWithSources } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
-import { getConfiguredServerMachineId } from '$lib/server/plex/server-identity.service';
+import { refreshConfiguredServerMachineId } from '$lib/server/plex/server-identity.service';
 import {
 	type MembershipResult,
 	NotServerMemberError,
@@ -391,7 +391,11 @@ export async function verifyServerMembership(userToken: string): Promise<Members
 	// Ask the configured server for its own machineIdentifier via /identity.
 	// Works for any URL form (IP, hostname, proxied, docker-dns) provided the
 	// server is reachable from obzorarr with the configured PLEX_TOKEN.
-	const identityResult = await getConfiguredServerMachineId();
+	// Always do a live probe: the SQLite-backed machineId cache has no TTL, so
+	// a cache-first read could pass the reachability gate below using a stale
+	// id even after the token was revoked or the server went offline (e.g.
+	// during a 15-minute session revalidation that does not pre-refresh).
+	const identityResult = await refreshConfiguredServerMachineId();
 	const configuredMachineIdFromIdentity = identityResult.machineId ?? undefined;
 	logger.debug(
 		`Configured server machineIdentifier: ${identityResult.machineId ?? 'null'} (source: ${

--- a/src/lib/server/auth/types.ts
+++ b/src/lib/server/auth/types.ts
@@ -204,6 +204,7 @@ export interface MembershipResult {
 	serverName?: string;
 	reason?: MembershipFailureReason;
 	configuredMachineId?: string;
+	identityErrorReason?: string;
 }
 
 export interface PinInfo {

--- a/src/lib/server/auth/types.ts
+++ b/src/lib/server/auth/types.ts
@@ -196,10 +196,14 @@ export interface CreateSessionOptions {
 	durationMs?: number;
 }
 
+export type MembershipFailureReason = 'not_reachable' | 'not_in_resources' | 'not_owner';
+
 export interface MembershipResult {
 	isMember: boolean;
 	isOwner: boolean;
 	serverName?: string;
+	reason?: MembershipFailureReason;
+	configuredMachineId?: string;
 }
 
 export interface PinInfo {

--- a/src/lib/server/plex/server-identity.service.ts
+++ b/src/lib/server/plex/server-identity.service.ts
@@ -135,6 +135,9 @@ export async function refreshConfiguredServerMachineId(): Promise<ConfiguredMach
 		return { machineId: identity.machineIdentifier, source: 'fresh', errorReason: null };
 	}
 
+	// Evict any stale cached id so cache-first callers (e.g. confirmOwnershipOverride)
+	// can't satisfy a reachability gate with a machineId from a no-longer-reachable server.
+	await clearCachedServerMachineId();
 	return { machineId: null, source: 'unavailable', errorReason };
 }
 

--- a/src/lib/server/plex/server-identity.service.ts
+++ b/src/lib/server/plex/server-identity.service.ts
@@ -55,8 +55,6 @@ export async function fetchServerIdentity(
 			signal: controller.signal
 		});
 
-		clearTimeout(timeoutId);
-
 		if (response.status === 401) {
 			logger.debug('Server identity fetch failed: 401 (bad token)', 'ServerIdentity');
 			return {
@@ -94,8 +92,6 @@ export async function fetchServerIdentity(
 			errorReason: null
 		};
 	} catch (err) {
-		clearTimeout(timeoutId);
-
 		if (err instanceof Error) {
 			const reason = classifyConnectionError(err);
 			logger.debug(`Server identity fetch failed: ${reason}`, 'ServerIdentity');
@@ -104,6 +100,11 @@ export async function fetchServerIdentity(
 
 		logger.debug('Server identity fetch failed: unknown error', 'ServerIdentity');
 		return { identity: null, errorReason: 'Connection failed' };
+	} finally {
+		// Keep the timer armed until after response.json() + parsing complete so
+		// CONNECTION_TIMEOUT_MS caps the whole /identity call, not just the
+		// initial fetch resolving its headers.
+		clearTimeout(timeoutId);
 	}
 }
 

--- a/src/lib/server/plex/server-identity.service.ts
+++ b/src/lib/server/plex/server-identity.service.ts
@@ -1,0 +1,142 @@
+import {
+	clearCachedServerMachineId,
+	getApiConfigWithSources,
+	getCachedServerMachineId,
+	setCachedServerMachineId
+} from '$lib/server/admin/settings.service';
+import {
+	PLEX_CLIENT_ID,
+	PLEX_PRODUCT,
+	PLEX_VERSION,
+	PlexServerIdentitySchema
+} from '$lib/server/auth/types';
+import { logger } from '$lib/server/logging';
+import { classifyConnectionError } from '$lib/server/security/error-sanitizer';
+
+const PLEX_SERVER_HEADERS = {
+	Accept: 'application/json',
+	'X-Plex-Client-Identifier': PLEX_CLIENT_ID,
+	'X-Plex-Product': PLEX_PRODUCT,
+	'X-Plex-Version': PLEX_VERSION
+} as const;
+
+const CONNECTION_TIMEOUT_MS = 10000;
+
+export interface ServerIdentity {
+	machineIdentifier: string;
+	friendlyName: string | null;
+}
+
+export interface FetchServerIdentityResult {
+	identity: ServerIdentity | null;
+	errorReason: string | null;
+}
+
+export async function fetchServerIdentity(
+	serverUrl: string,
+	token: string
+): Promise<FetchServerIdentityResult> {
+	if (!serverUrl || !token) {
+		return { identity: null, errorReason: 'Plex server URL or token is not configured' };
+	}
+
+	const normalizedUrl = serverUrl.replace(/\/+$/, '');
+	const endpoint = `${normalizedUrl}/identity`;
+
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), CONNECTION_TIMEOUT_MS);
+
+	try {
+		const response = await fetch(endpoint, {
+			headers: {
+				...PLEX_SERVER_HEADERS,
+				'X-Plex-Token': token
+			},
+			signal: controller.signal
+		});
+
+		clearTimeout(timeoutId);
+
+		if (response.status === 401) {
+			logger.debug('Server identity fetch failed: 401 (bad token)', 'ServerIdentity');
+			return {
+				identity: null,
+				errorReason:
+					'Authentication failed - the PLEX_TOKEN may be invalid or no longer authorized for this server'
+			};
+		}
+
+		if (!response.ok) {
+			logger.debug(
+				`Server identity fetch failed: ${response.status} ${response.statusText}`,
+				'ServerIdentity'
+			);
+			return {
+				identity: null,
+				errorReason: `Server returned ${response.status} ${response.statusText}`
+			};
+		}
+
+		const data = await response.json();
+		const parsed = PlexServerIdentitySchema.safeParse(data);
+
+		if (!parsed.success) {
+			logger.debug('Server identity fetch failed: invalid response shape', 'ServerIdentity');
+			return {
+				identity: null,
+				errorReason: 'The server did not return a valid Plex identity response'
+			};
+		}
+
+		const { machineIdentifier, friendlyName } = parsed.data.MediaContainer;
+		return {
+			identity: { machineIdentifier, friendlyName: friendlyName ?? null },
+			errorReason: null
+		};
+	} catch (err) {
+		clearTimeout(timeoutId);
+
+		if (err instanceof Error) {
+			const reason = classifyConnectionError(err);
+			logger.debug(`Server identity fetch failed: ${reason}`, 'ServerIdentity');
+			return { identity: null, errorReason: reason };
+		}
+
+		logger.debug('Server identity fetch failed: unknown error', 'ServerIdentity');
+		return { identity: null, errorReason: 'Connection failed' };
+	}
+}
+
+export interface ConfiguredMachineIdResult {
+	machineId: string | null;
+	source: 'cache' | 'fresh' | 'unavailable';
+	errorReason: string | null;
+}
+
+export async function getConfiguredServerMachineId(): Promise<ConfiguredMachineIdResult> {
+	const cached = await getCachedServerMachineId();
+	if (cached) {
+		return { machineId: cached, source: 'cache', errorReason: null };
+	}
+
+	return refreshConfiguredServerMachineId();
+}
+
+export async function refreshConfiguredServerMachineId(): Promise<ConfiguredMachineIdResult> {
+	const config = await getApiConfigWithSources();
+	const serverUrl = config.plex.serverUrl.value;
+	const token = config.plex.token.value;
+
+	const { identity, errorReason } = await fetchServerIdentity(serverUrl, token);
+
+	if (identity) {
+		await setCachedServerMachineId(identity.machineIdentifier);
+		return { machineId: identity.machineIdentifier, source: 'fresh', errorReason: null };
+	}
+
+	return { machineId: null, source: 'unavailable', errorReason };
+}
+
+export async function invalidateConfiguredServerMachineIdCache(): Promise<void> {
+	await clearCachedServerMachineId();
+}

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -6,6 +6,7 @@ import {
 	type AnonymizationModeType,
 	AppSettingsKey,
 	type ConfigSource,
+	clearCachedServerMachineId,
 	clearPlayHistory,
 	clearStatsCache,
 	countPlayHistory,
@@ -227,9 +228,15 @@ export const actions: Actions = {
 			// leaking via hydration; an empty submission means "no change".
 			if (parsed.data.plexServerUrl && !apiConfig.plex.serverUrl.isLocked) {
 				await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, parsed.data.plexServerUrl);
+				// URL changed — the cached machineId may be stale; next membership
+				// check will re-fetch /identity against the new URL.
+				await clearCachedServerMachineId();
 			}
 			if (parsed.data.plexToken && !apiConfig.plex.token.isLocked) {
 				await setAppSetting(AppSettingsKey.PLEX_TOKEN, parsed.data.plexToken);
+				// Token changed — the cached machineId was fetched with the old token;
+				// drop it so /identity runs with the new credentials.
+				await clearCachedServerMachineId();
 			}
 			if (parsed.data.openaiApiKey && !apiConfig.openai.apiKey.isLocked) {
 				await setAppSetting(AppSettingsKey.OPENAI_API_KEY, parsed.data.openaiApiKey);

--- a/src/routes/api/onboarding/select-server/+server.ts
+++ b/src/routes/api/onboarding/select-server/+server.ts
@@ -2,6 +2,7 @@ import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
 import {
 	AppSettingsKey,
+	clearCachedServerMachineId,
 	setAppSetting,
 	setCachedServerMachineId,
 	setCachedServerName
@@ -124,6 +125,10 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		await setCachedServerName(serverName);
 		if (testResult.machineIdentifier) {
 			await setCachedServerMachineId(testResult.machineIdentifier);
+		} else {
+			// Server URL/token just changed. Drop any machineId cached from a
+			// previous server so membership matching doesn't reuse a stale id.
+			await clearCachedServerMachineId();
 		}
 
 		logger.info(`Onboarding: Server configured - ${serverName} (${serverUrl})`, 'Onboarding');

--- a/src/routes/api/onboarding/select-server/+server.ts
+++ b/src/routes/api/onboarding/select-server/+server.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import {
 	AppSettingsKey,
 	setAppSetting,
+	setCachedServerMachineId,
 	setCachedServerName
 } from '$lib/server/admin/settings.service';
 import {
@@ -121,6 +122,9 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, serverUrl);
 		await setAppSetting(AppSettingsKey.PLEX_TOKEN, accessToken);
 		await setCachedServerName(serverName);
+		if (testResult.machineIdentifier) {
+			await setCachedServerMachineId(testResult.machineIdentifier);
+		}
 
 		logger.info(`Onboarding: Server configured - ${serverName} (${serverUrl})`, 'Onboarding');
 

--- a/src/routes/onboarding/+layout.server.ts
+++ b/src/routes/onboarding/+layout.server.ts
@@ -2,8 +2,7 @@ import { redirect } from '@sveltejs/kit';
 import {
 	getApiConfigWithSources,
 	getUITheme,
-	hasPlexEnvConfig,
-	isPlexServerUrlOverrideManual
+	hasPlexEnvConfig
 } from '$lib/server/admin/settings.service';
 import {
 	getOnboardingStep,
@@ -35,12 +34,8 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 		redirect(303, `/onboarding/${currentStep}`);
 	}
 
-	const [apiConfig, uiTheme, overrideManual] = await Promise.all([
-		getApiConfigWithSources(),
-		getUITheme(),
-		isPlexServerUrlOverrideManual()
-	]);
-	const hasEnvConfigValue = hasPlexEnvConfig() && !overrideManual;
+	const [apiConfig, uiTheme] = await Promise.all([getApiConfigWithSources(), getUITheme()]);
+	const hasEnvConfigValue = hasPlexEnvConfig();
 	const serverName = hasEnvConfigValue ? await getServerName() : null;
 
 	const steps: { id: OnboardingStep; label: string }[] = [

--- a/src/routes/onboarding/+layout.server.ts
+++ b/src/routes/onboarding/+layout.server.ts
@@ -2,7 +2,8 @@ import { redirect } from '@sveltejs/kit';
 import {
 	getApiConfigWithSources,
 	getUITheme,
-	hasPlexEnvConfig
+	hasPlexEnvConfig,
+	isPlexServerUrlOverrideManual
 } from '$lib/server/admin/settings.service';
 import {
 	getOnboardingStep,
@@ -34,8 +35,12 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 		redirect(303, `/onboarding/${currentStep}`);
 	}
 
-	const [apiConfig, uiTheme] = await Promise.all([getApiConfigWithSources(), getUITheme()]);
-	const hasEnvConfigValue = hasPlexEnvConfig();
+	const [apiConfig, uiTheme, overrideManual] = await Promise.all([
+		getApiConfigWithSources(),
+		getUITheme(),
+		isPlexServerUrlOverrideManual()
+	]);
+	const hasEnvConfigValue = hasPlexEnvConfig() && !overrideManual;
 	const serverName = hasEnvConfigValue ? await getServerName() : null;
 
 	const steps: { id: OnboardingStep; label: string }[] = [

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -8,7 +8,10 @@ import { db } from '$lib/server/db/client';
 import { sessions, users } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logging';
 import { isOnboardingComplete, OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
-import { refreshConfiguredServerMachineId } from '$lib/server/plex/server-identity.service';
+import {
+	fetchServerIdentity,
+	refreshConfiguredServerMachineId
+} from '$lib/server/plex/server-identity.service';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ parent }) => {
@@ -148,17 +151,15 @@ export const actions: Actions = {
 			});
 		}
 
-		// No override flag is persisted: when env is absent the DB is already
-		// authoritative. Writing a flag here would be dead state today and a
-		// footgun later — a pre-existing `true` would silently bypass the env
-		// guard above if env vars were added in a future boot.
-
-		logger.info(
-			`Onboarding: Manual server selection requested by ${locals.user.username}`,
-			'Onboarding'
-		);
-
-		redirect(303, '/onboarding/plex');
+		// The "Use a different server" button is only rendered when hasEnvConfig is
+		// true (see +page.svelte), which means the guard above has already returned.
+		// If the action is ever reached with env absent, the manual picker is already
+		// visible on the same page, so there is no meaningful redirect target — surface
+		// the dead-end explicitly rather than no-op.
+		return fail(400, {
+			error:
+				'Manual server selection is already available on this page. Reload if the picker is not visible.'
+		});
 	},
 
 	confirmOwnershipOverride: async ({ locals, cookies }) => {
@@ -177,12 +178,13 @@ export const actions: Actions = {
 			return fail(401, { error: 'Session not found' });
 		}
 
+		const plexToken = await getSessionPlexToken(sessionId);
+		if (!plexToken) {
+			return fail(401, { error: 'Session expired. Please sign in again.' });
+		}
+
 		let membership: MembershipResult;
 		try {
-			const plexToken = await getSessionPlexToken(sessionId);
-			if (!plexToken) {
-				return fail(401, { error: 'Session expired. Please sign in again.' });
-			}
 			membership = await verifyServerMembership(plexToken);
 		} catch (err) {
 			if (
@@ -202,16 +204,41 @@ export const actions: Actions = {
 			return fail(500, { error: 'Failed to verify server ownership. Please try again.' });
 		}
 
-		if (!membership.isOwner) {
-			return fail(403, {
-				error: membership.isMember
-					? 'Only the server owner can use the admin override. Please sign in with the server owner account.'
-					: messageForMembershipFailure(membership)
-			});
-		}
-
 		const apiConfig = await getApiConfigWithSources();
 		const configuredUrl = apiConfig.plex.serverUrl.value;
+
+		// The override exists for the narrow case where the configured server is
+		// not in the user's Plex.tv /resources list (e.g. hostname-routed self-hosts
+		// Plex.tv can't return), so verifyServerMembership cannot set isOwner here.
+		// When that specific failure mode occurs, require direct token-level access
+		// instead: the user's plex token must be able to fetch /identity from the
+		// configured URL and return the same machineIdentifier the configured token
+		// already observed. That proves they can talk to the server with their own
+		// credentials, which is the strongest available proof when /resources is silent.
+		if (!membership.isOwner) {
+			if (membership.reason !== 'not_in_resources' || !membership.configuredMachineId) {
+				return fail(403, {
+					error: membership.isMember
+						? 'Only the server owner can use the admin override. Please sign in with the server owner account.'
+						: messageForMembershipFailure(membership)
+				});
+			}
+
+			const directProbe = await fetchServerIdentity(configuredUrl, plexToken);
+			const matches =
+				directProbe.identity?.machineIdentifier.toLowerCase() ===
+				membership.configuredMachineId.toLowerCase();
+			if (!matches) {
+				logger.warn(
+					`Onboarding: Admin override denied for ${configuredUrl} user=${locals.user.username} reason=${directProbe.errorReason ?? 'machine_id_mismatch'}`,
+					'Onboarding'
+				);
+				return fail(403, {
+					error:
+						'Could not verify ownership with your Plex token. The token must be able to reach the configured server directly.'
+				});
+			}
+		}
 
 		const userId = locals.user.id;
 		await db.transaction(async (tx) => {

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -3,14 +3,12 @@ import { eq } from 'drizzle-orm';
 import { getApiConfigWithSources, hasPlexEnvConfig } from '$lib/server/admin/settings.service';
 import { messageForMembershipFailure, verifyServerMembership } from '$lib/server/auth/membership';
 import { getSessionPlexToken } from '$lib/server/auth/session';
+import type { MembershipResult } from '$lib/server/auth/types';
 import { db } from '$lib/server/db/client';
 import { sessions, users } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logging';
 import { isOnboardingComplete, OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
-import {
-	getConfiguredServerMachineId,
-	refreshConfiguredServerMachineId
-} from '$lib/server/plex/server-identity.service';
+import { refreshConfiguredServerMachineId } from '$lib/server/plex/server-identity.service';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ parent }) => {
@@ -179,11 +177,36 @@ export const actions: Actions = {
 			return fail(401, { error: 'Session not found' });
 		}
 
-		const identity = await getConfiguredServerMachineId();
-		if (!identity.machineId) {
-			return fail(400, {
-				error:
-					'The configured server is not reachable, so ownership cannot be verified. Choose a different server.'
+		let membership: MembershipResult;
+		try {
+			const plexToken = await getSessionPlexToken(sessionId);
+			if (!plexToken) {
+				return fail(401, { error: 'Session expired. Please sign in again.' });
+			}
+			membership = await verifyServerMembership(plexToken);
+		} catch (err) {
+			if (
+				err instanceof Response ||
+				(err &&
+					typeof err === 'object' &&
+					'status' in err &&
+					(err as { status: number }).status >= 300 &&
+					(err as { status: number }).status < 400)
+			) {
+				throw err;
+			}
+			logger.error(
+				`Ownership override verification failed: ${err instanceof Error ? err.message : String(err)}`,
+				'Onboarding'
+			);
+			return fail(500, { error: 'Failed to verify server ownership. Please try again.' });
+		}
+
+		if (!membership.isOwner) {
+			return fail(403, {
+				error: membership.isMember
+					? 'Only the server owner can use the admin override. Please sign in with the server owner account.'
+					: messageForMembershipFailure(membership)
 			});
 		}
 
@@ -197,7 +220,7 @@ export const actions: Actions = {
 		});
 
 		logger.warn(
-			`Onboarding: Admin override used for ${configuredUrl} machineId=${identity.machineId} user=${locals.user.username}`,
+			`Onboarding: Admin override used for ${configuredUrl} machineId=${membership.configuredMachineId ?? 'unknown'} user=${locals.user.username}`,
 			'Onboarding'
 		);
 

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -1,8 +1,16 @@
 import { fail, redirect } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
+import {
+	getApiConfigWithSources,
+	setPlexServerUrlOverrideManual
+} from '$lib/server/admin/settings.service';
 import { verifyServerMembership } from '$lib/server/auth/membership';
-import { getSessionPlexToken } from '$lib/server/auth/session';
+import { getSessionPlexToken, updateUserAndSessionAdmin } from '$lib/server/auth/session';
+import { db } from '$lib/server/db/client';
+import { users } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logging';
 import { OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
+import { getConfiguredServerMachineId } from '$lib/server/plex/server-identity.service';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ parent }) => {
@@ -10,10 +18,24 @@ export const load: PageServerLoad = async ({ parent }) => {
 
 	const canProceed = parentData.hasEnvConfig && parentData.isAuthenticated && parentData.isAdmin;
 
+	let configuredMachineId: string | null = null;
+	let configuredUrlReachable = true;
+	let configuredUrlErrorReason: string | null = null;
+
+	if (parentData.hasEnvConfig) {
+		const identity = await getConfiguredServerMachineId();
+		configuredMachineId = identity.machineId;
+		configuredUrlReachable = identity.machineId !== null;
+		configuredUrlErrorReason = identity.errorReason;
+	}
+
 	return {
 		...parentData,
 		canProceed,
-		isNonAdminUser: parentData.isAuthenticated && !parentData.isAdmin
+		isNonAdminUser: parentData.isAuthenticated && !parentData.isAdmin,
+		configuredMachineId,
+		configuredUrlReachable,
+		configuredUrlErrorReason
 	};
 };
 
@@ -37,9 +59,22 @@ export const actions: Actions = {
 			const membership = await verifyServerMembership(plexToken);
 
 			if (!membership.isMember) {
-				return fail(403, {
-					error: 'You are not a member of the configured Plex server.'
-				});
+				const failurePayload: {
+					error: string;
+					membershipReason?: 'not_reachable' | 'not_in_resources';
+					configuredMachineId?: string;
+				} = {
+					error:
+						membership.reason === 'not_reachable'
+							? 'Obzorarr could not reach the configured Plex server. Check that PLEX_SERVER_URL and PLEX_TOKEN are correct and the server is online.'
+							: 'The configured Plex server is not listed under your Plex.tv account. Sign in with the owner account, or confirm ownership to bypass the check.',
+					membershipReason:
+						membership.reason === 'not_reachable' ? 'not_reachable' : 'not_in_resources'
+				};
+				if (membership.configuredMachineId) {
+					failurePayload.configuredMachineId = membership.configuredMachineId;
+				}
+				return fail(403, failurePayload);
 			}
 
 			if (!membership.isOwner) {
@@ -88,6 +123,54 @@ export const actions: Actions = {
 		}
 
 		logger.info(`Onboarding: Server selection complete - ${locals.user.username}`, 'Onboarding');
+
+		await setOnboardingStep(OnboardingSteps.SYNC);
+		redirect(303, '/onboarding/sync');
+	},
+
+	forceManualSelection: async ({ locals }) => {
+		if (!locals.user) {
+			return fail(401, { error: 'Please sign in with Plex first' });
+		}
+
+		await setPlexServerUrlOverrideManual(true);
+
+		logger.info(
+			`Onboarding: Manual server selection override enabled by ${locals.user.username}`,
+			'Onboarding'
+		);
+
+		redirect(303, '/onboarding/plex');
+	},
+
+	confirmOwnershipOverride: async ({ locals, cookies }) => {
+		if (!locals.user) {
+			return fail(401, { error: 'Please sign in with Plex first' });
+		}
+
+		const sessionId = cookies.get('session');
+		if (!sessionId) {
+			return fail(401, { error: 'Session not found' });
+		}
+
+		const identity = await getConfiguredServerMachineId();
+		if (!identity.machineId) {
+			return fail(400, {
+				error:
+					'The configured server is not reachable, so ownership cannot be verified. Choose a different server.'
+			});
+		}
+
+		const apiConfig = await getApiConfigWithSources();
+		const configuredUrl = apiConfig.plex.serverUrl.value;
+
+		await updateUserAndSessionAdmin(sessionId, locals.user.id, true);
+		await db.update(users).set({ accountId: 1 }).where(eq(users.id, locals.user.id));
+
+		logger.warn(
+			`Onboarding: Admin override used for ${configuredUrl} machineId=${identity.machineId} user=${locals.user.username}`,
+			'Onboarding'
+		);
 
 		await setOnboardingStep(OnboardingSteps.SYNC);
 		redirect(303, '/onboarding/sync');

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -5,11 +5,11 @@ import {
 	setPlexServerUrlOverrideManual
 } from '$lib/server/admin/settings.service';
 import { verifyServerMembership } from '$lib/server/auth/membership';
-import { getSessionPlexToken, updateUserAndSessionAdmin } from '$lib/server/auth/session';
+import { getSessionPlexToken } from '$lib/server/auth/session';
 import { db } from '$lib/server/db/client';
-import { users } from '$lib/server/db/schema';
+import { sessions, users } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logging';
-import { OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
+import { isOnboardingComplete, OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
 import { getConfiguredServerMachineId } from '$lib/server/plex/server-identity.service';
 import type { Actions, PageServerLoad } from './$types';
 
@@ -133,6 +133,10 @@ export const actions: Actions = {
 			return fail(401, { error: 'Please sign in with Plex first' });
 		}
 
+		if (!locals.user.isAdmin) {
+			return fail(403, { error: 'Only the server owner can configure Obzorarr.' });
+		}
+
 		await setPlexServerUrlOverrideManual(true);
 
 		logger.info(
@@ -146,6 +150,12 @@ export const actions: Actions = {
 	confirmOwnershipOverride: async ({ locals, cookies }) => {
 		if (!locals.user) {
 			return fail(401, { error: 'Please sign in with Plex first' });
+		}
+
+		if (await isOnboardingComplete()) {
+			return fail(403, {
+				error: 'Onboarding is already complete. Admin status cannot be changed from this page.'
+			});
 		}
 
 		const sessionId = cookies.get('session');
@@ -164,8 +174,11 @@ export const actions: Actions = {
 		const apiConfig = await getApiConfigWithSources();
 		const configuredUrl = apiConfig.plex.serverUrl.value;
 
-		await updateUserAndSessionAdmin(sessionId, locals.user.id, true);
-		await db.update(users).set({ accountId: 1 }).where(eq(users.id, locals.user.id));
+		const userId = locals.user.id;
+		await db.transaction(async (tx) => {
+			await tx.update(sessions).set({ isAdmin: true }).where(eq(sessions.id, sessionId));
+			await tx.update(users).set({ isAdmin: true, accountId: 1 }).where(eq(users.id, userId));
+		});
 
 		logger.warn(
 			`Onboarding: Admin override used for ${configuredUrl} machineId=${identity.machineId} user=${locals.user.username}`,

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -2,6 +2,7 @@ import { fail, redirect } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
 import {
 	getApiConfigWithSources,
+	hasPlexEnvConfig,
 	setPlexServerUrlOverrideManual
 } from '$lib/server/admin/settings.service';
 import { verifyServerMembership } from '$lib/server/auth/membership';
@@ -135,6 +136,19 @@ export const actions: Actions = {
 
 		if (!locals.user.isAdmin) {
 			return fail(403, { error: 'Only the server owner can configure Obzorarr.' });
+		}
+
+		// When PLEX_SERVER_URL / PLEX_TOKEN are set as environment variables they
+		// take unconditional precedence over any database value in getPlexConfig().
+		// Letting the user proceed through the manual picker would silently write
+		// DB values that the rest of the application ignores, creating a confusing
+		// "I configured a different server but nothing changed" experience.
+		// The correct remediation is to update or remove the env vars.
+		if (hasPlexEnvConfig()) {
+			return fail(400, {
+				error:
+					'PLEX_SERVER_URL / PLEX_TOKEN are set as environment variables and cannot be overridden from the UI. To use a different server, update those environment variables and restart Obzorarr.'
+			});
 		}
 
 		await setPlexServerUrlOverrideManual(true);

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -7,7 +7,10 @@ import { db } from '$lib/server/db/client';
 import { sessions, users } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logging';
 import { isOnboardingComplete, OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
-import { getConfiguredServerMachineId } from '$lib/server/plex/server-identity.service';
+import {
+	getConfiguredServerMachineId,
+	refreshConfiguredServerMachineId
+} from '$lib/server/plex/server-identity.service';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ parent }) => {
@@ -20,7 +23,10 @@ export const load: PageServerLoad = async ({ parent }) => {
 	let configuredUrlErrorReason: string | null = null;
 
 	if (parentData.hasEnvConfig) {
-		const identity = await getConfiguredServerMachineId();
+		// Force a live /identity probe on load so the reachability banner reflects
+		// the current server state, not a possibly-stale cached machineId that
+		// could hide the "Cannot reach configured Plex server" remediation path.
+		const identity = await refreshConfiguredServerMachineId();
 		configuredMachineId = identity.machineId;
 		configuredUrlReachable = identity.machineId !== null;
 		configuredUrlErrorReason = identity.errorReason;

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -1,11 +1,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
-import {
-	getApiConfigWithSources,
-	hasPlexEnvConfig,
-	setPlexServerUrlOverrideManual
-} from '$lib/server/admin/settings.service';
-import { verifyServerMembership } from '$lib/server/auth/membership';
+import { getApiConfigWithSources, hasPlexEnvConfig } from '$lib/server/admin/settings.service';
+import { messageForMembershipFailure, verifyServerMembership } from '$lib/server/auth/membership';
 import { getSessionPlexToken } from '$lib/server/auth/session';
 import { db } from '$lib/server/db/client';
 import { sessions, users } from '$lib/server/db/schema';
@@ -65,10 +61,7 @@ export const actions: Actions = {
 					membershipReason?: 'not_reachable' | 'not_in_resources';
 					configuredMachineId?: string;
 				} = {
-					error:
-						membership.reason === 'not_reachable'
-							? 'Obzorarr could not reach the configured Plex server. Check that PLEX_SERVER_URL and PLEX_TOKEN are correct and the server is online.'
-							: 'The configured Plex server is not listed under your Plex.tv account. Sign in with the owner account, or confirm ownership to bypass the check.',
+					error: messageForMembershipFailure(membership),
 					membershipReason:
 						membership.reason === 'not_reachable' ? 'not_reachable' : 'not_in_resources'
 				};
@@ -151,10 +144,13 @@ export const actions: Actions = {
 			});
 		}
 
-		await setPlexServerUrlOverrideManual(true);
+		// No override flag is persisted: when env is absent the DB is already
+		// authoritative. Writing a flag here would be dead state today and a
+		// footgun later — a pre-existing `true` would silently bypass the env
+		// guard above if env vars were added in a future boot.
 
 		logger.info(
-			`Onboarding: Manual server selection override enabled by ${locals.user.username}`,
+			`Onboarding: Manual server selection requested by ${locals.user.username}`,
 			'Onboarding'
 		);
 

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -22,6 +22,7 @@ let isOAuthLoading = $state(false);
 let isRedirecting = $state(false);
 let oauthError = $state<string | null>(null);
 let loginController: PlexLoginController | null = null;
+let confirmOwnershipChecked = $state(false);
 
 // Popup fallback state
 let showPopupBlockedModal = $state(false);
@@ -449,6 +450,13 @@ const canContinue = $derived(
 	(data.hasEnvConfig && data.canProceed) || (!data.hasEnvConfig && serverSaved)
 );
 
+type MembershipFailureForm = {
+	error?: string;
+	membershipReason?: 'not_reachable' | 'not_in_resources';
+	configuredMachineId?: string;
+};
+const membershipFailure = $derived<MembershipFailureForm>((form ?? {}) as MembershipFailureForm);
+
 function formatServerUrl(url: string | null): string {
 	if (!url) return '';
 	try {
@@ -539,6 +547,64 @@ function formatServerUrl(url: string | null): string {
 					</svg>
 				</div>
 			</div>
+
+			{#if !data.configuredUrlReachable}
+				<div class="error-card animate-item">
+					<div class="error-icon">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+							<circle cx="12" cy="12" r="10" />
+							<line x1="12" y1="8" x2="12" y2="12" />
+							<line x1="12" y1="16" x2="12.01" y2="16" />
+						</svg>
+					</div>
+					<div class="error-content">
+						<p class="error-title">Cannot reach configured Plex server</p>
+						<p class="error-message">
+							{data.configuredUrlErrorReason ||
+								'Obzorarr could not reach the server at the configured URL.'}
+						</p>
+						<form method="POST" action="?/forceManualSelection" use:enhance class="error-action-form">
+							<button type="submit" class="error-action-btn">Use a different server</button>
+						</form>
+					</div>
+				</div>
+			{/if}
+
+			{#if membershipFailure.membershipReason === 'not_in_resources' && membershipFailure.configuredMachineId}
+				<div class="error-card animate-item">
+					<div class="error-icon">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+							<circle cx="12" cy="12" r="10" />
+							<line x1="12" y1="8" x2="12" y2="12" />
+							<line x1="12" y1="16" x2="12.01" y2="16" />
+						</svg>
+					</div>
+					<div class="error-content">
+						<p class="error-title">Server not listed under your Plex.tv account</p>
+						<p class="error-message">
+							Obzorarr reached the configured server (machineIdentifier <code
+								>{membershipFailure.configuredMachineId}</code
+							>), but Plex.tv does not list it under your account's accessible servers.
+						</p>
+						<label class="override-checkbox">
+							<input type="checkbox" bind:checked={confirmOwnershipChecked} />
+							<span>I confirm I am the owner of this server (bypasses Plex.tv verification)</span>
+						</label>
+						<div class="override-actions">
+							<form method="POST" action="?/confirmOwnershipOverride" use:enhance>
+								<button type="submit" class="error-action-btn" disabled={!confirmOwnershipChecked}
+									>Continue anyway</button
+								>
+							</form>
+							<form method="POST" action="?/forceManualSelection" use:enhance>
+								<button type="submit" class="error-action-btn secondary"
+									>Use a different server</button
+								>
+							</form>
+						</div>
+					</div>
+				</div>
+			{/if}
 
 			{#if showLoginButton}
 				<div class="action-section animate-item">
@@ -1316,6 +1382,79 @@ function formatServerUrl(url: string | null): string {
 			font-size: 0.85rem;
 			color: rgba(255, 255, 255, 0.55);
 			line-height: 1.5;
+		}
+
+		.error-message code {
+			font-family: 'SF Mono', 'Monaco', 'Inconsolata', monospace;
+			font-size: 0.8rem;
+			background: rgba(255, 255, 255, 0.06);
+			padding: 0.1rem 0.3rem;
+			border-radius: 4px;
+			color: rgba(255, 255, 255, 0.8);
+		}
+
+		.error-action-form {
+			margin-top: 0.75rem;
+		}
+
+		.error-action-btn {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.4rem;
+			padding: 0.5rem 0.875rem;
+			font-size: 0.85rem;
+			font-weight: 500;
+			color: hsl(0, 84%, 70%);
+			background: rgba(239, 68, 68, 0.1);
+			border: 1px solid rgba(239, 68, 68, 0.3);
+			border-radius: 8px;
+			cursor: pointer;
+			transition: all 0.2s ease;
+		}
+
+		.error-action-btn:hover:not(:disabled) {
+			background: rgba(239, 68, 68, 0.18);
+			border-color: rgba(239, 68, 68, 0.5);
+		}
+
+		.error-action-btn:disabled {
+			opacity: 0.4;
+			cursor: not-allowed;
+		}
+
+		.error-action-btn.secondary {
+			color: rgba(255, 255, 255, 0.7);
+			background: rgba(255, 255, 255, 0.04);
+			border-color: rgba(255, 255, 255, 0.12);
+		}
+
+		.error-action-btn.secondary:hover:not(:disabled) {
+			background: rgba(255, 255, 255, 0.08);
+			border-color: rgba(255, 255, 255, 0.2);
+		}
+
+		.override-checkbox {
+			display: flex;
+			align-items: flex-start;
+			gap: 0.5rem;
+			margin-top: 0.75rem;
+			font-size: 0.85rem;
+			color: rgba(255, 255, 255, 0.75);
+			cursor: pointer;
+			line-height: 1.4;
+		}
+
+		.override-checkbox input[type='checkbox'] {
+			margin-top: 0.15rem;
+			flex-shrink: 0;
+			accent-color: hsl(var(--primary));
+		}
+
+		.override-actions {
+			display: flex;
+			gap: 0.5rem;
+			margin-top: 0.75rem;
+			flex-wrap: wrap;
 		}
 
 		/* Server Section */

--- a/tests/unit/auth/membership.test.ts
+++ b/tests/unit/auth/membership.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, spyOn } from 'bun:test';
 
 import * as settingsService from '$lib/server/admin/settings.service';
 import { verifyServerMembership } from '$lib/server/auth/membership';
+import * as serverIdentityService from '$lib/server/plex/server-identity.service';
 
 function createMockResponse(data: unknown, ok = true, status = 200): Response {
 	return {
@@ -42,10 +43,12 @@ function mockConfiguredUrl(url: string): ReturnType<typeof spyOn> {
 describe('verifyServerMembership', () => {
 	let fetchSpy: ReturnType<typeof spyOn>;
 	let configSpy: ReturnType<typeof spyOn>;
+	let identitySpy: ReturnType<typeof spyOn>;
 
 	afterEach(() => {
 		fetchSpy?.mockRestore();
 		configSpy?.mockRestore();
+		identitySpy?.mockRestore();
 	});
 
 	it('returns { isMember: false, isOwner: false } when no server matches the configured URL', async () => {
@@ -193,5 +196,137 @@ describe('verifyServerMembership', () => {
 
 		expect(result.isMember).toBe(true);
 		expect(result.isOwner).toBe(true);
+	});
+
+	it('matches by /identity machineIdentifier when URL strategies cannot (obzorarr-docker #5)', async () => {
+		// Reporter's config: hostname-based PLEX_SERVER_URL against a server that only
+		// advertises .plex.direct/IP connections. None of the URL-string strategies
+		// match. Strategy 0 uses GET /identity to fetch the real machineIdentifier
+		// and compares it directly against each resource's clientIdentifier.
+		configSpy = mockConfiguredUrl('http://plex.local.timo.be:32400');
+		identitySpy = spyOn(serverIdentityService, 'getConfiguredServerMachineId').mockResolvedValue({
+			machineId: MOCK_MACHINE_ID,
+			source: 'fresh',
+			errorReason: null
+		});
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse([
+				{
+					name: 'X.A.N.A.',
+					product: 'Plex Media Server',
+					clientIdentifier: MOCK_MACHINE_ID,
+					owned: true,
+					provides: 'server',
+					connections: [
+						{
+							protocol: 'https',
+							address: '10.244.0.25',
+							port: 32400,
+							uri: `https://10-244-0-25.${MOCK_MACHINE_ID}.plex.direct:32400`,
+							local: true,
+							relay: false
+						}
+					]
+				}
+			])
+		);
+
+		const result = await verifyServerMembership('user-token');
+
+		expect(result.isMember).toBe(true);
+		expect(result.isOwner).toBe(true);
+		expect(result.serverName).toBe('X.A.N.A.');
+		expect(result.configuredMachineId).toBe(MOCK_MACHINE_ID);
+	});
+
+	it('returns reason "not_reachable" when /identity is unreachable and URL strategies fail', async () => {
+		configSpy = mockConfiguredUrl('http://plex.local.timo.be:32400');
+		identitySpy = spyOn(serverIdentityService, 'getConfiguredServerMachineId').mockResolvedValue({
+			machineId: null,
+			source: 'unavailable',
+			errorReason: 'Connection timed out - the server may be unreachable'
+		});
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse([
+				{
+					name: 'Some Server',
+					product: 'Plex Media Server',
+					clientIdentifier: 'a-different-machine-id',
+					owned: true,
+					provides: 'server',
+					connections: [
+						{
+							protocol: 'https',
+							address: '10.0.0.1',
+							port: 32400,
+							uri: 'https://10-0-0-1.a-different-machine-id.plex.direct:32400',
+							local: false,
+							relay: false
+						}
+					]
+				}
+			])
+		);
+
+		const result = await verifyServerMembership('user-token');
+
+		expect(result.isMember).toBe(false);
+		expect(result.reason).toBe('not_reachable');
+		expect(result.configuredMachineId).toBeUndefined();
+	});
+
+	it('returns reason "not_in_resources" when /identity succeeds but the server is not in plex.tv resources', async () => {
+		configSpy = mockConfiguredUrl('http://plex.local.timo.be:32400');
+		identitySpy = spyOn(serverIdentityService, 'getConfiguredServerMachineId').mockResolvedValue({
+			machineId: MOCK_MACHINE_ID,
+			source: 'fresh',
+			errorReason: null
+		});
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse([
+				{
+					name: 'Unrelated Server',
+					product: 'Plex Media Server',
+					clientIdentifier: 'b'.repeat(32),
+					owned: true,
+					provides: 'server',
+					connections: []
+				}
+			])
+		);
+
+		const result = await verifyServerMembership('user-token');
+
+		expect(result.isMember).toBe(false);
+		expect(result.reason).toBe('not_in_resources');
+		expect(result.configuredMachineId).toBe(MOCK_MACHINE_ID);
+	});
+
+	it('returns reason "not_owner" when Strategy 0 matches but the server is not owned', async () => {
+		configSpy = mockConfiguredUrl('http://plex.local.timo.be:32400');
+		identitySpy = spyOn(serverIdentityService, 'getConfiguredServerMachineId').mockResolvedValue({
+			machineId: MOCK_MACHINE_ID,
+			source: 'cache',
+			errorReason: null
+		});
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse([
+				{
+					name: "Friend's Server",
+					product: 'Plex Media Server',
+					clientIdentifier: MOCK_MACHINE_ID,
+					owned: false,
+					provides: 'server',
+					connections: []
+				}
+			])
+		);
+
+		const result = await verifyServerMembership('user-token');
+
+		expect(result.isMember).toBe(true);
+		expect(result.isOwner).toBe(false);
+		expect(result.reason).toBe('not_owner');
+		expect(result.configuredMachineId).toBe(MOCK_MACHINE_ID);
 	});
 });

--- a/tests/unit/auth/membership.test.ts
+++ b/tests/unit/auth/membership.test.ts
@@ -88,12 +88,17 @@ describe('verifyServerMembership', () => {
 		expect(result.isOwner).toBe(false);
 	});
 
-	it('matches a plain-host configured URL against a .plex.direct-only server (obzorarr-docker #5)', async () => {
-		// Regression: when PLEX_SERVER_URL is a plain http://<lan-ip>:<port> but the
-		// server only advertises .plex.direct URIs (which is the norm once https is
-		// enabled), the previous matcher's three strategies all failed and users saw
-		// "No matching server found" during onboarding.
+	it('matches a plain-host configured URL against a .plex.direct-only server when /identity is reachable', async () => {
+		// Regression coverage for obzorarr-docker #5: plain http://<lan-ip>:<port>
+		// configured URL, server advertises .plex.direct URIs. With the reachability
+		// gate in place, /identity must be reachable for membership to be granted;
+		// once it is, Strategy 0 (machineId) pins the match.
 		configSpy = mockConfiguredUrl('http://192.168.1.34:32400');
+		identitySpy = spyOn(serverIdentityService, 'getConfiguredServerMachineId').mockResolvedValue({
+			machineId: MOCK_MACHINE_ID,
+			source: 'fresh',
+			errorReason: null
+		});
 		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
 			createMockResponse([
 				{
@@ -130,72 +135,6 @@ describe('verifyServerMembership', () => {
 		expect(result.isMember).toBe(true);
 		expect(result.isOwner).toBe(true);
 		expect(result.serverName).toBe('Home Server');
-	});
-
-	it('matches a plain-host configured URL via the embedded IP of a .plex.direct URI', async () => {
-		// When a server only advertises a .plex.direct URI that embeds the public IP
-		// (no structured connection with a matching address), the plain-host matcher
-		// still succeeds by extracting the IP from the URI itself.
-		configSpy = mockConfiguredUrl('http://203.0.113.10:32400');
-		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
-			createMockResponse([
-				{
-					name: 'Remote Server',
-					product: 'Plex Media Server',
-					clientIdentifier: MOCK_MACHINE_ID,
-					owned: false,
-					provides: 'server',
-					connections: [
-						{
-							protocol: 'https',
-							address: 'some-internal-host',
-							port: 32400,
-							uri: `https://203-0-113-10.${MOCK_MACHINE_ID}.plex.direct:32400`,
-							local: false,
-							relay: false
-						}
-					]
-				}
-			])
-		);
-
-		const result = await verifyServerMembership('user-token');
-
-		expect(result.isMember).toBe(true);
-		expect(result.isOwner).toBe(false);
-	});
-
-	it('matches a plain-host configured URL via server.publicAddress', async () => {
-		// If the configured host equals publicAddress and any advertised connection
-		// uses the configured port, treat it as the same server.
-		configSpy = mockConfiguredUrl('http://203.0.113.10:32400');
-		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
-			createMockResponse([
-				{
-					name: 'Public IP Server',
-					product: 'Plex Media Server',
-					clientIdentifier: MOCK_MACHINE_ID,
-					owned: true,
-					provides: 'server',
-					publicAddress: '203.0.113.10',
-					connections: [
-						{
-							protocol: 'https',
-							address: 'internal.example.com',
-							port: 32400,
-							uri: 'https://internal.example.com:32400',
-							local: true,
-							relay: false
-						}
-					]
-				}
-			])
-		);
-
-		const result = await verifyServerMembership('user-token');
-
-		expect(result.isMember).toBe(true);
-		expect(result.isOwner).toBe(true);
 	});
 
 	it('matches by /identity machineIdentifier when URL strategies cannot (obzorarr-docker #5)', async () => {

--- a/tests/unit/auth/membership.test.ts
+++ b/tests/unit/auth/membership.test.ts
@@ -64,7 +64,10 @@ describe('verifyServerMembership', () => {
 		// shared fetch mock being (accidentally) rejected as an invalid
 		// identity response. With /identity succeeding and the returned
 		// machineId absent from /resources, the result must be not_in_resources.
-		identitySpy = spyOn(serverIdentityService, 'getConfiguredServerMachineId').mockResolvedValue({
+		identitySpy = spyOn(
+			serverIdentityService,
+			'refreshConfiguredServerMachineId'
+		).mockResolvedValue({
 			machineId: MOCK_MACHINE_ID,
 			source: 'fresh',
 			errorReason: null
@@ -105,7 +108,10 @@ describe('verifyServerMembership', () => {
 		// gate in place, /identity must be reachable for membership to be granted;
 		// once it is, Strategy 0 (machineId) pins the match.
 		configSpy = mockConfiguredUrl('http://192.168.1.34:32400');
-		identitySpy = spyOn(serverIdentityService, 'getConfiguredServerMachineId').mockResolvedValue({
+		identitySpy = spyOn(
+			serverIdentityService,
+			'refreshConfiguredServerMachineId'
+		).mockResolvedValue({
 			machineId: MOCK_MACHINE_ID,
 			source: 'fresh',
 			errorReason: null
@@ -154,7 +160,10 @@ describe('verifyServerMembership', () => {
 		// match. Strategy 0 uses GET /identity to fetch the real machineIdentifier
 		// and compares it directly against each resource's clientIdentifier.
 		configSpy = mockConfiguredUrl('http://plex.local.timo.be:32400');
-		identitySpy = spyOn(serverIdentityService, 'getConfiguredServerMachineId').mockResolvedValue({
+		identitySpy = spyOn(
+			serverIdentityService,
+			'refreshConfiguredServerMachineId'
+		).mockResolvedValue({
 			machineId: MOCK_MACHINE_ID,
 			source: 'fresh',
 			errorReason: null
@@ -191,7 +200,10 @@ describe('verifyServerMembership', () => {
 
 	it('returns reason "not_reachable" when /identity is unreachable and URL strategies fail', async () => {
 		configSpy = mockConfiguredUrl('http://plex.local.timo.be:32400');
-		identitySpy = spyOn(serverIdentityService, 'getConfiguredServerMachineId').mockResolvedValue({
+		identitySpy = spyOn(
+			serverIdentityService,
+			'refreshConfiguredServerMachineId'
+		).mockResolvedValue({
 			machineId: null,
 			source: 'unavailable',
 			errorReason: 'Connection timed out - the server may be unreachable'
@@ -227,7 +239,10 @@ describe('verifyServerMembership', () => {
 
 	it('returns reason "not_in_resources" when /identity succeeds but the server is not in plex.tv resources', async () => {
 		configSpy = mockConfiguredUrl('http://plex.local.timo.be:32400');
-		identitySpy = spyOn(serverIdentityService, 'getConfiguredServerMachineId').mockResolvedValue({
+		identitySpy = spyOn(
+			serverIdentityService,
+			'refreshConfiguredServerMachineId'
+		).mockResolvedValue({
 			machineId: MOCK_MACHINE_ID,
 			source: 'fresh',
 			errorReason: null
@@ -254,7 +269,10 @@ describe('verifyServerMembership', () => {
 
 	it('returns reason "not_owner" when Strategy 0 matches but the server is not owned', async () => {
 		configSpy = mockConfiguredUrl('http://plex.local.timo.be:32400');
-		identitySpy = spyOn(serverIdentityService, 'getConfiguredServerMachineId').mockResolvedValue({
+		identitySpy = spyOn(
+			serverIdentityService,
+			'refreshConfiguredServerMachineId'
+		).mockResolvedValue({
 			machineId: MOCK_MACHINE_ID,
 			source: 'cache',
 			errorReason: null

--- a/tests/unit/auth/membership.test.ts
+++ b/tests/unit/auth/membership.test.ts
@@ -60,6 +60,15 @@ describe('verifyServerMembership', () => {
 		// there is no meaningful configured server to check against, and without the
 		// gate the revalidator would incorrectly revoke the freshly-created session.
 		configSpy = mockConfiguredUrl('http://test-plex-server:32400');
+		// Mock /identity explicitly so the outcome does not depend on the
+		// shared fetch mock being (accidentally) rejected as an invalid
+		// identity response. With /identity succeeding and the returned
+		// machineId absent from /resources, the result must be not_in_resources.
+		identitySpy = spyOn(serverIdentityService, 'getConfiguredServerMachineId').mockResolvedValue({
+			machineId: MOCK_MACHINE_ID,
+			source: 'fresh',
+			errorReason: null
+		});
 		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
 			createMockResponse([
 				{
@@ -86,6 +95,8 @@ describe('verifyServerMembership', () => {
 
 		expect(result.isMember).toBe(false);
 		expect(result.isOwner).toBe(false);
+		expect(result.reason).toBe('not_in_resources');
+		expect(result.configuredMachineId).toBe(MOCK_MACHINE_ID);
 	});
 
 	it('matches a plain-host configured URL against a .plex.direct-only server when /identity is reachable', async () => {

--- a/tests/unit/plex/server-identity.service.test.ts
+++ b/tests/unit/plex/server-identity.service.test.ts
@@ -230,4 +230,17 @@ describe('refreshConfiguredServerMachineId', () => {
 		expect(result.source).toBe('fresh');
 		expect(await settingsService.getCachedServerMachineId()).toBe(MOCK_MACHINE_ID);
 	});
+
+	it('evicts the cached machineId when /identity fails so stale ids cannot survive a failed refresh', async () => {
+		await settingsService.setCachedServerMachineId(MOCK_MACHINE_ID);
+		configSpy = mockApiConfig(MOCK_URL, MOCK_TOKEN);
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(createMockResponse(null, false, 401));
+
+		const result = await refreshConfiguredServerMachineId();
+
+		expect(result.machineId).toBeNull();
+		expect(result.source).toBe('unavailable');
+		expect(result.errorReason).toContain('Authentication failed');
+		expect(await settingsService.getCachedServerMachineId()).toBeNull();
+	});
 });

--- a/tests/unit/plex/server-identity.service.test.ts
+++ b/tests/unit/plex/server-identity.service.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import * as settingsService from '$lib/server/admin/settings.service';
+import {
+	fetchServerIdentity,
+	getConfiguredServerMachineId,
+	refreshConfiguredServerMachineId
+} from '$lib/server/plex/server-identity.service';
+
+const MOCK_MACHINE_ID = 'a'.repeat(32);
+const MOCK_URL = 'http://plex.example.com:32400';
+const MOCK_TOKEN = 'plex-token';
+
+function createMockResponse(data: unknown, ok = true, status = 200): Response {
+	return {
+		ok,
+		status,
+		statusText: ok ? 'OK' : 'Error',
+		json: () => Promise.resolve(data),
+		headers: new Headers(),
+		redirected: false,
+		type: 'basic',
+		url: '',
+		clone: () => createMockResponse(data, ok, status),
+		body: null,
+		bodyUsed: false,
+		arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+		blob: () => Promise.resolve(new Blob()),
+		formData: () => Promise.resolve(new FormData()),
+		text: () => Promise.resolve(JSON.stringify(data))
+	} as Response;
+}
+
+function mockApiConfig(serverUrl: string, token: string): ReturnType<typeof spyOn> {
+	return spyOn(settingsService, 'getApiConfigWithSources').mockResolvedValue({
+		plex: {
+			serverUrl: { value: serverUrl, source: 'env', isLocked: false },
+			token: { value: token, source: 'env', isLocked: false }
+		},
+		openai: {
+			apiKey: { value: '', source: 'default', isLocked: false },
+			baseUrl: { value: 'https://api.openai.com/v1', source: 'default', isLocked: false },
+			model: { value: 'gpt-5-mini', source: 'default', isLocked: false }
+		}
+	});
+}
+
+describe('fetchServerIdentity', () => {
+	let fetchSpy: ReturnType<typeof spyOn>;
+
+	afterEach(() => {
+		fetchSpy?.mockRestore();
+	});
+
+	it('returns machineIdentifier and friendlyName for a valid /identity response', async () => {
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse({
+				MediaContainer: {
+					machineIdentifier: MOCK_MACHINE_ID,
+					friendlyName: 'X.A.N.A.',
+					version: '1.32.0',
+					claimed: true
+				}
+			})
+		);
+
+		const result = await fetchServerIdentity(MOCK_URL, MOCK_TOKEN);
+
+		expect(result.identity).toEqual({
+			machineIdentifier: MOCK_MACHINE_ID,
+			friendlyName: 'X.A.N.A.'
+		});
+		expect(result.errorReason).toBeNull();
+	});
+
+	it('returns identity with null friendlyName when the field is missing', async () => {
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse({
+				MediaContainer: { machineIdentifier: MOCK_MACHINE_ID }
+			})
+		);
+
+		const result = await fetchServerIdentity(MOCK_URL, MOCK_TOKEN);
+
+		expect(result.identity?.friendlyName).toBeNull();
+		expect(result.identity?.machineIdentifier).toBe(MOCK_MACHINE_ID);
+	});
+
+	it('returns a specific auth error reason on 401', async () => {
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(createMockResponse(null, false, 401));
+
+		const result = await fetchServerIdentity(MOCK_URL, MOCK_TOKEN);
+
+		expect(result.identity).toBeNull();
+		expect(result.errorReason).toContain('Authentication failed');
+	});
+
+	it('returns errorReason on non-401 HTTP error', async () => {
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(createMockResponse(null, false, 500));
+
+		const result = await fetchServerIdentity(MOCK_URL, MOCK_TOKEN);
+
+		expect(result.identity).toBeNull();
+		expect(result.errorReason).toContain('500');
+	});
+
+	it('classifies AbortError (timeout) using security.classifyConnectionError', async () => {
+		const abortError = new Error('aborted');
+		abortError.name = 'AbortError';
+		fetchSpy = spyOn(global, 'fetch').mockRejectedValue(abortError);
+
+		const result = await fetchServerIdentity(MOCK_URL, MOCK_TOKEN);
+
+		expect(result.identity).toBeNull();
+		expect(result.errorReason).toContain('timed out');
+	});
+
+	it('returns invalid-shape error when /identity returns unexpected JSON', async () => {
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse({ notAPlexServer: true })
+		);
+
+		const result = await fetchServerIdentity(MOCK_URL, MOCK_TOKEN);
+
+		expect(result.identity).toBeNull();
+		expect(result.errorReason).toContain('valid Plex identity');
+	});
+
+	it('returns "not configured" reason when URL or token is empty', async () => {
+		const result = await fetchServerIdentity('', MOCK_TOKEN);
+		expect(result.identity).toBeNull();
+		expect(result.errorReason).toContain('not configured');
+	});
+
+	it('strips trailing slashes from the server URL before calling /identity', async () => {
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse({
+				MediaContainer: { machineIdentifier: MOCK_MACHINE_ID }
+			})
+		);
+
+		await fetchServerIdentity(`${MOCK_URL}///`, MOCK_TOKEN);
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const firstCall = fetchSpy.mock.calls[0] as [string, RequestInit];
+		expect(firstCall[0]).toBe(`${MOCK_URL}/identity`);
+	});
+});
+
+describe('getConfiguredServerMachineId', () => {
+	let fetchSpy: ReturnType<typeof spyOn>;
+	let configSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(async () => {
+		await settingsService.clearCachedServerMachineId();
+	});
+
+	afterEach(async () => {
+		fetchSpy?.mockRestore();
+		configSpy?.mockRestore();
+		await settingsService.clearCachedServerMachineId();
+	});
+
+	it('returns the cached machineId without making an HTTP call', async () => {
+		await settingsService.setCachedServerMachineId(MOCK_MACHINE_ID);
+		fetchSpy = spyOn(global, 'fetch');
+
+		const result = await getConfiguredServerMachineId();
+
+		expect(result.machineId).toBe(MOCK_MACHINE_ID);
+		expect(result.source).toBe('cache');
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('fetches /identity on cache miss and writes the result back to the cache', async () => {
+		configSpy = mockApiConfig(MOCK_URL, MOCK_TOKEN);
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse({
+				MediaContainer: { machineIdentifier: MOCK_MACHINE_ID, friendlyName: 'X.A.N.A.' }
+			})
+		);
+
+		const result = await getConfiguredServerMachineId();
+
+		expect(result.machineId).toBe(MOCK_MACHINE_ID);
+		expect(result.source).toBe('fresh');
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(await settingsService.getCachedServerMachineId()).toBe(MOCK_MACHINE_ID);
+	});
+
+	it('returns unavailable + errorReason when /identity fails and no cache is present', async () => {
+		configSpy = mockApiConfig(MOCK_URL, MOCK_TOKEN);
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(createMockResponse(null, false, 401));
+
+		const result = await getConfiguredServerMachineId();
+
+		expect(result.machineId).toBeNull();
+		expect(result.source).toBe('unavailable');
+		expect(result.errorReason).toContain('Authentication failed');
+		expect(await settingsService.getCachedServerMachineId()).toBeNull();
+	});
+});
+
+describe('refreshConfiguredServerMachineId', () => {
+	let fetchSpy: ReturnType<typeof spyOn>;
+	let configSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(async () => {
+		await settingsService.clearCachedServerMachineId();
+	});
+
+	afterEach(async () => {
+		fetchSpy?.mockRestore();
+		configSpy?.mockRestore();
+		await settingsService.clearCachedServerMachineId();
+	});
+
+	it('bypasses the cache and always hits /identity', async () => {
+		await settingsService.setCachedServerMachineId('stale-id');
+		configSpy = mockApiConfig(MOCK_URL, MOCK_TOKEN);
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			createMockResponse({
+				MediaContainer: { machineIdentifier: MOCK_MACHINE_ID }
+			})
+		);
+
+		const result = await refreshConfiguredServerMachineId();
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(result.machineId).toBe(MOCK_MACHINE_ID);
+		expect(result.source).toBe('fresh');
+		expect(await settingsService.getCachedServerMachineId()).toBe(MOCK_MACHINE_ID);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes [engels74/obzorarr-docker#5](https://github.com/engels74/obzorarr-docker/issues/5).

When `PLEX_SERVER_URL` is a hostname (e.g. `http://plex.local.timo.be:32400`, a LAN DNS name, or a reverse-proxied URL) and the Plex server advertises only `.plex.direct` connection URIs under the signed-in user's Plex.tv resources list, Obzorarr's four URL-string matching strategies all fail and `verifyServerMembership` returns `{ isMember: false }`. The user sees a greyed-out Continue button with no actionable error message and cannot complete onboarding.

The authoritative test is not URL-string matching — Obzorarr already reaches the configured server successfully, so it can ask the server for its own identity via `GET /identity` and match the returned `machineIdentifier` against each Plex.tv resource's `clientIdentifier`. This is the same value Plex itself uses for server identity and matches regardless of how the URL is expressed.

## Changes

**New `Strategy 0`: match by machineIdentifier from `/identity`**

- New service `src/lib/server/plex/server-identity.service.ts` exposes `fetchServerIdentity()`, `getConfiguredServerMachineId()` (cache-first), and `refreshConfiguredServerMachineId()` (force refresh). Uses a 10 s `AbortController` timeout and the existing `classifyConnectionError` helper.
- `src/lib/server/auth/membership.ts` prepends a new matching strategy that compares the fetched `machineIdentifier` against each server's `clientIdentifier`. The existing four URL-based strategies remain as fallbacks for when `/identity` is unreachable.
- `MembershipResult` gains a discriminated `reason?: 'not_reachable' | 'not_in_resources' | 'not_owner'` and `configuredMachineId?: string` so the UI can render specific messages and offer an explicit ownership override.

**Cache + invalidation**

- `app_settings` gains a `SERVER_MACHINE_ID` row, mirroring the existing `SERVER_NAME` cache (`getCachedServerMachineId` / `setCachedServerMachineId` / `clearCachedServerMachineId`).
- The admin settings form invalidates the cache whenever `PLEX_SERVER_URL` or `PLEX_TOKEN` changes so the next membership check re-fetches `/identity`.

**Onboarding UX**

- `src/routes/onboarding/plex/+page.server.ts` proactively calls `getConfiguredServerMachineId()` in `load` and returns `configuredUrlReachable`, `configuredUrlErrorReason`, and `configuredMachineId` so the page can warn before the user signs in.
- New `forceManualSelection` action sets an app-settings flag that forces the manual server picker on the next load; `src/routes/onboarding/+layout.server.ts` respects the flag.
- New `confirmOwnershipOverride` action: when `/identity` succeeded but Plex.tv does not list the server for the signed-in user, the user can explicitly attest ownership to bypass the resources check. Logged at `logger.warn` with URL, machineId, and username for audit trail.
- `src/routes/onboarding/plex/+page.svelte` renders specific error cards with remediation buttons instead of the previous silent disabled state.

**Tests**

- `tests/unit/auth/membership.test.ts` — four new cases covering Strategy 0 match, fallback when `/identity` unreachable, `not_in_resources` with machineId, and the cache interaction.
- `tests/unit/plex/server-identity.service.test.ts` — new file covering the valid response, missing `friendlyName`, 401 / non-401 HTTP errors, `AbortError` classification, URL trailing-slash normalization, cache hit/miss, and the force-refresh path.

## Reproduction and verification

Bug reproduced locally against a Bun proxy (`/tmp/plex-proxy.ts`) that forwards a plain `http://localhost:7777` origin to the live Plex server. Pre-fix, the logs show the exact failure from the upstream issue:

```
[Membership] Configured PLEX_SERVER_URL: http://localhost:7777 (source: env)
[Membership] Found 1 server(s) accessible to user
[Membership] Server: PARENTi | clientIdentifier: <id> | owned: true
[Membership]   - Connection URI: https://<ip>.<hash>.plex.direct:32400 ...
[Membership] No matching server found for configured URL
```

Sign-in throws `NotServerMemberError` and the onboarding page renders the authentication-failure card:

![Authentication error card](https://litter.catbox.moe/631gb6.png)

Pre-fix, onboarding step 2 leaves the user stuck at CONNECT (URL blurred):

![Before: CONNECT step disabled](https://litter.catbox.moe/ifxcod.png)

Post-fix, with the same hostname-only `PLEX_SERVER_URL`, Strategy 0 fetches `/identity`, matches the returned `machineIdentifier` against Plex.tv resources, and the user advances to SYNC:

![After: advanced to SYNC](https://litter.catbox.moe/9lskcy.png)

## Test plan

- [x] `bun run check` — 0 errors
- [x] `bun run test` — full suite passes, new tests included, coverage ≥ 80 %
- [x] `bun run check:biome` — lint + format clean
- [x] Manual repro against live Plex server via local proxy: pre-fix blocks on CONNECT with `No matching server found`; post-fix matches via `machineIdentifier` and advances to SYNC
- [x] Manual unreachable-URL path: error card appears before sign-in with specific reason, `forceManualSelection` button falls back to manual picker
- [x] Cache invalidation on `PLEX_SERVER_URL` / `PLEX_TOKEN` change in admin settings