### PR TITLE
fix(security): strip share tokens on payload + gate proxy header trust

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ PLEX_TOKEN=your-plex-token-here
 # PORT=3000
 # HOST=0.0.0.0
 # ORIGIN=https://your-domain.com    # Required for CSRF protection in production
+# TRUST_PROXY=false                 # Set to "true" only if your reverse proxy strips inbound X-Forwarded-* headers from clients
 
 # Database
 # DATABASE_PATH=data/obzorarr.db

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -22,6 +22,7 @@ import { getOnboardingStep, requiresOnboarding } from '$lib/server/onboarding';
 import {
 	applySecurityHeaders,
 	csrfHandle,
+	proxyHandle,
 	rateLimitHandle,
 	requestFilterHandle
 } from '$lib/server/security';
@@ -40,25 +41,6 @@ function redirectResponse(event: { request: Request }, location: string): Respon
 		event.request
 	);
 }
-
-const proxyHandle: Handle = async ({ event, resolve }) => {
-	const proto = event.request.headers.get('x-forwarded-proto');
-	const host = event.request.headers.get('x-forwarded-host');
-
-	if (proto && host) {
-		const forwardedUrl = new URL(event.url);
-		forwardedUrl.protocol = proto.includes('https') ? 'https:' : 'http:';
-		forwardedUrl.host = host;
-
-		Object.defineProperty(event, 'url', {
-			value: forwardedUrl,
-			writable: true,
-			configurable: true
-		});
-	}
-
-	return resolve(event);
-};
 
 const COOKIE_DELETE_OPTIONS = {
 	path: '/'

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -500,7 +500,7 @@ export async function clearConflictingDbSettings(): Promise<string[]> {
 	const plexEnv = getPlexEnvConfig();
 	const openaiEnv = getOpenAIEnvConfig();
 	const csrfEnvOrigin = env.ORIGIN ?? '';
-	const trustProxyEnv = env.TRUST_PROXY ?? '';
+	const trustProxyEnv = (env.TRUST_PROXY ?? '').trim();
 
 	const envToDbMapping: Array<{ envValue: string; dbKey: AppSettingsKeyType; label: string }> = [
 		{

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -471,7 +471,14 @@ export interface TrustProxyConfigWithSource {
 
 export async function getTrustProxyConfigWithSource(): Promise<TrustProxyConfigWithSource> {
 	const dbSettings = await getAllAppSettings();
-	const envValue = env.TRUST_PROXY ?? '';
+	// resolveConfigValue treats any non-empty envValue as "env-locked" and returns
+	// it verbatim. getTrustProxy() / proxyHandle then compare with === 'true', so a
+	// raw env like 'TRUE' or ' true ' would lock the UI on while runtime stays off.
+	// Normalize to the canonical 'true'/'false' the rest of the pipeline expects.
+	// An empty string means "not set" (no lock). Mirrors the case-insensitive
+	// 'true' convention used by isLiveSyncEnabled() in sync/live-sync.ts.
+	const rawEnv = env.TRUST_PROXY ?? '';
+	const envValue = rawEnv === '' ? '' : rawEnv.trim().toLowerCase() === 'true' ? 'true' : 'false';
 
 	return {
 		trustProxy: resolveConfigValue(dbSettings, AppSettingsKey.TRUST_PROXY, envValue, 'false')

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -477,8 +477,8 @@ export async function getTrustProxyConfigWithSource(): Promise<TrustProxyConfigW
 	// Normalize to the canonical 'true'/'false' the rest of the pipeline expects.
 	// An empty string means "not set" (no lock). Mirrors the case-insensitive
 	// 'true' convention used by isLiveSyncEnabled() in sync/live-sync.ts.
-	const rawEnv = env.TRUST_PROXY ?? '';
-	const envValue = rawEnv === '' ? '' : rawEnv.trim().toLowerCase() === 'true' ? 'true' : 'false';
+	const rawEnv = (env.TRUST_PROXY ?? '').trim();
+	const envValue = rawEnv === '' ? '' : rawEnv.toLowerCase() === 'true' ? 'true' : 'false';
 
 	return {
 		trustProxy: resolveConfigValue(dbSettings, AppSettingsKey.TRUST_PROXY, envValue, 'false')

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -29,7 +29,8 @@ export const AppSettingsKey = {
 	ONBOARDING_CURRENT_STEP: 'onboarding_current_step',
 	CSRF_ORIGIN: 'csrf_origin',
 	CSRF_ORIGIN_SKIPPED: 'csrf_origin_skipped',
-	CSRF_WARNING_DISMISSED: 'csrf_warning_dismissed'
+	CSRF_WARNING_DISMISSED: 'csrf_warning_dismissed',
+	TRUST_PROXY: 'trust_proxy'
 } as const;
 
 export type AppSettingsKeyType = (typeof AppSettingsKey)[keyof typeof AppSettingsKey];
@@ -464,6 +465,24 @@ export async function getCsrfOrigin(): Promise<string | null> {
 	return config.origin.value || null;
 }
 
+export interface TrustProxyConfigWithSource {
+	trustProxy: ConfigValue<string>;
+}
+
+export async function getTrustProxyConfigWithSource(): Promise<TrustProxyConfigWithSource> {
+	const dbSettings = await getAllAppSettings();
+	const envValue = env.TRUST_PROXY ?? '';
+
+	return {
+		trustProxy: resolveConfigValue(dbSettings, AppSettingsKey.TRUST_PROXY, envValue, 'false')
+	};
+}
+
+export async function getTrustProxy(): Promise<boolean> {
+	const config = await getTrustProxyConfigWithSource();
+	return config.trustProxy.value === 'true';
+}
+
 /**
  * Clear database settings that conflict with environment variables.
  * When ENV takes precedence, we auto-clear conflicting DB values to avoid confusion.
@@ -474,6 +493,7 @@ export async function clearConflictingDbSettings(): Promise<string[]> {
 	const plexEnv = getPlexEnvConfig();
 	const openaiEnv = getOpenAIEnvConfig();
 	const csrfEnvOrigin = env.ORIGIN ?? '';
+	const trustProxyEnv = env.TRUST_PROXY ?? '';
 
 	const envToDbMapping: Array<{ envValue: string; dbKey: AppSettingsKeyType; label: string }> = [
 		{
@@ -489,7 +509,8 @@ export async function clearConflictingDbSettings(): Promise<string[]> {
 			label: 'OPENAI_BASE_URL'
 		},
 		{ envValue: openaiEnv.model, dbKey: AppSettingsKey.OPENAI_MODEL, label: 'OPENAI_MODEL' },
-		{ envValue: csrfEnvOrigin, dbKey: AppSettingsKey.CSRF_ORIGIN, label: 'CSRF_ORIGIN' }
+		{ envValue: csrfEnvOrigin, dbKey: AppSettingsKey.CSRF_ORIGIN, label: 'CSRF_ORIGIN' },
+		{ envValue: trustProxyEnv, dbKey: AppSettingsKey.TRUST_PROXY, label: 'TRUST_PROXY' }
 	];
 
 	const dbSettings = await getAllAppSettings();

--- a/src/lib/server/security/index.ts
+++ b/src/lib/server/security/index.ts
@@ -4,6 +4,7 @@ export {
 	sanitizeApiError,
 	sanitizeConnectionError
 } from './error-sanitizer';
+export { proxyHandle } from './proxy-handle';
 export { rateLimitHandle } from './rate-limit-handle';
 export { requestFilterHandle } from './request-filter';
 export { applySecurityHeaders } from './security-headers';

--- a/src/lib/server/security/proxy-handle.ts
+++ b/src/lib/server/security/proxy-handle.ts
@@ -1,0 +1,90 @@
+import type { Handle } from '@sveltejs/kit';
+import { getTrustProxyConfigWithSource } from '$lib/server/admin/settings.service';
+import { logger } from '$lib/server/logging';
+
+let proxyStartupLogged = false;
+
+// Take the rightmost (last-hop) value from a comma-separated forwarded header.
+// Returns null if no usable value is present.
+function lastHopValue(headerValue: string | null): string | null {
+	if (!headerValue) return null;
+	const parts = headerValue.split(',');
+	const last = parts[parts.length - 1]?.trim();
+	return last && last.length > 0 ? last : null;
+}
+
+function isValidForwardedProto(value: string): value is 'http' | 'https' {
+	return value === 'http' || value === 'https';
+}
+
+// Reject CR/LF (response-splitting / header-injection defense) and any
+// whitespace inside the host token.
+function isSafeForwardedHost(value: string): boolean {
+	return value.length > 0 && !/[\r\n\s]/.test(value);
+}
+
+// NOTE: this handler does NOT touch event.getClientAddress(); the production
+// adapter (svelte-adapter-bun) resolves the client IP independently. Operators
+// who need IP trust must configure their adapter / runtime separately.
+export const proxyHandle: Handle = async ({ event, resolve }) => {
+	const config = await getTrustProxyConfigWithSource();
+	const trustProxy = config.trustProxy.value === 'true';
+
+	if (!proxyStartupLogged) {
+		proxyStartupLogged = true;
+		if (trustProxy) {
+			const sourceLabel = config.trustProxy.source === 'env' ? 'environment' : 'database';
+			logger.warn(
+				`Trusting reverse-proxy x-forwarded-* headers (source: ${sourceLabel}). ` +
+					'The upstream proxy MUST strip inbound x-forwarded-* headers from clients ' +
+					'or attackers can poison event.url.host / event.url.protocol.',
+				'Proxy'
+			);
+		}
+	}
+
+	if (!trustProxy) {
+		return resolve(event);
+	}
+
+	const protoCandidate = lastHopValue(event.request.headers.get('x-forwarded-proto'));
+	const hostCandidate = lastHopValue(event.request.headers.get('x-forwarded-host'));
+
+	const safeProto =
+		protoCandidate && isValidForwardedProto(protoCandidate.toLowerCase())
+			? (protoCandidate.toLowerCase() as 'http' | 'https')
+			: null;
+	const safeHost = hostCandidate && isSafeForwardedHost(hostCandidate) ? hostCandidate : null;
+
+	if (!safeProto || !safeHost) {
+		return resolve(event);
+	}
+
+	// Parse the forwarded host through URL to validate syntax and split
+	// hostname/port cleanly. Setting URL.host directly preserves the existing
+	// port when the new value omits one — not what we want for a public URL.
+	let parsedHost: URL;
+	try {
+		parsedHost = new URL(`${safeProto}://${safeHost}/`);
+	} catch {
+		return resolve(event);
+	}
+
+	const forwardedUrl = new URL(event.url);
+	forwardedUrl.protocol = parsedHost.protocol;
+	forwardedUrl.hostname = parsedHost.hostname;
+	forwardedUrl.port = parsedHost.port;
+
+	Object.defineProperty(event, 'url', {
+		value: forwardedUrl,
+		writable: true,
+		configurable: true
+	});
+
+	return resolve(event);
+};
+
+// Test-only: reset the one-shot startup-log flag so tests can re-exercise it.
+export function _resetProxyStartupLogged(): void {
+	proxyStartupLogged = false;
+}

--- a/src/lib/server/security/proxy-handle.ts
+++ b/src/lib/server/security/proxy-handle.ts
@@ -17,10 +17,17 @@ function isValidForwardedProto(value: string): value is 'http' | 'https' {
 	return value === 'http' || value === 'https';
 }
 
-// Reject CR/LF (response-splitting / header-injection defense) and any
-// whitespace inside the host token.
+// Reject CR/LF (response-splitting / header-injection defense), whitespace,
+// and URL delimiter characters that would confuse new URL() into parsing a
+// different host than intended.  Specifically:
+//   @  — userinfo delimiter: "trusted@evil.com" → hostname is evil.com
+//   /  — path delimiter: "evil.com/path" passes through to pathname
+//   ?  — query delimiter: "evil.com?x=1" passes through to search
+//   #  — fragment delimiter: "evil.com#foo" passes through to hash
+// IPv6 literals like "[::1]:8443" are NOT rejected because they contain no
+// delimiter characters from the banned set.
 function isSafeForwardedHost(value: string): boolean {
-	return value.length > 0 && !/[\r\n\s]/.test(value);
+	return value.length > 0 && !/[\r\n\s@/?#]/.test(value);
 }
 
 // NOTE: this handler does NOT touch event.getClientAddress(); the production

--- a/src/lib/server/security/proxy-handle.ts
+++ b/src/lib/server/security/proxy-handle.ts
@@ -30,17 +30,15 @@ export const proxyHandle: Handle = async ({ event, resolve }) => {
 	const config = await getTrustProxyConfigWithSource();
 	const trustProxy = config.trustProxy.value === 'true';
 
-	if (!proxyStartupLogged) {
+	if (!proxyStartupLogged && trustProxy) {
 		proxyStartupLogged = true;
-		if (trustProxy) {
-			const sourceLabel = config.trustProxy.source === 'env' ? 'environment' : 'database';
-			logger.warn(
-				`Trusting reverse-proxy x-forwarded-* headers (source: ${sourceLabel}). ` +
-					'The upstream proxy MUST strip inbound x-forwarded-* headers from clients ' +
-					'or attackers can poison event.url.host / event.url.protocol.',
-				'Proxy'
-			);
-		}
+		const sourceLabel = config.trustProxy.source === 'env' ? 'environment' : 'database';
+		logger.warn(
+			`Trusting reverse-proxy x-forwarded-* headers (source: ${sourceLabel}). ` +
+				'The upstream proxy MUST strip inbound x-forwarded-* headers from clients ' +
+				'or attackers can poison event.url.host / event.url.protocol.',
+			'Proxy'
+		);
 	}
 
 	if (!trustProxy) {

--- a/src/lib/server/sharing/access-control.ts
+++ b/src/lib/server/sharing/access-control.ts
@@ -11,6 +11,7 @@ import {
 	InvalidShareTokenError,
 	ShareAccessDeniedError,
 	ShareMode,
+	ShareModePrivacyLevel,
 	type ShareModeType,
 	type ShareSettings
 } from './types';
@@ -136,19 +137,34 @@ export async function checkTokenAccess(token: string): Promise<CheckTokenAccessR
 		throw new InvalidShareTokenError();
 	}
 
-	if (settings.mode !== ShareMode.PRIVATE_LINK) {
+	// A per-user mode that is explicitly MORE restrictive than private-link
+	// (e.g. private-oauth) means the owner has chosen auth over tokens; the
+	// token is stale regardless of the global floor.
+	if (ShareModePrivacyLevel[settings.mode] > ShareModePrivacyLevel[ShareMode.PRIVATE_LINK]) {
 		throw new InvalidShareTokenError('This share link is no longer valid.');
 	}
 
-	// Apply the global privacy floor: if the admin has raised the floor above
-	// private-link (e.g. to private-oauth), a token alone is no longer sufficient
-	// even though the per-user mode is still stored as private-link.
+	// Resolve against the global privacy floor. This mirrors the effective-mode
+	// computation done at mint-time (see `+page.server.ts` for user wrapped) and
+	// in `checkWrappedAccess`, so that a token minted because the floor raised a
+	// less-restrictive per-user row (e.g. EXPLICIT 'public') up to 'private-link'
+	// is also honored here. Without this symmetry, `checkTokenAccess` would reject
+	// tokens on the raw `settings.mode` while the minting site happily issues them
+	// on `effectiveMode`, producing share URLs that work for the owner but not
+	// for any non-owner they send them to.
 	const globalFloor = await getGlobalDefaultShareMode();
 	const effectiveMode = getMoreRestrictiveMode(settings.mode, globalFloor);
 	if (effectiveMode !== ShareMode.PRIVATE_LINK) {
-		throw new ShareAccessDeniedError(
-			'This wrapped is visible only to members of this Plex server. Sign in with your Plex account to view.'
-		);
+		// Floor pushed the effective mode above private-link (e.g. private-oauth):
+		// token alone is no longer sufficient, direct the viewer to sign in.
+		if (ShareModePrivacyLevel[effectiveMode] > ShareModePrivacyLevel[ShareMode.PRIVATE_LINK]) {
+			throw new ShareAccessDeniedError(
+				'This wrapped is visible only to members of this Plex server. Sign in with your Plex account to view.'
+			);
+		}
+		// Both per-user mode and floor are public: the page is public, so the
+		// token is meaningless; treat as a stale link.
+		throw new InvalidShareTokenError('This share link is no longer valid.');
 	}
 
 	return {

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -320,14 +320,24 @@ export async function regenerateShareToken(userId: number, year: number): Promis
 }
 
 export async function ensureShareToken(userId: number, year: number): Promise<string> {
-	const settings = await getShareSettings(userId, year);
+	// Read the raw DB row directly (bypassing toShareSettings sanitization) so
+	// that we see any existing token even when the stored mode is not private-link
+	// but the global floor has raised the effective mode to private-link. Using the
+	// sanitized ShareSettings path would always return shareToken=null in that case,
+	// causing a new token to be minted on every page load and breaking shared URLs.
+	const raw = await db
+		.select({ shareToken: shareSettings.shareToken })
+		.from(shareSettings)
+		.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)))
+		.limit(1);
 
-	if (!settings) {
+	const row = raw[0];
+	if (!row) {
 		throw new ShareSettingsNotFoundError();
 	}
 
-	if (settings.shareToken) {
-		return settings.shareToken;
+	if (row.shareToken) {
+		return row.shareToken;
 	}
 
 	const newToken = generateShareToken();
@@ -335,9 +345,23 @@ export async function ensureShareToken(userId: number, year: number): Promise<st
 	await db
 		.update(shareSettings)
 		.set({ shareToken: newToken })
-		.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)));
+		.where(
+			and(
+				eq(shareSettings.userId, userId),
+				eq(shareSettings.year, year),
+				isNull(shareSettings.shareToken)
+			)
+		);
 
-	return newToken;
+	// Re-read to get the winner in case of a concurrent mint (same pattern as
+	// getShareSettings uses for its own lazy-mint path).
+	const refreshed = await db
+		.select({ shareToken: shareSettings.shareToken })
+		.from(shareSettings)
+		.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)))
+		.limit(1);
+
+	return refreshed[0]?.shareToken ?? newToken;
 }
 
 export async function getShareSettingsByToken(token: string): Promise<ShareSettings | null> {

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -61,27 +61,40 @@ export async function getGlobalAllowUserControl(): Promise<boolean> {
 }
 
 export async function setGlobalShareDefaults(defaults: GlobalShareDefaults): Promise<void> {
-	await db
-		.insert(appSettings)
-		.values({
-			key: ShareSettingsKey.DEFAULT_SHARE_MODE,
-			value: defaults.defaultShareMode
-		})
-		.onConflictDoUpdate({
-			target: appSettings.key,
-			set: { value: defaults.defaultShareMode }
-		});
+	await db.transaction(async (tx) => {
+		await tx
+			.insert(appSettings)
+			.values({
+				key: ShareSettingsKey.DEFAULT_SHARE_MODE,
+				value: defaults.defaultShareMode
+			})
+			.onConflictDoUpdate({
+				target: appSettings.key,
+				set: { value: defaults.defaultShareMode }
+			});
 
-	await db
-		.insert(appSettings)
-		.values({
-			key: ShareSettingsKey.ALLOW_USER_CONTROL,
-			value: String(defaults.allowUserControl)
-		})
-		.onConflictDoUpdate({
-			target: appSettings.key,
-			set: { value: String(defaults.allowUserControl) }
-		});
+		await tx
+			.insert(appSettings)
+			.values({
+				key: ShareSettingsKey.ALLOW_USER_CONTROL,
+				value: String(defaults.allowUserControl)
+			})
+			.onConflictDoUpdate({
+				target: appSettings.key,
+				set: { value: String(defaults.allowUserControl) }
+			});
+
+		// Rotate tokens for default-sourced rows when the new global default is
+		// no longer PRIVATE_LINK. Any captured token from a previous PRIVATE_LINK
+		// default becomes unusable; getShareSettings re-mints on demand if the
+		// default later flips back to PRIVATE_LINK.
+		if (defaults.defaultShareMode !== ShareMode.PRIVATE_LINK) {
+			await tx
+				.update(shareSettings)
+				.set({ shareToken: null })
+				.where(eq(shareSettings.modeSource, ShareModeSource.DEFAULT));
+		}
+	});
 }
 
 export async function bulkApplyUserControl(canUserControl: boolean): Promise<number> {
@@ -170,13 +183,18 @@ function toShareSettings(record: ShareSettingsRecord, globalDefault: ShareModeTy
 	const modeSource = (record.modeSource ?? ShareModeSource.EXPLICIT) as ShareModeSourceType;
 	const mode = modeSource === ShareModeSource.DEFAULT ? globalDefault : storedMode;
 
+	// Defense-in-depth: never expose a stored token unless the effective mode is
+	// PRIVATE_LINK. This guards against capture-and-replay if a row still holds
+	// a token after the effective mode was widened (e.g. global default changed).
+	const shareToken = mode === ShareMode.PRIVATE_LINK ? record.shareToken : null;
+
 	return {
 		userId: record.userId,
 		year: record.year,
 		mode,
 		storedMode,
 		modeSource,
-		shareToken: record.shareToken,
+		shareToken,
 		canUserControl: record.canUserControl ?? false
 	};
 }

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -16,6 +16,7 @@ import {
 	getApiConfigWithSources,
 	getAppSetting,
 	getCsrfConfigWithSource,
+	getTrustProxyConfigWithSource,
 	getUITheme,
 	getWrappedLogoMode,
 	getWrappedTheme,
@@ -131,7 +132,8 @@ export const load: PageServerLoad = async () => {
 		serverWrappedShareMode,
 		csrfConfig,
 		csrfWarningDismissed,
-		csrfOriginSkippedRaw
+		csrfOriginSkippedRaw,
+		trustProxyConfig
 	] = await Promise.all([
 		getApiConfigWithSources(),
 		getUITheme(),
@@ -147,7 +149,8 @@ export const load: PageServerLoad = async () => {
 		getServerWrappedShareMode(),
 		getCsrfConfigWithSource(),
 		isCsrfWarningDismissed(),
-		getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)
+		getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED),
+		getTrustProxyConfigWithSource()
 	]);
 
 	const currentYear = new Date().getFullYear();
@@ -201,7 +204,10 @@ export const load: PageServerLoad = async () => {
 			originLocked: csrfConfig.origin.isLocked,
 			warningDismissed: csrfWarningDismissed,
 			// Flag is only effective when no origin is configured; mirror csrfHandle semantics
-			csrfOriginSkipped: csrfOriginSkippedRaw === 'true' && !csrfConfig.origin.value
+			csrfOriginSkipped: csrfOriginSkippedRaw === 'true' && !csrfConfig.origin.value,
+			trustProxyValue: trustProxyConfig.trustProxy.value === 'true',
+			trustProxySource: trustProxyConfig.trustProxy.source,
+			trustProxyLocked: trustProxyConfig.trustProxy.isLocked
 		}
 	};
 };
@@ -841,6 +847,40 @@ export const actions: Actions = {
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to reset CSRF warning';
 			logger.error(`Failed to reset CSRF warning: ${message}`, 'Security');
+			return fail(500, { error: message });
+		}
+	},
+
+	updateTrustProxy: async ({ request }) => {
+		const trustProxyConfig = await getTrustProxyConfigWithSource();
+		if (trustProxyConfig.trustProxy.isLocked) {
+			return fail(400, {
+				error: 'TRUST_PROXY is set via environment variable and cannot be changed here'
+			});
+		}
+
+		const formData = await request.formData();
+		const enabled = formData.get('enabled') === 'true';
+
+		try {
+			await setAppSetting(AppSettingsKey.TRUST_PROXY, enabled ? 'true' : 'false');
+			if (enabled) {
+				logger.warn(
+					'Reverse-proxy header trust enabled by admin. Verify your upstream proxy strips inbound x-forwarded-* headers.',
+					'Security'
+				);
+			} else {
+				logger.info('Reverse-proxy header trust disabled by admin', 'Security');
+			}
+			return {
+				success: true,
+				message: enabled
+					? 'Reverse-proxy header trust enabled.'
+					: 'Reverse-proxy header trust disabled.'
+			};
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Failed to update TRUST_PROXY';
+			logger.error(`Failed to update TRUST_PROXY: ${message}`, 'Security');
 			return fail(500, { error: message });
 		}
 	}

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -108,6 +108,10 @@ const CsrfOriginSchema = z.object({
 		})
 });
 
+const TrustProxySchema = z.object({
+	enabled: z.enum(['true', 'false']).transform((v) => v === 'true')
+});
+
 interface SettingValue {
 	value: string;
 	source: ConfigSource;
@@ -860,7 +864,11 @@ export const actions: Actions = {
 		}
 
 		const formData = await request.formData();
-		const enabled = formData.get('enabled') === 'true';
+		const parsed = TrustProxySchema.safeParse({ enabled: formData.get('enabled') });
+		if (!parsed.success) {
+			return fail(400, { error: 'Invalid input: enabled must be "true" or "false"' });
+		}
+		const enabled = parsed.data.enabled;
 
 		try {
 			await setAppSetting(AppSettingsKey.TRUST_PROXY, enabled ? 'true' : 'false');

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -454,12 +454,19 @@ let isSavingCsrf = $state(false);
 let csrfClearDialogOpen = $state(false);
 let isClearingCsrf = $state(false);
 let isResettingCsrfWarning = $state(false);
+let trustProxyValue = $state(false);
+let trustProxySource = $state<'env' | 'db' | 'default'>('default');
+let trustProxyLocked = $state(false);
+let isSavingTrustProxy = $state(false);
 
 // Sync CSRF state from data
 $effect(() => {
 	csrfOriginValue = data.security.originValue;
 	csrfOriginSource = data.security.originSource;
 	csrfOriginLocked = data.security.originLocked;
+	trustProxyValue = data.security.trustProxyValue;
+	trustProxySource = data.security.trustProxySource;
+	trustProxyLocked = data.security.trustProxyLocked;
 });
 
 // Detect current URL for CSRF origin
@@ -1587,6 +1594,125 @@ const logFieldErrors = $derived(
 									</form>
 								{/if}
 							</div>
+						</div>
+					</section>
+
+					<!-- TRUST_PROXY Panel -->
+					<section class="panel csrf-panel">
+						<div class="panel-header">
+							<div class="panel-title">
+								<ShieldCheck class="panel-icon security" />
+								<h2>Reverse Proxy Header Trust</h2>
+								<Tooltip.Root>
+									<Tooltip.Trigger>
+										<span
+											role="button"
+											tabindex="0"
+											class="help-trigger"
+											aria-label="Learn how reverse-proxy header trust works"
+										>
+											<CircleHelp />
+										</span>
+									</Tooltip.Trigger>
+									<Tooltip.Content side="right" sideOffset={8} class="csrf-tooltip">
+										<div class="csrf-tooltip-inner">
+											<strong>How Reverse-Proxy Header Trust Works</strong>
+											<p>
+												When enabled, Obzorarr trusts <code>X-Forwarded-Proto</code> and
+												<code>X-Forwarded-Host</code> from the upstream proxy and uses them to
+												build absolute URLs. Enable ONLY if your reverse proxy strips inbound
+												forwarded headers from clients — otherwise an attacker can poison the
+												app's view of its own host and protocol.
+											</p>
+										</div>
+									</Tooltip.Content>
+								</Tooltip.Root>
+							</div>
+							<div class="connection-status" class:connected={trustProxyValue}>
+								<span class="status-dot"></span>
+								<span class="status-text">{trustProxyValue ? 'Trusted' : 'Disabled'}</span>
+							</div>
+						</div>
+
+						<p class="panel-description">
+							Trust <code>X-Forwarded-Proto</code> and <code>X-Forwarded-Host</code> from the
+							upstream reverse proxy. Default: off.
+						</p>
+
+						<div class="panel-form">
+							<div class="form-field">
+								<div class="field-header">
+									<label for="trustProxy">TRUST_PROXY</label>
+									{#if trustProxyLocked}
+										<span class="env-lock-badge">
+											<Lock class="badge-icon" />
+											Set via environment variable
+										</span>
+									{:else if trustProxySource !== 'default'}
+										<span class="source-badge" class:env={trustProxySource === 'env'}>
+											{getSourceLabel(trustProxySource)}
+										</span>
+									{/if}
+								</div>
+								{#if trustProxyLocked}
+									<span class="field-hint env-hint">
+										This value is set via TRUST_PROXY environment variable and cannot be changed
+										here.
+									</span>
+								{:else}
+									<span class="field-hint">
+										Enable only if your reverse proxy strips inbound <code>X-Forwarded-*</code>
+										headers from clients. Environment variable takes priority over database.
+									</span>
+								{/if}
+							</div>
+
+							{#if !trustProxyLocked}
+								<div class="csrf-actions">
+									<form
+										method="POST"
+										action="?/updateTrustProxy"
+										use:enhance={() => {
+											isSavingTrustProxy = true;
+											return async ({ result, update }) => {
+												isSavingTrustProxy = false;
+												if (result.type === 'success' || result.type === 'failure') {
+													handleFormToast(
+														result.data as {
+															success?: boolean;
+															message?: string;
+															error?: string;
+														}
+													);
+												}
+												await update({ reset: false });
+											};
+										}}
+									>
+										<input
+											type="hidden"
+											name="enabled"
+											value={trustProxyValue ? 'false' : 'true'}
+										/>
+										<button
+											type="submit"
+											class={trustProxyValue ? 'btn-destructive' : 'btn-primary'}
+											disabled={isSavingTrustProxy}
+										>
+											{#if isSavingTrustProxy}
+												<Loader2 class="btn-icon spinning" />
+												Saving...
+											{:else if trustProxyValue}
+												<ShieldAlert class="btn-icon" />
+												Disable Header Trust
+											{:else}
+												<ShieldCheck class="btn-icon" />
+												Enable Header Trust
+											{/if}
+										</button>
+									</form>
+								</div>
+							{/if}
 						</div>
 					</section>
 

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -172,6 +172,14 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 			? (shareSettings.shareToken ?? (await ensureShareToken(userId, year)))
 			: userId;
 
+	// Only owner/admin sees the raw token, and only when the effective mode is
+	// actually private-link. Anonymous and non-owner viewers never receive it,
+	// even if the row still holds one (defense-in-depth against capture/replay).
+	const exposedShareToken =
+		(isOwner || isAdmin) && effectiveModeForUrl === ShareMode.PRIVATE_LINK
+			? shareSettings.shareToken
+			: null;
+
 	return {
 		stats,
 		slides,
@@ -188,7 +196,7 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 			mode: shareSettings.mode,
 			storedMode: shareSettings.storedMode,
 			modeSource: shareSettings.modeSource,
-			shareToken: shareSettings.shareToken,
+			shareToken: exposedShareToken,
 			canUserControl: shareSettings.canUserControl || isAdmin
 		},
 		isOwner,

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -167,17 +167,23 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 
 	const globalFloorForUrl = await getGlobalDefaultShareMode();
 	const effectiveModeForUrl = getMoreRestrictiveMode(shareSettings.mode, globalFloorForUrl);
-	const urlIdentifier =
+	// Resolve the share token for the URL, minting one lazily if needed (e.g. when
+	// the global floor raises the effective mode to private-link but the per-user
+	// row was created under a less-restrictive mode and has no token yet).
+	const resolvedShareToken =
 		effectiveModeForUrl === ShareMode.PRIVATE_LINK
 			? (shareSettings.shareToken ?? (await ensureShareToken(userId, year)))
-			: userId;
+			: null;
+	const urlIdentifier = resolvedShareToken ?? userId;
 
 	// Only owner/admin sees the raw token, and only when the effective mode is
 	// actually private-link. Anonymous and non-owner viewers never receive it,
 	// even if the row still holds one (defense-in-depth against capture/replay).
+	// Use resolvedShareToken (not the stale shareSettings.shareToken) so that a
+	// freshly-minted token is correctly surfaced to the owner/admin.
 	const exposedShareToken =
 		(isOwner || isAdmin) && effectiveModeForUrl === ShareMode.PRIVATE_LINK
-			? shareSettings.shareToken
+			? resolvedShareToken
 			: null;
 
 	return {

--- a/tests/unit/security/proxy-handle.test.ts
+++ b/tests/unit/security/proxy-handle.test.ts
@@ -209,6 +209,74 @@ describe('proxyHandle', () => {
 
 			expect(rewrittenUrl.host).toBe('localhost:5173');
 		});
+
+		it('rejects a forwarded host containing @ (userinfo-delimiter hostname spoof)', async () => {
+			// new URL('https://trusted.example@evil.example/') → hostname=evil.example
+			const { rewrittenUrl } = await invokeWithRawHeaders({
+				url: 'http://localhost:5173/p',
+				headerLookup: (name) => {
+					if (name === 'x-forwarded-proto') return 'https';
+					if (name === 'x-forwarded-host') return 'trusted.example@evil.example';
+					return null;
+				}
+			});
+
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+			expect(rewrittenUrl.protocol).toBe('http:');
+		});
+
+		it('rejects a forwarded host containing / (path delimiter)', async () => {
+			const { rewrittenUrl } = await invokeWithRawHeaders({
+				url: 'http://localhost:5173/p',
+				headerLookup: (name) => {
+					if (name === 'x-forwarded-proto') return 'https';
+					if (name === 'x-forwarded-host') return 'evil.com/injected';
+					return null;
+				}
+			});
+
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+		});
+
+		it('rejects a forwarded host containing ? (query delimiter)', async () => {
+			const { rewrittenUrl } = await invokeWithRawHeaders({
+				url: 'http://localhost:5173/p',
+				headerLookup: (name) => {
+					if (name === 'x-forwarded-proto') return 'https';
+					if (name === 'x-forwarded-host') return 'evil.com?x=1';
+					return null;
+				}
+			});
+
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+		});
+
+		it('rejects a forwarded host containing # (fragment delimiter)', async () => {
+			const { rewrittenUrl } = await invokeWithRawHeaders({
+				url: 'http://localhost:5173/p',
+				headerLookup: (name) => {
+					if (name === 'x-forwarded-proto') return 'https';
+					if (name === 'x-forwarded-host') return 'evil.com#frag';
+					return null;
+				}
+			});
+
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+		});
+
+		it('accepts a legitimate IPv6 host with port ([::1]:8443)', async () => {
+			const { rewrittenUrl } = await invoke({
+				url: 'http://localhost:5173/p',
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': '[::1]:8443'
+				}
+			});
+
+			expect(rewrittenUrl.hostname).toBe('[::1]');
+			expect(rewrittenUrl.port).toBe('8443');
+			expect(rewrittenUrl.protocol).toBe('https:');
+		});
 	});
 
 	describe('TRUST_PROXY env override', () => {

--- a/tests/unit/security/proxy-handle.test.ts
+++ b/tests/unit/security/proxy-handle.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { env } from '$env/dynamic/private';
+import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import { _resetProxyStartupLogged, proxyHandle } from '$lib/server/security/proxy-handle';
+
+interface InvokeOptions {
+	url: string;
+	headers?: Record<string, string>;
+}
+
+interface InvokeResult {
+	rewrittenUrl: URL;
+}
+
+async function invoke(options: InvokeOptions): Promise<InvokeResult> {
+	const headers = new Headers();
+	for (const [k, v] of Object.entries(options.headers ?? {})) {
+		// Avoid the platform-level header sanitizer rejecting CR/LF before we see it.
+		// Some runtimes refuse to set malicious values via Headers.set; for those tests
+		// we construct the request via a Proxy below.
+		headers.set(k, v);
+	}
+
+	const request = new Request(options.url, { method: 'GET', headers });
+	const event = {
+		request,
+		url: new URL(options.url),
+		route: { id: null }
+	} as unknown as Parameters<typeof proxyHandle>[0]['event'];
+
+	let observedUrl: URL = event.url;
+	const resolve = mock(async (e: typeof event) => {
+		observedUrl = e.url;
+		return new Response('ok');
+	});
+
+	await proxyHandle({ event, resolve } as unknown as Parameters<typeof proxyHandle>[0]);
+
+	return { rewrittenUrl: observedUrl };
+}
+
+// Build a request whose headers map can return CR/LF — the WHATWG Headers API
+// strips/rejects these, so we use a fake headers object to exercise the
+// header-injection guard inside proxyHandle.
+async function invokeWithRawHeaders(options: {
+	url: string;
+	headerLookup: (name: string) => string | null;
+}): Promise<InvokeResult> {
+	const url = new URL(options.url);
+	const fakeRequest = {
+		headers: { get: options.headerLookup }
+	} as unknown as Request;
+
+	const event = {
+		request: fakeRequest,
+		url,
+		route: { id: null }
+	} as unknown as Parameters<typeof proxyHandle>[0]['event'];
+
+	let observedUrl: URL = event.url;
+	const resolve = mock(async (e: typeof event) => {
+		observedUrl = e.url;
+		return new Response('ok');
+	});
+
+	await proxyHandle({ event, resolve } as unknown as Parameters<typeof proxyHandle>[0]);
+	return { rewrittenUrl: observedUrl };
+}
+
+describe('proxyHandle', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		// The env mock from tests/setup.ts is a shared mutable object; clean any
+		// per-test mutations between runs.
+		delete (env as Record<string, string | undefined>).TRUST_PROXY;
+		_resetProxyStartupLogged();
+	});
+
+	afterEach(() => {
+		delete (env as Record<string, string | undefined>).TRUST_PROXY;
+	});
+
+	describe('TRUST_PROXY=false (default)', () => {
+		it('does NOT rewrite event.url even when malicious x-forwarded-* headers are present', async () => {
+			const { rewrittenUrl } = await invoke({
+				url: 'http://localhost:5173/some/path',
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'evil.example.com'
+				}
+			});
+
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+			expect(rewrittenUrl.protocol).toBe('http:');
+		});
+	});
+
+	describe('TRUST_PROXY=true via DB', () => {
+		beforeEach(async () => {
+			await setAppSetting(AppSettingsKey.TRUST_PROXY, 'true');
+		});
+
+		it('rewrites event.url to the forwarded host and proto', async () => {
+			const { rewrittenUrl } = await invoke({
+				url: 'http://localhost:5173/some/path',
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'real.example.com'
+				}
+			});
+
+			expect(rewrittenUrl.protocol).toBe('https:');
+			expect(rewrittenUrl.host).toBe('real.example.com');
+			expect(rewrittenUrl.pathname).toBe('/some/path');
+		});
+
+		it('leaves event.url unchanged when both forwarded headers are missing', async () => {
+			const { rewrittenUrl } = await invoke({
+				url: 'http://localhost:5173/p'
+			});
+
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+			expect(rewrittenUrl.protocol).toBe('http:');
+		});
+
+		it('leaves event.url unchanged when only one forwarded header is present', async () => {
+			const { rewrittenUrl } = await invoke({
+				url: 'http://localhost:5173/p',
+				headers: { 'x-forwarded-proto': 'https' }
+			});
+
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+		});
+
+		it('takes the rightmost (last-hop) value when the host header is comma-separated', async () => {
+			const { rewrittenUrl } = await invoke({
+				url: 'http://localhost:5173/p',
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'a.evil.example.com, real.example.com'
+				}
+			});
+
+			expect(rewrittenUrl.host).toBe('real.example.com');
+		});
+
+		it('takes the rightmost (last-hop) value when the proto header is comma-separated', async () => {
+			const { rewrittenUrl } = await invoke({
+				url: 'http://localhost:5173/p',
+				headers: {
+					'x-forwarded-proto': 'http, https',
+					'x-forwarded-host': 'real.example.com'
+				}
+			});
+
+			expect(rewrittenUrl.protocol).toBe('https:');
+		});
+
+		it('rejects an invalid forwarded proto and skips the rewrite entirely', async () => {
+			const { rewrittenUrl } = await invoke({
+				url: 'http://localhost:5173/p',
+				headers: {
+					'x-forwarded-proto': 'javascript',
+					'x-forwarded-host': 'real.example.com'
+				}
+			});
+
+			expect(rewrittenUrl.protocol).toBe('http:');
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+		});
+
+		it('rejects a forwarded host containing CR/LF (header-injection defense)', async () => {
+			const { rewrittenUrl } = await invokeWithRawHeaders({
+				url: 'http://localhost:5173/p',
+				headerLookup: (name) => {
+					if (name === 'x-forwarded-proto') return 'https';
+					if (name === 'x-forwarded-host') return 'evil.example.com\r\nSet-Cookie: x=1';
+					return null;
+				}
+			});
+
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+			expect(rewrittenUrl.protocol).toBe('http:');
+		});
+
+		it('rejects a forwarded host containing internal whitespace', async () => {
+			const { rewrittenUrl } = await invokeWithRawHeaders({
+				url: 'http://localhost:5173/p',
+				headerLookup: (name) => {
+					if (name === 'x-forwarded-proto') return 'https';
+					if (name === 'x-forwarded-host') return 'evil .example.com';
+					return null;
+				}
+			});
+
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+		});
+
+		it('rejects an empty / whitespace-only forwarded host', async () => {
+			const { rewrittenUrl } = await invoke({
+				url: 'http://localhost:5173/p',
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': '   '
+				}
+			});
+
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+		});
+	});
+
+	describe('TRUST_PROXY env override', () => {
+		it('honors env=true regardless of DB value', async () => {
+			await setAppSetting(AppSettingsKey.TRUST_PROXY, 'false');
+			(env as Record<string, string | undefined>).TRUST_PROXY = 'true';
+
+			const { rewrittenUrl } = await invoke({
+				url: 'http://localhost:5173/p',
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'real.example.com'
+				}
+			});
+
+			expect(rewrittenUrl.host).toBe('real.example.com');
+			expect(rewrittenUrl.protocol).toBe('https:');
+		});
+
+		it('honors env=false regardless of DB value', async () => {
+			await setAppSetting(AppSettingsKey.TRUST_PROXY, 'true');
+			(env as Record<string, string | undefined>).TRUST_PROXY = 'false';
+
+			const { rewrittenUrl } = await invoke({
+				url: 'http://localhost:5173/p',
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'real.example.com'
+				}
+			});
+
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+		});
+	});
+});

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -154,6 +154,138 @@ describe('Sharing Service', () => {
 				expect(mode).toBe(ShareMode.PRIVATE_OAUTH);
 				expect(allowed).toBe(true);
 			});
+
+			it('nulls tokens on default-source rows when widening from PRIVATE_LINK to PUBLIC', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: true
+				});
+
+				const defaultToken = generateShareToken();
+				const explicitToken = generateShareToken();
+
+				await db.insert(shareSettings).values([
+					{
+						userId: 1,
+						year: 2024,
+						mode: ShareMode.PRIVATE_LINK,
+						modeSource: ShareModeSource.DEFAULT,
+						shareToken: defaultToken,
+						canUserControl: true
+					},
+					{
+						userId: 2,
+						year: 2024,
+						mode: ShareMode.PRIVATE_LINK,
+						modeSource: ShareModeSource.EXPLICIT,
+						shareToken: explicitToken,
+						canUserControl: true
+					}
+				]);
+
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: true
+				});
+
+				const rows = await db.select().from(shareSettings);
+				const defaultRow = rows.find((r) => r.userId === 1);
+				const explicitRow = rows.find((r) => r.userId === 2);
+
+				expect(defaultRow?.shareToken).toBeNull();
+				expect(explicitRow?.shareToken).toBe(explicitToken);
+			});
+
+			it('nulls tokens on default-source rows when widening from PRIVATE_LINK to PRIVATE_OAUTH', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: true
+				});
+
+				const defaultToken = generateShareToken();
+				await db.insert(shareSettings).values({
+					userId: 1,
+					year: 2024,
+					mode: ShareMode.PRIVATE_LINK,
+					modeSource: ShareModeSource.DEFAULT,
+					shareToken: defaultToken,
+					canUserControl: true
+				});
+
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_OAUTH,
+					allowUserControl: true
+				});
+
+				const row = await db.select().from(shareSettings).limit(1);
+				expect(row[0]?.shareToken).toBeNull();
+			});
+
+			it('does not touch tokens when transitioning from PUBLIC to PRIVATE_LINK', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: true
+				});
+
+				const explicitToken = generateShareToken();
+				await db.insert(shareSettings).values({
+					userId: 1,
+					year: 2024,
+					mode: ShareMode.PRIVATE_LINK,
+					modeSource: ShareModeSource.EXPLICIT,
+					shareToken: explicitToken,
+					canUserControl: true
+				});
+
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: true
+				});
+
+				const row = await db.select().from(shareSettings).limit(1);
+				expect(row[0]?.shareToken).toBe(explicitToken);
+			});
+		});
+
+		describe('toShareSettings token stripping', () => {
+			it('returns shareToken: null when effective mode is PUBLIC even if DB row holds a token', async () => {
+				const stashedToken = generateShareToken();
+				// Default-sourced row originally created when global default was PRIVATE_LINK.
+				await db.insert(shareSettings).values({
+					userId: 1,
+					year: 2024,
+					mode: ShareMode.PRIVATE_LINK,
+					modeSource: ShareModeSource.DEFAULT,
+					shareToken: stashedToken,
+					canUserControl: true
+				});
+
+				// Force a PUBLIC global default WITHOUT going through setGlobalShareDefaults
+				// (which would null the token) so we exercise the in-memory strip path.
+				await db.insert(appSettings).values({
+					key: ShareSettingsKey.DEFAULT_SHARE_MODE,
+					value: ShareMode.PUBLIC
+				});
+
+				const settings = await getShareSettings(1, 2024);
+				expect(settings?.mode).toBe(ShareMode.PUBLIC);
+				expect(settings?.shareToken).toBeNull();
+			});
+
+			it('returns shareToken when effective mode is PRIVATE_LINK', async () => {
+				const token = generateShareToken();
+				await db.insert(shareSettings).values({
+					userId: 1,
+					year: 2024,
+					mode: ShareMode.PRIVATE_LINK,
+					modeSource: ShareModeSource.EXPLICIT,
+					shareToken: token,
+					canUserControl: true
+				});
+
+				const settings = await getShareSettings(1, 2024);
+				expect(settings?.shareToken).toBe(token);
+			});
 		});
 	});
 

--- a/tests/unit/sharing/wrapped-identifier-loader.test.ts
+++ b/tests/unit/sharing/wrapped-identifier-loader.test.ts
@@ -66,14 +66,22 @@ async function getStoredToken(userId: number, year: number): Promise<string | nu
 
 type LoadData = Extract<Awaited<ReturnType<typeof load>>, { yearIdentifiers?: unknown }>;
 
+interface TestUser {
+	id: number;
+	plexId: number;
+	username: string;
+	isAdmin: boolean;
+}
+
 async function invokeLoad(params: {
 	year: number;
 	identifier: string;
 	availableYears: number[];
+	currentUser?: TestUser;
 }): Promise<LoadData> {
 	const result = await load({
 		params: { year: String(params.year), identifier: params.identifier },
-		locals: {},
+		locals: params.currentUser ? { user: params.currentUser } : {},
 		parent: async () => ({ availableYears: params.availableYears })
 	} as unknown as LoadArgs);
 	return result as LoadData;
@@ -144,5 +152,174 @@ describe('wrapped/[year]/u/[identifier] loader: cross-year token isolation', () 
 			.from(shareSettings)
 			.where(and(eq(shareSettings.userId, USER_ID), eq(shareSettings.year, OTHER_YEAR)));
 		expect(rows.length).toBe(0);
+	});
+});
+
+/**
+ * Regression tests for the shareToken payload gating fix (security audit Fix #1).
+ *
+ * The wrapped loader must only embed shareSettings.shareToken in the response
+ * when BOTH:
+ *   1. The viewer is the owner or an admin, AND
+ *   2. The effective share mode is private-link.
+ *
+ * Anonymous viewers, authenticated non-owners, and even owners viewing in a
+ * widened mode must receive shareToken: null in the payload.
+ */
+describe('wrapped/[year]/u/[identifier] loader: shareToken payload gating', () => {
+	const USER_ID = 42;
+	const ADMIN_ID = 7;
+	const OTHER_USER_ID = 99;
+	const TOKEN = '770e8400-e29b-41d4-a716-446655440222';
+	const YEAR = 2024;
+
+	beforeEach(async () => {
+		await db.delete(shareSettings);
+		await db.delete(appSettings);
+		await db.delete(users);
+		await db.delete(cachedStats);
+		await db.delete(playHistory);
+		await db.delete(slideConfig);
+
+		await seedUser(USER_ID, 100042, 200042);
+	});
+
+	it('returns shareToken: null for an anonymous viewer accessing via token (private-link)', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		await seedShareSettings({
+			userId: USER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: TOKEN
+		});
+
+		const data = await invokeLoad({
+			year: YEAR,
+			identifier: TOKEN,
+			availableYears: [YEAR]
+		});
+
+		expect(data.shareSettings.shareToken).toBeNull();
+	});
+
+	it('returns shareToken: null for an authenticated non-owner viewer in private-oauth mode', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_OAUTH,
+			allowUserControl: false
+		});
+		// Stash a token in the DB row even though the mode is private-oauth.
+		// toShareSettings should already strip it; this guards against a future
+		// regression that bypasses that helper.
+		await seedShareSettings({
+			userId: USER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_OAUTH,
+			token: TOKEN
+		});
+
+		await seedUser(OTHER_USER_ID, 100099, 200099);
+
+		const data = await invokeLoad({
+			year: YEAR,
+			identifier: String(USER_ID),
+			availableYears: [YEAR],
+			currentUser: {
+				id: OTHER_USER_ID,
+				plexId: 100099,
+				username: `user-${OTHER_USER_ID}`,
+				isAdmin: false
+			}
+		});
+
+		expect(data.shareSettings.shareToken).toBeNull();
+	});
+
+	it('returns the real token for the owner when effectiveMode === private-link', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		await seedShareSettings({
+			userId: USER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: TOKEN
+		});
+
+		const data = await invokeLoad({
+			year: YEAR,
+			identifier: String(USER_ID),
+			availableYears: [YEAR],
+			currentUser: {
+				id: USER_ID,
+				plexId: 100042,
+				username: `user-${USER_ID}`,
+				isAdmin: false
+			}
+		});
+
+		expect(data.shareSettings.shareToken).toBe(TOKEN);
+	});
+
+	it('returns the real token for an admin viewer when effectiveMode === private-link', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		await seedShareSettings({
+			userId: USER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: TOKEN
+		});
+
+		await seedUser(ADMIN_ID, 100007, 200007);
+
+		const data = await invokeLoad({
+			year: YEAR,
+			identifier: String(USER_ID),
+			availableYears: [YEAR],
+			currentUser: {
+				id: ADMIN_ID,
+				plexId: 100007,
+				username: `user-${ADMIN_ID}`,
+				isAdmin: true
+			}
+		});
+
+		expect(data.shareSettings.shareToken).toBe(TOKEN);
+	});
+
+	it('returns null for the owner when the global floor pushes effectiveMode above private-link', async () => {
+		// Stored as private-link/explicit (token preserved through toShareSettings),
+		// but the global floor of private-oauth raises the EFFECTIVE mode above
+		// private-link. The defense-in-depth gate at the loader must still strip.
+		await seedShareSettings({
+			userId: USER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: TOKEN
+		});
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_OAUTH,
+			allowUserControl: false
+		});
+
+		const data = await invokeLoad({
+			year: YEAR,
+			identifier: String(USER_ID),
+			availableYears: [YEAR],
+			currentUser: {
+				id: USER_ID,
+				plexId: 100042,
+				username: `user-${USER_ID}`,
+				isAdmin: false
+			}
+		});
+
+		expect(data.shareSettings.shareToken).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

Closes two MEDIUM-severity findings raised by the full-codebase security audit.

1. **`shareToken` capture-and-replay** — the per-user wrapped `load()` unconditionally returned `shareSettings.shareToken` to every viewer, and `setGlobalShareDefaults` never cleared stored tokens. Combined, a row could be in effective-mode `public` while still carrying a usable `private-link` UUID, enabling a capture-and-replay when an admin later tightened the global default back to `private-link`.
2. **`proxyHandle` unconditionally trusted client `x-forwarded-*`** — no env gate, no last-hop parsing, no validation. Any deployment where the container port was reachable without (or with a misconfigured) reverse proxy let an attacker poison `event.url.protocol` / `event.url.host` for every downstream handler (CSRF origin checks, absolute URL generation, etc.).

## Finding 1 — share-token stripping and rotation

- `src/lib/server/sharing/service.ts`
  - `toShareSettings(record, globalDefault)` now returns `shareToken: null` whenever the **effective** mode is not `private-link`. Single defense-in-depth chokepoint: any caller that forgets to gate still gets `null` when the floor has widened the mode.
  - `setGlobalShareDefaults(defaults)` wraps both `app_settings` upserts in a `db.transaction(...)` (matches the pattern in `auth/session.ts`). After updating, when the new global default is not `private-link`, every row in `share_settings` with `modeSource='default'` has its `shareToken` nulled. This invalidates any previously-captured token. The existing `getShareSettings` regeneration path (`service.ts:146-163`) seamlessly mints a fresh token per user the next time the default is restored to `private-link`.
- `src/routes/wrapped/[year]/u/[identifier]/+page.server.ts`
  - The returned `shareSettings.shareToken` is now `(isOwner || isAdmin) && effectiveMode === ShareMode.PRIVATE_LINK ? token : null`. `effectiveMode` already accounts for the global floor via `getMoreRestrictiveMode` in `access-control.ts`, so this also handles the defense-in-depth case where the owner views their own page after the global default has widened.

The owner-self-viewing path in `dashboard/settings` was audited and intentionally left unchanged: the token must remain visible there to populate the copy-share-URL UI, and the `(isOwner || isAdmin)` guard above closes the exploitable path.

## Finding 2 — TRUST_PROXY gate

- `src/lib/server/admin/settings.service.ts`
  - New `AppSettingsKey.TRUST_PROXY = 'trust_proxy'` and `getTrustProxyConfigWithSource()` returning `{ trustProxy: ConfigValue<string> }`. Mirrors the existing `getCsrfConfigWithSource()` shape (env > db > default `'false'`), so the env-precedence and DB-conflict-clearing logic (`clearConflictingDbSettings`) works without bespoke handling.
- `src/lib/server/security/proxy-handle.ts` (new module, extracted from `hooks.server.ts`)
  - Skips the rewrite entirely when `TRUST_PROXY=false`.
  - When on:
    - Takes the **rightmost** value of comma-separated `x-forwarded-proto` / `x-forwarded-host` (last-hop only).
    - Accepts only `http` / `https` for the proto.
    - Rejects empty, whitespace-only, CR/LF-bearing, or internal-whitespace hosts (header-injection defense).
    - Parses the forwarded host through `new URL(\`${safeProto}://${safeHost}/\`)` and copies `protocol` / `hostname` / `port` separately. Setting `URL.host` directly would have preserved the original `:5173` socket port when the forwarded value omitted one.
  - One-shot `logger.warn` at first invocation when trust is on, indicating which source (env vs db) activated it and reminding operators that the upstream proxy must strip inbound `x-forwarded-*`.
  - Brief code comment notes that `event.getClientAddress()` is resolved by the adapter independently of this handler — operators who need IP trust must configure the adapter separately.
- `src/routes/admin/settings/+page.server.ts`
  - `load()` exposes `trustProxyValue` / `trustProxySource` / `trustProxyLocked`.
  - New `updateTrustProxy` form action validates a boolean, refuses the write when the env-lock is active, persists via `setAppSetting`, and emits `logger.warn` / `logger.info` on transition.
- `src/routes/admin/settings/+page.svelte`
  - New panel in the Security tab: ShieldCheck title + tooltip, connected/disabled status, env-lock badge / source badge, single submit button (`Enable Header Trust` / `Disable Header Trust`) wired through `handleFormToast`.
- `.env.example` documents the new flag with the default and the reverse-proxy precondition.

## Operator migration

`TRUST_PROXY` defaults to **off**. Existing deployments behind a reverse proxy that relies on `X-Forwarded-Proto` / `X-Forwarded-Host` to generate absolute URLs need to either set `TRUST_PROXY=true` in their environment **or** flip the toggle on in **Admin → Settings → Security** after upgrading. The audit found that all current in-tree reads of `event.url` go through `pathname` (unaffected by the rewrite), so the practical break risk in this repo is low — but third-party integrations or future code that reads `event.url.origin` / `host` / `protocol` will see the direct-socket values until the flag is enabled.

The change does not touch `event.getClientAddress()` — IP-based features (rate limiting) continue to behave as before.

## Tests

- `tests/unit/sharing/service.test.ts` — token rotation across all global-default transitions and the `toShareSettings` strip path.
- `tests/unit/sharing/wrapped-identifier-loader.test.ts` — payload-gating regression tests covering anonymous viewer, authenticated non-owner in `private-oauth`, owner / admin in `private-link` (token visible), and owner with a widened global floor (defense-in-depth, token nulled).
- `tests/unit/security/proxy-handle.test.ts` — 12 new tests: default-off skips rewrite, DB-on rewrites correctly, missing / partial headers leave `event.url` unchanged, last-hop parsing on both proto and host, invalid proto rejected, CR/LF rejected (via a custom raw-headers helper because the WHATWG `Headers` API strips them), internal-whitespace host rejected, env-true and env-false override the DB value.

## Verification

- `bun run check` — 0 errors / 0 warnings.
- `bun run test` — **1346 pass / 0 fail**, coverage above the 80% threshold; new `proxy-handle.ts` is at 100% line / 98.18% function.
- `bun run lint` — only pre-existing diagnostics in `src/app.html` and `src/routes/plex/thumb/[...path]/+server.ts`; no files touched by this PR introduce new warnings.

## Test plan

- [ ] As an admin: set the global default to `private-link`, note a user's stored token, switch the default to `public`. Visit `/wrapped/<year>/u/<userId>` in a fresh incognito window and confirm the SvelteKit hydration payload contains `shareToken: null`.
- [ ] In Drizzle Studio (`bun run db:studio`): confirm `share_settings.share_token` is `NULL` for the `modeSource='default'` row affected above.
- [ ] Switch the global default back to `private-link`, reload the user's dashboard, and confirm a freshly generated token appears (and that the previously captured token no longer authorizes a `private-link` URL).
- [ ] Leave `TRUST_PROXY` unset and start `bun run dev`. Send `curl -H 'x-forwarded-host: evil.example.com' -H 'x-forwarded-proto: https' http://localhost:5173/` and confirm `event.url.host` remains `localhost:5173`.
- [ ] In **Admin → Settings → Security**, enable Reverse Proxy Header Trust. Repeat the curl and confirm the rewrite takes effect; the source badge shows `Database` and the lock badge is absent.
- [ ] Set `TRUST_PROXY=false` in env and restart. Confirm the toggle renders as locked off in the UI and the rewrite is disabled regardless of the DB value.