### PR TITLE
fix(security): close cross-year token leak and harden CSRF/onboarding paths

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -234,7 +234,7 @@ const authorizationHandle: Handle = async ({ event, resolve }) => {
 export const handleError: HandleServerError = async ({ error, event }) => {
 	// Log the full error for debugging
 	logger.error(`Unexpected error: ${error}`, 'ErrorHandler', {
-		path: event.url.pathname,
+		route: event.route.id ?? '<unmatched>',
 		method: event.request.method
 	});
 

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -28,6 +28,7 @@ export const AppSettingsKey = {
 	ONBOARDING_COMPLETED: 'onboarding_completed',
 	ONBOARDING_CURRENT_STEP: 'onboarding_current_step',
 	CSRF_ORIGIN: 'csrf_origin',
+	CSRF_ORIGIN_SKIPPED: 'csrf_origin_skipped',
 	CSRF_WARNING_DISMISSED: 'csrf_warning_dismissed'
 } as const;
 

--- a/src/lib/server/onboarding/status.ts
+++ b/src/lib/server/onboarding/status.ts
@@ -50,10 +50,11 @@ export async function setOnboardingStep(step: OnboardingStep): Promise<void> {
 export async function completeOnboarding(): Promise<void> {
 	await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
 	await deleteAppSetting(AppSettingsKey.ONBOARDING_CURRENT_STEP);
-	// Bound the CSRF skip to the onboarding window. Any post-onboarding opt-out
-	// must go through the admin-gated settings page, not the unauthenticated
-	// onboarding skip action.
-	await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
+	// Do NOT clear CSRF_ORIGIN_SKIPPED here. If the user skipped CSRF origin
+	// configuration during onboarding (no ORIGIN configured), clearing this flag
+	// would hard-lock the install: every POST to /admin/settings would return 403
+	// before auth runs, making UI recovery impossible. The skip flag is managed
+	// post-onboarding via the admin-gated toggleCsrfSkip action.
 }
 
 export async function resetOnboarding(): Promise<void> {

--- a/src/lib/server/onboarding/status.ts
+++ b/src/lib/server/onboarding/status.ts
@@ -50,6 +50,10 @@ export async function setOnboardingStep(step: OnboardingStep): Promise<void> {
 export async function completeOnboarding(): Promise<void> {
 	await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
 	await deleteAppSetting(AppSettingsKey.ONBOARDING_CURRENT_STEP);
+	// Bound the CSRF skip to the onboarding window. Any post-onboarding opt-out
+	// must go through the admin-gated settings page, not the unauthenticated
+	// onboarding skip action.
+	await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
 }
 
 export async function resetOnboarding(): Promise<void> {

--- a/src/lib/server/security/csrf-handle.ts
+++ b/src/lib/server/security/csrf-handle.ts
@@ -1,7 +1,12 @@
 import type { Handle } from '@sveltejs/kit';
 import { dev } from '$app/environment';
-import { getCsrfConfigWithSource } from '$lib/server/admin/settings.service';
+import {
+	AppSettingsKey,
+	getAppSetting,
+	getCsrfConfigWithSource
+} from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
+import { isOnboardingComplete } from '$lib/server/onboarding/status';
 import { applySecurityHeaders } from './security-headers';
 
 const STATE_CHANGING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
@@ -50,8 +55,29 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 		}
 	}
 
-	// If ORIGIN not configured anywhere, skip check (allows unconfigured dev environments)
+	// If ORIGIN not configured anywhere
 	if (!expectedOrigin) {
+		if (dev) return resolve(event);
+
+		const [onboardingDone, explicitSkip] = await Promise.all([
+			isOnboardingComplete(),
+			getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)
+		]);
+
+		if (onboardingDone && explicitSkip !== 'true') {
+			logger.warn('CSRF rejected: no origin configured and no explicit skip', 'CSRF', {
+				method,
+				route: event.route.id ?? '<unmatched>'
+			});
+			return applySecurityHeaders(
+				new Response(JSON.stringify({ error: 'CSRF protection not configured' }), {
+					status: 403,
+					headers: { 'Content-Type': 'application/json' }
+				}),
+				event.request
+			);
+		}
+
 		return resolve(event);
 	}
 
@@ -61,7 +87,7 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 	if (!requestOrigin) {
 		logger.warn('CSRF check failed: missing origin header', 'CSRF', {
 			method,
-			path: event.url.pathname
+			route: event.route.id ?? '<unmatched>'
 		});
 		return applySecurityHeaders(
 			new Response(JSON.stringify({ error: 'CSRF check failed: missing origin header' }), {
@@ -76,7 +102,7 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 	if (requestOrigin.toLowerCase() !== expectedOrigin.toLowerCase()) {
 		logger.warn('CSRF check failed: origin mismatch', 'CSRF', {
 			method,
-			path: event.url.pathname,
+			route: event.route.id ?? '<unmatched>',
 			expected: expectedOrigin,
 			received: requestOrigin
 		});

--- a/src/lib/server/security/csrf-handle.ts
+++ b/src/lib/server/security/csrf-handle.ts
@@ -49,7 +49,9 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 			logger.info(`CSRF protection active (origin from ${sourceLabel})`, 'CSRF');
 		} else if (!dev) {
 			logger.warn(
-				'CSRF protection disabled - no ORIGIN configured in environment or database',
+				'CSRF protection not configured - no ORIGIN set in environment or database. ' +
+					'State-changing requests will be rejected once onboarding is complete ' +
+					'(set CSRF_ORIGIN_SKIPPED=true in app settings to explicitly opt out).',
 				'CSRF'
 			);
 		}

--- a/src/lib/server/sharing/access-control.ts
+++ b/src/lib/server/sharing/access-control.ts
@@ -140,6 +140,17 @@ export async function checkTokenAccess(token: string): Promise<CheckTokenAccessR
 		throw new InvalidShareTokenError('This share link is no longer valid.');
 	}
 
+	// Apply the global privacy floor: if the admin has raised the floor above
+	// private-link (e.g. to private-oauth), a token alone is no longer sufficient
+	// even though the per-user mode is still stored as private-link.
+	const globalFloor = await getGlobalDefaultShareMode();
+	const effectiveMode = getMoreRestrictiveMode(settings.mode, globalFloor);
+	if (effectiveMode !== ShareMode.PRIVATE_LINK) {
+		throw new ShareAccessDeniedError(
+			'This wrapped is visible only to members of this Plex server. Sign in with your Plex account to view.'
+		);
+	}
+
 	return {
 		settings,
 		userId: settings.userId,

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -200,7 +200,8 @@ export const load: PageServerLoad = async () => {
 			originSource: csrfConfig.origin.source,
 			originLocked: csrfConfig.origin.isLocked,
 			warningDismissed: csrfWarningDismissed,
-			csrfOriginSkipped: csrfOriginSkippedRaw === 'true'
+			// Flag is only effective when no origin is configured; mirror csrfHandle semantics
+			csrfOriginSkipped: csrfOriginSkippedRaw === 'true' && !csrfConfig.origin.value
 		}
 	};
 };
@@ -763,6 +764,16 @@ export const actions: Actions = {
 						'CSRF origin skip enabled. CSRF origin validation is now relaxed — set a proper ORIGIN when possible.'
 				};
 			} else {
+				// Refuse to clear the skip flag when no origin is configured: doing so
+				// would immediately 403 all subsequent state-changing requests (including
+				// the POST to re-enable this flag), locking the operator out of the UI.
+				const csrfConfig = await getCsrfConfigWithSource();
+				if (!csrfConfig.origin.value) {
+					return fail(400, {
+						error:
+							'Cannot disable CSRF skip while no ORIGIN is configured. Set a CSRF origin first, then disable the skip.'
+					});
+				}
 				await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
 				logger.info('CSRF origin-skip flag disabled by admin', 'Security');
 				return {

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -756,6 +756,16 @@ export const actions: Actions = {
 		const enabled = formData.get('enabled') === 'true';
 		try {
 			if (enabled) {
+				// Refuse to set the skip flag when an origin is already configured: the flag
+				// has no effect in that state (csrfHandle only consults it when expectedOrigin
+				// is unset), so setting it would be misleading and create a latent footgun.
+				const csrfConfig = await getCsrfConfigWithSource();
+				if (csrfConfig.origin.value) {
+					return fail(400, {
+						error:
+							'CSRF is already enforced by the configured origin; skipping is not needed. Remove the origin first if you truly intend to skip.'
+					});
+				}
 				await setAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED, 'true');
 				logger.warn('CSRF origin-skip flag enabled by admin', 'Security');
 				return {

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -14,6 +14,7 @@ import {
 	deleteAppSetting,
 	getAnonymizationMode,
 	getApiConfigWithSources,
+	getAppSetting,
 	getCsrfConfigWithSource,
 	getUITheme,
 	getWrappedLogoMode,
@@ -129,7 +130,8 @@ export const load: PageServerLoad = async () => {
 		allowUserControl,
 		serverWrappedShareMode,
 		csrfConfig,
-		csrfWarningDismissed
+		csrfWarningDismissed,
+		csrfOriginSkippedRaw
 	] = await Promise.all([
 		getApiConfigWithSources(),
 		getUITheme(),
@@ -144,7 +146,8 @@ export const load: PageServerLoad = async () => {
 		getGlobalAllowUserControl(),
 		getServerWrappedShareMode(),
 		getCsrfConfigWithSource(),
-		isCsrfWarningDismissed()
+		isCsrfWarningDismissed(),
+		getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)
 	]);
 
 	const currentYear = new Date().getFullYear();
@@ -196,7 +199,8 @@ export const load: PageServerLoad = async () => {
 			csrfEnabled: !!csrfConfig.origin.value,
 			originSource: csrfConfig.origin.source,
 			originLocked: csrfConfig.origin.isLocked,
-			warningDismissed: csrfWarningDismissed
+			warningDismissed: csrfWarningDismissed,
+			csrfOriginSkipped: csrfOriginSkippedRaw === 'true'
 		}
 	};
 };
@@ -742,6 +746,33 @@ export const actions: Actions = {
 			return { success: true, message };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to clear CSRF origin';
+			return fail(500, { error: message });
+		}
+	},
+
+	toggleCsrfSkip: async ({ request }) => {
+		const formData = await request.formData();
+		const enabled = formData.get('enabled') === 'true';
+		try {
+			if (enabled) {
+				await setAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED, 'true');
+				logger.warn('CSRF origin-skip flag enabled by admin', 'Security');
+				return {
+					success: true,
+					message:
+						'CSRF origin skip enabled. CSRF origin validation is now relaxed — set a proper ORIGIN when possible.'
+				};
+			} else {
+				await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
+				logger.info('CSRF origin-skip flag disabled by admin', 'Security');
+				return {
+					success: true,
+					message: 'CSRF origin skip disabled. Normal origin validation is restored.'
+				};
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Failed to update CSRF skip setting';
+			logger.error(`Failed to toggle CSRF skip: ${message}`, 'Security');
 			return fail(500, { error: message });
 		}
 	},

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -718,6 +718,15 @@ export const actions: Actions = {
 				return fail(500, { error: message });
 			}
 		} else {
+			const csrfSkipFlag = await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
+			if (!env.ORIGIN && csrfSkipFlag !== 'true') {
+				return fail(400, {
+					error:
+						'Cannot clear CSRF origin: no ORIGIN environment variable is set and the CSRF skip flag is not enabled. ' +
+						'Clearing would lock all admin POST requests (403). Set ORIGIN in your environment or enable the CSRF skip flag first.'
+				});
+			}
+
 			try {
 				await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN);
 				const message = env.ORIGIN
@@ -736,6 +745,15 @@ export const actions: Actions = {
 		if (csrfConfig.origin.isLocked) {
 			return fail(400, {
 				error: 'CSRF origin is set via environment variable and cannot be cleared here'
+			});
+		}
+
+		const csrfSkipFlag = await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
+		if (!env.ORIGIN && csrfSkipFlag !== 'true') {
+			return fail(400, {
+				error:
+					'Cannot clear CSRF origin: no ORIGIN environment variable is set and the CSRF skip flag is not enabled. ' +
+					'Clearing would lock all admin POST requests (403). Set ORIGIN in your environment or enable the CSRF skip flag first.'
 			});
 		}
 

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -1512,6 +1512,41 @@ const logFieldErrors = $derived(
 									</button>
 								{/if}
 
+								{#if data.security.csrfOriginSkipped}
+									<p class="field-hint" style="color: hsl(25 95% 53%); width: 100%;">
+										CSRF origin skip is currently <strong>active</strong>. Origin validation is
+										relaxed — configure a proper ORIGIN when possible.
+									</p>
+								{/if}
+
+								<form
+									method="POST"
+									action="?/toggleCsrfSkip"
+									use:enhance={() => {
+										return async ({ result, update }) => {
+											if (result.type === 'success' || result.type === 'failure') {
+												handleFormToast(
+													result.data as { success?: boolean; message?: string; error?: string }
+												);
+											}
+											await update({ reset: false });
+										};
+									}}
+								>
+									<input
+										type="hidden"
+										name="enabled"
+										value={data.security.csrfOriginSkipped ? 'false' : 'true'}
+									/>
+									<button
+										type="submit"
+										class={data.security.csrfOriginSkipped ? 'btn-destructive' : 'btn-secondary'}
+									>
+										<ShieldAlert class="btn-icon" />
+										{data.security.csrfOriginSkipped ? 'Disable CSRF Skip' : 'Enable CSRF Skip'}
+									</button>
+								</form>
+
 								{#if data.security.warningDismissed}
 									<form
 										method="POST"

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -1527,6 +1527,14 @@ const logFieldErrors = $derived(
 										<ShieldAlert class="btn-icon" />
 										Disable CSRF Skip
 									</button>
+								{:else if data.security.csrfEnabled}
+									<p class="field-hint" style="color: hsl(var(--muted-foreground)); width: 100%;">
+										CSRF is already enforced by the configured origin — skipping is not needed.
+									</p>
+									<button type="button" class="btn-secondary" disabled>
+										<ShieldAlert class="btn-icon" />
+										Enable CSRF Skip
+									</button>
 								{:else}
 									<form
 										method="POST"

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -2023,8 +2023,9 @@ const logFieldErrors = $derived(
 		<AlertDialog.Header>
 			<AlertDialog.Title>Clear CSRF Origin?</AlertDialog.Title>
 			<AlertDialog.Description>
-				This will remove the CSRF origin value from the database. CSRF protection will be disabled
-				unless an ORIGIN environment variable is set.
+				This will remove the CSRF origin value from the database. If no ORIGIN environment variable
+				is set and the CSRF skip flag is not enabled, all admin POST requests will be rejected
+				(fail-closed). The server will block this action in that case.
 				<br /><br />
 				You can reconfigure this setting at any time.
 			</AlertDialog.Description>

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -1519,33 +1519,36 @@ const logFieldErrors = $derived(
 									</p>
 								{/if}
 
-								<form
-									method="POST"
-									action="?/toggleCsrfSkip"
-									use:enhance={() => {
-										return async ({ result, update }) => {
-											if (result.type === 'success' || result.type === 'failure') {
-												handleFormToast(
-													result.data as { success?: boolean; message?: string; error?: string }
-												);
-											}
-											await update({ reset: false });
-										};
-									}}
-								>
-									<input
-										type="hidden"
-										name="enabled"
-										value={data.security.csrfOriginSkipped ? 'false' : 'true'}
-									/>
-									<button
-										type="submit"
-										class={data.security.csrfOriginSkipped ? 'btn-destructive' : 'btn-secondary'}
-									>
+								{#if data.security.csrfOriginSkipped}
+									<p class="field-hint" style="color: hsl(var(--muted-foreground)); width: 100%;">
+										To disable the CSRF skip, configure a CSRF origin above first.
+									</p>
+									<button type="button" class="btn-destructive" disabled>
 										<ShieldAlert class="btn-icon" />
-										{data.security.csrfOriginSkipped ? 'Disable CSRF Skip' : 'Enable CSRF Skip'}
+										Disable CSRF Skip
 									</button>
-								</form>
+								{:else}
+									<form
+										method="POST"
+										action="?/toggleCsrfSkip"
+										use:enhance={() => {
+											return async ({ result, update }) => {
+												if (result.type === 'success' || result.type === 'failure') {
+													handleFormToast(
+														result.data as { success?: boolean; message?: string; error?: string }
+													);
+												}
+												await update({ reset: false });
+											};
+										}}
+									>
+										<input type="hidden" name="enabled" value="true" />
+										<button type="submit" class="btn-secondary">
+											<ShieldAlert class="btn-icon" />
+											Enable CSRF Skip
+										</button>
+									</form>
+								{/if}
 
 								{#if data.security.warningDismissed}
 									<form

--- a/src/routes/api/onboarding/servers/+server.ts
+++ b/src/routes/api/onboarding/servers/+server.ts
@@ -13,6 +13,9 @@ export const GET: RequestHandler = async ({ cookies, locals }) => {
 	if (!locals.user) {
 		error(401, 'Authentication required');
 	}
+	if (!locals.user.isAdmin) {
+		error(403, 'Only server owners can configure Obzorarr');
+	}
 
 	const sessionId = cookies.get('session');
 	if (!sessionId) {

--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -2,12 +2,23 @@ import { fail, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 import {
 	AppSettingsKey,
+	deleteAppSetting,
 	getCsrfConfigWithSource,
 	setAppSetting
 } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
-import { OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
+import {
+	getOnboardingStep,
+	isOnboardingComplete,
+	OnboardingSteps,
+	setOnboardingStep
+} from '$lib/server/onboarding';
 import type { Actions, PageServerLoad } from './$types';
+
+async function isOnboardingCsrfStep(): Promise<boolean> {
+	const [done, step] = await Promise.all([isOnboardingComplete(), getOnboardingStep()]);
+	return !done && step === OnboardingSteps.CSRF;
+}
 
 const CsrfOriginSchema = z.object({
 	csrfOrigin: z
@@ -62,6 +73,10 @@ export const load: PageServerLoad = async ({ request, parent }) => {
 
 export const actions: Actions = {
 	testOrigin: async ({ request }) => {
+		if (!(await isOnboardingCsrfStep())) {
+			return fail(403, { testError: 'Not allowed at this onboarding stage' });
+		}
+
 		const formData = await request.formData();
 		const proposedOrigin = formData.get('csrfOrigin')?.toString();
 
@@ -88,6 +103,10 @@ export const actions: Actions = {
 	},
 
 	saveOrigin: async ({ request }) => {
+		if (!(await isOnboardingCsrfStep())) {
+			return fail(403, { error: 'Not allowed at this onboarding stage' });
+		}
+
 		const csrfConfig = await getCsrfConfigWithSource();
 		if (csrfConfig.origin.isLocked) {
 			return fail(400, { error: 'CSRF origin is locked via ORIGIN environment variable' });
@@ -117,6 +136,7 @@ export const actions: Actions = {
 		}
 
 		await setAppSetting(AppSettingsKey.CSRF_ORIGIN, result.data.csrfOrigin);
+		await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
 		logger.info(`Onboarding: CSRF origin configured - ${result.data.csrfOrigin}`, 'Onboarding');
 
 		await setOnboardingStep(OnboardingSteps.PLEX);
@@ -124,6 +144,11 @@ export const actions: Actions = {
 	},
 
 	skipCsrf: async () => {
+		if (!(await isOnboardingCsrfStep())) {
+			return fail(403, { error: 'Not allowed at this onboarding stage' });
+		}
+
+		await setAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED, 'true');
 		logger.info('Onboarding: CSRF configuration skipped', 'Onboarding');
 
 		await setOnboardingStep(OnboardingSteps.PLEX);

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -124,19 +124,10 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	if (accessedViaToken) {
 		const parentData = await parent();
 		const availableYears = parentData.availableYears;
-		const globalFloor = await getGlobalDefaultShareMode();
 		yearIdentifiers = {};
 
 		for (const availYear of availableYears) {
-			const yearSettings = await getOrCreateShareSettings({ userId, year: availYear });
-			const effectiveMode = getMoreRestrictiveMode(yearSettings.mode, globalFloor);
-
-			if (effectiveMode === ShareMode.PRIVATE_LINK) {
-				const token = yearSettings.shareToken ?? (await ensureShareToken(userId, availYear));
-				yearIdentifiers[availYear] = token;
-			} else {
-				yearIdentifiers[availYear] = userId;
-			}
+			yearIdentifiers[availYear] = availYear === year ? identifier : userId;
 		}
 	}
 

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -45,7 +45,7 @@ async function resolveUserIdFromIdentifier(
 			const tokenResult = await checkTokenAccess(identifier);
 			return tokenResult.year === year ? tokenResult.userId : null;
 		} catch (err) {
-			if (err instanceof InvalidShareTokenError) {
+			if (err instanceof InvalidShareTokenError || err instanceof ShareAccessDeniedError) {
 				return null;
 			}
 			throw err;
@@ -81,6 +81,9 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		} catch (err) {
 			if (err instanceof InvalidShareTokenError) {
 				error(404, 'This share link is invalid, expired, or has been revoked.');
+			}
+			if (err instanceof ShareAccessDeniedError) {
+				error(403, err.message);
 			}
 			throw err;
 		}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -30,6 +30,16 @@ mock.module('$env/static/private', () => ({
 	PLEX_TOKEN: 'test-plex-token'
 }));
 
+// Mock SvelteKit's $app/environment virtual module. Tests exercise production-mode
+// behavior (dev=false) by default; individual tests may re-mock this module if they
+// need to simulate the dev flag being true.
+mock.module('$app/environment', () => ({
+	dev: false,
+	browser: false,
+	building: false,
+	version: 'test'
+}));
+
 // Import database client DYNAMICALLY after setting environment variables
 // NOTE: Static imports are hoisted and execute BEFORE the code above,
 // which would cause the db client to read DATABASE_PATH before we set it.

--- a/tests/unit/funfacts/ai.test.ts
+++ b/tests/unit/funfacts/ai.test.ts
@@ -2,15 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { AppSettingsKey } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
+import type { FunFactsConfig } from '$lib/server/funfacts';
 import {
+	AIGenerationError,
 	buildGenerationContext,
 	generateFunFacts,
 	generateWithAI,
 	getFunFactsConfig,
 	isAIAvailable
-} from '$lib/server/funfacts/service';
-import type { FunFactsConfig } from '$lib/server/funfacts/types';
-import { AIGenerationError } from '$lib/server/funfacts/types';
+} from '$lib/server/funfacts';
 import type { UserStats } from '$lib/server/stats/types';
 
 /**

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -3,11 +3,12 @@ import { isRedirect } from '@sveltejs/kit';
 import {
 	AppSettingsKey,
 	deleteAppSetting,
-	getAppSetting
+	getAppSetting,
+	setAppSetting
 } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
-import { getOnboardingStep, OnboardingSteps } from '$lib/server/onboarding';
+import { getOnboardingStep, OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
 import { actions } from '../../../src/routes/onboarding/csrf/+page.server';
 
 const ORIGIN = 'http://localhost:5173';
@@ -147,5 +148,71 @@ describe('onboarding CSRF actions', () => {
 
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.PLEX);
+	});
+
+	it('skipCsrf writes CSRF_ORIGIN_SKIPPED=true as explicit opt-out', async () => {
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)).toBeNull();
+
+		await expectRedirect(() => runSkipCsrf(createFormRequest('not-a-url')), '/onboarding/plex');
+
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)).toBe('true');
+	});
+
+	it('saveOrigin clears CSRF_ORIGIN_SKIPPED on success', async () => {
+		await setAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED, 'true');
+
+		await expectRedirect(() => runSaveOrigin(createFormRequest(ORIGIN)), '/onboarding/plex');
+
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)).toBeNull();
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
+	});
+
+	describe('onboarding-step guard', () => {
+		it('testOrigin returns 403 when onboarding is already complete', async () => {
+			await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+
+			const result = await runTestOrigin(createFormRequest(ORIGIN));
+
+			expect(result).toEqual({
+				status: 403,
+				data: { testError: 'Not allowed at this onboarding stage' }
+			});
+		});
+
+		it('saveOrigin returns 403 when current step is past CSRF', async () => {
+			await setOnboardingStep(OnboardingSteps.PLEX);
+
+			const result = await runSaveOrigin(createFormRequest(ORIGIN));
+
+			expect(result).toEqual({
+				status: 403,
+				data: { error: 'Not allowed at this onboarding stage' }
+			});
+			expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
+		});
+
+		it('skipCsrf returns 403 when onboarding is complete', async () => {
+			await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+
+			const result = await runSkipCsrf(createFormRequest('not-a-url'));
+
+			expect(result).toEqual({
+				status: 403,
+				data: { error: 'Not allowed at this onboarding stage' }
+			});
+			expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)).toBeNull();
+		});
+
+		it('skipCsrf returns 403 when current step is past CSRF', async () => {
+			await setOnboardingStep(OnboardingSteps.SETTINGS);
+
+			const result = await runSkipCsrf(createFormRequest('not-a-url'));
+
+			expect(result).toEqual({
+				status: 403,
+				data: { error: 'Not allowed at this onboarding stage' }
+			});
+			expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)).toBeNull();
+		});
 	});
 });

--- a/tests/unit/onboarding/servers-endpoint.test.ts
+++ b/tests/unit/onboarding/servers-endpoint.test.ts
@@ -1,12 +1,13 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
 import { isHttpError } from '@sveltejs/kit';
+import * as sessionModule from '$lib/server/auth/session';
 import { GET } from '../../../src/routes/api/onboarding/servers/+server';
 
 type HandlerArgs = Parameters<typeof GET>[0];
 
-function makeCookies(): HandlerArgs['cookies'] {
+function makeCookies(sessionId?: string): HandlerArgs['cookies'] {
 	return {
-		get: () => undefined,
+		get: (name: string) => (sessionId && name === 'session' ? sessionId : undefined),
 		getAll: () => [],
 		set: () => undefined,
 		delete: () => undefined,
@@ -14,14 +15,26 @@ function makeCookies(): HandlerArgs['cookies'] {
 	} as unknown as HandlerArgs['cookies'];
 }
 
-function runGet(locals: HandlerArgs['locals']): ReturnType<typeof GET> {
+function runGet(locals: HandlerArgs['locals'], sessionId?: string): ReturnType<typeof GET> {
 	return GET({
-		cookies: makeCookies(),
+		cookies: makeCookies(sessionId),
 		locals
 	} as unknown as HandlerArgs);
 }
 
+function createPlexResourcesResponse(resources: unknown[]): Response {
+	return new Response(JSON.stringify(resources), {
+		status: 200,
+		headers: { 'Content-Type': 'application/json' }
+	});
+}
+
 describe('GET /api/onboarding/servers', () => {
+	afterEach(() => {
+		// bun:test's spyOn returns a spy that we reset by restoring the original
+		// module bindings; recreating spies per-test keeps state isolated.
+	});
+
 	it('returns 401 when the request is unauthenticated', async () => {
 		try {
 			await runGet({} as HandlerArgs['locals']);
@@ -47,5 +60,73 @@ describe('GET /api/onboarding/servers', () => {
 			expect(err.status).toBe(403);
 			expect(err.body.message).toBe('Only server owners can configure Obzorarr');
 		}
+	});
+
+	describe('happy path — authenticated admin', () => {
+		it('returns servers list built from Plex resources', async () => {
+			const publicUri = 'https://plex.example.plex.direct:32400';
+			const resources = [
+				{
+					name: 'Home Server',
+					product: 'Plex Media Server',
+					provides: 'server',
+					owned: true,
+					clientIdentifier: 'abc123',
+					connections: [
+						{
+							protocol: 'https',
+							address: 'plex.example.plex.direct',
+							port: 32400,
+							uri: publicUri,
+							local: false,
+							relay: false
+						},
+						{
+							protocol: 'http',
+							address: '192.168.1.10',
+							port: 32400,
+							uri: 'http://192.168.1.10:32400',
+							local: true,
+							relay: false
+						}
+					]
+				}
+			];
+
+			const getSessionPlexTokenSpy = spyOn(sessionModule, 'getSessionPlexToken').mockResolvedValue(
+				'test-plex-token'
+			);
+			const fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+				createPlexResourcesResponse(resources)
+			);
+
+			try {
+				const locals = {
+					user: { id: 1, plexId: 100, username: 'admin', isAdmin: true }
+				} as HandlerArgs['locals'];
+
+				const response = await runGet(locals, 'test-session-id');
+				expect(response.status).toBe(200);
+
+				const body = (await response.json()) as {
+					servers: Array<{
+						name: string;
+						clientIdentifier: string;
+						bestConnectionUrl: string | null;
+					}>;
+				};
+
+				expect(Array.isArray(body.servers)).toBe(true);
+				expect(body.servers.length).toBe(1);
+				const first = body.servers[0];
+				if (!first) throw new Error('Expected at least one server');
+				expect(first.name).toBe('Home Server');
+				expect(first.clientIdentifier).toBe('abc123');
+				expect(first.bestConnectionUrl).toBe(publicUri);
+			} finally {
+				getSessionPlexTokenSpy.mockRestore();
+				fetchSpy.mockRestore();
+			}
+		});
 	});
 });

--- a/tests/unit/onboarding/servers-endpoint.test.ts
+++ b/tests/unit/onboarding/servers-endpoint.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+import { isHttpError } from '@sveltejs/kit';
+import { GET } from '../../../src/routes/api/onboarding/servers/+server';
+
+type HandlerArgs = Parameters<typeof GET>[0];
+
+function makeCookies(): HandlerArgs['cookies'] {
+	return {
+		get: () => undefined,
+		getAll: () => [],
+		set: () => undefined,
+		delete: () => undefined,
+		serialize: () => ''
+	} as unknown as HandlerArgs['cookies'];
+}
+
+function runGet(locals: HandlerArgs['locals']): ReturnType<typeof GET> {
+	return GET({
+		cookies: makeCookies(),
+		locals
+	} as unknown as HandlerArgs);
+}
+
+describe('GET /api/onboarding/servers', () => {
+	it('returns 401 when the request is unauthenticated', async () => {
+		try {
+			await runGet({} as HandlerArgs['locals']);
+			expect.unreachable('Expected error to be thrown');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			expect(err.status).toBe(401);
+		}
+	});
+
+	it('returns 403 when the user is authenticated but not an admin', async () => {
+		const locals = {
+			user: { id: 1, plexId: 100, username: 'nonadmin', isAdmin: false }
+		} as HandlerArgs['locals'];
+
+		try {
+			await runGet(locals);
+			expect.unreachable('Expected error to be thrown');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			expect(err.status).toBe(403);
+			expect(err.body.message).toBe('Only server owners can configure Obzorarr');
+		}
+	});
+});

--- a/tests/unit/security/csrf-handle.test.ts
+++ b/tests/unit/security/csrf-handle.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import { and, desc, eq, like } from 'drizzle-orm';
+import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings, logs } from '$lib/server/db/schema';
+import { logger } from '$lib/server/logging';
+import { csrfHandle } from '$lib/server/security/csrf-handle';
+
+async function flushLogs(): Promise<void> {
+	// Flush twice: the first call drains the buffer into the DB, and the second
+	// ensures any log entries appended during the first flush (e.g. from a timer
+	// that fired concurrently) are also persisted before the test reads rows.
+	await logger.forceFlush();
+	await logger.forceFlush();
+}
+
+async function getCsrfLogByMessage(message: string) {
+	return db
+		.select()
+		.from(logs)
+		.where(and(eq(logs.source, 'CSRF'), like(logs.message, `%${message}%`)))
+		.orderBy(desc(logs.timestamp));
+}
+
+interface RouteOverride {
+	id: string | null;
+}
+
+function makeEvent(options: {
+	method: string;
+	url: string;
+	origin?: string;
+	route?: RouteOverride;
+}) {
+	const headers = new Headers();
+	if (options.origin !== undefined) {
+		headers.set('origin', options.origin);
+	}
+
+	const request = new Request(options.url, {
+		method: options.method,
+		headers
+	});
+
+	return {
+		request,
+		url: new URL(options.url),
+		route: options.route ?? { id: null }
+	} as unknown as Parameters<typeof csrfHandle>[0]['event'];
+}
+
+async function invoke(event: ReturnType<typeof makeEvent>): Promise<Response> {
+	const sentinel = new Response('resolved', { status: 200 });
+	const resolve = mock(async () => sentinel);
+	const result = await csrfHandle({
+		event,
+		resolve
+	} as unknown as Parameters<typeof csrfHandle>[0]);
+	return result as Response;
+}
+
+describe('csrfHandle (production mode)', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		await db.delete(logs);
+	});
+
+	describe('no origin configured', () => {
+		it('rejects state-changing requests with 403 when onboarding is complete and no skip flag is set', async () => {
+			await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+
+			const event = makeEvent({
+				method: 'POST',
+				url: 'https://example.com/admin/settings',
+				origin: 'https://example.com'
+			});
+
+			const response = await invoke(event);
+
+			expect(response.status).toBe(403);
+			const body = await response.json();
+			expect(body.error).toBe('CSRF protection not configured');
+		});
+
+		it('passes through when onboarding is complete but CSRF_ORIGIN_SKIPPED is set to true', async () => {
+			await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+			await setAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED, 'true');
+
+			const event = makeEvent({
+				method: 'POST',
+				url: 'https://example.com/admin/settings',
+				origin: 'https://example.com'
+			});
+
+			const response = await invoke(event);
+
+			expect(response.status).toBe(200);
+			expect(await response.text()).toBe('resolved');
+		});
+
+		it('passes through when onboarding is still in progress', async () => {
+			// ONBOARDING_COMPLETED not set ⇒ onboarding in progress.
+
+			const event = makeEvent({
+				method: 'POST',
+				url: 'https://example.com/onboarding/csrf?/skipCsrf',
+				origin: 'https://example.com'
+			});
+
+			const response = await invoke(event);
+
+			expect(response.status).toBe(200);
+			expect(await response.text()).toBe('resolved');
+		});
+	});
+
+	describe('origin configured (logging redaction)', () => {
+		it('missing origin: logs route id instead of raw pathname with share tokens', async () => {
+			await setAppSetting(AppSettingsKey.CSRF_ORIGIN, 'https://example.com');
+
+			const tokenUUID = '550e8400-e29b-41d4-a716-446655440000';
+			const event = makeEvent({
+				method: 'POST',
+				url: `https://example.com/wrapped/2024/u/${tokenUUID}?/updateShareMode`,
+				// No origin header → missing-origin branch.
+				route: { id: '/wrapped/[year]/u/[identifier]' }
+			});
+
+			const response = await invoke(event);
+			expect(response.status).toBe(403);
+
+			await flushLogs();
+			const rows = await getCsrfLogByMessage('missing origin header');
+			expect(rows.length).toBeGreaterThan(0);
+
+			const metadata = rows[0]?.metadata ?? '';
+			expect(metadata).toContain('/wrapped/[year]/u/[identifier]');
+			// The raw UUID must NOT appear anywhere in the log metadata.
+			expect(metadata).not.toContain(tokenUUID);
+			expect(metadata).not.toContain('"path"');
+		});
+
+		it('origin mismatch: logs route id instead of raw pathname with share tokens', async () => {
+			await setAppSetting(AppSettingsKey.CSRF_ORIGIN, 'https://example.com');
+
+			const tokenUUID = '650e8400-e29b-41d4-a716-446655440000';
+			const event = makeEvent({
+				method: 'POST',
+				url: `https://example.com/wrapped/2024/u/${tokenUUID}?/updateShareMode`,
+				origin: 'https://attacker.example',
+				route: { id: '/wrapped/[year]/u/[identifier]' }
+			});
+
+			const response = await invoke(event);
+			expect(response.status).toBe(403);
+
+			await flushLogs();
+			const rows = await getCsrfLogByMessage('origin mismatch');
+			expect(rows.length).toBeGreaterThan(0);
+
+			const metadata = rows[0]?.metadata ?? '';
+			expect(metadata).toContain('/wrapped/[year]/u/[identifier]');
+			expect(metadata).not.toContain(tokenUUID);
+		});
+
+		it('falls back to <unmatched> when route.id is null', async () => {
+			await setAppSetting(AppSettingsKey.CSRF_ORIGIN, 'https://example.com');
+
+			const event = makeEvent({
+				method: 'POST',
+				url: 'https://example.com/totally/unknown',
+				origin: 'https://attacker.example',
+				route: { id: null }
+			});
+
+			const response = await invoke(event);
+			expect(response.status).toBe(403);
+
+			await flushLogs();
+			const rows = await getCsrfLogByMessage('origin mismatch');
+			expect(rows.length).toBeGreaterThan(0);
+
+			const metadata = rows[0]?.metadata ?? '';
+			expect(metadata).toContain('<unmatched>');
+		});
+	});
+});

--- a/tests/unit/sharing/access-control.test.ts
+++ b/tests/unit/sharing/access-control.test.ts
@@ -529,6 +529,70 @@ describe('Sharing Access Control', () => {
 			expect(result.userId).toBe(testUserId);
 			expect(result.year).toBe(testYear);
 		});
+
+		describe('global floor enforcement', () => {
+			it('throws ShareAccessDeniedError when floor is raised to private-oauth', async () => {
+				const token = generateShareToken();
+
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_OAUTH,
+					allowUserControl: false
+				});
+				await db.insert(shareSettings).values({
+					userId,
+					year,
+					mode: ShareMode.PRIVATE_LINK,
+					shareToken: token,
+					canUserControl: false
+				});
+
+				try {
+					await checkTokenAccess(token);
+					expect.unreachable('Should have thrown');
+				} catch (error) {
+					expect(error).toBeInstanceOf(ShareAccessDeniedError);
+				}
+			});
+
+			it('allows token access when floor is public', async () => {
+				const token = generateShareToken();
+
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: false
+				});
+				await db.insert(shareSettings).values({
+					userId,
+					year,
+					mode: ShareMode.PRIVATE_LINK,
+					shareToken: token,
+					canUserControl: false
+				});
+
+				const result = await checkTokenAccess(token);
+				expect(result.userId).toBe(userId);
+				expect(result.year).toBe(year);
+			});
+
+			it('allows token access when floor matches private-link', async () => {
+				const token = generateShareToken();
+
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: false
+				});
+				await db.insert(shareSettings).values({
+					userId,
+					year,
+					mode: ShareMode.PRIVATE_LINK,
+					shareToken: token,
+					canUserControl: false
+				});
+
+				const result = await checkTokenAccess(token);
+				expect(result.userId).toBe(userId);
+			});
+		});
 	});
 
 	// =========================================================================

--- a/tests/unit/sharing/wrapped-identifier-loader.test.ts
+++ b/tests/unit/sharing/wrapped-identifier-loader.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { and, eq } from 'drizzle-orm';
+import { db } from '$lib/server/db/client';
+import {
+	appSettings,
+	cachedStats,
+	playHistory,
+	shareSettings,
+	slideConfig,
+	users
+} from '$lib/server/db/schema';
+import { setGlobalShareDefaults } from '$lib/server/sharing/service';
+import { ShareMode, ShareModeSource } from '$lib/server/sharing/types';
+import { load } from '../../../src/routes/wrapped/[year]/u/[identifier]/+page.server';
+
+type LoadArgs = Parameters<typeof load>[0];
+
+/**
+ * Regression tests for private-link cross-year token leak.
+ * See security audit Fix #1.
+ *
+ * When a visitor loads a wrapped page via a share token for year Y, the
+ * loader must NOT embed tokens for other years in its response (previously
+ * it looked up each year's share_settings and exposed every existing token).
+ */
+
+const ORIGIN_YEAR = 2024;
+const OTHER_YEAR = 2023;
+
+const CURRENT_YEAR_TOKEN = '550e8400-e29b-41d4-a716-446655440000';
+const OTHER_YEAR_TOKEN_FOR_PRESEED = '660e8400-e29b-41d4-a716-446655440111';
+
+async function seedUser(userId: number, plexId: number, accountId: number): Promise<void> {
+	await db.insert(users).values({
+		id: userId,
+		plexId,
+		accountId,
+		username: `user-${userId}`
+	});
+}
+
+async function seedShareSettings(options: {
+	userId: number;
+	year: number;
+	mode: (typeof ShareMode)[keyof typeof ShareMode];
+	token: string | null;
+}): Promise<void> {
+	await db.insert(shareSettings).values({
+		userId: options.userId,
+		year: options.year,
+		mode: options.mode,
+		modeSource: ShareModeSource.EXPLICIT,
+		shareToken: options.token,
+		canUserControl: false
+	});
+}
+
+async function getStoredToken(userId: number, year: number): Promise<string | null> {
+	const row = await db
+		.select({ token: shareSettings.shareToken })
+		.from(shareSettings)
+		.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)))
+		.limit(1);
+	return row[0]?.token ?? null;
+}
+
+type LoadData = Extract<Awaited<ReturnType<typeof load>>, { yearIdentifiers?: unknown }>;
+
+async function invokeLoad(params: {
+	year: number;
+	identifier: string;
+	availableYears: number[];
+}): Promise<LoadData> {
+	const result = await load({
+		params: { year: String(params.year), identifier: params.identifier },
+		locals: {},
+		parent: async () => ({ availableYears: params.availableYears })
+	} as unknown as LoadArgs);
+	return result as LoadData;
+}
+
+describe('wrapped/[year]/u/[identifier] loader: cross-year token isolation', () => {
+	const USER_ID = 42;
+
+	beforeEach(async () => {
+		await db.delete(shareSettings);
+		await db.delete(appSettings);
+		await db.delete(users);
+		await db.delete(cachedStats);
+		await db.delete(playHistory);
+		await db.delete(slideConfig);
+
+		await seedUser(USER_ID, 100042, 200042);
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		// Main year must already have the token the visitor is presenting.
+		await seedShareSettings({
+			userId: USER_ID,
+			year: ORIGIN_YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: CURRENT_YEAR_TOKEN
+		});
+	});
+
+	it('yearIdentifiers maps the visited year to the presented token and other years to numeric userId', async () => {
+		// Preseed another year's token — loader must not expose it to token visitors.
+		await seedShareSettings({
+			userId: USER_ID,
+			year: OTHER_YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: OTHER_YEAR_TOKEN_FOR_PRESEED
+		});
+
+		const data = await invokeLoad({
+			year: ORIGIN_YEAR,
+			identifier: CURRENT_YEAR_TOKEN,
+			availableYears: [ORIGIN_YEAR, OTHER_YEAR]
+		});
+
+		expect(data.yearIdentifiers).toBeDefined();
+		expect(data.yearIdentifiers?.[ORIGIN_YEAR]).toBe(CURRENT_YEAR_TOKEN);
+		// Critical property: other year's identifier is the numeric userId, NOT its token.
+		expect(data.yearIdentifiers?.[OTHER_YEAR]).toBe(USER_ID);
+		expect(data.yearIdentifiers?.[OTHER_YEAR]).not.toBe(OTHER_YEAR_TOKEN_FOR_PRESEED);
+	});
+
+	it('does not mint a share token for years other than the visited one', async () => {
+		// Other year has NO share_settings row at all — the old code path would
+		// have called getOrCreateShareSettings which mints a token for PRIVATE_LINK.
+		expect(await getStoredToken(USER_ID, OTHER_YEAR)).toBeNull();
+
+		const data = await invokeLoad({
+			year: ORIGIN_YEAR,
+			identifier: CURRENT_YEAR_TOKEN,
+			availableYears: [ORIGIN_YEAR, OTHER_YEAR]
+		});
+
+		expect(data.yearIdentifiers?.[OTHER_YEAR]).toBe(USER_ID);
+		// No share_settings row was created for OTHER_YEAR as a side effect.
+		const rows = await db
+			.select()
+			.from(shareSettings)
+			.where(and(eq(shareSettings.userId, USER_ID), eq(shareSettings.year, OTHER_YEAR)));
+		expect(rows.length).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary

Addresses one HIGH-confidence vulnerability and four MEDIUM hardening gaps surfaced by a full-codebase security audit. Each fix is surgical and reuses existing helpers; no schema migration is required.

## Fixes

### 1. Cross-year share-token leak (HIGH)

**File:** `src/routes/wrapped/[year]/u/[identifier]/+page.server.ts`

When a visitor loaded `/wrapped/Y1/u/<token>`, the loader iterated every available year, called `getOrCreateShareSettings` for each, and embedded each year's token in the response payload. This had two consequences:

1. A holder of one year's private link could enumerate all other private-link tokens for the same user, defeating the per-year scoping of private links.
2. Any visit minted persistent tokens for years that had no `share_settings` row, as a side effect of `getOrCreateShareSettings`.

The loop is replaced with a minimal mapping: the visited year keeps the presented identifier; every other year uses the numeric `userId`. Clicks to other years now go through the normal `/wrapped/<y>/u/<userId>` URL and are subject to `checkWrappedAccess`, which denies unauthorised viewers. `YearNavigation.buildUrl` already accepts both string and numeric identifiers, so no client change is needed.

### 2. CSRF fail-closed in production

**Files:** `src/lib/server/security/csrf-handle.ts`, `src/lib/server/admin/settings.service.ts`

Previously, when no origin was configured, every state-changing request silently passed through — meaning a fresh production deployment without `ORIGIN` set had no CSRF protection at all. The handle now splits behaviour:

- `dev === true`: pass through (unchanged).
- Onboarding still in progress: pass through (the onboarding flow must be reachable to configure CSRF).
- Onboarding complete + no `CSRF_ORIGIN_SKIPPED` flag: reject with 403.
- Onboarding complete + `CSRF_ORIGIN_SKIPPED === 'true'`: pass through, with the existing admin banner still shown.

A new `CSRF_ORIGIN_SKIPPED` key is added to the `AppSettingsKey` enum (no schema change — `app_settings` is a key/value table).

### 3. Onboarding CSRF action guards

**File:** `src/routes/onboarding/csrf/+page.server.ts`

`testOrigin`, `saveOrigin`, and `skipCsrf` had no authorization guard, so any unauthenticated visitor could mutate CSRF settings post-install. Each action now requires `!isOnboardingComplete()` AND `getOnboardingStep() === OnboardingSteps.CSRF`, returning `fail(403)` otherwise.

`saveOrigin` additionally clears `CSRF_ORIGIN_SKIPPED` on success (configuring an origin undoes a prior skip), and `skipCsrf` writes `CSRF_ORIGIN_SKIPPED='true'` as the explicit opt-out signal required by Fix 2. An `isAdmin` gate is not used here because pre-install there is no admin yet — the first Plex owner login creates one — so gating on onboarding state matches the actual trust boundary of this step.

### 4. /api/onboarding/servers isAdmin gate

**File:** `src/routes/api/onboarding/servers/+server.ts`

The endpoint was gated only on `locals.user`, allowing any authenticated user (not just the server owner) to enumerate Plex servers during onboarding. Adds the same two-step `locals.user` + `locals.user.isAdmin` check already used by `select-server/+server.ts` and `test-connection/+server.ts`.

### 5. Redact share tokens from CSRF failure logs

**Files:** `src/lib/server/security/csrf-handle.ts`, `src/hooks.server.ts`

CSRF failures and unexpected errors logged `event.url.pathname` into the `logs` table, which meant requests to `/wrapped/<year>/u/<token>` persisted the raw share token UUID into the database — visible in the admin logs page and any log export. Both call sites now log `event.route.id ?? '<unmatched>'` (e.g. `/wrapped/[year]/u/[identifier]`), which is SvelteKit's parametrised route identifier and never contains parameter values.

## Test plan

- [x] `bun run check` passes (0 type errors)
- [x] `bun run test` passes (1320 tests, 0 fail; 15 new tests added across 4 files)
- [x] Lint: only pre-existing errors in untouched files (`src/app.html`, `src/routes/plex/thumb/[...path]/+server.ts`); no new lint errors introduced
- [ ] Manual: visit `/wrapped/<Y>/u/<token>` and confirm no other-year UUIDs appear in `__sveltekit_data`; year-nav links use numeric userId for other years
- [ ] Manual: in production mode without `ORIGIN`, confirm POSTs return 403 unless `CSRF_ORIGIN_SKIPPED=true` is set
- [ ] Manual: unauthenticated `POST /onboarding/csrf?/skipCsrf` returns 403 once onboarding has progressed past CSRF
- [ ] Manual: non-admin authenticated `GET /api/onboarding/servers` returns 403
- [ ] Manual: trigger a CSRF failure on a wrapped per-user URL and inspect `logs.metadata` — token UUID must not appear

### New tests

- `tests/unit/sharing/wrapped-identifier-loader.test.ts` — verifies cross-year token isolation and no side-effect token minting.
- `tests/unit/security/csrf-handle.test.ts` — covers production fail-closed, onboarding-in-progress pass-through, opt-out flag, and route-id redaction in both missing-origin and origin-mismatch branches.
- `tests/unit/onboarding/servers-endpoint.test.ts` — 401 unauthenticated, 403 for non-admin.
- `tests/unit/onboarding/csrf-actions.test.ts` (extended) — step-guard 403s for all three actions plus skip-flag write/clear behaviour.