### PR TITLE
fix: restore CSRF onboarding form submission

### DIFF
--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -119,7 +119,7 @@ export const actions: Actions = {
 			return fail(400, { testError: errorMessage });
 		}
 
-		const actualOrigin = request.headers.get('origin');
+		const actualOrigin = getRequestOrigin(request);
 		if (!actualOrigin) {
 			return fail(400, {
 				testError: 'Could not detect browser origin. Ensure you are accessing via HTTP/HTTPS.'
@@ -155,7 +155,7 @@ export const actions: Actions = {
 			return fail(400, { error: errorMessage });
 		}
 
-		const actualOrigin = request.headers.get('origin');
+		const actualOrigin = getRequestOrigin(request);
 		if (!actualOrigin) {
 			return fail(400, {
 				error: 'Could not detect browser origin. Ensure you are accessing via HTTP/HTTPS.'

--- a/src/routes/onboarding/csrf/+page.svelte
+++ b/src/routes/onboarding/csrf/+page.svelte
@@ -8,27 +8,36 @@ import type { ActionData, PageData } from './$types';
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
-const initialOrigin = $derived(data.csrfConfig.value || data.detection.detectedOrigin);
-let csrfOriginInput = $state<string | undefined>(undefined);
+function getInitialOrigin(): string {
+	return data.csrfConfig.value || data.detection.detectedOrigin;
+}
 
-let testResult = $state<'idle' | 'testing' | 'success' | 'failure'>('idle');
+function isDetectedOrigin(origin: string): boolean {
+	return origin === data.detection.detectedOrigin;
+}
+
+const initialOrigin = getInitialOrigin();
+const initialOriginVerified = isDetectedOrigin(initialOrigin);
+let csrfOriginInput = $state<string>(initialOrigin);
+
+let testResult = $state<'idle' | 'testing' | 'success' | 'failure'>(
+	initialOriginVerified ? 'success' : 'idle'
+);
 let testError = $state<string | null>(null);
-let testedOrigin = $state<string | null>(null);
+let testedOrigin = $state<string | null>(initialOriginVerified ? initialOrigin : null);
 
-let previousInput = $state<string | undefined>(undefined);
-
-$effect.pre(() => {
-	if (csrfOriginInput === undefined) {
-		csrfOriginInput = initialOrigin;
-		previousInput = initialOrigin;
-	}
-});
+let previousInput = $state<string>(initialOrigin);
 $effect(() => {
 	if (csrfOriginInput !== previousInput) {
 		previousInput = csrfOriginInput;
-		if (testResult !== 'idle') {
+		if (isDetectedOrigin(csrfOriginInput)) {
+			testResult = 'success';
+			testError = null;
+			testedOrigin = csrfOriginInput;
+		} else if (testResult !== 'idle') {
 			testResult = 'idle';
 			testError = null;
+			testedOrigin = null;
 		}
 	}
 });

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -27,6 +27,20 @@ function createFormRequest(csrfOrigin: string, origin = ORIGIN): Request {
 	});
 }
 
+function createFormRequestWithRefererOnly(
+	csrfOrigin: string,
+	referer = `${ORIGIN}/onboarding/csrf`
+): Request {
+	const formData = new FormData();
+	formData.set('csrfOrigin', csrfOrigin);
+
+	return new Request(`${ORIGIN}/onboarding/csrf`, {
+		method: 'POST',
+		headers: { referer },
+		body: formData
+	});
+}
+
 async function runSaveOrigin(request: Request) {
 	const saveOrigin = actions.saveOrigin as SaveOriginAction;
 	return saveOrigin({ request } as Parameters<SaveOriginAction>[0]);
@@ -72,6 +86,13 @@ describe('onboarding CSRF actions', () => {
 		);
 
 		expect(result).toEqual({ testSuccess: true, testedOrigin: 'https://example.com' });
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
+	it('test origin accepts same-origin form submissions that only include a Referer header', async () => {
+		const result = await runTestOrigin(createFormRequestWithRefererOnly(ORIGIN));
+
+		expect(result).toEqual({ testSuccess: true, testedOrigin: ORIGIN });
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
 	});
 
@@ -132,6 +153,16 @@ describe('onboarding CSRF actions', () => {
 		);
 
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe('https://example.com');
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.PLEX);
+	});
+
+	it('saves a matching CSRF origin and advances when the form submission only includes a Referer header', async () => {
+		await expectRedirect(
+			() => runSaveOrigin(createFormRequestWithRefererOnly(ORIGIN)),
+			'/onboarding/plex'
+		);
+
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.PLEX);
 	});
 


### PR DESCRIPTION
## Summary

This PR fixes the first-run onboarding CSRF step so the user can advance from Security to the Plex connection step. The CSRF page now renders the detected origin and verified state consistently during SSR and hydration, and the footer actions use native SvelteKit form submissions for both `Save & Continue` and `Skip`.

## Problem

Dogfooding found that the CSRF onboarding page appeared valid and interactive, but clicking `Save & Continue` or `Skip` did not advance to `/onboarding/plex`. The page also had a hydration mismatch because the server-rendered HTML emitted an empty CSRF origin and disabled submit state, while the client later initialized the detected origin and verified state.

## Changes

- Initialize CSRF origin, verification state, and hidden form value during component setup so SSR and hydration agree.
- Keep the CSRF footer actions as native SvelteKit POST forms instead of relying on a client-side save bridge.
- Use the shared request-origin helper for both origin testing and saving, preserving support for same-origin submissions that provide only a `Referer` header.
- Add regression coverage for Referer-only CSRF action submissions.

## Validation

- `bun run test tests/unit/onboarding/csrf-actions.test.ts tests/unit/onboarding/csrf-page-source.test.ts`
- `bun run check`
- Retried the onboarding CSRF step with an isolated `agent-browser` session after cleaning browser state and restarting the dev server. `Save & Continue` advanced from `/onboarding/csrf` to `/onboarding/plex`, and the DB updated to `csrf_origin=http://localhost:5173` and `onboarding_current_step=plex`.

## Notes

The QA evidence directory remains untracked and is not included in this PR.