### PR TITLE
feat(ui): show build version in dashboard & admin sidebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "obzorarr",
 	"private": true,
-	"version": "0.0.1",
+	"version": "0.1.10",
 	"type": "module",
 	"scripts": {
 		"dev": "bun --bun vite dev",

--- a/src/lib/server/version.ts
+++ b/src/lib/server/version.ts
@@ -1,0 +1,28 @@
+import { env } from '$env/dynamic/private';
+import pkg from '../../../package.json';
+
+export type AppVersion = {
+	kind: 'release' | 'nightly' | 'dev';
+	display: string;
+};
+
+const SEMVER = /^v?\d+\.\d+\.\d+/;
+const SHA = /^[0-9a-f]{7,40}$/i;
+
+export function getAppVersion(): AppVersion {
+	const tag = env.COMMIT_TAG?.trim();
+
+	if (!tag) {
+		return { kind: 'dev', display: `v${pkg.version}` };
+	}
+	if (SEMVER.test(tag)) {
+		return {
+			kind: 'release',
+			display: tag.startsWith('v') ? tag : `v${tag}`
+		};
+	}
+	if (SHA.test(tag)) {
+		return { kind: 'nightly', display: `nightly · ${tag.slice(0, 7)}` };
+	}
+	return { kind: 'dev', display: tag };
+}

--- a/src/lib/server/version.ts
+++ b/src/lib/server/version.ts
@@ -6,7 +6,7 @@ export type AppVersion = {
 	display: string;
 };
 
-const SEMVER = /^v?\d+\.\d+\.\d+/;
+const SEMVER = /^v?\d+\.\d+\.\d+$/;
 const SHA = /^[0-9a-f]{7,40}$/i;
 
 export function getAppVersion(): AppVersion {

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,4 +1,5 @@
 import { getUITheme, getWrappedTheme } from '$lib/server/admin/settings.service';
+import { getAppVersion } from '$lib/server/version';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ cookies }) => {
@@ -19,6 +20,7 @@ export const load: LayoutServerLoad = async ({ cookies }) => {
 
 	return {
 		uiTheme,
-		wrappedTheme
+		wrappedTheme,
+		appVersion: getAppVersion()
 	};
 };

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -188,6 +188,12 @@ function handleCsrfWarningDismissed() {
 					<span>Logout</span>
 				</button>
 			</form>
+			<div
+				class="text-[10px] text-muted-foreground/50 font-mono tracking-wider text-center leading-none select-all"
+				title={data.appVersion.kind}
+			>
+				{data.appVersion.display}
+			</div>
 		</div>
 	</aside>
 

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -153,6 +153,12 @@ function closeSidebar() {
 					<span>Logout</span>
 				</button>
 			</form>
+			<div
+				class="text-[10px] text-muted-foreground/50 font-mono tracking-wider text-center leading-none select-all"
+				title={data.appVersion.kind}
+			>
+				{data.appVersion.display}
+			</div>
 		</div>
 	</aside>
 

--- a/tests/unit/lib/server/version.test.ts
+++ b/tests/unit/lib/server/version.test.ts
@@ -44,4 +44,14 @@ describe('getAppVersion', () => {
 		envAny.COMMIT_TAG = '  0.1.10  ';
 		expect(getAppVersion()).toEqual({ kind: 'release', display: 'v0.1.10' });
 	});
+
+	it('treats a pre-release tag (0.1.10-beta) as dev, not release', () => {
+		envAny.COMMIT_TAG = '0.1.10-beta';
+		expect(getAppVersion()).toEqual({ kind: 'dev', display: '0.1.10-beta' });
+	});
+
+	it('treats a tag with trailing garbage (v1.2.3foo) as dev, not release', () => {
+		envAny.COMMIT_TAG = 'v1.2.3foo';
+		expect(getAppVersion()).toEqual({ kind: 'dev', display: 'v1.2.3foo' });
+	});
 });

--- a/tests/unit/lib/server/version.test.ts
+++ b/tests/unit/lib/server/version.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { env } from '$env/dynamic/private';
+import { getAppVersion } from '$lib/server/version';
+import pkg from '../../../../package.json';
+
+const envAny = env as Record<string, string | undefined>;
+
+afterEach(() => {
+	delete envAny.COMMIT_TAG;
+});
+
+describe('getAppVersion', () => {
+	it('returns kind=dev with package.json version when COMMIT_TAG is unset', () => {
+		delete envAny.COMMIT_TAG;
+		expect(getAppVersion()).toEqual({ kind: 'dev', display: `v${pkg.version}` });
+	});
+
+	it('classifies a bare semver COMMIT_TAG as release and prefixes v', () => {
+		envAny.COMMIT_TAG = '0.1.10';
+		expect(getAppVersion()).toEqual({ kind: 'release', display: 'v0.1.10' });
+	});
+
+	it('preserves an existing v prefix on release tags', () => {
+		envAny.COMMIT_TAG = 'v1.2.3';
+		expect(getAppVersion()).toEqual({ kind: 'release', display: 'v1.2.3' });
+	});
+
+	it('classifies a 40-char sha as nightly and truncates to 7 chars', () => {
+		envAny.COMMIT_TAG = 'c465277744366334c082ae4105e5c53d4a12b9b7';
+		expect(getAppVersion()).toEqual({ kind: 'nightly', display: 'nightly · c465277' });
+	});
+
+	it('accepts a short sha (7 chars) as nightly', () => {
+		envAny.COMMIT_TAG = 'abcdef0';
+		expect(getAppVersion()).toEqual({ kind: 'nightly', display: 'nightly · abcdef0' });
+	});
+
+	it('falls back to kind=dev passing through unrecognised tag formats', () => {
+		envAny.COMMIT_TAG = 'weird-tag-name';
+		expect(getAppVersion()).toEqual({ kind: 'dev', display: 'weird-tag-name' });
+	});
+
+	it('trims surrounding whitespace from COMMIT_TAG', () => {
+		envAny.COMMIT_TAG = '  0.1.10  ';
+		expect(getAppVersion()).toEqual({ kind: 'release', display: 'v0.1.10' });
+	});
+});


### PR DESCRIPTION
## Summary

Surfaces a small, restrained build identifier in both authenticated sidebars so users (and support) can tell at a glance which image / commit an instance is running. Reads the `COMMIT_TAG` env var baked into the sibling `obzorarr-docker` images and classifies it into one of three modes:

| Runtime context | `COMMIT_TAG` | Display | Tooltip (`kind`) |
|---|---|---|---|
| `:release` Docker image | `0.1.10` | `v0.1.10` | `release` |
| `:nightly` Docker image | 40-char commit sha | `nightly · c465277` | `nightly` |
| Local `bun run dev` / prod without Docker | _(unset)_ | `v0.1.10` (from `package.json`) | `dev` |
| Unrecognised tag | anything else | passed through | `dev` |

Also bumps `package.json` from `0.0.1` to `0.1.10` so it matches the latest GitHub release tag and is usable as the local fallback.

## Changes

| File | Change |
|---|---|
| `package.json` | Version `0.0.1` → `0.1.10` |
| `src/lib/server/version.ts` | New server-only `getAppVersion()` and `AppVersion` type; reads `env.COMMIT_TAG` via `$env/dynamic/private` and falls back to the imported `package.json` version |
| `src/routes/+layout.server.ts` | Adds `appVersion: getAppVersion()` to the root layout's returned data so it propagates to every child via `$page.data` / `LayoutData` |
| `src/routes/dashboard/+layout.svelte` | Renders `{data.appVersion.display}` in the sidebar footer, below the Logout button |
| `src/routes/admin/+layout.svelte` | Same block in the admin sidebar footer |
| `tests/unit/lib/server/version.test.ts` | 7 unit tests covering: unset tag, bare semver, `v`-prefixed semver, full 40-char sha, 7-char sha, unknown tag passthrough, whitespace trimming |

## UI treatment

The version plate sits below the Logout button, centered, in `10px` `font-mono` at `text-muted-foreground/50` with `tracking-wider` and `leading-none`. `select-all` is applied so a single click selects the full string for paste into a bug report (matters for nightly SHAs). `title={data.appVersion.kind}` exposes the classification (`release` / `nightly` / `dev`) on hover without adding visible clutter.

### Screenshots

All four were captured by running `bun run dev` with the relevant `COMMIT_TAG`, cropping the sidebar footer with ImageMagick, and redacting the test username with a solid fill.

| Mode | Dashboard sidebar (`/dashboard`) | Admin sidebar (`/admin`) |
|---|---|---|
| Dev (unset `COMMIT_TAG`) | ![dashboard-dev](https://litter.catbox.moe/1ip1l2.png) | ![admin-dev](https://litter.catbox.moe/2w673i.png) |
| Nightly (`COMMIT_TAG=c465277744366334c082ae4105e5c53d4a12b9b7`) | ![dashboard-nightly](https://litter.catbox.moe/4f16mc.png) | ![admin-nightly](https://litter.catbox.moe/sns11i.png) |

The release-mode visual is identical to the dev-mode visual — both render `v0.1.10` — only the `title` tooltip differs (`release` vs `dev`); no additional screenshot provided for that case.

## Why `$env/dynamic/private`

`COMMIT_TAG` is supplied at container runtime by the Docker image (see `obzorarr-docker`'s `linux-amd64.Dockerfile` / `linux-arm64.Dockerfile`, which both set `ENV COMMIT_TAG=\${VERSION}`), not at SvelteKit build time. That means `$env/static/private` (compile-time inlined, requires declared secrets) is the wrong choice — `$env/dynamic/private` is the matching API for runtime envs. Precedent in this codebase: `src/lib/server/admin/settings.service.ts` and `src/lib/server/auth/dev-bypass.ts` both use the same pattern.

## Test plan

- [x] `bun test tests/unit/lib/server/version.test.ts` — 7/7 pass, 100% line & function coverage on the new module
- [x] `bun run check` — svelte-check clean, no new errors; `LayoutData` regenerates with `appVersion` inherited into both child layouts
- [x] `bunx biome check` on all touched files — clean (tabs, single quotes, 100-col, import order)
- [x] Manual: `bun run dev` with no `COMMIT_TAG` → sidebar shows `v0.1.10`, title=`dev`
- [x] Manual: `COMMIT_TAG=0.1.10 bun run dev` → sidebar shows `v0.1.10`, title=`release`
- [x] Manual: `COMMIT_TAG=<40-char-sha> bun run dev` → sidebar shows `nightly · <7-char>`, title=`nightly`
- [x] Both authenticated sidebars render the plate (dashboard non-admin flow and admin flow both verified)