### PR TITLE
refactor(onboarding): move clearTimeout to finally in connection tests

### DIFF
--- a/src/routes/api/onboarding/select-server/+server.ts
+++ b/src/routes/api/onboarding/select-server/+server.ts
@@ -54,8 +54,6 @@ async function testConnection(url: string, accessToken: string): Promise<Connect
 			signal: controller.signal
 		});
 
-		clearTimeout(timeoutId);
-
 		if (response.status === 401) {
 			return { success: false, error: 'Authentication failed - the access token may be invalid' };
 		}
@@ -79,13 +77,13 @@ async function testConnection(url: string, accessToken: string): Promise<Connect
 			machineIdentifier: identityResult.data.MediaContainer.machineIdentifier
 		};
 	} catch (fetchError) {
-		clearTimeout(timeoutId);
-
 		if (fetchError instanceof Error) {
 			return { success: false, error: classifyConnectionError(fetchError) };
 		}
 
 		return { success: false, error: 'Connection failed' };
+	} finally {
+		clearTimeout(timeoutId);
 	}
 }
 

--- a/src/routes/api/onboarding/test-connection/+server.ts
+++ b/src/routes/api/onboarding/test-connection/+server.ts
@@ -65,8 +65,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 				signal: controller.signal
 			});
 
-			clearTimeout(timeoutId);
-
 			// Check for authentication errors
 			if (response.status === 401) {
 				logger.debug('Connection test failed: Authentication failed', 'Onboarding');
@@ -110,8 +108,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 				machineIdentifier
 			});
 		} catch (fetchError) {
-			clearTimeout(timeoutId);
-
 			if (fetchError instanceof Error) {
 				const errorMessage = classifyConnectionError(fetchError);
 				logger.debug(`Connection test failed: ${errorMessage}`, 'Onboarding');
@@ -126,6 +122,11 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 				success: false,
 				error: 'Connection failed'
 			});
+		} finally {
+			// Keep the timer armed until after response.json() + parsing complete so
+			// CONNECTION_TIMEOUT_MS caps the whole /identity call, not just the
+			// initial fetch resolving its headers.
+			clearTimeout(timeoutId);
 		}
 	} catch (err) {
 		// Re-throw SvelteKit errors


### PR DESCRIPTION
## Summary

Align the two onboarding connection-test endpoints with the timeout pattern adopted in [`fetchServerIdentity`](src/lib/server/plex/server-identity.service.ts) (PR #74, review discussion `r3106076263`). Both endpoints previously cleared the abort timer immediately after `await fetch` resolved its response headers, leaving `response.json()` and `PlexServerIdentitySchema.safeParse()` unguarded by `CONNECTION_TIMEOUT_MS`. A Plex server that sent headers and then stalled mid-body could hang the request until the TCP layer gave up.

This PR consolidates `clearTimeout(timeoutId)` into a single `finally` block per call-site so the timeout budget spans the entire `/identity` call: `fetch` + body read + schema validation.

## Changes

### `src/routes/api/onboarding/test-connection/+server.ts`
- Removed `clearTimeout(timeoutId)` from after `await fetch`.
- Removed `clearTimeout(timeoutId)` from the first line of the inner `catch` block.
- Added a `finally { clearTimeout(timeoutId); }` after the inner `catch`, with the explanatory comment preserved from the reference implementation.
- `CONNECTION_TIMEOUT_MS` remains `10000`.

### `src/routes/api/onboarding/select-server/+server.ts`
- Same structural refactor inside the local `testConnection()` helper.
- `CONNECTION_TIMEOUT_MS` remains `15000` (intentionally higher than the test-connection endpoint; preserved as-is since the refactor is purely structural).

## Behavioural impact

- Happy path: unchanged. On success the timer is cleared in `finally` just as the response is returned.
- Pre-existing timeout path (network stall before headers): unchanged. `AbortController.abort()` still fires at `CONNECTION_TIMEOUT_MS`, `fetch` still rejects, the `catch` still routes through `classifyConnectionError`, and `finally` clears the (already fired) timer.
- New guarantee: a server that sends headers quickly but then stalls the response body — or returns a pathological payload that makes `safeParse` slow — will now abort within `CONNECTION_TIMEOUT_MS` instead of running to completion.

No signature changes, no public API changes, no new dependencies.

## Reference

`src/lib/server/plex/server-identity.service.ts:46-108` — the canonical pattern: single `AbortController` armed before the `try`, single `clearTimeout(timeoutId)` in `finally`.

## Test plan

- [x] `bun run check` — svelte-check passes (0 errors, 0 warnings).
- [x] `bun run test` — full suite passes (1281/1281, 17264 expect() calls).
- [x] `bun run lint` on the two touched files — clean. (Pre-existing lint findings elsewhere in the repo are untouched by this PR.)
- [ ] Manual smoke (reviewer, optional): in the onboarding flow, point `POST /api/onboarding/test-connection` and `POST /api/onboarding/select-server` at (a) a valid Plex URL + token — expect `success: true`; (b) an unreachable URL — expect `success: false` with a `classifyConnectionError` message within ~10-15s.

No new automated tests added: the only new behavioural guarantee (post-header body stall aborts within the timeout) is not deterministically unit-testable without introducing a mock HTTP server that can pause mid-body, which is disproportionate for a local control-flow refactor.