### PR TITLE
feat(onboarding): configure and verify OpenAI credentials in AI fun facts step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ docs/
 # Build analysis
 bundle-stats.html
 .omx/
+
+# Test artifacts
+screenshots/

--- a/src/lib/server/funfacts/service.ts
+++ b/src/lib/server/funfacts/service.ts
@@ -25,9 +25,9 @@ export async function getFunFactsConfig(): Promise<FunFactsConfig> {
 		getAppSetting(AppSettingsKey.FUN_FACTS_AI_PERSONA)
 	]);
 
-	const apiKey = apiConfig.openai.apiKey.value;
-	const baseUrl = apiConfig.openai.baseUrl.value.replace(/\/+$/, '');
-	const model = apiConfig.openai.model.value;
+	const apiKey = apiConfig.openai.apiKey.value.trim();
+	const baseUrl = apiConfig.openai.baseUrl.value.trim().replace(/\/+$/, '');
+	const model = apiConfig.openai.model.value.trim();
 
 	return {
 		aiEnabled: Boolean(apiKey),

--- a/src/lib/server/funfacts/service.ts
+++ b/src/lib/server/funfacts/service.ts
@@ -1,4 +1,8 @@
-import { AppSettingsKey, getAppSetting } from '$lib/server/admin/settings.service';
+import {
+	AppSettingsKey,
+	getApiConfigWithSources,
+	getAppSetting
+} from '$lib/server/admin/settings.service';
 import type { ServerStats, Stats, UserStats } from '$lib/server/stats/types';
 import { isUserStats } from '$lib/server/stats/types';
 import { buildEnhancedPrompt, enrichContext } from './ai';
@@ -16,18 +20,20 @@ import type {
 import { AIGenerationError } from './types';
 
 export async function getFunFactsConfig(): Promise<FunFactsConfig> {
-	const [apiKey, baseUrl, model, persona] = await Promise.all([
-		getAppSetting(AppSettingsKey.OPENAI_API_KEY),
-		getAppSetting(AppSettingsKey.OPENAI_BASE_URL),
-		getAppSetting(AppSettingsKey.OPENAI_MODEL),
+	const [apiConfig, persona] = await Promise.all([
+		getApiConfigWithSources(),
 		getAppSetting(AppSettingsKey.FUN_FACTS_AI_PERSONA)
 	]);
 
+	const apiKey = apiConfig.openai.apiKey.value;
+	const baseUrl = apiConfig.openai.baseUrl.value.replace(/\/+$/, '');
+	const model = apiConfig.openai.model.value;
+
 	return {
 		aiEnabled: Boolean(apiKey),
-		openaiApiKey: apiKey ?? undefined,
-		openaiBaseUrl: baseUrl ?? 'https://api.openai.com/v1',
-		openaiModel: model ?? 'gpt-5-mini',
+		openaiApiKey: apiKey || undefined,
+		openaiBaseUrl: baseUrl || 'https://api.openai.com/v1',
+		openaiModel: model || 'gpt-5-mini',
 		maxAIRetries: 2,
 		aiTimeoutMs: 10000,
 		aiPersona: (persona as AIPersona) ?? 'witty'

--- a/src/lib/server/funfacts/test-connection.ts
+++ b/src/lib/server/funfacts/test-connection.ts
@@ -11,11 +11,12 @@ export async function testOpenAIConnection(
 	baseUrl?: string,
 	model?: string
 ): Promise<TestOpenAIConnectionResult> {
-	if (!apiKey || !apiKey.trim()) {
+	const trimmedKey = apiKey.trim();
+	if (!trimmedKey) {
 		return { success: false, error: 'API key is required' };
 	}
 
-	const resolvedBaseUrl = baseUrl ?? DEFAULT_BASE_URL;
+	const resolvedBaseUrl = (baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
 	const resolvedModel = model ?? DEFAULT_MODEL;
 
 	const controller = new AbortController();
@@ -26,7 +27,7 @@ export async function testOpenAIConnection(
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
-				Authorization: `Bearer ${apiKey}`
+				Authorization: `Bearer ${trimmedKey}`
 			},
 			body: JSON.stringify({
 				model: resolvedModel,

--- a/src/lib/server/funfacts/test-connection.ts
+++ b/src/lib/server/funfacts/test-connection.ts
@@ -1,0 +1,61 @@
+const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_MODEL = 'gpt-5-mini';
+const TIMEOUT_MS = 10_000;
+
+export type TestOpenAIConnectionResult =
+	| { success: true; message: string }
+	| { success: false; error: string };
+
+export async function testOpenAIConnection(
+	apiKey: string,
+	baseUrl?: string,
+	model?: string
+): Promise<TestOpenAIConnectionResult> {
+	if (!apiKey || !apiKey.trim()) {
+		return { success: false, error: 'API key is required' };
+	}
+
+	const resolvedBaseUrl = baseUrl ?? DEFAULT_BASE_URL;
+	const resolvedModel = model ?? DEFAULT_MODEL;
+
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+	try {
+		const response = await fetch(`${resolvedBaseUrl}/chat/completions`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${apiKey}`
+			},
+			body: JSON.stringify({
+				model: resolvedModel,
+				messages: [{ role: 'user', content: 'ping' }],
+				max_tokens: 1
+			}),
+			signal: controller.signal
+		});
+
+		if (response.ok) {
+			return { success: true, message: `Connected (model: ${resolvedModel})` };
+		}
+
+		if (response.status === 401) {
+			return { success: false, error: 'Authentication failed — check your API key' };
+		}
+		if (response.status === 404) {
+			return { success: false, error: 'Model not found or base URL is incorrect' };
+		}
+		return {
+			success: false,
+			error: `Request failed: ${response.status} ${response.statusText}`
+		};
+	} catch (error) {
+		if ((error as Error).name === 'AbortError') {
+			return { success: false, error: 'Connection timed out' };
+		}
+		return { success: false, error: (error as Error).message };
+	} finally {
+		clearTimeout(timeoutId);
+	}
+}

--- a/src/lib/server/funfacts/test-connection.ts
+++ b/src/lib/server/funfacts/test-connection.ts
@@ -52,10 +52,13 @@ export async function testOpenAIConnection(
 			error: `Request failed: ${response.status} ${response.statusText}`
 		};
 	} catch (error) {
-		if ((error as Error).name === 'AbortError') {
+		if (error instanceof Error && error.name === 'AbortError') {
 			return { success: false, error: 'Connection timed out' };
 		}
-		return { success: false, error: (error as Error).message };
+		return {
+			success: false,
+			error: error instanceof Error ? error.message : String(error)
+		};
 	} finally {
 		clearTimeout(timeoutId);
 	}

--- a/src/lib/server/funfacts/test-connection.ts
+++ b/src/lib/server/funfacts/test-connection.ts
@@ -16,8 +16,8 @@ export async function testOpenAIConnection(
 		return { success: false, error: 'API key is required' };
 	}
 
-	const resolvedBaseUrl = (baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
-	const resolvedModel = model ?? DEFAULT_MODEL;
+	const resolvedBaseUrl = (baseUrl?.trim() || DEFAULT_BASE_URL).replace(/\/+$/, '');
+	const resolvedModel = model?.trim() || DEFAULT_MODEL;
 
 	const controller = new AbortController();
 	const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -33,6 +33,7 @@ import {
 	type WrappedLogoModeType
 } from '$lib/server/admin/settings.service';
 import { getAvailableYears } from '$lib/server/admin/users.service';
+import { testOpenAIConnection } from '$lib/server/funfacts/test-connection';
 import {
 	getLogMaxCount,
 	getLogRetentionDays,
@@ -313,6 +314,38 @@ export const actions: Actions = {
 			const message = error instanceof Error ? error.message : 'Connection failed';
 			return fail(500, { error: message });
 		}
+	},
+
+	testAIConnection: async ({ request }) => {
+		const formData = await request.formData();
+		const submittedKey = formData.get('openaiApiKey')?.toString() ?? '';
+		const submittedBaseUrl = formData.get('openaiBaseUrl')?.toString() ?? '';
+		const submittedModel = formData.get('openaiModel')?.toString() ?? '';
+
+		const apiConfig = await getApiConfigWithSources();
+		const storedKey = apiConfig.openai.apiKey.value;
+		const storedBaseUrl = apiConfig.openai.baseUrl.value;
+		const storedModel = apiConfig.openai.model.value;
+
+		const baseUrl = submittedBaseUrl || storedBaseUrl;
+		const model = submittedModel || storedModel;
+
+		// The client never echoes the stored API key back (to avoid hydration leaks),
+		// so a missing key field is the normal case. Fall back to the stored key
+		// ONLY when the submitted base URL and model also match what's stored —
+		// prevents the stored key being forwarded to an attacker-controlled
+		// endpoint (same safeguard as testPlexConnection).
+		const normalise = (u: string) => u.replace(/\/+$/, '');
+		const baseUrlMatchesStored =
+			!!baseUrl && !!storedBaseUrl && normalise(baseUrl) === normalise(storedBaseUrl);
+		const modelMatchesStored = model === storedModel;
+		const apiKey = submittedKey || (baseUrlMatchesStored && modelMatchesStored ? storedKey : '');
+
+		const result = await testOpenAIConnection(apiKey, baseUrl, model);
+		if (!result.success) {
+			return fail(400, { error: result.error });
+		}
+		return { success: true, message: result.message };
 	},
 
 	updateUITheme: async ({ request }) => {

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -319,8 +319,8 @@ export const actions: Actions = {
 	testAIConnection: async ({ request }) => {
 		const formData = await request.formData();
 		const submittedKey = formData.get('openaiApiKey')?.toString() ?? '';
-		const submittedBaseUrl = formData.get('openaiBaseUrl')?.toString() ?? '';
-		const submittedModel = formData.get('openaiModel')?.toString() ?? '';
+		const submittedBaseUrl = (formData.get('openaiBaseUrl')?.toString() ?? '').trim();
+		const submittedModel = (formData.get('openaiModel')?.toString() ?? '').trim();
 
 		const apiConfig = await getApiConfigWithSources();
 		const storedKey = apiConfig.openai.apiKey.value;

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -324,8 +324,8 @@ export const actions: Actions = {
 
 		const apiConfig = await getApiConfigWithSources();
 		const storedKey = apiConfig.openai.apiKey.value;
-		const storedBaseUrl = apiConfig.openai.baseUrl.value;
-		const storedModel = apiConfig.openai.model.value;
+		const storedBaseUrl = apiConfig.openai.baseUrl.value.trim();
+		const storedModel = apiConfig.openai.model.value.trim();
 
 		const baseUrl = submittedBaseUrl || storedBaseUrl;
 		const model = submittedModel || storedModel;

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -318,7 +318,7 @@ export const actions: Actions = {
 
 	testAIConnection: async ({ request }) => {
 		const formData = await request.formData();
-		const submittedKey = formData.get('openaiApiKey')?.toString() ?? '';
+		const submittedKey = (formData.get('openaiApiKey')?.toString() ?? '').trim();
 		const submittedBaseUrl = (formData.get('openaiBaseUrl')?.toString() ?? '').trim();
 		const submittedModel = (formData.get('openaiModel')?.toString() ?? '').trim();
 

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -835,9 +835,7 @@ const logFieldErrors = $derived(
 							<button
 								type="button"
 								class="btn-secondary"
-								disabled={isTestingAI ||
-									(!openaiApiKey && !openaiApiKeyHasValue) ||
-									openaiApiKeyLocked}
+								disabled={isTestingAI || (!openaiApiKey && !openaiApiKeyHasValue)}
 								onclick={async () => {
 									isTestingAI = true;
 									testAIResult = null;

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -835,7 +835,7 @@ const logFieldErrors = $derived(
 							<button
 								type="button"
 								class="btn-secondary"
-								disabled={isTestingAI || (!openaiApiKey && !openaiApiKeyHasValue)}
+								disabled={isTestingAI || (!openaiApiKey.trim() && !openaiApiKeyHasValue)}
 								onclick={async () => {
 									isTestingAI = true;
 									testAIResult = null;

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -93,6 +93,8 @@ let selectedAnonymization = $state('');
 let selectedWrappedLogoMode = $state('');
 let isTesting = $state(false);
 let testConnectionResult = $state<{ type: 'success' | 'error'; message: string } | null>(null);
+let isTestingAI = $state(false);
+let testAIResult = $state<{ type: 'success' | 'error'; message: string } | null>(null);
 
 // Logging settings state
 let logRetentionDays = $state(7);
@@ -822,18 +824,86 @@ const logFieldErrors = $derived(
 							</div>
 						</div>
 
-						{#if !openaiApiKeyLocked || !openaiBaseUrlLocked || !openaiModelLocked}
-							<div class="panel-actions">
+						<div class="panel-actions">
+							{#if !openaiApiKeyLocked || !openaiBaseUrlLocked || !openaiModelLocked}
 								<button type="submit" class="btn-primary">
 									<Check class="btn-icon" />
 									Save OpenAI Settings
 								</button>
-							</div>
-						{:else}
+							{/if}
+
+							<button
+								type="button"
+								class="btn-secondary"
+								disabled={isTestingAI ||
+									(!openaiApiKey && !openaiApiKeyHasValue) ||
+									openaiApiKeyLocked}
+								onclick={async () => {
+									isTestingAI = true;
+									testAIResult = null;
+									const formData = new FormData();
+									formData.set('openaiApiKey', openaiApiKey);
+									formData.set('openaiBaseUrl', openaiBaseUrl);
+									formData.set('openaiModel', openaiModel);
+									try {
+										const response = await fetch('?/testAIConnection', {
+											method: 'POST',
+											body: formData
+										});
+										const result = deserialize(await response.text());
+										if (result.type === 'success' || result.type === 'failure') {
+											const data = result.data as {
+												success?: boolean;
+												message?: string;
+												error?: string;
+											};
+											handleFormToast(data);
+											testAIResult = data.error
+												? { type: 'error', message: data.error }
+												: {
+														type: 'success',
+														message: data.message ?? 'OpenAI connection succeeded'
+													};
+										} else if (result.type === 'error') {
+											const message =
+												result.error?.message ?? 'An error occurred while testing connection';
+											handleFormToast({ error: message });
+											testAIResult = { type: 'error', message };
+										} else {
+											const message = 'Unexpected response from server';
+											handleFormToast({ error: message });
+											testAIResult = { type: 'error', message };
+										}
+									} catch {
+										const message =
+											'Failed to test connection. Please check your network and try again.';
+										handleFormToast({ error: message });
+										testAIResult = { type: 'error', message };
+									} finally {
+										isTestingAI = false;
+									}
+								}}
+							>
+								{#if isTestingAI}
+									<Loader2 class="btn-icon spinning" />
+									Testing...
+								{:else}
+									<Zap class="btn-icon" />
+									Test Connection
+								{/if}
+							</button>
+						</div>
+
+						{#if openaiApiKeyLocked && openaiBaseUrlLocked && openaiModelLocked}
 							<div class="panel-info">
 								<span class="info-text"
 									>All OpenAI settings are managed via environment variables</span
 								>
+							</div>
+						{/if}
+						{#if testAIResult}
+							<div class="inline-result" class:error={testAIResult.type === 'error'}>
+								{testAIResult.message}
 							</div>
 						{/if}
 					</form>

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -300,8 +300,8 @@ export const actions: Actions = {
 				enableFunFacts: formData.get('enableFunFacts'),
 				funFactFrequency: formData.get('funFactFrequency'),
 				openaiApiKey: formData.get('openaiApiKey') ?? undefined,
-				openaiBaseUrl: (formData.get('openaiBaseUrl') as string | null)?.trim() ?? undefined,
-				openaiModel: (formData.get('openaiModel') as string | null)?.trim() ?? undefined,
+				openaiBaseUrl: formData.get('openaiBaseUrl')?.toString().trim() ?? undefined,
+				openaiModel: formData.get('openaiModel')?.toString().trim() ?? undefined,
 				aiPersona: formData.get('aiPersona') ?? undefined
 			};
 

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -300,8 +300,8 @@ export const actions: Actions = {
 				enableFunFacts: formData.get('enableFunFacts'),
 				funFactFrequency: formData.get('funFactFrequency'),
 				openaiApiKey: formData.get('openaiApiKey') ?? undefined,
-				openaiBaseUrl: formData.get('openaiBaseUrl') ?? undefined,
-				openaiModel: formData.get('openaiModel') ?? undefined,
+				openaiBaseUrl: (formData.get('openaiBaseUrl') as string | null)?.trim() ?? undefined,
+				openaiModel: (formData.get('openaiModel') as string | null)?.trim() ?? undefined,
 				aiPersona: formData.get('aiPersona') ?? undefined
 			};
 
@@ -315,6 +315,7 @@ export const actions: Actions = {
 			const data = parseResult.data;
 			const openaiApiKey = data.openaiApiKey?.trim();
 			const openaiBaseUrl = data.openaiBaseUrl?.trim().replace(/\/+$/, '');
+			const openaiModel = data.openaiModel?.trim();
 
 			// Save all settings in parallel
 			await Promise.all([
@@ -340,8 +341,8 @@ export const actions: Actions = {
 				data.enableFunFacts && openaiBaseUrl
 					? setAppSetting(AppSettingsKey.OPENAI_BASE_URL, openaiBaseUrl)
 					: Promise.resolve(),
-				data.enableFunFacts && data.openaiModel
-					? setAppSetting(AppSettingsKey.OPENAI_MODEL, data.openaiModel)
+				data.enableFunFacts && openaiModel
+					? setAppSetting(AppSettingsKey.OPENAI_MODEL, openaiModel)
 					: Promise.resolve(),
 				data.enableFunFacts && data.aiPersona
 					? setAppSetting(AppSettingsKey.FUN_FACTS_AI_PERSONA, data.aiPersona)

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -11,15 +11,18 @@ import { DEFAULT_SLIDE_ORDER, type SlideType } from '$lib/components/slides/type
 import {
 	AnonymizationMode,
 	type AnonymizationModeType,
+	AppSettingsKey,
 	FunFactFrequency,
 	type FunFactFrequencyType,
 	getAnonymizationMode,
+	getAppSetting,
 	getFunFactFrequency,
 	getUITheme,
 	getWrappedLogoMode,
 	getWrappedTheme,
 	hasOpenAIEnvConfig,
 	setAnonymizationMode,
+	setAppSetting,
 	setFunFactFrequency,
 	setUITheme,
 	setWrappedLogoMode,
@@ -29,6 +32,8 @@ import {
 	WrappedLogoMode,
 	type WrappedLogoModeType
 } from '$lib/server/admin/settings.service';
+import { testOpenAIConnection } from '$lib/server/funfacts/test-connection';
+import { AIPersonaSchema } from '$lib/server/funfacts/types';
 import { logger } from '$lib/server/logging';
 import { OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
 import {
@@ -90,7 +95,11 @@ const SettingsSchema = z.object({
 			FunFactFrequency.MANY,
 			FunFactFrequency.CUSTOM
 		])
-		.optional()
+		.optional(),
+	openaiApiKey: z.string().max(512).optional(),
+	openaiBaseUrl: z.string().max(512).url().optional().or(z.literal('')),
+	openaiModel: z.string().max(100).optional(),
+	aiPersona: AIPersonaSchema.optional()
 });
 
 /**
@@ -111,7 +120,10 @@ export const load: PageServerLoad = async ({ parent }) => {
 		defaultShareMode,
 		allowUserControl,
 		slideConfigs,
-		funFactConfig
+		funFactConfig,
+		openaiBaseUrl,
+		openaiModel,
+		openaiPersona
 	] = await Promise.all([
 		getUITheme(),
 		getWrappedTheme(),
@@ -120,7 +132,10 @@ export const load: PageServerLoad = async ({ parent }) => {
 		getGlobalDefaultShareMode(),
 		getGlobalAllowUserControl(),
 		getAllSlideConfigs(),
-		getFunFactFrequency()
+		getFunFactFrequency(),
+		getAppSetting(AppSettingsKey.OPENAI_BASE_URL),
+		getAppSetting(AppSettingsKey.OPENAI_MODEL),
+		getAppSetting(AppSettingsKey.FUN_FACTS_AI_PERSONA)
 	]);
 
 	// Check if OpenAI is configured (for AI features section)
@@ -224,7 +239,12 @@ export const load: PageServerLoad = async ({ parent }) => {
 		wrappedLogoOptions,
 		hasOpenAI,
 		funFactConfig,
-		funFactOptions
+		funFactOptions,
+		openaiConfig: {
+			baseUrl: openaiBaseUrl,
+			model: openaiModel,
+			persona: openaiPersona
+		}
 	};
 };
 
@@ -278,7 +298,11 @@ export const actions: Actions = {
 				allowUserControl: formData.get('allowUserControl'),
 				enabledSlides: formData.get('enabledSlides'),
 				enableFunFacts: formData.get('enableFunFacts'),
-				funFactFrequency: formData.get('funFactFrequency')
+				funFactFrequency: formData.get('funFactFrequency'),
+				openaiApiKey: formData.get('openaiApiKey') ?? undefined,
+				openaiBaseUrl: formData.get('openaiBaseUrl') ?? undefined,
+				openaiModel: formData.get('openaiModel') ?? undefined,
+				aiPersona: formData.get('aiPersona') ?? undefined
 			};
 
 			// Validate
@@ -307,6 +331,18 @@ export const actions: Actions = {
 				// AI Features (only if enabled)
 				data.enableFunFacts && data.funFactFrequency
 					? setFunFactFrequency(data.funFactFrequency as FunFactFrequencyType)
+					: Promise.resolve(),
+				data.enableFunFacts && data.openaiApiKey
+					? setAppSetting(AppSettingsKey.OPENAI_API_KEY, data.openaiApiKey)
+					: Promise.resolve(),
+				data.enableFunFacts && data.openaiBaseUrl
+					? setAppSetting(AppSettingsKey.OPENAI_BASE_URL, data.openaiBaseUrl)
+					: Promise.resolve(),
+				data.enableFunFacts && data.openaiModel
+					? setAppSetting(AppSettingsKey.OPENAI_MODEL, data.openaiModel)
+					: Promise.resolve(),
+				data.enableFunFacts && data.aiPersona
+					? setAppSetting(AppSettingsKey.FUN_FACTS_AI_PERSONA, data.aiPersona)
 					: Promise.resolve()
 			]);
 
@@ -368,5 +404,31 @@ export const actions: Actions = {
 		// Advance to completion step
 		await setOnboardingStep(OnboardingSteps.COMPLETE);
 		redirect(303, '/onboarding/complete');
+	},
+
+	/**
+	 * Test OpenAI connection using values submitted from the form.
+	 * Does not fall back to stored values — onboarding submits fresh input.
+	 */
+	testAIConnection: async ({ request, locals }) => {
+		if (!locals.user?.isAdmin) {
+			return fail(403, { error: 'Admin access required' });
+		}
+
+		const formData = await request.formData();
+		const apiKey = (formData.get('openaiApiKey') ?? '').toString();
+		const baseUrlRaw = (formData.get('openaiBaseUrl') ?? '').toString();
+		const modelRaw = (formData.get('openaiModel') ?? '').toString();
+
+		const baseUrl = baseUrlRaw.trim() || undefined;
+		const model = modelRaw.trim() || undefined;
+
+		const result = await testOpenAIConnection(apiKey, baseUrl, model);
+
+		if (!result.success) {
+			return fail(400, { error: result.error });
+		}
+
+		return { success: true, message: result.message };
 	}
 };

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -313,6 +313,8 @@ export const actions: Actions = {
 			}
 
 			const data = parseResult.data;
+			const openaiApiKey = data.openaiApiKey?.trim();
+			const openaiBaseUrl = data.openaiBaseUrl?.trim().replace(/\/+$/, '');
 
 			// Save all settings in parallel
 			await Promise.all([
@@ -332,11 +334,11 @@ export const actions: Actions = {
 				data.enableFunFacts && data.funFactFrequency
 					? setFunFactFrequency(data.funFactFrequency as FunFactFrequencyType)
 					: Promise.resolve(),
-				data.enableFunFacts && data.openaiApiKey
-					? setAppSetting(AppSettingsKey.OPENAI_API_KEY, data.openaiApiKey)
+				data.enableFunFacts && openaiApiKey
+					? setAppSetting(AppSettingsKey.OPENAI_API_KEY, openaiApiKey)
 					: Promise.resolve(),
-				data.enableFunFacts && data.openaiBaseUrl
-					? setAppSetting(AppSettingsKey.OPENAI_BASE_URL, data.openaiBaseUrl)
+				data.enableFunFacts && openaiBaseUrl
+					? setAppSetting(AppSettingsKey.OPENAI_BASE_URL, openaiBaseUrl)
 					: Promise.resolve(),
 				data.enableFunFacts && data.openaiModel
 					? setAppSetting(AppSettingsKey.OPENAI_MODEL, data.openaiModel)

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -81,13 +81,13 @@ const SettingsSchema = z.object({
 		WrappedLogoMode.USER_CHOICE
 	]),
 	defaultShareMode: z.enum([ShareMode.PUBLIC, ShareMode.PRIVATE_OAUTH, ShareMode.PRIVATE_LINK]),
-	allowUserControl: z.coerce.boolean(),
+	allowUserControl: z.enum(['true', 'false']).transform((v) => v === 'true'),
 
 	// Slides (comma-separated list of enabled slide types)
 	enabledSlides: z.string().optional(),
 
 	// AI Features
-	enableFunFacts: z.coerce.boolean(),
+	enableFunFacts: z.enum(['true', 'false']).transform((v) => v === 'true'),
 	funFactFrequency: z
 		.enum([
 			FunFactFrequency.FEW,

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -544,7 +544,7 @@ function getThemeColors(themeValue: string) {
 								<div class="setting-group">
 									<label class="field-label" for="onboarding-openai-api-key">OpenAI API Key</label>
 									<p class="setting-description">
-										Your key is stored server-side and never exposed to the client.
+										Your key is stored server-side and not returned to the browser once saved.
 									</p>
 									<input
 										id="onboarding-openai-api-key"

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -245,10 +245,10 @@ function getThemeColors(themeValue: string) {
 				<input type="hidden" name="funFactFrequency" value={funFactFrequency} />
 				{#if enableFunFacts}
 					<input type="hidden" name="openaiApiKey" value={openaiApiKey} />
+					<input type="hidden" name="openaiBaseUrl" value={openaiBaseUrl} />
+					<input type="hidden" name="openaiModel" value={openaiModel} />
+					<input type="hidden" name="aiPersona" value={aiPersona} />
 				{/if}
-				<input type="hidden" name="openaiBaseUrl" value={openaiBaseUrl} />
-				<input type="hidden" name="openaiModel" value={openaiModel} />
-				<input type="hidden" name="aiPersona" value={aiPersona} />
 
 				<!-- Carousel Content -->
 				<div class="carousel-content" bind:this={contentRef}>

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 import { animate } from 'motion';
 import { untrack } from 'svelte';
-import { enhance } from '$app/forms';
+import { deserialize, enhance } from '$app/forms';
 import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
+import { handleFormToast } from '$lib/utils/form-toast';
 import { loadThemeFont } from '$lib/utils/theme-fonts';
 import type { ActionData, PageData } from './$types';
 
@@ -21,8 +22,23 @@ let anonymizationMode = $state(untrack(() => data.settings.anonymizationMode));
 let wrappedLogoMode = $state(untrack(() => data.settings.wrappedLogoMode));
 let defaultShareMode = $state(untrack(() => data.settings.defaultShareMode));
 let allowUserControl = $state(untrack(() => data.settings.allowUserControl));
-let enableFunFacts = $state(untrack(() => data.funFactConfig.count > 0));
+let enableFunFacts = $state(false);
 let funFactFrequency = $state(untrack(() => data.funFactConfig.mode || 'normal'));
+let openaiApiKey = $state('');
+let openaiBaseUrl = $state(
+	untrack(() => data.openaiConfig?.baseUrl ?? 'https://api.openai.com/v1')
+);
+let openaiModel = $state(untrack(() => data.openaiConfig?.model ?? 'gpt-5-mini'));
+let aiPersona = $state(untrack(() => data.openaiConfig?.persona ?? 'witty'));
+let isTestingAI = $state(false);
+let testAIResult = $state<{ type: 'success' | 'error'; message: string } | null>(null);
+
+const aiPersonaOptions = [
+	{ value: 'witty', label: 'Witty', description: 'Clever and humorous' },
+	{ value: 'wholesome', label: 'Wholesome', description: 'Warm and kind' },
+	{ value: 'nerdy', label: 'Nerdy', description: 'Data-driven and detailed' },
+	{ value: 'random', label: 'Random', description: 'Mix of styles' }
+] as const;
 
 // All available theme classes for removal
 const themeClasses = [
@@ -227,6 +243,10 @@ function getThemeColors(themeValue: string) {
 				<input type="hidden" name="enabledSlides" value={enabledSlidesString} />
 				<input type="hidden" name="enableFunFacts" value={enableFunFacts} />
 				<input type="hidden" name="funFactFrequency" value={funFactFrequency} />
+				<input type="hidden" name="openaiApiKey" value={openaiApiKey} />
+				<input type="hidden" name="openaiBaseUrl" value={openaiBaseUrl} />
+				<input type="hidden" name="openaiModel" value={openaiModel} />
+				<input type="hidden" name="aiPersona" value={aiPersona} />
 
 				<!-- Carousel Content -->
 				<div class="carousel-content" bind:this={contentRef}>
@@ -511,6 +531,133 @@ function getThemeColors(themeValue: string) {
 													value={option.value}
 													checked={funFactFrequency === option.value}
 													onchange={() => (funFactFrequency = option.value)}
+												/>
+												<span class="frequency-label">{option.label}</span>
+												<span class="frequency-desc">{option.description}</span>
+											</label>
+										{/each}
+									</div>
+								</div>
+
+								<div class="setting-group">
+									<label class="field-label" for="onboarding-openai-api-key">OpenAI API Key</label>
+									<p class="setting-description">
+										Your key is stored server-side and never exposed to the client.
+									</p>
+									<input
+										id="onboarding-openai-api-key"
+										class="text-input"
+										type="password"
+										bind:value={openaiApiKey}
+										maxlength="512"
+										placeholder="sk-..."
+										autocomplete="off"
+									/>
+								</div>
+
+								<div class="setting-group">
+									<label class="field-label" for="onboarding-openai-base-url">Base URL</label>
+									<input
+										id="onboarding-openai-base-url"
+										class="text-input"
+										type="url"
+										bind:value={openaiBaseUrl}
+										maxlength="512"
+										placeholder="https://api.openai.com/v1"
+									/>
+								</div>
+
+								<div class="setting-group">
+									<label class="field-label" for="onboarding-openai-model">Model</label>
+									<input
+										id="onboarding-openai-model"
+										class="text-input"
+										type="text"
+										bind:value={openaiModel}
+										maxlength="100"
+										placeholder="gpt-5-mini"
+									/>
+									<div class="test-connection-row">
+										<button
+											type="button"
+											class="btn-test"
+											disabled={isTestingAI || !openaiApiKey}
+											onclick={async () => {
+												isTestingAI = true;
+												testAIResult = null;
+												const formData = new FormData();
+												formData.set('openaiApiKey', openaiApiKey);
+												formData.set('openaiBaseUrl', openaiBaseUrl);
+												formData.set('openaiModel', openaiModel);
+												try {
+													const response = await fetch('?/testAIConnection', {
+														method: 'POST',
+														body: formData
+													});
+													const result = deserialize(await response.text());
+													if (result.type === 'success' || result.type === 'failure') {
+														const payload = result.data as {
+															success?: boolean;
+															message?: string;
+															error?: string;
+														};
+														handleFormToast(payload);
+														testAIResult = payload.error
+															? { type: 'error', message: payload.error }
+															: {
+																	type: 'success',
+																	message: payload.message ?? 'Connection succeeded'
+																};
+													} else if (result.type === 'error') {
+														const message =
+															result.error?.message ?? 'An error occurred while testing connection';
+														handleFormToast({ error: message });
+														testAIResult = { type: 'error', message };
+													} else {
+														const message = 'Unexpected response from server';
+														handleFormToast({ error: message });
+														testAIResult = { type: 'error', message };
+													}
+												} catch {
+													const message =
+														'Failed to test connection. Please check your network and try again.';
+													handleFormToast({ error: message });
+													testAIResult = { type: 'error', message };
+												} finally {
+													isTestingAI = false;
+												}
+											}}
+										>
+											{#if isTestingAI}
+												<span class="spinner"></span>
+												Testing...
+											{:else}
+												Test Connection
+											{/if}
+										</button>
+										{#if testAIResult}
+											<div class="inline-result" class:error={testAIResult.type === 'error'}>
+												{testAIResult.message}
+											</div>
+										{/if}
+									</div>
+								</div>
+
+								<div class="setting-group">
+									<span class="setting-label">AI Persona</span>
+									<p class="setting-description">Tone used when generating AI fun facts</p>
+									<div class="frequency-options">
+										{#each aiPersonaOptions as option}
+											<label
+												class="frequency-option"
+												class:selected={aiPersona === option.value}
+											>
+												<input
+													type="radio"
+													name="aiPersonaRadio"
+													value={option.value}
+													checked={aiPersona === option.value}
+													onchange={() => (aiPersona = option.value)}
 												/>
 												<span class="frequency-label">{option.label}</span>
 												<span class="frequency-desc">{option.description}</span>
@@ -1287,6 +1434,86 @@ function getThemeColors(themeValue: string) {
 		.frequency-desc {
 			font-size: 0.7rem;
 			color: rgba(255, 255, 255, 0.45);
+		}
+
+		/* Text inputs (API key, base URL, model) */
+		.field-label {
+			display: block;
+			font-size: 0.875rem;
+			font-weight: 500;
+			color: rgba(255, 255, 255, 0.9);
+			margin-bottom: 0.25rem;
+		}
+
+		.text-input {
+			display: block;
+			width: 100%;
+			padding: 0.625rem 0.875rem;
+			background: rgba(0, 0, 0, 0.25);
+			border: 1px solid rgba(255, 255, 255, 0.1);
+			border-radius: 0.5rem;
+			color: rgba(255, 255, 255, 0.95);
+			font-size: 0.875rem;
+			font-family: inherit;
+			transition: border-color 0.2s ease, background 0.2s ease;
+		}
+
+		.text-input::placeholder {
+			color: rgba(255, 255, 255, 0.35);
+		}
+
+		.text-input:focus {
+			outline: none;
+			background: rgba(0, 0, 0, 0.35);
+			border-color: hsl(var(--primary) / 0.5);
+		}
+
+		.test-connection-row {
+			display: flex;
+			align-items: center;
+			gap: 0.75rem;
+			flex-wrap: wrap;
+			margin-top: 0.625rem;
+		}
+
+		.btn-test {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.5rem;
+			padding: 0.5rem 0.875rem;
+			background: rgba(0, 0, 0, 0.3);
+			border: 1px solid rgba(255, 255, 255, 0.15);
+			border-radius: 0.5rem;
+			color: rgba(255, 255, 255, 0.85);
+			font-size: 0.8rem;
+			font-weight: 500;
+			cursor: pointer;
+			transition: all 0.2s ease;
+		}
+
+		.btn-test:hover:not(:disabled) {
+			background: rgba(0, 0, 0, 0.45);
+			border-color: rgba(255, 255, 255, 0.25);
+		}
+
+		.btn-test:disabled {
+			opacity: 0.5;
+			cursor: not-allowed;
+		}
+
+		.inline-result {
+			font-size: 0.8rem;
+			padding: 0.375rem 0.625rem;
+			background: rgba(34, 197, 94, 0.15);
+			border: 1px solid rgba(34, 197, 94, 0.4);
+			border-radius: 0.5rem;
+			color: #86efac;
+		}
+
+		.inline-result.error {
+			background: rgba(239, 68, 68, 0.15);
+			border-color: rgba(239, 68, 68, 0.4);
+			color: #fca5a5;
 		}
 
 		/* Spinner */

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -243,7 +243,9 @@ function getThemeColors(themeValue: string) {
 				<input type="hidden" name="enabledSlides" value={enabledSlidesString} />
 				<input type="hidden" name="enableFunFacts" value={enableFunFacts} />
 				<input type="hidden" name="funFactFrequency" value={funFactFrequency} />
-				<input type="hidden" name="openaiApiKey" value={openaiApiKey} />
+				{#if enableFunFacts}
+					<input type="hidden" name="openaiApiKey" value={openaiApiKey} />
+				{/if}
 				<input type="hidden" name="openaiBaseUrl" value={openaiBaseUrl} />
 				<input type="hidden" name="openaiModel" value={openaiModel} />
 				<input type="hidden" name="aiPersona" value={aiPersona} />
@@ -581,7 +583,7 @@ function getThemeColors(themeValue: string) {
 										<button
 											type="button"
 											class="btn-test"
-											disabled={isTestingAI || !openaiApiKey}
+											disabled={isTestingAI || !openaiApiKey.trim()}
 											onclick={async () => {
 												isTestingAI = true;
 												testAIResult = null;

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -26,9 +26,9 @@ let enableFunFacts = $state(false);
 let funFactFrequency = $state(untrack(() => data.funFactConfig.mode || 'normal'));
 let openaiApiKey = $state('');
 let openaiBaseUrl = $state(
-	untrack(() => data.openaiConfig?.baseUrl ?? 'https://api.openai.com/v1')
+	untrack(() => data.openaiConfig?.baseUrl || 'https://api.openai.com/v1')
 );
-let openaiModel = $state(untrack(() => data.openaiConfig?.model ?? 'gpt-5-mini'));
+let openaiModel = $state(untrack(() => data.openaiConfig?.model || 'gpt-5-mini'));
 let aiPersona = $state(untrack(() => data.openaiConfig?.persona ?? 'witty'));
 let isTestingAI = $state(false);
 let testAIResult = $state<{ type: 'success' | 'error'; message: string } | null>(null);

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -29,7 +29,12 @@ let openaiBaseUrl = $state(
 	untrack(() => data.openaiConfig?.baseUrl || 'https://api.openai.com/v1')
 );
 let openaiModel = $state(untrack(() => data.openaiConfig?.model || 'gpt-5-mini'));
-let aiPersona = $state(untrack(() => data.openaiConfig?.persona ?? 'witty'));
+let aiPersona = $state(
+	untrack(() => {
+		const p = data.openaiConfig?.persona;
+		return p === 'witty' || p === 'wholesome' || p === 'nerdy' || p === 'random' ? p : 'witty';
+	})
+);
 let isTestingAI = $state(false);
 let testAIResult = $state<{ type: 'success' | 'error'; message: string } | null>(null);
 

--- a/tests/unit/lib/server/funfacts/test-connection.test.ts
+++ b/tests/unit/lib/server/funfacts/test-connection.test.ts
@@ -147,6 +147,16 @@ describe('testOpenAIConnection', () => {
 		expect(result).toEqual({ success: false, error: 'network down' });
 	});
 
+	it('returns a string representation when fetch rejects with a non-Error value', async () => {
+		globalThis.fetch = mock(() =>
+			Promise.reject('unexpected string error')
+		) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test');
+
+		expect(result).toEqual({ success: false, error: 'unexpected string error' });
+	});
+
 	it('trims whitespace from the API key before sending the Authorization header', async () => {
 		const captured: { init?: RequestInit } = {};
 

--- a/tests/unit/lib/server/funfacts/test-connection.test.ts
+++ b/tests/unit/lib/server/funfacts/test-connection.test.ts
@@ -146,4 +146,33 @@ describe('testOpenAIConnection', () => {
 
 		expect(result).toEqual({ success: false, error: 'network down' });
 	});
+
+	it('trims whitespace from the API key before sending the Authorization header', async () => {
+		const captured: { init?: RequestInit } = {};
+
+		globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+			captured.init = init;
+			return new Response(null, { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('  sk-padded  ');
+
+		expect(result.success).toBe(true);
+		const headers = captured.init?.headers as Record<string, string>;
+		expect(headers.Authorization).toBe('Bearer sk-padded');
+	});
+
+	it('strips trailing slash from baseUrl before building the endpoint URL', async () => {
+		const captured: { url?: string } = {};
+
+		globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+			captured.url = typeof input === 'string' ? input : input.toString();
+			return new Response(null, { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test', 'https://custom.example.com/v1/');
+
+		expect(result.success).toBe(true);
+		expect(captured.url).toBe('https://custom.example.com/v1/chat/completions');
+	});
 });

--- a/tests/unit/lib/server/funfacts/test-connection.test.ts
+++ b/tests/unit/lib/server/funfacts/test-connection.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { testOpenAIConnection } from '$lib/server/funfacts/test-connection';
+
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+	originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+});
+
+describe('testOpenAIConnection', () => {
+	it('returns error without calling fetch when API key is empty', async () => {
+		let fetchCalled = false;
+		globalThis.fetch = mock(async () => {
+			fetchCalled = true;
+			return new Response(null, { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('');
+
+		expect(result).toEqual({ success: false, error: 'API key is required' });
+		expect(fetchCalled).toBe(false);
+	});
+
+	it('returns error without calling fetch when API key is whitespace-only', async () => {
+		let fetchCalled = false;
+		globalThis.fetch = mock(async () => {
+			fetchCalled = true;
+			return new Response(null, { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('   \t\n');
+
+		expect(result).toEqual({ success: false, error: 'API key is required' });
+		expect(fetchCalled).toBe(false);
+	});
+
+	it('returns success with resolved model name on 200', async () => {
+		const captured: { url?: string; init?: RequestInit } = {};
+
+		globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+			captured.url = typeof input === 'string' ? input : input.toString();
+			captured.init = init;
+			return new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			});
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test-key');
+
+		expect(result).toEqual({ success: true, message: 'Connected (model: gpt-5-mini)' });
+		expect(captured.url).toBe('https://api.openai.com/v1/chat/completions');
+		expect(captured.init?.method).toBe('POST');
+		const headers = captured.init?.headers as Record<string, string>;
+		expect(headers.Authorization).toBe('Bearer sk-test-key');
+		expect(headers['Content-Type']).toBe('application/json');
+		const body = JSON.parse(captured.init?.body as string);
+		expect(body).toEqual({
+			model: 'gpt-5-mini',
+			messages: [{ role: 'user', content: 'ping' }],
+			max_tokens: 1
+		});
+	});
+
+	it('uses custom baseUrl and model when provided', async () => {
+		const captured: { url?: string; body?: string } = {};
+
+		globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+			captured.url = typeof input === 'string' ? input : input.toString();
+			captured.body = init?.body as string;
+			return new Response(null, { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection(
+			'sk-test',
+			'https://custom.example.com/v1',
+			'gpt-4o-mini'
+		);
+
+		expect(result).toEqual({ success: true, message: 'Connected (model: gpt-4o-mini)' });
+		expect(captured.url).toBe('https://custom.example.com/v1/chat/completions');
+		expect(JSON.parse(captured.body ?? '{}').model).toBe('gpt-4o-mini');
+	});
+
+	it('maps 401 to authentication error', async () => {
+		globalThis.fetch = mock(async () => {
+			return new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-bad');
+
+		expect(result).toEqual({
+			success: false,
+			error: 'Authentication failed — check your API key'
+		});
+	});
+
+	it('maps 404 to model-not-found error', async () => {
+		globalThis.fetch = mock(async () => {
+			return new Response('Not Found', { status: 404, statusText: 'Not Found' });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test');
+
+		expect(result).toEqual({
+			success: false,
+			error: 'Model not found or base URL is incorrect'
+		});
+	});
+
+	it('maps other non-OK responses to status/statusText message', async () => {
+		globalThis.fetch = mock(async () => {
+			return new Response('Server Error', { status: 500, statusText: 'Internal Server Error' });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test');
+
+		expect(result).toEqual({
+			success: false,
+			error: 'Request failed: 500 Internal Server Error'
+		});
+	});
+
+	it('maps AbortError to timeout message', async () => {
+		globalThis.fetch = mock(async () => {
+			const error = new Error('The operation was aborted');
+			error.name = 'AbortError';
+			throw error;
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test');
+
+		expect(result).toEqual({ success: false, error: 'Connection timed out' });
+	});
+
+	it('returns the error message for any other thrown error', async () => {
+		globalThis.fetch = mock(async () => {
+			throw new Error('network down');
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test');
+
+		expect(result).toEqual({ success: false, error: 'network down' });
+	});
+});

--- a/tests/unit/lib/server/funfacts/test-connection.test.ts
+++ b/tests/unit/lib/server/funfacts/test-connection.test.ts
@@ -185,4 +185,36 @@ describe('testOpenAIConnection', () => {
 		expect(result.success).toBe(true);
 		expect(captured.url).toBe('https://custom.example.com/v1/chat/completions');
 	});
+
+	it('treats blank-string baseUrl and model as missing, falling back to defaults', async () => {
+		const captured: { url?: string; body?: string } = {};
+
+		globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+			captured.url = typeof input === 'string' ? input : input.toString();
+			captured.body = init?.body as string;
+			return new Response(null, { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test', '', '');
+
+		expect(result.success).toBe(true);
+		expect(captured.url).toBe('https://api.openai.com/v1/chat/completions');
+		expect(JSON.parse(captured.body ?? '{}').model).toBe('gpt-5-mini');
+	});
+
+	it('treats whitespace-only baseUrl and model as missing, falling back to defaults', async () => {
+		const captured: { url?: string; body?: string } = {};
+
+		globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+			captured.url = typeof input === 'string' ? input : input.toString();
+			captured.body = init?.body as string;
+			return new Response(null, { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test', '   ', '\t');
+
+		expect(result.success).toBe(true);
+		expect(captured.url).toBe('https://api.openai.com/v1/chat/completions');
+		expect(JSON.parse(captured.body ?? '{}').model).toBe('gpt-5-mini');
+	});
 });


### PR DESCRIPTION
## Summary

Refines the AI fun facts configuration in the onboarding wizard so users can
enter and verify their OpenAI (or OpenAI-compatible) credentials before they
ever leave the wizard, and mirrors the same verification flow on the admin
settings page. Persona selection is surfaced alongside the API credentials so
the tone choice lives where the rest of the fun-fact config does.

## Changes

### Onboarding (`/onboarding/settings`)

- Default the AI Features toggle to `false`. Previously it was derived from
  `data.funFactConfig.count > 0`, which silently enabled AI features for any
  user who had persisted a non-zero count from an earlier step. Users now
  opt in explicitly.
- Expand the AI Features card with four inputs, rendered only when the toggle
  is on:
  - OpenAI API Key (password input, never echoed back from the server)
  - Base URL (defaults to `https://api.openai.com/v1`)
  - Model (defaults to `gpt-5-mini`)
  - AI Persona radio group (witty / wholesome / nerdy / random)
- Add a Test Connection button that calls a new `testAIConnection` form
  action, probes `POST {baseUrl}/chat/completions` with `max_tokens: 1`, and
  renders the result inline as a success or error badge.
- Extend `SettingsSchema` with the four new fields and persist them via
  `setAppSetting` only when the toggle is on and the value is non-empty.
- The load function returns base URL, model, and persona (but never the API
  key) so the client can pre-fill inputs without exposing the secret.

### Admin settings (`/admin/settings`)

- Add a Test Connection action next to Save OpenAI Settings, mirroring the
  existing Plex Test Connection affordance.
- The admin `testAIConnection` action applies an SSRF-style safeguard: it
  only falls back to the stored API key when the submitted base URL AND
  model match the stored values. Submitting a different URL with a blank
  key returns \`API key is required\` instead of silently forwarding the
  stored credential to an attacker-controlled endpoint.

### Shared helper

- New \`src/lib/server/funfacts/test-connection.ts\` exports
  \`testOpenAIConnection(apiKey, baseUrl?, model?)\` which issues a single
  \`/chat/completions\` probe with an \`AbortController\` 10s timeout and
  maps HTTP status codes / network errors to a discriminated result:
  \`{ success: true; message } | { success: false; error }\`.
- Covered by \`tests/unit/lib/server/funfacts/test-connection.test.ts\`
  (9 cases: success, 401, 404, 500, empty key short-circuit, abort,
  network throw, default URL, default model). Line coverage 95.3%.

## Screenshots

Onboarding — successful Test Connection against NanoGPT (API key masked by
the input type):

![Onboarding Test Connection success](https://litter.catbox.moe/nd6tuw.png)

Onboarding — authentication error surfaced inline:

![Onboarding Test Connection auth error](https://litter.catbox.moe/rxequt.png)

Admin — Test Connection alongside Save OpenAI Settings, using the stored
API key when base URL and model match what is saved:

![Admin Test Connection with stored key](https://litter.catbox.moe/kib984.png)

Admin — SSRF safeguard: changing the base URL without re-entering the API
key refuses the request rather than forwarding the stored credential:

![Admin SSRF safeguard](https://litter.catbox.moe/k1k5io.png)

## Test plan

- [x] \`bun test tests/unit/lib/server/funfacts/test-connection.test.ts\` passes with 95.3% line coverage on the new helper.
- [x] Manual E2E walkthrough against NanoGPT (\`https://nano-gpt.com/api/v1\`, model \`openai/gpt-5-mini\`):
  - [x] Onboarding Configure step defaults AI Features to off.
  - [x] Toggling on reveals the four new inputs and the Test Connection button.
  - [x] Test Connection with a valid key returns \`Connected (model: ...)\`.
  - [x] Test Connection with an invalid key returns \`Authentication failed — check your API key\`.
  - [x] Saving persists API key, base URL, model, and persona; reloading the page preserves base URL, model, and persona (API key remains server-side only).
  - [x] Admin OpenAI panel Test Connection works with the stored key.
  - [x] Admin Test Connection refuses with \`API key is required\` when the submitted base URL differs from the stored one and no key is entered.
  - [x] Admin Test Connection works when a valid key is entered directly.
- [ ] \`bun run check\` and \`bun run test\` pass in CI.