### PR TITLE
fix: harden security audit findings

### DIFF
--- a/drizzle/0005_pin_transactions.sql
+++ b/drizzle/0005_pin_transactions.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `pin_transactions` (
+	`state` text PRIMARY KEY NOT NULL,
+	`pin_id` integer NOT NULL,
+	`expires_at` integer NOT NULL,
+	`callback_verified` integer DEFAULT false NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `idx_pin_transactions_expires_at` ON `pin_transactions` (`expires_at`);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,841 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6d01e99e-c15f-4e44-a5ab-97c5cb418178",
+  "prevId": "1ead892c-77cf-433f-b668-973bccf97336",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cached_stats": {
+      "name": "cached_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stats_type": {
+          "name": "stats_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stats_json": {
+          "name": "stats_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cached_stats_lookup": {
+          "name": "idx_cached_stats_lookup",
+          "columns": [
+            "user_id",
+            "year",
+            "stats_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_slides": {
+      "name": "custom_slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "logs": {
+      "name": "logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_logs_timestamp": {
+          "name": "idx_logs_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "idx_logs_level": {
+          "name": "idx_logs_level",
+          "columns": [
+            "level"
+          ],
+          "isUnique": false
+        },
+        "idx_logs_level_timestamp": {
+          "name": "idx_logs_level_timestamp",
+          "columns": [
+            "level",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metadata_cache": {
+      "name": "metadata_cache",
+      "columns": {
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetch_failed": {
+          "name": "fetch_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "play_history": {
+      "name": "play_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "history_key": {
+          "name": "history_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_section_id": {
+          "name": "library_section_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_title": {
+          "name": "grandparent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_rating_key": {
+          "name": "grandparent_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_thumb": {
+          "name": "grandparent_thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_title": {
+          "name": "parent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "play_history_history_key_unique": {
+          "name": "play_history_history_key_unique",
+          "columns": [
+            "history_key"
+          ],
+          "isUnique": true
+        },
+        "idx_play_history_rating_key": {
+          "name": "idx_play_history_rating_key",
+          "columns": [
+            "rating_key"
+          ],
+          "isUnique": false
+        },
+        "idx_play_history_account_id": {
+          "name": "idx_play_history_account_id",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "idx_play_history_viewed_at": {
+          "name": "idx_play_history_viewed_at",
+          "columns": [
+            "viewed_at"
+          ],
+          "isUnique": false
+        },
+        "idx_play_history_account_viewed": {
+          "name": "idx_play_history_account_viewed",
+          "columns": [
+            "account_id",
+            "viewed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pin_transactions": {
+      "name": "pin_transactions",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pin_id": {
+          "name": "pin_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_verified": {
+          "name": "callback_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_pin_transactions_expires_at": {
+          "name": "idx_pin_transactions_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plex_accounts": {
+      "name": "plex_accounts",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_id": {
+          "name": "plex_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_token": {
+          "name": "plex_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_settings": {
+      "name": "share_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "mode_source": {
+          "name": "mode_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'explicit'"
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "can_user_control": {
+          "name": "can_user_control",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_logo": {
+          "name": "show_logo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "share_settings_share_token_unique": {
+          "name": "share_settings_share_token_unique",
+          "columns": [
+            "share_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_config": {
+      "name": "slide_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slide_type": {
+          "name": "slide_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_status": {
+      "name": "sync_status",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "records_processed": {
+          "name": "records_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "plex_id": {
+          "name": "plex_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_plex_id_unique": {
+          "name": "users_plex_id_unique",
+          "columns": [
+            "plex_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1776268800000,
       "tag": "0004_quiet_mode_source",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1777021121000,
+      "tag": "0005_pin_transactions",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app.html
+++ b/src/app.html
@@ -8,36 +8,36 @@
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		%sveltekit.head%
 		<script nonce="%sveltekit.nonce%">
-			(function () {
+			(() => {
 				try {
-					var validThemes = ['modern-minimal','supabase','doom-64','amber-minimal','soviet-red','obsidian-premium','aurora-premium','champagne-premium'];
-					var cookies = document.cookie || '';
-					var ui = (cookies.match(/(?:^|;\s*)ui_theme=([^;]+)/) || [])[1];
-					var wrapped = (cookies.match(/(?:^|;\s*)wrapped_theme=([^;]+)/) || [])[1];
-					var isWrapped = location.pathname.indexOf('/wrapped') === 0;
-					var raw = (isWrapped ? wrapped : ui) || ui || '';
-					var theme = 'modern-minimal';
-					try { theme = decodeURIComponent(raw) || 'modern-minimal'; } catch (e) {}
+					const validThemes = ['modern-minimal','supabase','doom-64','amber-minimal','soviet-red','obsidian-premium','aurora-premium','champagne-premium'];
+					const cookies = document.cookie || '';
+					const ui = (cookies.match(/(?:^|;\s*)ui_theme=([^;]+)/) || [])[1];
+					const wrapped = (cookies.match(/(?:^|;\s*)wrapped_theme=([^;]+)/) || [])[1];
+					const isWrapped = location.pathname.indexOf('/wrapped') === 0;
+					const raw = (isWrapped ? wrapped : ui) || ui || '';
+					let theme = 'modern-minimal';
+					try { theme = decodeURIComponent(raw) || 'modern-minimal'; } catch {}
 					if (validThemes.indexOf(theme) === -1) theme = 'modern-minimal';
 					document.documentElement.setAttribute('data-theme', theme);
 					if (isWrapped) {
 						document.documentElement.setAttribute('data-wrapped-route', '1');
 					}
-				} catch (e) {}
+				} catch {}
 			})();
 		</script>
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>
 		<script nonce="%sveltekit.nonce%">
-			(function () {
+			(() => {
 				try {
-					var theme = document.documentElement.getAttribute('data-theme');
-					var isWrapped =
+					const theme = document.documentElement.getAttribute('data-theme');
+					const isWrapped =
 						document.documentElement.getAttribute('data-wrapped-route') === '1';
-					if (theme) document.body.classList.add('theme-' + theme);
+					if (theme) document.body.classList.add(`theme-${theme}`);
 					if (isWrapped) document.body.classList.add('wrapped-route');
-				} catch (e) {}
+				} catch {}
 			})();
 		</script>
 	</body>

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,6 +5,7 @@ import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
 import { clearConflictingDbSettings } from '$lib/server/admin/settings.service';
 import { getOrCreateDevSession, isDevBypassEnabled } from '$lib/server/auth/dev-bypass';
+import { isAdminRouteId } from '$lib/server/auth/guards';
 import {
 	needsRevalidation,
 	revalidateMembership,
@@ -204,7 +205,7 @@ const onboardingHandle: Handle = async ({ event, resolve }) => {
 };
 
 const authorizationHandle: Handle = async ({ event, resolve }) => {
-	if (event.url.pathname.startsWith('/admin')) {
+	if (isAdminRouteId(event.route.id)) {
 		if (!event.locals.user || !event.locals.user.isAdmin) {
 			return redirectResponse(event, '/');
 		}

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -149,7 +149,8 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 
 	void (async () => {
 		try {
-			const { pinId, authUrl } = await fetchPin();
+			const redirectUrl = `${getBrowserWindow().location.origin}/auth/plex/redirect?flow=popup`;
+			const { pinId, authUrl } = await fetchPin(redirectUrl);
 			if (cancelled) return;
 
 			authWindow = getBrowserWindow().open(authUrl, 'plex-auth', 'width=600,height=700');

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -89,6 +89,29 @@ export async function setAppSetting(key: AppSettingsKeyType, value: string): Pro
 	});
 }
 
+export async function getOrCreateAppSetting(
+	key: AppSettingsKeyType,
+	createValue: () => string
+): Promise<string> {
+	const existing = await getAppSetting(key);
+	if (existing !== null && existing !== '') {
+		return existing;
+	}
+
+	const generated = createValue();
+	await db
+		.insert(appSettings)
+		.values({ key, value: generated })
+		.onConflictDoUpdate({
+			target: appSettings.key,
+			set: { value: generated },
+			setWhere: eq(appSettings.value, '')
+		});
+
+	const persisted = await getAppSetting(key);
+	return persisted === null || persisted === '' ? generated : persisted;
+}
+
 export async function deleteAppSetting(key: AppSettingsKeyType): Promise<void> {
 	await db.delete(appSettings).where(eq(appSettings.key, key));
 }

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -30,7 +30,8 @@ export const AppSettingsKey = {
 	CSRF_ORIGIN: 'csrf_origin',
 	CSRF_ORIGIN_SKIPPED: 'csrf_origin_skipped',
 	CSRF_WARNING_DISMISSED: 'csrf_warning_dismissed',
-	TRUST_PROXY: 'trust_proxy'
+	TRUST_PROXY: 'trust_proxy',
+	THUMBNAIL_SIGNING_SECRET: 'thumbnail_signing_secret'
 } as const;
 
 export type AppSettingsKeyType = (typeof AppSettingsKey)[keyof typeof AppSettingsKey];

--- a/src/lib/server/auth/guards.ts
+++ b/src/lib/server/auth/guards.ts
@@ -1,0 +1,46 @@
+import { error, fail } from '@sveltejs/kit';
+
+const ADMIN_REQUIRED_MESSAGE = 'Admin access required';
+
+type AdminActionEvent = { locals: App.Locals } & Record<string, unknown>;
+
+export function isAdminRouteId(routeId: string | null | undefined): boolean {
+	return routeId === '/admin' || routeId?.startsWith('/admin/') === true;
+}
+
+export function requireAdmin(locals: App.Locals): NonNullable<App.Locals['user']> {
+	if (!locals.user?.isAdmin) {
+		error(403, ADMIN_REQUIRED_MESSAGE);
+	}
+
+	return locals.user;
+}
+
+export function requireAdminAction(locals: App.Locals) {
+	if (!locals.user?.isAdmin) {
+		return fail(403, { error: ADMIN_REQUIRED_MESSAGE });
+	}
+
+	return null;
+}
+
+export function requireAdminActions<T extends Record<string, unknown>>(actions: T): T {
+	const wrapped: Record<string, unknown> = {};
+
+	for (const key of Object.keys(actions)) {
+		const action = actions[key];
+		if (typeof action !== 'function') {
+			wrapped[key] = action;
+			continue;
+		}
+
+		wrapped[key] = async (event: AdminActionEvent) => {
+			const denied = requireAdminAction(event.locals);
+			if (denied) return denied;
+
+			return (action as (event: AdminActionEvent) => unknown | Promise<unknown>)(event);
+		};
+	}
+
+	return wrapped as T;
+}

--- a/src/lib/server/auth/login-completion.ts
+++ b/src/lib/server/auth/login-completion.ts
@@ -5,9 +5,10 @@ import { db } from '$lib/server/db/client';
 import { users } from '$lib/server/db/schema';
 import { requiresOnboarding } from '$lib/server/onboarding';
 import { requireServerMembership, verifyServerOwnership } from './membership';
+import { clearPinTransaction, getPinTransactionForRequest } from './pin-transactions';
 import { checkPinStatus, getPlexUserInfo } from './plex-oauth';
 import { createSession } from './session';
-import { NotServerMemberError, SESSION_DURATION_MS } from './types';
+import { NotServerMemberError, PinExpiredError, SESSION_DURATION_MS } from './types';
 
 const COOKIE_OPTIONS = {
 	path: '/',
@@ -122,11 +123,22 @@ export async function completePlexPinLogin(
 	pinId: number,
 	cookies: Cookies
 ): Promise<PinLoginResult> {
+	const transaction = getPinTransactionForRequest(pinId, cookies);
+	if (!transaction) {
+		throw new PinExpiredError('Login session expired or invalid. Please try again.');
+	}
+
+	if (!transaction.callbackVerified) {
+		return { pending: true };
+	}
+
 	const pinStatus = await checkPinStatus(pinId);
 
 	if (!pinStatus.authToken) {
 		return { pending: true };
 	}
 
-	return createSessionFromPlexToken(pinStatus.authToken, cookies);
+	const completed = await createSessionFromPlexToken(pinStatus.authToken, cookies);
+	clearPinTransaction(cookies, transaction.state);
+	return completed;
 }

--- a/src/lib/server/auth/login-completion.ts
+++ b/src/lib/server/auth/login-completion.ts
@@ -139,6 +139,10 @@ export async function completePlexPinLogin(
 	}
 
 	const completed = await createSessionFromPlexToken(pinStatus.authToken, cookies);
-	await clearPinTransaction(cookies, transaction.state);
+	try {
+		await clearPinTransaction(cookies, transaction.state);
+	} catch (err) {
+		console.error('Failed to clear Plex PIN transaction after successful login:', err);
+	}
 	return completed;
 }

--- a/src/lib/server/auth/login-completion.ts
+++ b/src/lib/server/auth/login-completion.ts
@@ -123,7 +123,7 @@ export async function completePlexPinLogin(
 	pinId: number,
 	cookies: Cookies
 ): Promise<PinLoginResult> {
-	const transaction = getPinTransactionForRequest(pinId, cookies);
+	const transaction = await getPinTransactionForRequest(pinId, cookies);
 	if (!transaction) {
 		throw new PinExpiredError('Login session expired or invalid. Please try again.');
 	}
@@ -139,6 +139,6 @@ export async function completePlexPinLogin(
 	}
 
 	const completed = await createSessionFromPlexToken(pinStatus.authToken, cookies);
-	clearPinTransaction(cookies, transaction.state);
+	await clearPinTransaction(cookies, transaction.state);
 	return completed;
 }

--- a/src/lib/server/auth/pin-transactions.ts
+++ b/src/lib/server/auth/pin-transactions.ts
@@ -114,8 +114,11 @@ export async function getPinTransactionForRequest(
 }
 
 export async function clearPinTransaction(cookies: Cookies, state: string): Promise<void> {
-	await db.delete(pinTransactions).where(eq(pinTransactions.state, state));
-	cookies.delete(PIN_STATE_COOKIE, COOKIE_DELETE_OPTIONS);
+	try {
+		await db.delete(pinTransactions).where(eq(pinTransactions.state, state));
+	} finally {
+		cookies.delete(PIN_STATE_COOKIE, COOKIE_DELETE_OPTIONS);
+	}
 }
 
 export async function _resetPinTransactionsForTests(): Promise<void> {

--- a/src/lib/server/auth/pin-transactions.ts
+++ b/src/lib/server/auth/pin-transactions.ts
@@ -24,7 +24,10 @@ const COOKIE_OPTIONS = {
 };
 
 const COOKIE_DELETE_OPTIONS = {
-	path: '/'
+	path: COOKIE_OPTIONS.path,
+	httpOnly: COOKIE_OPTIONS.httpOnly,
+	secure: COOKIE_OPTIONS.secure,
+	sameSite: COOKIE_OPTIONS.sameSite
 };
 
 function generateState(): string {

--- a/src/lib/server/auth/pin-transactions.ts
+++ b/src/lib/server/auth/pin-transactions.ts
@@ -1,0 +1,115 @@
+import { Buffer } from 'node:buffer';
+import type { Cookies } from '@sveltejs/kit';
+
+const PIN_STATE_COOKIE = 'plex_login_state';
+const PIN_TRANSACTION_TTL_MS = 15 * 60 * 1000;
+
+interface PinTransaction {
+	pinId: number;
+	state: string;
+	expiresAt: number;
+	callbackVerified: boolean;
+}
+
+const transactions = new Map<string, PinTransaction>();
+
+const COOKIE_OPTIONS = {
+	path: '/',
+	httpOnly: true,
+	secure: process.env.NODE_ENV === 'production',
+	sameSite: 'lax' as const,
+	maxAge: Math.floor(PIN_TRANSACTION_TTL_MS / 1000)
+};
+
+const COOKIE_DELETE_OPTIONS = {
+	path: '/'
+};
+
+function generateState(): string {
+	const bytes = new Uint8Array(32);
+	crypto.getRandomValues(bytes);
+	return Buffer.from(bytes).toString('base64url');
+}
+
+function pruneExpired(now = Date.now()): void {
+	for (const [state, transaction] of transactions) {
+		if (transaction.expiresAt <= now) {
+			transactions.delete(state);
+		}
+	}
+}
+
+export function createPinTransaction(pinId: number, cookies: Cookies): string {
+	pruneExpired();
+
+	const state = generateState();
+	transactions.set(state, {
+		pinId,
+		state,
+		expiresAt: Date.now() + PIN_TRANSACTION_TTL_MS,
+		callbackVerified: false
+	});
+	cookies.set(PIN_STATE_COOKIE, state, COOKIE_OPTIONS);
+
+	return state;
+}
+
+export function appendPinStateToForwardUrl(
+	forwardUrl: string,
+	requestUrl: URL,
+	state: string
+): string {
+	const parsed = new URL(forwardUrl, requestUrl.origin);
+
+	if (parsed.origin !== requestUrl.origin) {
+		throw new Error('Plex redirect URL must use the Obzorarr origin');
+	}
+
+	parsed.searchParams.set('state', state);
+	return parsed.toString();
+}
+
+export function markPinCallbackVerified(cookies: Cookies, state: string | null): boolean {
+	pruneExpired();
+
+	const cookieState = cookies.get(PIN_STATE_COOKIE);
+	if (!state || !cookieState || state !== cookieState) {
+		return false;
+	}
+
+	const transaction = transactions.get(state);
+	if (!transaction) {
+		return false;
+	}
+
+	transaction.callbackVerified = true;
+	return true;
+}
+
+export function getPinTransactionForRequest(
+	pinId: number,
+	cookies: Cookies
+): PinTransaction | null {
+	pruneExpired();
+
+	const state = cookies.get(PIN_STATE_COOKIE);
+	if (!state) {
+		return null;
+	}
+
+	const transaction = transactions.get(state);
+	if (!transaction || transaction.pinId !== pinId) {
+		return null;
+	}
+
+	return transaction;
+}
+
+export function clearPinTransaction(cookies: Cookies, state: string): void {
+	transactions.delete(state);
+	cookies.delete(PIN_STATE_COOKIE, COOKIE_DELETE_OPTIONS);
+}
+
+export function _resetPinTransactionsForTests(): void {
+	transactions.clear();
+}

--- a/src/lib/server/auth/pin-transactions.ts
+++ b/src/lib/server/auth/pin-transactions.ts
@@ -1,5 +1,8 @@
 import { Buffer } from 'node:buffer';
 import type { Cookies } from '@sveltejs/kit';
+import { eq, lte } from 'drizzle-orm';
+import { db } from '$lib/server/db/client';
+import { pinTransactions } from '$lib/server/db/schema';
 
 const PIN_STATE_COOKIE = 'plex_login_state';
 const PIN_TRANSACTION_TTL_MS = 15 * 60 * 1000;
@@ -7,11 +10,9 @@ const PIN_TRANSACTION_TTL_MS = 15 * 60 * 1000;
 interface PinTransaction {
 	pinId: number;
 	state: string;
-	expiresAt: number;
+	expiresAt: Date;
 	callbackVerified: boolean;
 }
-
-const transactions = new Map<string, PinTransaction>();
 
 const COOKIE_OPTIONS = {
 	path: '/',
@@ -31,22 +32,18 @@ function generateState(): string {
 	return Buffer.from(bytes).toString('base64url');
 }
 
-function pruneExpired(now = Date.now()): void {
-	for (const [state, transaction] of transactions) {
-		if (transaction.expiresAt <= now) {
-			transactions.delete(state);
-		}
-	}
+async function pruneExpired(now = Date.now()): Promise<void> {
+	await db.delete(pinTransactions).where(lte(pinTransactions.expiresAt, new Date(now)));
 }
 
-export function createPinTransaction(pinId: number, cookies: Cookies): string {
-	pruneExpired();
+export async function createPinTransaction(pinId: number, cookies: Cookies): Promise<string> {
+	await pruneExpired();
 
 	const state = generateState();
-	transactions.set(state, {
+	await db.insert(pinTransactions).values({
 		pinId,
 		state,
-		expiresAt: Date.now() + PIN_TRANSACTION_TTL_MS,
+		expiresAt: new Date(Date.now() + PIN_TRANSACTION_TTL_MS),
 		callbackVerified: false
 	});
 	cookies.set(PIN_STATE_COOKIE, state, COOKIE_OPTIONS);
@@ -54,50 +51,61 @@ export function createPinTransaction(pinId: number, cookies: Cookies): string {
 	return state;
 }
 
-export function appendPinStateToForwardUrl(
-	forwardUrl: string,
-	requestUrl: URL,
-	state: string
-): string {
+export function parsePinForwardUrl(forwardUrl: string, requestUrl: URL): URL {
 	const parsed = new URL(forwardUrl, requestUrl.origin);
 
 	if (parsed.origin !== requestUrl.origin) {
 		throw new Error('Plex redirect URL must use the Obzorarr origin');
 	}
 
+	return parsed;
+}
+
+export function appendPinStateToForwardUrl(
+	forwardUrl: string,
+	requestUrl: URL,
+	state: string
+): string {
+	const parsed = parsePinForwardUrl(forwardUrl, requestUrl);
+
 	parsed.searchParams.set('state', state);
 	return parsed.toString();
 }
 
-export function markPinCallbackVerified(cookies: Cookies, state: string | null): boolean {
-	pruneExpired();
+export async function markPinCallbackVerified(
+	cookies: Cookies,
+	state: string | null
+): Promise<boolean> {
+	await pruneExpired();
 
 	const cookieState = cookies.get(PIN_STATE_COOKIE);
 	if (!state || !cookieState || state !== cookieState) {
 		return false;
 	}
 
-	const transaction = transactions.get(state);
-	if (!transaction) {
-		return false;
-	}
+	const updated = await db
+		.update(pinTransactions)
+		.set({ callbackVerified: true })
+		.where(eq(pinTransactions.state, state))
+		.returning({ state: pinTransactions.state });
 
-	transaction.callbackVerified = true;
-	return true;
+	return updated.length > 0;
 }
 
-export function getPinTransactionForRequest(
+export async function getPinTransactionForRequest(
 	pinId: number,
 	cookies: Cookies
-): PinTransaction | null {
-	pruneExpired();
+): Promise<PinTransaction | null> {
+	await pruneExpired();
 
 	const state = cookies.get(PIN_STATE_COOKIE);
 	if (!state) {
 		return null;
 	}
 
-	const transaction = transactions.get(state);
+	const transaction = await db.query.pinTransactions.findFirst({
+		where: eq(pinTransactions.state, state)
+	});
 	if (!transaction || transaction.pinId !== pinId) {
 		return null;
 	}
@@ -105,11 +113,11 @@ export function getPinTransactionForRequest(
 	return transaction;
 }
 
-export function clearPinTransaction(cookies: Cookies, state: string): void {
-	transactions.delete(state);
+export async function clearPinTransaction(cookies: Cookies, state: string): Promise<void> {
+	await db.delete(pinTransactions).where(eq(pinTransactions.state, state));
 	cookies.delete(PIN_STATE_COOKIE, COOKIE_DELETE_OPTIONS);
 }
 
-export function _resetPinTransactionsForTests(): void {
-	transactions.clear();
+export async function _resetPinTransactionsForTests(): Promise<void> {
+	await db.delete(pinTransactions);
 }

--- a/src/lib/server/auth/pin-transactions.ts
+++ b/src/lib/server/auth/pin-transactions.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'node:buffer';
 import type { Cookies } from '@sveltejs/kit';
 import { eq, lte } from 'drizzle-orm';
+import { dev } from '$app/environment';
 import { db } from '$lib/server/db/client';
 import { pinTransactions } from '$lib/server/db/schema';
 
@@ -17,7 +18,7 @@ interface PinTransaction {
 const COOKIE_OPTIONS = {
 	path: '/',
 	httpOnly: true,
-	secure: process.env.NODE_ENV === 'production',
+	secure: !dev,
 	sameSite: 'lax' as const,
 	maxAge: Math.floor(PIN_TRANSACTION_TTL_MS / 1000)
 };

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -104,6 +104,17 @@ export const sessions = sqliteTable('sessions', {
 	expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull()
 });
 
+export const pinTransactions = sqliteTable(
+	'pin_transactions',
+	{
+		state: text('state').primaryKey(),
+		pinId: integer('pin_id').notNull(),
+		expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
+		callbackVerified: integer('callback_verified', { mode: 'boolean' }).notNull().default(false)
+	},
+	(table) => [index('idx_pin_transactions_expires_at').on(table.expiresAt)]
+);
+
 export const logs = sqliteTable(
 	'logs',
 	{
@@ -151,6 +162,8 @@ export type CustomSlideRecord = typeof customSlides.$inferSelect;
 export type SlideConfigRecord = typeof slideConfig.$inferSelect;
 export type AppSettingRecord = typeof appSettings.$inferSelect;
 export type SessionRecord = typeof sessions.$inferSelect;
+export type PinTransactionRecord = typeof pinTransactions.$inferSelect;
+export type NewPinTransactionRecord = typeof pinTransactions.$inferInsert;
 export type LogRecord = typeof logs.$inferSelect;
 export type NewLogRecord = typeof logs.$inferInsert;
 export type MetadataCacheRecord = typeof metadataCache.$inferSelect;

--- a/src/lib/server/plex/thumbnail-auth.ts
+++ b/src/lib/server/plex/thumbnail-auth.ts
@@ -218,7 +218,7 @@ export async function authorizeThumbnailPayload(
 			return;
 		}
 
-		if (!payload.userId) {
+		if (payload.userId === undefined) {
 			error(403, { message: 'Invalid thumbnail token' });
 		}
 

--- a/src/lib/server/plex/thumbnail-auth.ts
+++ b/src/lib/server/plex/thumbnail-auth.ts
@@ -127,6 +127,10 @@ export async function verifyThumbnailToken(
 	return parsed;
 }
 
+function isPayloadInteger(value: unknown): value is number {
+	return typeof value === 'number' && Number.isInteger(value);
+}
+
 function isThumbnailTokenPayload(value: unknown): value is ThumbnailTokenPayload {
 	if (typeof value !== 'object' || value === null) return false;
 	const payload = value as Record<string, unknown>;
@@ -134,10 +138,10 @@ function isThumbnailTokenPayload(value: unknown): value is ThumbnailTokenPayload
 		payload.v === TOKEN_VERSION &&
 		typeof payload.path === 'string' &&
 		ALLOWED_THUMB_PATH.test(payload.path) &&
-		typeof payload.exp === 'number' &&
+		isPayloadInteger(payload.exp) &&
 		(payload.kind === 'server' || payload.kind === 'user') &&
-		typeof payload.year === 'number' &&
-		(payload.kind === 'server' || typeof payload.userId === 'number') &&
+		isPayloadInteger(payload.year) &&
+		(payload.kind === 'server' || isPayloadInteger(payload.userId)) &&
 		(payload.shareTokenHash === undefined || typeof payload.shareTokenHash === 'string')
 	);
 }

--- a/src/lib/server/plex/thumbnail-auth.ts
+++ b/src/lib/server/plex/thumbnail-auth.ts
@@ -1,0 +1,252 @@
+import { Buffer } from 'node:buffer';
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { error } from '@sveltejs/kit';
+import { AppSettingsKey, getAppSetting, setAppSetting } from '$lib/server/admin/settings.service';
+import { checkServerWrappedAccess, checkWrappedAccess } from '$lib/server/sharing/access-control';
+import { getGlobalDefaultShareMode, getOrCreateShareSettings } from '$lib/server/sharing/service';
+import {
+	getMoreRestrictiveMode,
+	InvalidShareTokenError,
+	ShareAccessDeniedError,
+	ShareMode
+} from '$lib/server/sharing/types';
+
+const TOKEN_VERSION = 1;
+const TOKEN_TTL_SECONDS = 30 * 60;
+const ALLOWED_THUMB_PATH = /^library\/metadata\/\d+\/thumb\/\d+$/;
+
+type ThumbnailKind = 'server' | 'user';
+
+interface ThumbnailTokenPayload {
+	v: typeof TOKEN_VERSION;
+	path: string;
+	exp: number;
+	kind: ThumbnailKind;
+	year: number;
+	userId?: number;
+	shareTokenHash?: string;
+}
+
+export type ThumbnailSigningContext =
+	| {
+			kind: 'server';
+			year: number;
+	  }
+	| {
+			kind: 'user';
+			year: number;
+			userId: number;
+			shareToken?: string;
+	  };
+
+function base64UrlEncode(value: string | Buffer): string {
+	return Buffer.from(value).toString('base64url');
+}
+
+function base64UrlDecode(value: string): Buffer {
+	return Buffer.from(value, 'base64url');
+}
+
+function hashToken(token: string): string {
+	return createHash('sha256').update(token).digest('base64url');
+}
+
+async function getSigningSecret(): Promise<string> {
+	const existing = await getAppSetting(AppSettingsKey.THUMBNAIL_SIGNING_SECRET);
+	if (existing) {
+		return existing;
+	}
+
+	const generated = randomBytes(32).toString('base64url');
+	await setAppSetting(AppSettingsKey.THUMBNAIL_SIGNING_SECRET, generated);
+	return generated;
+}
+
+function signPayload(encodedPayload: string, secret: string): string {
+	return createHmac('sha256', secret).update(encodedPayload).digest('base64url');
+}
+
+export function normalizePlexThumbPath(thumb: string): string | null {
+	let path = thumb;
+
+	if (path.startsWith('/plex/thumb/')) {
+		path = path.slice('/plex/thumb/'.length);
+	} else if (path.startsWith('/')) {
+		path = path.slice(1);
+	} else {
+		return null;
+	}
+
+	const queryStart = path.indexOf('?');
+	if (queryStart >= 0) {
+		path = path.slice(0, queryStart);
+	}
+
+	return ALLOWED_THUMB_PATH.test(path) ? path : null;
+}
+
+async function createThumbnailToken(payload: ThumbnailTokenPayload): Promise<string> {
+	const secret = await getSigningSecret();
+	const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+	const signature = signPayload(encodedPayload, secret);
+	return `${encodedPayload}.${signature}`;
+}
+
+export async function verifyThumbnailToken(
+	token: string | null
+): Promise<ThumbnailTokenPayload | null> {
+	if (!token) return null;
+
+	const [encodedPayload, signature] = token.split('.');
+	if (!encodedPayload || !signature) return null;
+
+	const secret = await getSigningSecret();
+	const expected = signPayload(encodedPayload, secret);
+	const actualBuffer = Buffer.from(signature);
+	const expectedBuffer = Buffer.from(expected);
+	if (
+		actualBuffer.length !== expectedBuffer.length ||
+		!timingSafeEqual(actualBuffer, expectedBuffer)
+	) {
+		return null;
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(base64UrlDecode(encodedPayload).toString('utf8'));
+	} catch {
+		return null;
+	}
+
+	if (!isThumbnailTokenPayload(parsed)) {
+		return null;
+	}
+
+	if (parsed.exp <= Math.floor(Date.now() / 1000)) {
+		return null;
+	}
+
+	return parsed;
+}
+
+function isThumbnailTokenPayload(value: unknown): value is ThumbnailTokenPayload {
+	if (typeof value !== 'object' || value === null) return false;
+	const payload = value as Record<string, unknown>;
+	return (
+		payload.v === TOKEN_VERSION &&
+		typeof payload.path === 'string' &&
+		ALLOWED_THUMB_PATH.test(payload.path) &&
+		typeof payload.exp === 'number' &&
+		(payload.kind === 'server' || payload.kind === 'user') &&
+		typeof payload.year === 'number' &&
+		(payload.kind === 'server' || typeof payload.userId === 'number') &&
+		(payload.shareTokenHash === undefined || typeof payload.shareTokenHash === 'string')
+	);
+}
+
+export async function createSignedThumbnailUrl(
+	thumb: string | null | undefined,
+	context: ThumbnailSigningContext
+): Promise<string | null> {
+	if (!thumb) return null;
+
+	const path = normalizePlexThumbPath(thumb);
+	if (!path) {
+		return thumb;
+	}
+
+	const payload: ThumbnailTokenPayload = {
+		v: TOKEN_VERSION,
+		path,
+		exp: Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS,
+		kind: context.kind,
+		year: context.year
+	};
+
+	if (context.kind === 'user') {
+		payload.userId = context.userId;
+		if (context.shareToken) {
+			payload.shareTokenHash = hashToken(context.shareToken);
+		}
+	}
+
+	const token = await createThumbnailToken(payload);
+	return `/plex/thumb/${path}?token=${encodeURIComponent(token)}`;
+}
+
+export async function signStatsThumbnails<T>(
+	stats: T,
+	context: ThumbnailSigningContext
+): Promise<T> {
+	const clone = structuredClone(stats);
+	await rewriteThumbs(clone, context);
+	return clone;
+}
+
+async function rewriteThumbs(value: unknown, context: ThumbnailSigningContext): Promise<void> {
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			await rewriteThumbs(item, context);
+		}
+		return;
+	}
+
+	if (typeof value !== 'object' || value === null) {
+		return;
+	}
+
+	const record = value as Record<string, unknown>;
+	for (const [key, nested] of Object.entries(record)) {
+		if (key === 'thumb' && (typeof nested === 'string' || nested === null)) {
+			record[key] = await createSignedThumbnailUrl(nested, context);
+			continue;
+		}
+
+		await rewriteThumbs(nested, context);
+	}
+}
+
+export async function authorizeThumbnailPayload(
+	payload: ThumbnailTokenPayload,
+	locals: App.Locals
+): Promise<void> {
+	try {
+		if (payload.kind === 'server') {
+			await checkServerWrappedAccess({ year: payload.year, currentUser: locals.user });
+			return;
+		}
+
+		if (!payload.userId) {
+			error(403, { message: 'Invalid thumbnail token' });
+		}
+
+		if (payload.shareTokenHash) {
+			const settings = await getOrCreateShareSettings({
+				userId: payload.userId,
+				year: payload.year
+			});
+			const globalFloor = await getGlobalDefaultShareMode();
+			const effectiveMode = getMoreRestrictiveMode(settings.mode, globalFloor);
+
+			if (
+				effectiveMode !== ShareMode.PRIVATE_LINK ||
+				!settings.shareToken ||
+				hashToken(settings.shareToken) !== payload.shareTokenHash
+			) {
+				error(403, { message: 'Thumbnail access denied' });
+			}
+			return;
+		}
+
+		await checkWrappedAccess({
+			userId: payload.userId,
+			year: payload.year,
+			currentUser: locals.user
+		});
+	} catch (err) {
+		if (err instanceof ShareAccessDeniedError || err instanceof InvalidShareTokenError) {
+			error(403, { message: 'Thumbnail access denied' });
+		}
+		throw err;
+	}
+}

--- a/src/lib/server/plex/thumbnail-auth.ts
+++ b/src/lib/server/plex/thumbnail-auth.ts
@@ -92,7 +92,10 @@ export async function verifyThumbnailToken(
 ): Promise<ThumbnailTokenPayload | null> {
 	if (!token) return null;
 
-	const [encodedPayload, signature] = token.split('.');
+	const tokenParts = token.split('.');
+	if (tokenParts.length !== 2) return null;
+
+	const [encodedPayload, signature] = tokenParts;
 	if (!encodedPayload || !signature) return null;
 
 	const secret = await getSigningSecret();

--- a/src/lib/server/plex/thumbnail-auth.ts
+++ b/src/lib/server/plex/thumbnail-auth.ts
@@ -3,7 +3,7 @@ import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypt
 import { error } from '@sveltejs/kit';
 import { AppSettingsKey, getOrCreateAppSetting } from '$lib/server/admin/settings.service';
 import { checkServerWrappedAccess, checkWrappedAccess } from '$lib/server/sharing/access-control';
-import { getGlobalDefaultShareMode, getOrCreateShareSettings } from '$lib/server/sharing/service';
+import { getGlobalDefaultShareMode, getShareSettingsReadOnly } from '$lib/server/sharing/service';
 import {
 	getMoreRestrictiveMode,
 	InvalidShareTokenError,
@@ -223,16 +223,15 @@ export async function authorizeThumbnailPayload(
 		}
 
 		if (payload.shareTokenHash) {
-			const settings = await getOrCreateShareSettings({
-				userId: payload.userId,
-				year: payload.year
-			});
+			const settings = await getShareSettingsReadOnly(payload.userId, payload.year);
 			const globalFloor = await getGlobalDefaultShareMode();
-			const effectiveMode = getMoreRestrictiveMode(settings.mode, globalFloor);
+			const effectiveMode = settings
+				? getMoreRestrictiveMode(settings.mode, globalFloor)
+				: globalFloor;
 
 			if (
 				effectiveMode !== ShareMode.PRIVATE_LINK ||
-				!settings.shareToken ||
+				!settings?.shareToken ||
 				hashToken(settings.shareToken) !== payload.shareTokenHash
 			) {
 				error(403, { message: 'Thumbnail access denied' });

--- a/src/lib/server/plex/thumbnail-auth.ts
+++ b/src/lib/server/plex/thumbnail-auth.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'node:buffer';
 import { createHash, createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 import { error } from '@sveltejs/kit';
-import { AppSettingsKey, getAppSetting, setAppSetting } from '$lib/server/admin/settings.service';
+import { AppSettingsKey, getOrCreateAppSetting } from '$lib/server/admin/settings.service';
 import { checkServerWrappedAccess, checkWrappedAccess } from '$lib/server/sharing/access-control';
 import { getGlobalDefaultShareMode, getOrCreateShareSettings } from '$lib/server/sharing/service';
 import {
@@ -52,14 +52,9 @@ function hashToken(token: string): string {
 }
 
 async function getSigningSecret(): Promise<string> {
-	const existing = await getAppSetting(AppSettingsKey.THUMBNAIL_SIGNING_SECRET);
-	if (existing) {
-		return existing;
-	}
-
-	const generated = randomBytes(32).toString('base64url');
-	await setAppSetting(AppSettingsKey.THUMBNAIL_SIGNING_SECRET, generated);
-	return generated;
+	return getOrCreateAppSetting(AppSettingsKey.THUMBNAIL_SIGNING_SECRET, () =>
+		randomBytes(32).toString('base64url')
+	);
 }
 
 function signPayload(encodedPayload: string, secret: string): string {

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -227,7 +227,8 @@ export async function getShareSettingsReadOnly(
 }
 
 function toShareSettings(record: ShareSettingsRecord, globalDefault: ShareModeType): ShareSettings {
-	const storedMode = record.mode as ShareModeType;
+	const parsedMode = ShareModeSchema.safeParse(record.mode);
+	const storedMode = parsedMode.success ? parsedMode.data : globalDefault;
 	const modeSource = normalizeShareModeSource(record.modeSource);
 	const mode = modeSource === ShareModeSource.DEFAULT ? globalDefault : storedMode;
 

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -208,6 +208,24 @@ export async function getShareSettings(
 	return { ...settings, shareToken: refreshed[0]?.shareToken ?? generatedToken };
 }
 
+export async function getShareSettingsReadOnly(
+	userId: number,
+	year: number
+): Promise<ShareSettings | null> {
+	const result = await db
+		.select()
+		.from(shareSettings)
+		.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)))
+		.limit(1);
+
+	const record = result[0];
+	if (!record) {
+		return null;
+	}
+
+	return toShareSettings(record, await getGlobalDefaultShareMode());
+}
+
 function toShareSettings(record: ShareSettingsRecord, globalDefault: ShareModeType): ShareSettings {
 	const storedMode = record.mode as ShareModeType;
 	const modeSource = normalizeShareModeSource(record.modeSource);

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -4,6 +4,7 @@ import { appSettings, shareSettings } from '$lib/server/db/schema';
 import {
 	type GetOrCreateShareSettingsOptions,
 	type GlobalShareDefaults,
+	getMoreRestrictiveMode,
 	meetsPrivacyFloor,
 	PermissionExceededError,
 	ShareError,
@@ -58,6 +59,29 @@ export async function getGlobalAllowUserControl(): Promise<boolean> {
 	}
 
 	return setting.value === 'true';
+}
+
+export async function getEffectiveShareMode(userId: number, year: number): Promise<ShareModeType> {
+	const globalDefault = await getGlobalDefaultShareMode();
+	const result = await db
+		.select({
+			mode: shareSettings.mode,
+			modeSource: shareSettings.modeSource
+		})
+		.from(shareSettings)
+		.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)))
+		.limit(1);
+
+	const record = result[0];
+	if (!record) {
+		return globalDefault;
+	}
+
+	const parsed = ShareModeSchema.safeParse(record.mode);
+	const storedMode = parsed.success ? parsed.data : globalDefault;
+	const source = (record.modeSource ?? ShareModeSource.EXPLICIT) as ShareModeSourceType;
+	const rowMode = source === ShareModeSource.DEFAULT ? globalDefault : storedMode;
+	return getMoreRestrictiveMode(rowMode, globalDefault);
 }
 
 export async function setGlobalShareDefaults(defaults: GlobalShareDefaults): Promise<void> {

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -11,6 +11,7 @@ import {
 	ShareMode,
 	ShareModeSchema,
 	ShareModeSource,
+	ShareModeSourceSchema,
 	type ShareModeSourceType,
 	type ShareModeType,
 	type ShareSettings,
@@ -28,6 +29,11 @@ export function generateShareToken(): string {
 export function isValidTokenFormat(token: string): boolean {
 	const uuidV4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 	return uuidV4Regex.test(token);
+}
+
+function normalizeShareModeSource(value: string | null): ShareModeSourceType {
+	const parsed = ShareModeSourceSchema.safeParse(value ?? ShareModeSource.EXPLICIT);
+	return parsed.success ? parsed.data : ShareModeSource.EXPLICIT;
 }
 
 export async function getGlobalDefaultShareMode(): Promise<ShareModeType> {
@@ -79,7 +85,7 @@ export async function getEffectiveShareMode(userId: number, year: number): Promi
 
 	const parsed = ShareModeSchema.safeParse(record.mode);
 	const storedMode = parsed.success ? parsed.data : globalDefault;
-	const source = (record.modeSource ?? ShareModeSource.EXPLICIT) as ShareModeSourceType;
+	const source = normalizeShareModeSource(record.modeSource);
 	const rowMode = source === ShareModeSource.DEFAULT ? globalDefault : storedMode;
 	return getMoreRestrictiveMode(rowMode, globalDefault);
 }
@@ -204,7 +210,7 @@ export async function getShareSettings(
 
 function toShareSettings(record: ShareSettingsRecord, globalDefault: ShareModeType): ShareSettings {
 	const storedMode = record.mode as ShareModeType;
-	const modeSource = (record.modeSource ?? ShareModeSource.EXPLICIT) as ShareModeSourceType;
+	const modeSource = normalizeShareModeSource(record.modeSource);
 	const mode = modeSource === ShareModeSource.DEFAULT ? globalDefault : storedMode;
 
 	// Defense-in-depth: never expose a stored token unless the effective mode is

--- a/src/lib/server/sync/plex-accounts.service.ts
+++ b/src/lib/server/sync/plex-accounts.service.ts
@@ -338,7 +338,11 @@ export interface UserLookupResult {
 	accountId: number;
 }
 
-export async function findUserByUsername(username: string): Promise<UserLookupResult | null> {
+export async function findUserByUsername(
+	username: string,
+	options: { createIfMissing?: boolean } = {}
+): Promise<UserLookupResult | null> {
+	const { createIfMissing = true } = options;
 	const plexAccountResults = await db
 		.select()
 		.from(plexAccounts)
@@ -363,6 +367,10 @@ export async function findUserByUsername(username: string): Promise<UserLookupRe
 			username: user.username,
 			accountId: plexAccount.accountId
 		};
+	}
+
+	if (!createIfMissing) {
+		return null;
 	}
 
 	const insertResult = await db

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,6 +1,8 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 import { checkRateLimit } from '$lib/server/ratelimit';
+import { getEffectiveShareMode } from '$lib/server/sharing/service';
+import { ShareMode } from '$lib/server/sharing/types';
 import { triggerLiveSyncIfNeeded } from '$lib/server/sync/live-sync';
 import { findUserByUsername } from '$lib/server/sync/plex-accounts.service';
 import type { Actions, PageServerLoad } from './$types';
@@ -53,17 +55,22 @@ export const actions: Actions = {
 
 		const { username } = parsed.data;
 
-		const userResult = await findUserByUsername(username);
+		const userResult = await findUserByUsername(username, { createIfMissing: false });
+		const currentYear = new Date().getFullYear();
+		const publicLookupFailure = {
+			error: 'No public Wrapped found for that username.',
+			username,
+			requiresAuth: true
+		};
 
 		if (!userResult) {
-			return fail(404, {
-				error: 'User not found. Make sure you have signed into Obzorarr at least once.',
-				username,
-				requiresAuth: true
-			});
+			return fail(404, publicLookupFailure);
 		}
 
-		const currentYear = new Date().getFullYear();
+		const effectiveMode = await getEffectiveShareMode(userResult.userId, currentYear);
+		if (effectiveMode !== ShareMode.PUBLIC) {
+			return fail(404, publicLookupFailure);
+		}
 
 		triggerLiveSyncIfNeeded('landing-page-lookup').catch(() => {});
 

--- a/src/routes/admin/logs/+page.server.ts
+++ b/src/routes/admin/logs/+page.server.ts
@@ -1,5 +1,6 @@
 import { fail } from '@sveltejs/kit';
 import { z } from 'zod';
+import { requireAdminActions } from '$lib/server/auth/guards';
 import {
 	deleteAllLogs,
 	getDistinctSources,
@@ -122,7 +123,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	};
 };
 
-export const actions: Actions = {
+export const actions: Actions = requireAdminActions({
 	clearLogs: async () => {
 		try {
 			const count = await deleteAllLogs();
@@ -184,4 +185,4 @@ export const actions: Actions = {
 			return fail(500, { error: message });
 		}
 	}
-};
+});

--- a/src/routes/admin/logs/stream/+server.ts
+++ b/src/routes/admin/logs/stream/+server.ts
@@ -1,3 +1,4 @@
+import { requireAdmin } from '$lib/server/auth/guards';
 import { getLatestLogId, getLogsAfterId, type LogEntry } from '$lib/server/logging';
 import type { RequestHandler } from './$types';
 
@@ -5,7 +6,9 @@ const POLL_INTERVAL_BASE_MS = 1000;
 const POLL_INTERVAL_MAX_MS = 5000;
 const BACKOFF_MULTIPLIER = 1.5;
 
-export const GET: RequestHandler = async ({ request }) => {
+export const GET: RequestHandler = async ({ locals, request }) => {
+	requireAdmin(locals);
+
 	const url = new URL(request.url);
 	const initialCursor = url.searchParams.get('cursor');
 	let lastId = initialCursor ? parseInt(initialCursor, 10) : await getLatestLogId();

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -35,6 +35,7 @@ import {
 	type WrappedLogoModeType
 } from '$lib/server/admin/settings.service';
 import { getAvailableYears } from '$lib/server/admin/users.service';
+import { requireAdminActions } from '$lib/server/auth/guards';
 import { testOpenAIConnection } from '$lib/server/funfacts/test-connection';
 import {
 	getLogMaxCount,
@@ -216,7 +217,7 @@ export const load: PageServerLoad = async () => {
 	};
 };
 
-export const actions: Actions = {
+export const actions: Actions = requireAdminActions({
 	updateApiConfig: async ({ request }) => {
 		const formData = await request.formData();
 
@@ -892,4 +893,4 @@ export const actions: Actions = {
 			return fail(500, { error: message });
 		}
 	}
-};
+});

--- a/src/routes/admin/slides/+page.server.ts
+++ b/src/routes/admin/slides/+page.server.ts
@@ -7,6 +7,7 @@ import {
 	setFunFactFrequency
 } from '$lib/server/admin/settings.service';
 import { getAvailableYears } from '$lib/server/admin/users.service';
+import { requireAdminActions } from '$lib/server/auth/guards';
 import {
 	getAllSlideConfigs,
 	initializeDefaultSlideConfig,
@@ -55,7 +56,7 @@ export const load: PageServerLoad = async () => {
 	};
 };
 
-export const actions: Actions = {
+export const actions: Actions = requireAdminActions({
 	/**
 	 * Toggle a slide's enabled state
 	 */
@@ -352,4 +353,4 @@ export const actions: Actions = {
 			return fail(500, { error: message });
 		}
 	}
-};
+});

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail } from '@sveltejs/kit';
 import { z } from 'zod';
 import { AppSettingsKey, getAppSetting, setAppSetting } from '$lib/server/admin/settings.service';
+import { requireAdminActions } from '$lib/server/auth/guards';
 import { cancelSync } from '$lib/server/sync/progress';
 import {
 	getSchedulerStatus,
@@ -90,7 +91,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	};
 };
 
-export const actions: Actions = {
+export const actions: Actions = requireAdminActions({
 	startSync: async ({ request }) => {
 		const formData = await request.formData();
 		const backfillYearRaw = formData.get('backfillYear');
@@ -214,4 +215,4 @@ export const actions: Actions = {
 			return fail(500, { error: message });
 		}
 	}
-};
+});

--- a/src/routes/admin/sync/stream/+server.ts
+++ b/src/routes/admin/sync/stream/+server.ts
@@ -1,3 +1,4 @@
+import { requireAdmin } from '$lib/server/auth/guards';
 import { getSyncProgress, type LiveSyncProgress } from '$lib/server/sync/progress';
 import type { RequestHandler } from './$types';
 
@@ -12,7 +13,9 @@ import type { RequestHandler } from './$types';
 
 const POLL_INTERVAL_MS = 500;
 
-export const GET: RequestHandler = async ({ request }) => {
+export const GET: RequestHandler = async ({ locals, request }) => {
+	requireAdmin(locals);
+
 	// Create a readable stream for SSE
 	const stream = new ReadableStream({
 		async start(controller) {

--- a/src/routes/admin/users/+page.server.ts
+++ b/src/routes/admin/users/+page.server.ts
@@ -5,6 +5,7 @@ import {
 	getAvailableYears,
 	updateUserSharePermission
 } from '$lib/server/admin/users.service';
+import { requireAdminActions } from '$lib/server/auth/guards';
 import type { Actions, PageServerLoad } from './$types';
 
 const UpdateUserPermissionSchema = z.object({
@@ -44,7 +45,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	};
 };
 
-export const actions: Actions = {
+export const actions: Actions = requireAdminActions({
 	updateUserPermission: async ({ request }) => {
 		const formData = await request.formData();
 
@@ -72,4 +73,4 @@ export const actions: Actions = {
 			return fail(500, { error: message });
 		}
 	}
-};
+});

--- a/src/routes/auth/plex/+server.ts
+++ b/src/routes/auth/plex/+server.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 import { completePlexPinLogin } from '$lib/server/auth/login-completion';
 import {
 	appendPinStateToForwardUrl,
-	createPinTransaction
+	createPinTransaction,
+	parsePinForwardUrl
 } from '$lib/server/auth/pin-transactions';
 import { buildPlexOAuthUrl, requestPin } from '$lib/server/auth/plex-oauth';
 import { NotServerMemberError, PinExpiredError, PlexAuthApiError } from '$lib/server/auth/types';
@@ -15,9 +16,11 @@ const PollRequestSchema = z.object({
 
 export const GET: RequestHandler = async ({ cookies, url }) => {
 	try {
-		const pin = await requestPin();
-		const state = createPinTransaction(pin.id, cookies);
 		const redirectUrl = url.searchParams.get('redirectUrl') ?? `${url.origin}/auth/plex/redirect`;
+		parsePinForwardUrl(redirectUrl, url);
+
+		const pin = await requestPin();
+		const state = await createPinTransaction(pin.id, cookies);
 		const forwardUrl = appendPinStateToForwardUrl(redirectUrl, url, state);
 		const pinInfo = {
 			pinId: pin.id,

--- a/src/routes/auth/plex/+server.ts
+++ b/src/routes/auth/plex/+server.ts
@@ -1,7 +1,11 @@
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
 import { completePlexPinLogin } from '$lib/server/auth/login-completion';
-import { getPinInfo } from '$lib/server/auth/plex-oauth';
+import {
+	appendPinStateToForwardUrl,
+	createPinTransaction
+} from '$lib/server/auth/pin-transactions';
+import { buildPlexOAuthUrl, requestPin } from '$lib/server/auth/plex-oauth';
 import { NotServerMemberError, PinExpiredError, PlexAuthApiError } from '$lib/server/auth/types';
 import type { RequestHandler } from './$types';
 
@@ -9,13 +13,30 @@ const PollRequestSchema = z.object({
 	pinId: z.number().int().positive()
 });
 
-export const GET: RequestHandler = async ({ url }) => {
+export const GET: RequestHandler = async ({ cookies, url }) => {
 	try {
-		const redirectUrl = url.searchParams.get('redirectUrl') ?? undefined;
-		const pinInfo = await getPinInfo(redirectUrl);
+		const pin = await requestPin();
+		const state = createPinTransaction(pin.id, cookies);
+		const redirectUrl = url.searchParams.get('redirectUrl') ?? `${url.origin}/auth/plex/redirect`;
+		const forwardUrl = appendPinStateToForwardUrl(redirectUrl, url, state);
+		const pinInfo = {
+			pinId: pin.id,
+			code: pin.code,
+			authUrl: buildPlexOAuthUrl(pin.code, forwardUrl),
+			expiresAt: pin.expiresAt ?? new Date(Date.now() + 15 * 60 * 1000).toISOString()
+		};
 
 		return json(pinInfo);
 	} catch (err) {
+		if (
+			err instanceof TypeError ||
+			(err instanceof Error && err.message.includes('redirect URL'))
+		) {
+			error(400, {
+				message: 'Invalid redirect URL'
+			});
+		}
+
 		if (err instanceof PlexAuthApiError) {
 			console.error('Plex OAuth error:', err.message);
 			error(502, {

--- a/src/routes/auth/plex/redirect/+page.server.ts
+++ b/src/routes/auth/plex/redirect/+page.server.ts
@@ -26,6 +26,6 @@ export const load: PageServerLoad = async ({ cookies, locals, request, url }) =>
 
 	return {
 		flow: url.searchParams.get('flow') === 'popup' ? 'popup' : 'redirect',
-		stateVerified: markPinCallbackVerified(cookies, url.searchParams.get('state'))
+		stateVerified: await markPinCallbackVerified(cookies, url.searchParams.get('state'))
 	};
 };

--- a/src/routes/auth/plex/redirect/+page.server.ts
+++ b/src/routes/auth/plex/redirect/+page.server.ts
@@ -1,7 +1,8 @@
 import { redirect } from '@sveltejs/kit';
+import { markPinCallbackVerified } from '$lib/server/auth/pin-transactions';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ locals, request, url }) => {
+export const load: PageServerLoad = async ({ cookies, locals, request, url }) => {
 	if (locals.user) {
 		redirect(303, locals.user.isAdmin ? '/admin' : '/dashboard');
 	}
@@ -23,5 +24,8 @@ export const load: PageServerLoad = async ({ locals, request, url }) => {
 		redirect(303, '/');
 	}
 
-	return {};
+	return {
+		flow: url.searchParams.get('flow') === 'popup' ? 'popup' : 'redirect',
+		stateVerified: markPinCallbackVerified(cookies, url.searchParams.get('state'))
+	};
 };

--- a/src/routes/auth/plex/redirect/+page.svelte
+++ b/src/routes/auth/plex/redirect/+page.svelte
@@ -2,11 +2,13 @@
 import { onMount } from 'svelte';
 import { browser } from '$app/environment';
 import { LOGIN_TIMEOUT_MS, PIN_STORAGE_KEY, POLL_INTERVAL_MS } from '$lib/client/plex-login';
+import type { PageData } from './$types';
 
 type Status = 'loading' | 'success' | 'error' | 'cancelled';
 
 let status = $state<Status>('loading');
 let errorMessage = $state<string | null>(null);
+let { data }: { data: PageData } = $props();
 
 const MAX_POLL_ATTEMPTS = Math.floor(LOGIN_TIMEOUT_MS / POLL_INTERVAL_MS);
 const PIN_MAX_AGE_MS = 15 * 60 * 1000;
@@ -19,6 +21,18 @@ interface StoredPinData {
 
 onMount(async () => {
 	if (!browser) return;
+
+	if (!data.stateVerified) {
+		status = 'error';
+		errorMessage = 'Authentication session could not be verified. Please try again.';
+		return;
+	}
+
+	if (data.flow === 'popup') {
+		status = 'success';
+		setTimeout(() => window.close(), 750);
+		return;
+	}
 
 	const storedData = sessionStorage.getItem(PIN_STORAGE_KEY);
 	if (!storedData) {

--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -20,6 +20,24 @@ async function isOnboardingCsrfStep(): Promise<boolean> {
 	return !done && step === OnboardingSteps.CSRF;
 }
 
+function getRequestOrigin(request: Request): string | null {
+	const origin = request.headers.get('origin');
+	if (origin) return origin;
+
+	const referer = request.headers.get('referer');
+	if (!referer) return null;
+
+	try {
+		return new URL(referer).origin;
+	} catch {
+		return null;
+	}
+}
+
+function isSameOriginOnboardingAction(request: Request, url: URL): boolean {
+	return getRequestOrigin(request)?.toLowerCase() === url.origin.toLowerCase();
+}
+
 const CsrfOriginSchema = z.object({
 	csrfOrigin: z
 		.string()
@@ -143,9 +161,13 @@ export const actions: Actions = {
 		redirect(303, '/onboarding/plex');
 	},
 
-	skipCsrf: async () => {
+	skipCsrf: async ({ request, url }) => {
 		if (!(await isOnboardingCsrfStep())) {
 			return fail(403, { error: 'Not allowed at this onboarding stage' });
+		}
+
+		if (!isSameOriginOnboardingAction(request, url)) {
+			return fail(403, { error: 'CSRF skip must be submitted from this Obzorarr origin' });
 		}
 
 		await setAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED, 'true');

--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -34,8 +34,23 @@ function getRequestOrigin(request: Request): string | null {
 	}
 }
 
+function normalizeOrigin(origin: string): string | null {
+	try {
+		return new URL(origin).origin.toLowerCase();
+	} catch {
+		return null;
+	}
+}
+
+function originsMatch(left: string, right: string): boolean {
+	const normalizedLeft = normalizeOrigin(left);
+	const normalizedRight = normalizeOrigin(right);
+	return normalizedLeft !== null && normalizedLeft === normalizedRight;
+}
+
 function isSameOriginOnboardingAction(request: Request, url: URL): boolean {
-	return getRequestOrigin(request)?.toLowerCase() === url.origin.toLowerCase();
+	const requestOrigin = getRequestOrigin(request);
+	return requestOrigin !== null && originsMatch(requestOrigin, url.origin);
 }
 
 const CsrfOriginSchema = z.object({
@@ -111,7 +126,7 @@ export const actions: Actions = {
 			});
 		}
 
-		if (result.data.csrfOrigin.toLowerCase() !== actualOrigin.toLowerCase()) {
+		if (!originsMatch(result.data.csrfOrigin, actualOrigin)) {
 			return fail(400, {
 				testError: `Origin mismatch: browser sends "${actualOrigin}" but you configured "${result.data.csrfOrigin}"`
 			});
@@ -147,7 +162,7 @@ export const actions: Actions = {
 			});
 		}
 
-		if (result.data.csrfOrigin.toLowerCase() !== actualOrigin.toLowerCase()) {
+		if (!originsMatch(result.data.csrfOrigin, actualOrigin)) {
 			return fail(400, {
 				error: `Origin mismatch: browser sends "${actualOrigin}" but you configured "${result.data.csrfOrigin}"`
 			});

--- a/src/routes/plex/thumb/[...path]/+server.ts
+++ b/src/routes/plex/thumb/[...path]/+server.ts
@@ -1,8 +1,9 @@
 import { error } from '@sveltejs/kit';
 import { getPlexConfig } from '$lib/server/admin/settings.service';
+import { authorizeThumbnailPayload, verifyThumbnailToken } from '$lib/server/plex/thumbnail-auth';
 import type { RequestHandler } from './$types';
 
-const CACHE_MAX_AGE = 7 * 24 * 60 * 60;
+const CACHE_CONTROL = 'private, no-cache';
 
 function getPlexHeaders(token: string) {
 	return {
@@ -19,10 +20,7 @@ function isAllowedPath(path: string): boolean {
 	return ALLOWED_PATH_PATTERNS.some((pattern) => pattern.test(path));
 }
 
-// Intentionally unauthenticated: shared/public wrapped pages render thumbnails
-// via getThumbUrl() without a user session. Path validation (ALLOWED_PATH_PATTERNS)
-// restricts access to Plex library metadata thumbnails only.
-export const GET: RequestHandler = async ({ params, request }) => {
+export const GET: RequestHandler = async ({ locals, params, request, url }) => {
 	const { path } = params;
 
 	if (!path) {
@@ -32,6 +30,12 @@ export const GET: RequestHandler = async ({ params, request }) => {
 	if (!isAllowedPath(path)) {
 		error(400, { message: 'Invalid thumbnail path' });
 	}
+
+	const tokenPayload = await verifyThumbnailToken(url.searchParams.get('token'));
+	if (!tokenPayload || tokenPayload.path !== path) {
+		error(403, { message: 'Invalid thumbnail token' });
+	}
+	await authorizeThumbnailPayload(tokenPayload, locals);
 
 	const config = await getPlexConfig();
 
@@ -55,11 +59,11 @@ export const GET: RequestHandler = async ({ params, request }) => {
 
 		if (response.status === 304) {
 			const notModHeaders: Record<string, string> = {
-				'Cache-Control': `public, max-age=${CACHE_MAX_AGE}, immutable`
+				'Cache-Control': CACHE_CONTROL
 			};
 			const etag = response.headers.get('etag');
 			const lastMod = response.headers.get('last-modified');
-			if (etag) notModHeaders['ETag'] = etag;
+			if (etag) notModHeaders.ETag = etag;
 			if (lastMod) notModHeaders['Last-Modified'] = lastMod;
 			return new Response(null, { status: 304, headers: notModHeaders });
 		}
@@ -82,10 +86,10 @@ export const GET: RequestHandler = async ({ params, request }) => {
 
 		const headers: Record<string, string> = {
 			'Content-Type': contentType,
-			'Cache-Control': `public, max-age=${CACHE_MAX_AGE}, immutable`,
+			'Cache-Control': CACHE_CONTROL,
 			'Content-Length': String(imageData.byteLength)
 		};
-		if (etag) headers['ETag'] = etag;
+		if (etag) headers.ETag = etag;
 		if (lastMod) headers['Last-Modified'] = lastMod;
 
 		return new Response(imageData, {

--- a/src/routes/wrapped/[year]/+page.server.ts
+++ b/src/routes/wrapped/[year]/+page.server.ts
@@ -3,6 +3,7 @@ import { getFunFactFrequency } from '$lib/server/admin/settings.service';
 import { generateFunFacts } from '$lib/server/funfacts';
 import { getLogoVisibility } from '$lib/server/logo';
 import { getServerName } from '$lib/server/plex/server-name.service';
+import { signStatsThumbnails } from '$lib/server/plex/thumbnail-auth';
 import { checkServerWrappedAccess } from '$lib/server/sharing/access-control';
 import { ShareAccessDeniedError } from '$lib/server/sharing/types';
 import {
@@ -65,9 +66,10 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 	const slides = intersperseFunFacts(baseSlides, funFacts);
 	const logoVisibility = await getLogoVisibility(null, year);
 	const serverName = await getServerName();
+	const signedStats = await signStatsThumbnails(stats, { kind: 'server', year });
 
 	return {
-		stats,
+		stats: signedStats,
 		slides,
 		customSlidesMap,
 		year,

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -5,6 +5,7 @@ import { db } from '$lib/server/db/client';
 import { users } from '$lib/server/db/schema';
 import { generateFunFacts } from '$lib/server/funfacts';
 import { getLogoVisibility, setUserLogoPreference } from '$lib/server/logo';
+import { signStatsThumbnails } from '$lib/server/plex/thumbnail-auth';
 import { checkTokenAccess, checkWrappedAccess } from '$lib/server/sharing/access-control';
 import {
 	ensureShareToken,
@@ -185,9 +186,15 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		(isOwner || isAdmin) && effectiveModeForUrl === ShareMode.PRIVATE_LINK
 			? resolvedShareToken
 			: null;
+	const signedStats = await signStatsThumbnails(stats, {
+		kind: 'user',
+		year,
+		userId,
+		shareToken: accessedViaToken ? identifier : undefined
+	});
 
 	return {
-		stats,
+		stats: signedStats,
 		slides,
 		customSlidesMap,
 		year,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -146,6 +146,17 @@ sqlite.exec(`
 		expires_at INTEGER NOT NULL
 	);
 
+	-- PIN transactions table
+	CREATE TABLE IF NOT EXISTS pin_transactions (
+		state TEXT PRIMARY KEY NOT NULL,
+		pin_id INTEGER NOT NULL,
+		expires_at INTEGER NOT NULL,
+		callback_verified INTEGER DEFAULT 0 NOT NULL
+	);
+
+	CREATE INDEX IF NOT EXISTS idx_pin_transactions_expires_at
+		ON pin_transactions (expires_at);
+
 	-- Logs table
 	CREATE TABLE IF NOT EXISTS logs (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/unit/auth/pin-transactions.test.ts
+++ b/tests/unit/auth/pin-transactions.test.ts
@@ -3,23 +3,42 @@ import type { Cookies } from '@sveltejs/kit';
 import { completePlexPinLogin } from '$lib/server/auth/login-completion';
 import {
 	_resetPinTransactionsForTests,
+	clearPinTransaction,
 	createPinTransaction,
 	getPinTransactionForRequest,
 	markPinCallbackVerified
 } from '$lib/server/auth/pin-transactions';
 import { PinExpiredError } from '$lib/server/auth/types';
 
-function createCookies(): Cookies {
+interface CookieCall {
+	name: string;
+	value?: string;
+	options?: unknown;
+}
+
+interface TestCookies extends Cookies {
+	sets: CookieCall[];
+	deletes: CookieCall[];
+}
+
+function createCookies(): TestCookies {
 	const values = new Map<string, string>();
+	const sets: CookieCall[] = [];
+	const deletes: CookieCall[] = [];
+
 	return {
+		sets,
+		deletes,
 		get: (name: string) => values.get(name),
-		set: (name: string, value: string) => {
+		set: (name: string, value: string, options?: unknown) => {
+			sets.push({ name, value, options });
 			values.set(name, value);
 		},
-		delete: (name: string) => {
+		delete: (name: string, options?: unknown) => {
+			deletes.push({ name, options });
 			values.delete(name);
 		}
-	} as unknown as Cookies;
+	} as unknown as TestCookies;
 }
 
 describe('Plex PIN transactions', () => {
@@ -36,6 +55,23 @@ describe('Plex PIN transactions', () => {
 		expect(transaction?.state).toBe(state);
 		expect(await getPinTransactionForRequest(456, cookies)).toBeNull();
 		expect(await getPinTransactionForRequest(123, createCookies())).toBeNull();
+	});
+
+	it('clears the PIN state cookie with the same security attributes used when it was set', async () => {
+		const cookies = createCookies();
+		const state = await createPinTransaction(123, cookies);
+
+		await clearPinTransaction(cookies, state);
+
+		const setOptions = cookies.sets[0]?.options as Record<string, unknown>;
+		expect(cookies.deletes).toHaveLength(1);
+		expect(cookies.deletes[0]?.name).toBe('plex_login_state');
+		expect(cookies.deletes[0]?.options).toEqual({
+			path: setOptions.path,
+			httpOnly: setOptions.httpOnly,
+			secure: setOptions.secure,
+			sameSite: setOptions.sameSite
+		});
 	});
 
 	it('requires the callback state to match the HttpOnly state cookie', async () => {

--- a/tests/unit/auth/pin-transactions.test.ts
+++ b/tests/unit/auth/pin-transactions.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import type { Cookies } from '@sveltejs/kit';
+import { completePlexPinLogin } from '$lib/server/auth/login-completion';
+import {
+	_resetPinTransactionsForTests,
+	createPinTransaction,
+	getPinTransactionForRequest,
+	markPinCallbackVerified
+} from '$lib/server/auth/pin-transactions';
+import { PinExpiredError } from '$lib/server/auth/types';
+
+function createCookies(): Cookies {
+	const values = new Map<string, string>();
+	return {
+		get: (name: string) => values.get(name),
+		set: (name: string, value: string) => {
+			values.set(name, value);
+		},
+		delete: (name: string) => {
+			values.delete(name);
+		}
+	} as unknown as Cookies;
+}
+
+describe('Plex PIN transactions', () => {
+	beforeEach(() => {
+		_resetPinTransactionsForTests();
+	});
+
+	it('binds a PIN transaction to the browser state cookie', () => {
+		const cookies = createCookies();
+		const state = createPinTransaction(123, cookies);
+
+		const transaction = getPinTransactionForRequest(123, cookies);
+
+		expect(transaction?.state).toBe(state);
+		expect(getPinTransactionForRequest(456, cookies)).toBeNull();
+		expect(getPinTransactionForRequest(123, createCookies())).toBeNull();
+	});
+
+	it('requires the callback state to match the HttpOnly state cookie', () => {
+		const cookies = createCookies();
+		const state = createPinTransaction(123, cookies);
+
+		expect(markPinCallbackVerified(cookies, 'wrong-state')).toBe(false);
+		expect(getPinTransactionForRequest(123, cookies)?.callbackVerified).toBe(false);
+
+		expect(markPinCallbackVerified(cookies, state)).toBe(true);
+		expect(getPinTransactionForRequest(123, cookies)?.callbackVerified).toBe(true);
+	});
+
+	it('does not poll Plex or create a session before callback verification', async () => {
+		const cookies = createCookies();
+		createPinTransaction(123, cookies);
+
+		await expect(completePlexPinLogin(123, cookies)).resolves.toEqual({ pending: true });
+	});
+
+	it('rejects PIN polling without the initiating browser transaction', async () => {
+		const cookies = createCookies();
+
+		await expect(completePlexPinLogin(123, cookies)).rejects.toBeInstanceOf(PinExpiredError);
+	});
+});

--- a/tests/unit/auth/pin-transactions.test.ts
+++ b/tests/unit/auth/pin-transactions.test.ts
@@ -23,35 +23,35 @@ function createCookies(): Cookies {
 }
 
 describe('Plex PIN transactions', () => {
-	beforeEach(() => {
-		_resetPinTransactionsForTests();
+	beforeEach(async () => {
+		await _resetPinTransactionsForTests();
 	});
 
-	it('binds a PIN transaction to the browser state cookie', () => {
+	it('binds a PIN transaction to the browser state cookie', async () => {
 		const cookies = createCookies();
-		const state = createPinTransaction(123, cookies);
+		const state = await createPinTransaction(123, cookies);
 
-		const transaction = getPinTransactionForRequest(123, cookies);
+		const transaction = await getPinTransactionForRequest(123, cookies);
 
 		expect(transaction?.state).toBe(state);
-		expect(getPinTransactionForRequest(456, cookies)).toBeNull();
-		expect(getPinTransactionForRequest(123, createCookies())).toBeNull();
+		expect(await getPinTransactionForRequest(456, cookies)).toBeNull();
+		expect(await getPinTransactionForRequest(123, createCookies())).toBeNull();
 	});
 
-	it('requires the callback state to match the HttpOnly state cookie', () => {
+	it('requires the callback state to match the HttpOnly state cookie', async () => {
 		const cookies = createCookies();
-		const state = createPinTransaction(123, cookies);
+		const state = await createPinTransaction(123, cookies);
 
-		expect(markPinCallbackVerified(cookies, 'wrong-state')).toBe(false);
-		expect(getPinTransactionForRequest(123, cookies)?.callbackVerified).toBe(false);
+		expect(await markPinCallbackVerified(cookies, 'wrong-state')).toBe(false);
+		expect((await getPinTransactionForRequest(123, cookies))?.callbackVerified).toBe(false);
 
-		expect(markPinCallbackVerified(cookies, state)).toBe(true);
-		expect(getPinTransactionForRequest(123, cookies)?.callbackVerified).toBe(true);
+		expect(await markPinCallbackVerified(cookies, state)).toBe(true);
+		expect((await getPinTransactionForRequest(123, cookies))?.callbackVerified).toBe(true);
 	});
 
 	it('does not poll Plex or create a session before callback verification', async () => {
 		const cookies = createCookies();
-		createPinTransaction(123, cookies);
+		await createPinTransaction(123, cookies);
 
 		await expect(completePlexPinLogin(123, cookies)).resolves.toEqual({ pending: true });
 	});

--- a/tests/unit/landing-lookup.test.ts
+++ b/tests/unit/landing-lookup.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { isRedirect } from '@sveltejs/kit';
+import { db } from '$lib/server/db/client';
+import { appSettings, plexAccounts, shareSettings, users } from '$lib/server/db/schema';
+import { setGlobalShareDefaults } from '$lib/server/sharing/service';
+import { ShareMode, ShareModeSource } from '$lib/server/sharing/types';
+import { actions } from '../../src/routes/+page.server';
+
+type LookupAction = NonNullable<typeof actions.lookupUser>;
+
+const USER_ID = 42;
+const YEAR = new Date().getFullYear();
+
+async function seedUser(mode?: (typeof ShareMode)[keyof typeof ShareMode]): Promise<void> {
+	await db.insert(plexAccounts).values({
+		accountId: 123,
+		plexId: 456,
+		username: 'alice',
+		isOwner: false
+	});
+	await db.insert(users).values({
+		id: USER_ID,
+		plexId: 456,
+		accountId: 123,
+		username: 'alice',
+		isAdmin: false
+	});
+
+	if (mode) {
+		await db.insert(shareSettings).values({
+			userId: USER_ID,
+			year: YEAR,
+			mode,
+			modeSource: ShareModeSource.EXPLICIT,
+			shareToken: mode === ShareMode.PRIVATE_LINK ? '550e8400-e29b-41d4-a716-446655440000' : null,
+			canUserControl: false
+		});
+	}
+}
+
+async function invokeLookup(username: string, ip: string) {
+	const formData = new FormData();
+	formData.set('username', username);
+	const request = new Request('https://obzorarr.example/', {
+		method: 'POST',
+		body: formData
+	});
+
+	const lookupUser = actions.lookupUser as LookupAction;
+	return lookupUser({
+		request,
+		getClientAddress: () => ip,
+		setHeaders: () => {}
+	} as unknown as Parameters<LookupAction>[0]);
+}
+
+describe('landing username lookup', () => {
+	beforeEach(async () => {
+		await db.delete(shareSettings);
+		await db.delete(appSettings);
+		await db.delete(users);
+		await db.delete(plexAccounts);
+	});
+
+	it('redirects anonymous lookup only for effectively public wrapped pages', async () => {
+		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
+		await seedUser();
+
+		try {
+			await invokeLookup('alice', '198.51.100.1');
+			throw new Error('Expected redirect');
+		} catch (error) {
+			expect(isRedirect(error)).toBe(true);
+			if (!isRedirect(error)) throw error;
+			expect(error.location).toBe(`/wrapped/${YEAR}/u/${USER_ID}`);
+		}
+	});
+
+	it('returns the same generic response for private users and missing users', async () => {
+		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
+		await seedUser(ShareMode.PRIVATE_OAUTH);
+
+		const privateResult = await invokeLookup('alice', '198.51.100.2');
+		const missingResult = await invokeLookup('nobody', '198.51.100.3');
+
+		expect(privateResult).toEqual({
+			status: 404,
+			data: {
+				error: 'No public Wrapped found for that username.',
+				username: 'alice',
+				requiresAuth: true
+			}
+		});
+		expect(missingResult).toEqual({
+			status: 404,
+			data: {
+				error: 'No public Wrapped found for that username.',
+				username: 'nobody',
+				requiresAuth: true
+			}
+		});
+	});
+
+	it('does not create local users from anonymous lookup', async () => {
+		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
+		await db.insert(plexAccounts).values({
+			accountId: 777,
+			plexId: 888,
+			username: 'synced-only',
+			isOwner: false
+		});
+
+		await invokeLookup('synced-only', '198.51.100.4');
+
+		const createdUsers = await db.select().from(users);
+		expect(createdUsers).toHaveLength(0);
+	});
+});

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -66,6 +66,15 @@ describe('onboarding CSRF actions', () => {
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
 	});
 
+	it('test origin accepts browser origins with explicit default ports', async () => {
+		const result = await runTestOrigin(
+			createFormRequest('https://example.com', 'https://example.com:443')
+		);
+
+		expect(result).toEqual({ testSuccess: true, testedOrigin: 'https://example.com' });
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
 	it('test origin rejects invalid URLs without advancing onboarding', async () => {
 		const result = await runTestOrigin(createFormRequest('not-a-url'));
 
@@ -113,6 +122,16 @@ describe('onboarding CSRF actions', () => {
 		await expectRedirect(() => runSaveOrigin(createFormRequest(ORIGIN)), '/onboarding/plex');
 
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.PLEX);
+	});
+
+	it('saves a matching CSRF origin when the browser origin has an explicit default port', async () => {
+		await expectRedirect(
+			() => runSaveOrigin(createFormRequest('https://example.com', 'https://example.com:443')),
+			'/onboarding/plex'
+		);
+
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe('https://example.com');
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.PLEX);
 	});
 

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -39,7 +39,7 @@ async function runTestOrigin(request: Request) {
 
 async function runSkipCsrf(request: Request) {
 	const skipCsrf = actions.skipCsrf as SkipCsrfAction;
-	return skipCsrf({ request } as Parameters<SkipCsrfAction>[0]);
+	return skipCsrf({ request, url: new URL(request.url) } as Parameters<SkipCsrfAction>[0]);
 }
 
 async function expectRedirect(run: () => Promise<unknown>, location: string) {
@@ -156,6 +156,30 @@ describe('onboarding CSRF actions', () => {
 		await expectRedirect(() => runSkipCsrf(createFormRequest('not-a-url')), '/onboarding/plex');
 
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)).toBe('true');
+	});
+
+	it('skipCsrf rejects cross-origin submissions without advancing onboarding', async () => {
+		const result = await runSkipCsrf(createFormRequest('not-a-url', 'https://evil.example'));
+
+		expect(result).toEqual({
+			status: 403,
+			data: { error: 'CSRF skip must be submitted from this Obzorarr origin' }
+		});
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)).toBeNull();
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
+	it('skipCsrf rejects missing Origin/Referer headers', async () => {
+		const request = new Request(`${ORIGIN}/onboarding/csrf`, { method: 'POST' });
+
+		const result = await runSkipCsrf(request);
+
+		expect(result).toEqual({
+			status: 403,
+			data: { error: 'CSRF skip must be submitted from this Obzorarr origin' }
+		});
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)).toBeNull();
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
 	});
 
 	it('saveOrigin clears CSRF_ORIGIN_SKIPPED on success', async () => {

--- a/tests/unit/plex/thumbnail-auth.test.ts
+++ b/tests/unit/plex/thumbnail-auth.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
+import { Buffer } from 'node:buffer';
+import { createHmac } from 'node:crypto';
 import { and, eq } from 'drizzle-orm';
 import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
@@ -27,6 +29,14 @@ async function expectHttpStatus(run: () => Promise<unknown>, status: number): Pr
 
 function extractToken(url: string): string {
 	return new URL(`https://obzorarr.example${url}`).searchParams.get('token') ?? '';
+}
+
+function createTestToken(payloadJson: string): string {
+	const encodedPayload = Buffer.from(payloadJson).toString('base64url');
+	const signature = createHmac('sha256', 'test-thumbnail-secret')
+		.update(encodedPayload)
+		.digest('base64url');
+	return `${encodedPayload}.${signature}`;
 }
 
 describe('thumbnail auth tokens', () => {
@@ -84,6 +94,19 @@ describe('thumbnail auth tokens', () => {
 		const token = extractToken(signedUrl as string);
 
 		await expect(verifyThumbnailToken(`${token}.extra`)).resolves.toBeNull();
+	});
+
+	it('rejects thumbnail tokens with non-finite numeric payload fields', async () => {
+		const futureExp = Math.floor(Date.now() / 1000) + 60;
+		const payloads = [
+			`{"v":1,"path":"library/metadata/123/thumb/456","exp":1e999,"kind":"server","year":${YEAR}}`,
+			`{"v":1,"path":"library/metadata/123/thumb/456","exp":${futureExp},"kind":"server","year":1e999}`,
+			`{"v":1,"path":"library/metadata/123/thumb/456","exp":${futureExp},"kind":"user","year":${YEAR},"userId":1e999}`
+		];
+
+		for (const payload of payloads) {
+			await expect(verifyThumbnailToken(createTestToken(payload))).resolves.toBeNull();
+		}
 	});
 
 	it('signs Plex-relative thumbnail paths and authorizes them while wrapped access is public', async () => {

--- a/tests/unit/plex/thumbnail-auth.test.ts
+++ b/tests/unit/plex/thumbnail-auth.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { and, eq } from 'drizzle-orm';
+import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings, shareSettings } from '$lib/server/db/schema';
+import {
+	authorizeThumbnailPayload,
+	createSignedThumbnailUrl,
+	verifyThumbnailToken
+} from '$lib/server/plex/thumbnail-auth';
+import { setGlobalShareDefaults } from '$lib/server/sharing/service';
+import { ShareMode, ShareModeSource } from '$lib/server/sharing/types';
+
+const USER_ID = 42;
+const YEAR = 2026;
+const TOKEN_A = '550e8400-e29b-41d4-a716-446655440000';
+const TOKEN_B = '660e8400-e29b-41d4-a716-446655440111';
+
+async function expectHttpStatus(run: () => Promise<unknown>, status: number): Promise<void> {
+	try {
+		await run();
+		throw new Error('Expected HTTP error');
+	} catch (error) {
+		expect((error as { status?: number }).status).toBe(status);
+	}
+}
+
+function extractToken(url: string): string {
+	return new URL(`https://obzorarr.example${url}`).searchParams.get('token') ?? '';
+}
+
+describe('thumbnail auth tokens', () => {
+	beforeEach(async () => {
+		await db.delete(shareSettings);
+		await db.delete(appSettings);
+		await setAppSetting(AppSettingsKey.THUMBNAIL_SIGNING_SECRET, 'test-thumbnail-secret');
+	});
+
+	it('signs Plex-relative thumbnail paths and authorizes them while wrapped access is public', async () => {
+		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
+
+		const signedUrl = await createSignedThumbnailUrl('/library/metadata/123/thumb/456', {
+			kind: 'user',
+			userId: USER_ID,
+			year: YEAR
+		});
+
+		expect(signedUrl?.startsWith('/plex/thumb/library/metadata/123/thumb/456?token=')).toBe(true);
+		const payload = await verifyThumbnailToken(extractToken(signedUrl as string));
+		expect(payload?.path).toBe('library/metadata/123/thumb/456');
+
+		await expect(authorizeThumbnailPayload(payload!, {})).resolves.toBeUndefined();
+	});
+
+	it('rejects a previously public thumbnail token after access becomes private-oauth', async () => {
+		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
+		const signedUrl = await createSignedThumbnailUrl('/library/metadata/123/thumb/456', {
+			kind: 'user',
+			userId: USER_ID,
+			year: YEAR
+		});
+		const payload = await verifyThumbnailToken(extractToken(signedUrl as string));
+
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_OAUTH,
+			allowUserControl: false
+		});
+
+		await expectHttpStatus(() => authorizeThumbnailPayload(payload!, {}), 403);
+	});
+
+	it('rejects private-link thumbnail tokens after the share token is regenerated', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		await db.insert(shareSettings).values({
+			userId: USER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			modeSource: ShareModeSource.EXPLICIT,
+			shareToken: TOKEN_A,
+			canUserControl: false
+		});
+
+		const signedUrl = await createSignedThumbnailUrl('/library/metadata/123/thumb/456', {
+			kind: 'user',
+			userId: USER_ID,
+			year: YEAR,
+			shareToken: TOKEN_A
+		});
+		const payload = await verifyThumbnailToken(extractToken(signedUrl as string));
+
+		await db
+			.update(shareSettings)
+			.set({ shareToken: TOKEN_B })
+			.where(and(eq(shareSettings.userId, USER_ID), eq(shareSettings.year, YEAR)));
+
+		await expectHttpStatus(() => authorizeThumbnailPayload(payload!, {}), 403);
+	});
+});

--- a/tests/unit/plex/thumbnail-auth.test.ts
+++ b/tests/unit/plex/thumbnail-auth.test.ts
@@ -76,6 +76,16 @@ describe('thumbnail auth tokens', () => {
 		expect(payload?.path).toBe('library/metadata/123/thumb/456');
 	});
 
+	it('rejects thumbnail tokens with extra segments', async () => {
+		const signedUrl = await createSignedThumbnailUrl('/library/metadata/123/thumb/456', {
+			kind: 'server',
+			year: YEAR
+		});
+		const token = extractToken(signedUrl as string);
+
+		await expect(verifyThumbnailToken(`${token}.extra`)).resolves.toBeNull();
+	});
+
 	it('signs Plex-relative thumbnail paths and authorizes them while wrapped access is public', async () => {
 		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
 

--- a/tests/unit/plex/thumbnail-auth.test.ts
+++ b/tests/unit/plex/thumbnail-auth.test.ts
@@ -125,6 +125,20 @@ describe('thumbnail auth tokens', () => {
 		await expect(authorizeThumbnailPayload(payload!, {})).resolves.toBeUndefined();
 	});
 
+	it('authorizes a valid user thumbnail token with user id 0', async () => {
+		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
+
+		const signedUrl = await createSignedThumbnailUrl('/library/metadata/123/thumb/456', {
+			kind: 'user',
+			userId: 0,
+			year: YEAR
+		});
+		const payload = await verifyThumbnailToken(extractToken(signedUrl as string));
+
+		expect(payload?.userId).toBe(0);
+		await expect(authorizeThumbnailPayload(payload!, {})).resolves.toBeUndefined();
+	});
+
 	it('rejects a previously public thumbnail token after access becomes private-oauth', async () => {
 		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
 		const signedUrl = await createSignedThumbnailUrl('/library/metadata/123/thumb/456', {

--- a/tests/unit/plex/thumbnail-auth.test.ts
+++ b/tests/unit/plex/thumbnail-auth.test.ts
@@ -185,4 +185,28 @@ describe('thumbnail auth tokens', () => {
 
 		await expectHttpStatus(() => authorizeThumbnailPayload(payload!, {}), 403);
 	});
+
+	it('rejects private-link thumbnail tokens without recreating missing share settings', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+
+		const signedUrl = await createSignedThumbnailUrl('/library/metadata/123/thumb/456', {
+			kind: 'user',
+			userId: USER_ID,
+			year: YEAR,
+			shareToken: TOKEN_A
+		});
+		const payload = await verifyThumbnailToken(extractToken(signedUrl as string));
+
+		await expectHttpStatus(() => authorizeThumbnailPayload(payload!, {}), 403);
+
+		const rows = await db
+			.select()
+			.from(shareSettings)
+			.where(and(eq(shareSettings.userId, USER_ID), eq(shareSettings.year, YEAR)));
+
+		expect(rows).toHaveLength(0);
+	});
 });

--- a/tests/unit/plex/thumbnail-auth.test.ts
+++ b/tests/unit/plex/thumbnail-auth.test.ts
@@ -156,6 +156,31 @@ describe('thumbnail auth tokens', () => {
 		await expectHttpStatus(() => authorizeThumbnailPayload(payload!, {}), 403);
 	});
 
+	it('authorizes private-link thumbnail tokens when persisted mode is invalid but global default is private-link', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		await db.insert(shareSettings).values({
+			userId: USER_ID,
+			year: YEAR,
+			mode: 'invalid-mode',
+			modeSource: ShareModeSource.EXPLICIT,
+			shareToken: TOKEN_A,
+			canUserControl: false
+		});
+
+		const signedUrl = await createSignedThumbnailUrl('/library/metadata/123/thumb/456', {
+			kind: 'user',
+			userId: USER_ID,
+			year: YEAR,
+			shareToken: TOKEN_A
+		});
+		const payload = await verifyThumbnailToken(extractToken(signedUrl as string));
+
+		await expect(authorizeThumbnailPayload(payload!, {})).resolves.toBeUndefined();
+	});
+
 	it('rejects private-link thumbnail tokens after the share token is regenerated', async () => {
 		await setGlobalShareDefaults({
 			defaultShareMode: ShareMode.PRIVATE_LINK,

--- a/tests/unit/plex/thumbnail-auth.test.ts
+++ b/tests/unit/plex/thumbnail-auth.test.ts
@@ -36,6 +36,46 @@ describe('thumbnail auth tokens', () => {
 		await setAppSetting(AppSettingsKey.THUMBNAIL_SIGNING_SECRET, 'test-thumbnail-secret');
 	});
 
+	it('keeps concurrently minted tokens valid when creating the signing secret', async () => {
+		await db.delete(appSettings);
+
+		const signedUrls = await Promise.all(
+			Array.from({ length: 20 }, () =>
+				createSignedThumbnailUrl('/library/metadata/123/thumb/456', {
+					kind: 'server',
+					year: YEAR
+				})
+			)
+		);
+
+		const payloads = await Promise.all(
+			signedUrls.map((url) => verifyThumbnailToken(extractToken(url as string)))
+		);
+
+		expect(payloads.every((payload) => payload?.path === 'library/metadata/123/thumb/456')).toBe(
+			true
+		);
+	});
+
+	it('replaces an empty signing secret before signing thumbnails', async () => {
+		await setAppSetting(AppSettingsKey.THUMBNAIL_SIGNING_SECRET, '');
+
+		const signedUrl = await createSignedThumbnailUrl('/library/metadata/123/thumb/456', {
+			kind: 'server',
+			year: YEAR
+		});
+
+		const secret = await db
+			.select({ value: appSettings.value })
+			.from(appSettings)
+			.where(eq(appSettings.key, AppSettingsKey.THUMBNAIL_SIGNING_SECRET))
+			.limit(1);
+
+		expect(secret[0]?.value).not.toBe('');
+		const payload = await verifyThumbnailToken(extractToken(signedUrl as string));
+		expect(payload?.path).toBe('library/metadata/123/thumb/456');
+	});
+
 	it('signs Plex-relative thumbnail paths and authorizes them while wrapped access is public', async () => {
 		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
 

--- a/tests/unit/security/admin-guards.test.ts
+++ b/tests/unit/security/admin-guards.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test';
+import { isAdminRouteId, requireAdminAction } from '$lib/server/auth/guards';
+
+describe('admin auth guards', () => {
+	it('identifies decoded admin route ids instead of relying on raw pathnames', () => {
+		expect(isAdminRouteId('/admin')).toBe(true);
+		expect(isAdminRouteId('/admin/logs/stream')).toBe(true);
+		expect(isAdminRouteId('/%61dmin/logs/stream')).toBe(false);
+		expect(isAdminRouteId('/dashboard')).toBe(false);
+		expect(isAdminRouteId(null)).toBe(false);
+	});
+
+	it('rejects admin actions without an admin local user', () => {
+		expect(requireAdminAction({})?.status).toBe(403);
+		expect(
+			requireAdminAction({ user: { id: 1, plexId: 1, username: 'u', isAdmin: false } })?.status
+		).toBe(403);
+		expect(
+			requireAdminAction({ user: { id: 1, plexId: 1, username: 'u', isAdmin: true } })
+		).toBeNull();
+	});
+});

--- a/tests/unit/sharing/access-control.test.ts
+++ b/tests/unit/sharing/access-control.test.ts
@@ -368,12 +368,16 @@ describe('Sharing Access Control', () => {
 		});
 
 		describe('error message mapping', () => {
-			it('maps mode_requires_auth to server member required message', async () => {
-				// Insert a share setting with an invalid/unknown mode to trigger default case
+			it('maps invalid persisted modes through the global privacy floor', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_OAUTH,
+					allowUserControl: false
+				});
+
 				await db.insert(shareSettings).values({
 					userId,
 					year,
-					mode: 'unknown-mode' as typeof ShareMode.PUBLIC, // Invalid mode
+					mode: 'unknown-mode' as typeof ShareMode.PUBLIC,
 					shareToken: null,
 					canUserControl: false
 				});
@@ -383,9 +387,7 @@ describe('Sharing Access Control', () => {
 					expect.unreachable('Should have thrown');
 				} catch (error) {
 					expect(error).toBeInstanceOf(ShareAccessDeniedError);
-					expect((error as ShareAccessDeniedError).message).toContain(
-						'members of this Plex server'
-					);
+					expect((error as ShareAccessDeniedError).message).toContain('Sign in');
 				}
 			});
 

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -11,6 +11,7 @@ import {
 	getOrCreateShareSettings,
 	getShareSettings,
 	getShareSettingsByToken,
+	getShareSettingsReadOnly,
 	getUserLogoPreference,
 	isValidTokenFormat,
 	regenerateShareToken,
@@ -337,6 +338,33 @@ describe('Sharing Service', () => {
 				expect(settings?.mode).toBe(ShareMode.PRIVATE_LINK);
 				expect(settings?.shareToken).toBe(token);
 				expect(effectiveMode).toBe(ShareMode.PRIVATE_LINK);
+			});
+
+			it('falls back to the global default for invalid persisted modes', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_OAUTH,
+					allowUserControl: false
+				});
+
+				await db.insert(shareSettings).values({
+					userId,
+					year,
+					mode: 'invalid-mode',
+					modeSource: ShareModeSource.EXPLICIT,
+					shareToken: generateShareToken(),
+					canUserControl: true
+				});
+
+				const settings = await getShareSettings(userId, year);
+				const readOnlySettings = await getShareSettingsReadOnly(userId, year);
+				const effectiveMode = await getEffectiveShareMode(userId, year);
+
+				expect(settings?.storedMode).toBe(ShareMode.PRIVATE_OAUTH);
+				expect(settings?.mode).toBe(ShareMode.PRIVATE_OAUTH);
+				expect(settings?.shareToken).toBeNull();
+				expect(readOnlySettings?.storedMode).toBe(ShareMode.PRIVATE_OAUTH);
+				expect(readOnlySettings?.mode).toBe(ShareMode.PRIVATE_OAUTH);
+				expect(effectiveMode).toBe(ShareMode.PRIVATE_OAUTH);
 			});
 
 			it('maps shareToken correctly', async () => {

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -5,6 +5,7 @@ import {
 	deleteShareSettings,
 	generateShareToken,
 	getAllUserShareSettings,
+	getEffectiveShareMode,
 	getGlobalAllowUserControl,
 	getGlobalDefaultShareMode,
 	getOrCreateShareSettings,
@@ -316,6 +317,26 @@ describe('Sharing Service', () => {
 				expect(settings).not.toBeNull();
 				expect(settings?.mode).toBe(ShareMode.PRIVATE_OAUTH);
 				expect(settings?.canUserControl).toBe(true);
+			});
+
+			it('normalizes invalid modeSource to explicit for persisted rows', async () => {
+				const token = generateShareToken();
+				await db.insert(shareSettings).values({
+					userId,
+					year,
+					mode: ShareMode.PRIVATE_LINK,
+					modeSource: 'invalid-source',
+					shareToken: token,
+					canUserControl: true
+				});
+
+				const settings = await getShareSettings(userId, year);
+				const effectiveMode = await getEffectiveShareMode(userId, year);
+
+				expect(settings?.modeSource).toBe(ShareModeSource.EXPLICIT);
+				expect(settings?.mode).toBe(ShareMode.PRIVATE_LINK);
+				expect(settings?.shareToken).toBe(token);
+				expect(effectiveMode).toBe(ShareMode.PRIVATE_LINK);
 			});
 
 			it('maps shareToken correctly', async () => {


### PR DESCRIPTION
## Summary

This pull request fixes the confirmed findings from the full-codebase security audit and adds focused regression coverage for each affected area.

## Security Fixes

- Hardened admin authorization by adding shared server-side guards, using SvelteKit route IDs for admin route detection, wrapping admin form actions, and adding explicit admin checks to admin-only SSE endpoints.
- Bound Plex OAuth PIN login completion to a server-side transaction and HttpOnly state cookie so a PIN can only complete after the matching callback is verified.
- Restricted the onboarding CSRF skip action to same-origin browser submissions, preventing cross-origin requests from silently opting out of CSRF origin configuration.
- Protected the Plex thumbnail proxy with HMAC-signed, short-lived thumbnail URLs and access revalidation before proxying media from Plex.
- Prevented anonymous landing-page username lookup from creating users or revealing private users by only redirecting for effectively public Wrapped pages and returning a generic response otherwise.
- Cleaned the early theme bootstrap script in `src/app.html` so repository linting remains clean.

## Tests

Added or updated regression tests for:

- Admin route ID detection and action guard behavior.
- Plex PIN transaction creation, state verification, and rejection paths.
- Thumbnail token signing, expiry/path validation, and private-link token invalidation.
- Onboarding CSRF skip same-origin enforcement.
- Landing-page username lookup privacy behavior and no-create lookup semantics.

## Verification

The following commands pass locally:

- `bun run lint`
- `bun run check:biome`
- `bun run check`
- `bun run test`
- `bun run build`
- `git diff --check`
