### PR TITLE
fix: submit onboarding settings form natively

### DIFF
--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -228,6 +228,7 @@ function getThemeColors(themeValue: string) {
 			</div>
 
 			<form
+				id="onboarding-settings-form"
 				method="POST"
 				action="?/saveSettings"
 				use:enhance={() => {
@@ -680,6 +681,7 @@ function getThemeColors(themeValue: string) {
 				<!-- Submit button (hidden) -->
 				<button
 					type="submit"
+					form="onboarding-settings-form"
 					class="hidden-submit"
 					disabled={isSubmitting}
 					aria-hidden="true"
@@ -718,13 +720,10 @@ function getThemeColors(themeValue: string) {
 			<!-- Next / Save Button -->
 			{#if isLastSubStep}
 				<button
-					type="button"
+					type="submit"
+					form="onboarding-settings-form"
 					class="btn-nav btn-save"
 					disabled={isSubmitting}
-					onclick={() => {
-						const form = document.querySelector('form[action="?/saveSettings"]') as HTMLFormElement;
-						form?.requestSubmit();
-					}}
 				>
 					{#if isSubmitting}
 						<span class="spinner"></span>


### PR DESCRIPTION
## Summary

This PR updates the onboarding settings wizard so the final `Save & Continue` control submits the SvelteKit form through native HTML form association instead of querying the DOM and calling `requestSubmit()` manually.

The visible footer button now uses `type="submit"` with `form="onboarding-settings-form"`, and the settings form has a stable id. This keeps the existing `?/saveSettings` action and `use:enhance` behavior intact while removing the brittle selector-dependent submit path.

## Motivation

During dogfooding, the onboarding settings step was the remaining blocker after the CSRF submit path had already been fixed. Server logs showed the settings action was not consistently reached from the final wizard control. Using native form association is simpler, more accessible, and more robust for a submit button rendered outside the form body.

## Verification

- `bun run check`
- `bunx biome check src/routes/onboarding/settings/+page.svelte`
- `bun test tests/unit/onboarding/csrf-actions.test.ts`
- Browser verification with `agent-browser`: after scrolling to the footer, a normal visible click on `Save & Continue` reached `/onboarding/complete`; the DB then showed `onboarding_completed=true`.

## Notes

The full `bun run check:biome` command was not used for final verification because the existing untracked `.omc/state/hud-stdin-cache.json` file causes a repository-wide formatting failure unrelated to this PR. The changed Svelte file passes Biome directly.