### PR TITLE
fix: address 20 QA findings from run OBZ-20260502-102506

### DIFF
--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -253,13 +253,18 @@ $effect(() => {
 				>
 					<div class="mode-options" role="radiogroup" aria-labelledby="visibility-label">
 						{#each availableModes as mode}
-							<label class="mode-option" class:active={displayMode === mode}>
+							<label
+								class="mode-option"
+								class:active={displayMode === mode}
+								class:below-floor={isBelowFloor(mode as ShareModeType)}
+								aria-disabled={isBelowFloor(mode as ShareModeType)}
+							>
 								<input
 									type="radio"
 									name="mode"
 									value={mode}
 									checked={displayMode === mode}
-									disabled={isUpdating}
+									disabled={isUpdating || isBelowFloor(mode as ShareModeType)}
 									onchange={(e) => {
 										optimisticMode = mode as ShareModeType;
 										e.currentTarget.form?.requestSubmit();
@@ -473,6 +478,15 @@ $effect(() => {
 		.mode-option.active {
 			border-color: hsl(var(--primary));
 			background-color: hsl(var(--primary) / 0.08);
+		}
+
+		.mode-option.below-floor {
+			opacity: 0.55;
+			cursor: not-allowed;
+		}
+
+		.mode-option.below-floor:hover {
+			background-color: transparent;
 		}
 
 		.mode-option input[type='radio'] {

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -296,7 +296,7 @@ $effect(() => {
 			flex-direction: column;
 			align-items: center;
 			justify-content: center;
-			padding: 2rem;
+			padding: 2rem 2rem 4rem;
 			background: var(
 				--slide-bg-gradient,
 				linear-gradient(
@@ -307,7 +307,8 @@ $effect(() => {
 			);
 			color: hsl(var(--foreground));
 			position: relative;
-			overflow: hidden;
+			overflow-x: hidden;
+			overflow-y: auto;
 		}
 
 		/* Radial overlay for depth */

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -294,6 +294,26 @@ export async function setApiConfigAtomic(opts: {
 				});
 		};
 
+		// For fields that are echoed back to the client (URLs, model name), an empty
+		// submission means "user cleared the field" — delete the row so resolveConfigValue
+		// falls through to the env value or the built-in default. For secret fields
+		// (PLEX_TOKEN, OPENAI_API_KEY) we never echo the stored value back, so an empty
+		// submission means "unchanged" and is handled by writeIfApplicable's skip path.
+		const clearIfEmpty = async (key: AppSettingsKeyType, value: string, locked: boolean) => {
+			if (locked) return;
+			if (value) {
+				await tx
+					.insert(appSettings)
+					.values({ key, value, updatedAt: now })
+					.onConflictDoUpdate({
+						target: appSettings.key,
+						set: { value, updatedAt: now }
+					});
+			} else {
+				await tx.delete(appSettings).where(eq(appSettings.key, key));
+			}
+		};
+
 		if (opts.values.plexServerUrl && !opts.locks.plexServerUrl) {
 			plexCredentialsChanged = true;
 		}
@@ -301,7 +321,7 @@ export async function setApiConfigAtomic(opts: {
 			plexCredentialsChanged = true;
 		}
 
-		await writeIfApplicable(
+		await clearIfEmpty(
 			AppSettingsKey.PLEX_SERVER_URL,
 			opts.values.plexServerUrl,
 			opts.locks.plexServerUrl
@@ -312,12 +332,12 @@ export async function setApiConfigAtomic(opts: {
 			opts.values.openaiApiKey,
 			opts.locks.openaiApiKey
 		);
-		await writeIfApplicable(
+		await clearIfEmpty(
 			AppSettingsKey.OPENAI_BASE_URL,
 			opts.values.openaiBaseUrl,
 			opts.locks.openaiBaseUrl
 		);
-		await writeIfApplicable(
+		await clearIfEmpty(
 			AppSettingsKey.OPENAI_MODEL,
 			opts.values.openaiModel,
 			opts.locks.openaiModel

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -11,6 +11,13 @@ export const AppSettingsKey = {
 	OPENAI_API_KEY: 'openai_api_key',
 	OPENAI_BASE_URL: 'openai_base_url',
 	OPENAI_MODEL: 'openai_model',
+	/**
+	 * Bookkeeping marker bumped on every successful `setApiConfigAtomic` mutation
+	 * (write OR clear). Included in `API_CONFIG_KEYS` so the optimistic-concurrency
+	 * version always advances, even when the only mutation was a row deletion.
+	 * Never read as configuration; only its `updatedAt` matters.
+	 */
+	API_CONFIG_VERSION: 'api_config_version',
 	UI_THEME: 'ui_theme',
 	WRAPPED_THEME: 'wrapped_theme',
 	/** @deprecated Use WRAPPED_THEME instead - kept for backward compatibility */
@@ -129,13 +136,19 @@ export const PRIVACY_SETTINGS_KEYS = [
 /**
  * Keys covered by the API configuration panel (Plex + OpenAI connections).
  * Used for the optimistic-concurrency timestamp on `updateApiConfig`.
+ *
+ * `API_CONFIG_VERSION` is a write-only bookkeeping row included so a successful
+ * mutation that *only deletes* config rows still advances `max(updatedAt)` — without
+ * it, a clear in tab A could leave the version unchanged and let stale tab B
+ * resurrect the cleared value while passing the OCC check.
  */
 export const API_CONFIG_KEYS = [
 	AppSettingsKey.PLEX_SERVER_URL,
 	AppSettingsKey.PLEX_TOKEN,
 	AppSettingsKey.OPENAI_API_KEY,
 	AppSettingsKey.OPENAI_BASE_URL,
-	AppSettingsKey.OPENAI_MODEL
+	AppSettingsKey.OPENAI_MODEL,
+	AppSettingsKey.API_CONFIG_VERSION
 ] as const;
 
 /**
@@ -229,12 +242,25 @@ export async function setPrivacySettingsAtomic(opts: {
 	});
 }
 
+/**
+ * Per-field intent for `setApiConfigAtomic`:
+ *  - `undefined` — field was not present in the submitted form (e.g. saved from
+ *    the OpenAI panel which doesn't include Plex fields). The row must NOT be
+ *    touched.
+ *  - `''` — field was present and submitted empty. For echoed-back keys
+ *    (PLEX_SERVER_URL, OPENAI_BASE_URL, OPENAI_MODEL) this clears the row so
+ *    `resolveConfigValue` falls through to env / default. For secret keys
+ *    (PLEX_TOKEN, OPENAI_API_KEY) the value is never echoed to the client, so
+ *    an empty submission means "leave the stored secret alone" — clearing those
+ *    is done via dedicated actions (e.g. `clearOpenaiKey`).
+ *  - non-empty string — write the new value (subject to the lock check).
+ */
 export interface SetApiConfigInput {
-	plexServerUrl: string;
-	plexToken: string;
-	openaiApiKey: string;
-	openaiBaseUrl: string;
-	openaiModel: string;
+	plexServerUrl: string | undefined;
+	plexToken: string | undefined;
+	openaiApiKey: string | undefined;
+	openaiBaseUrl: string | undefined;
+	openaiModel: string | undefined;
 }
 
 export interface SetApiConfigLocks {
@@ -283,8 +309,7 @@ export async function setApiConfigAtomic(opts: {
 		const now = new Date();
 		let plexCredentialsChanged = false;
 
-		const writeIfApplicable = async (key: AppSettingsKeyType, value: string, locked: boolean) => {
-			if (!value || locked) return;
+		const upsert = async (key: AppSettingsKeyType, value: string) => {
 			await tx
 				.insert(appSettings)
 				.values({ key, value, updatedAt: now })
@@ -294,24 +319,36 @@ export async function setApiConfigAtomic(opts: {
 				});
 		};
 
-		// For fields that are echoed back to the client (URLs, model name), an empty
-		// submission means "user cleared the field" — delete the row so resolveConfigValue
-		// falls through to the env value or the built-in default. For secret fields
-		// (PLEX_TOKEN, OPENAI_API_KEY) we never echo the stored value back, so an empty
-		// submission means "unchanged" and is handled by writeIfApplicable's skip path.
-		const clearIfEmpty = async (key: AppSettingsKeyType, value: string, locked: boolean) => {
+		// Secret keys: never echoed back to the client. `undefined` (field absent)
+		// AND `''` (field present but blank) both mean "leave the stored secret
+		// alone" — explicit clearing is done via dedicated actions.
+		const writeSecret = async (
+			key: AppSettingsKeyType,
+			value: string | undefined,
+			locked: boolean
+		) => {
 			if (locked) return;
-			if (value) {
-				await tx
-					.insert(appSettings)
-					.values({ key, value, updatedAt: now })
-					.onConflictDoUpdate({
-						target: appSettings.key,
-						set: { value, updatedAt: now }
-					});
-			} else {
+			if (value === undefined || value === '') return;
+			await upsert(key, value);
+		};
+
+		// Echoed-back keys (URLs, model name): the client renders the current
+		// value into the input. `undefined` (field absent — e.g. saved from a
+		// different panel that doesn't include this field) is a strict no-op.
+		// `''` means "user cleared the field" → delete the row so
+		// resolveConfigValue falls through to env / default.
+		const writeOrClearEchoed = async (
+			key: AppSettingsKeyType,
+			value: string | undefined,
+			locked: boolean
+		) => {
+			if (locked) return;
+			if (value === undefined) return;
+			if (value === '') {
 				await tx.delete(appSettings).where(eq(appSettings.key, key));
+				return;
 			}
+			await upsert(key, value);
 		};
 
 		if (opts.values.plexServerUrl && !opts.locks.plexServerUrl) {
@@ -321,27 +358,33 @@ export async function setApiConfigAtomic(opts: {
 			plexCredentialsChanged = true;
 		}
 
-		await clearIfEmpty(
+		await writeOrClearEchoed(
 			AppSettingsKey.PLEX_SERVER_URL,
 			opts.values.plexServerUrl,
 			opts.locks.plexServerUrl
 		);
-		await writeIfApplicable(AppSettingsKey.PLEX_TOKEN, opts.values.plexToken, opts.locks.plexToken);
-		await writeIfApplicable(
+		await writeSecret(AppSettingsKey.PLEX_TOKEN, opts.values.plexToken, opts.locks.plexToken);
+		await writeSecret(
 			AppSettingsKey.OPENAI_API_KEY,
 			opts.values.openaiApiKey,
 			opts.locks.openaiApiKey
 		);
-		await clearIfEmpty(
+		await writeOrClearEchoed(
 			AppSettingsKey.OPENAI_BASE_URL,
 			opts.values.openaiBaseUrl,
 			opts.locks.openaiBaseUrl
 		);
-		await clearIfEmpty(
+		await writeOrClearEchoed(
 			AppSettingsKey.OPENAI_MODEL,
 			opts.values.openaiModel,
 			opts.locks.openaiModel
 		);
+
+		// Bookkeeping: bump the API_CONFIG_VERSION marker on every successful
+		// transaction so `max(updatedAt)` over API_CONFIG_KEYS strictly advances —
+		// even if the only mutation above was a delete (which would otherwise
+		// leave the version unchanged or regressed, defeating the OCC check).
+		await upsert(AppSettingsKey.API_CONFIG_VERSION, now.toISOString());
 
 		return { status: 'ok', plexCredentialsChanged };
 	});

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -127,6 +127,18 @@ export const PRIVACY_SETTINGS_KEYS = [
 ] as const;
 
 /**
+ * Keys covered by the API configuration panel (Plex + OpenAI connections).
+ * Used for the optimistic-concurrency timestamp on `updateApiConfig`.
+ */
+export const API_CONFIG_KEYS = [
+	AppSettingsKey.PLEX_SERVER_URL,
+	AppSettingsKey.PLEX_TOKEN,
+	AppSettingsKey.OPENAI_API_KEY,
+	AppSettingsKey.OPENAI_BASE_URL,
+	AppSettingsKey.OPENAI_MODEL
+] as const;
+
+/**
  * Atomically validates that the privacy settings have not changed since
  * `submittedVersion` and, if so, writes all four values in a single SQLite
  * transaction. Returns `'conflict'` when the submitted version is stale.
@@ -214,6 +226,104 @@ export async function setPrivacySettingsAtomic(opts: {
 		}
 
 		return 'ok';
+	});
+}
+
+export interface SetApiConfigInput {
+	plexServerUrl: string;
+	plexToken: string;
+	openaiApiKey: string;
+	openaiBaseUrl: string;
+	openaiModel: string;
+}
+
+export interface SetApiConfigLocks {
+	plexServerUrl: boolean;
+	plexToken: boolean;
+	openaiApiKey: boolean;
+	openaiBaseUrl: boolean;
+	openaiModel: boolean;
+}
+
+export interface SetApiConfigResult {
+	status: 'ok' | 'conflict';
+	plexCredentialsChanged: boolean;
+}
+
+/**
+ * Atomically validates that the API config keys have not changed since
+ * `submittedVersion` and, if so, writes any non-empty, non-locked values in a
+ * single SQLite transaction. Returns `'conflict'` when the submitted version
+ * is stale; the caller should run cache-invalidation side effects (e.g.
+ * `clearCachedServerMachineId`) after commit when `plexCredentialsChanged`.
+ */
+export async function setApiConfigAtomic(opts: {
+	values: SetApiConfigInput;
+	locks: SetApiConfigLocks;
+	submittedVersion: string;
+}): Promise<SetApiConfigResult> {
+	return db.transaction(async (tx) => {
+		const rows = await tx
+			.select({ updatedAt: appSettings.updatedAt })
+			.from(appSettings)
+			.where(inArray(appSettings.key, API_CONFIG_KEYS as unknown as string[]));
+
+		if (rows.length > 0) {
+			let maxMs = 0;
+			for (const row of rows) {
+				const t = row.updatedAt.getTime();
+				if (t > maxMs) maxMs = t;
+			}
+			const submittedMs = opts.submittedVersion ? Date.parse(opts.submittedVersion) : Number.NaN;
+			if (Number.isNaN(submittedMs) || submittedMs < maxMs) {
+				return { status: 'conflict', plexCredentialsChanged: false };
+			}
+		}
+
+		const now = new Date();
+		let plexCredentialsChanged = false;
+
+		const writeIfApplicable = async (key: AppSettingsKeyType, value: string, locked: boolean) => {
+			if (!value || locked) return;
+			await tx
+				.insert(appSettings)
+				.values({ key, value, updatedAt: now })
+				.onConflictDoUpdate({
+					target: appSettings.key,
+					set: { value, updatedAt: now }
+				});
+		};
+
+		if (opts.values.plexServerUrl && !opts.locks.plexServerUrl) {
+			plexCredentialsChanged = true;
+		}
+		if (opts.values.plexToken && !opts.locks.plexToken) {
+			plexCredentialsChanged = true;
+		}
+
+		await writeIfApplicable(
+			AppSettingsKey.PLEX_SERVER_URL,
+			opts.values.plexServerUrl,
+			opts.locks.plexServerUrl
+		);
+		await writeIfApplicable(AppSettingsKey.PLEX_TOKEN, opts.values.plexToken, opts.locks.plexToken);
+		await writeIfApplicable(
+			AppSettingsKey.OPENAI_API_KEY,
+			opts.values.openaiApiKey,
+			opts.locks.openaiApiKey
+		);
+		await writeIfApplicable(
+			AppSettingsKey.OPENAI_BASE_URL,
+			opts.values.openaiBaseUrl,
+			opts.locks.openaiBaseUrl
+		);
+		await writeIfApplicable(
+			AppSettingsKey.OPENAI_MODEL,
+			opts.values.openaiModel,
+			opts.locks.openaiModel
+		);
+
+		return { status: 'ok', plexCredentialsChanged };
 	});
 }
 

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -351,9 +351,17 @@ export async function setApiConfigAtomic(opts: {
 			await upsert(key, value);
 		};
 
-		if (opts.values.plexServerUrl && !opts.locks.plexServerUrl) {
+		// PLEX_SERVER_URL is an echoed-back key: a non-undefined submission means the
+		// user touched the field. Both a write (non-empty) and an explicit clear ('')
+		// are credential changes — clearing the URL invalidates the cached machineId
+		// just as much as pointing at a different server, since the next resolution
+		// falls through to env / default which may target a different Plex instance.
+		if (opts.values.plexServerUrl !== undefined && !opts.locks.plexServerUrl) {
 			plexCredentialsChanged = true;
 		}
+		// PLEX_TOKEN is a secret key: writeSecret no-ops on both `undefined` and `''`,
+		// so a non-truthy submission causes no DB change. Flag only when the value
+		// will actually be written.
 		if (opts.values.plexToken && !opts.locks.plexToken) {
 			plexCredentialsChanged = true;
 		}

--- a/src/lib/server/sharing/access-control.ts
+++ b/src/lib/server/sharing/access-control.ts
@@ -88,6 +88,14 @@ export async function checkWrappedAccess(
 
 	const globalFloor = await getGlobalDefaultShareMode();
 	const effectiveMode = getMoreRestrictiveMode(settings.mode, globalFloor);
+	const isOwner = currentUser?.id === userId || currentUser?.isAdmin === true;
+
+	// Anti-enumeration: a private-link page accessed without a token by a
+	// non-owner must look identical to a missing share, so the existence of
+	// the underlying user can't be probed via the numeric URL.
+	if (effectiveMode === ShareMode.PRIVATE_LINK && !shareToken && !isOwner) {
+		throw new InvalidShareTokenError();
+	}
 
 	const context: AccessCheckContext = {
 		shareMode: effectiveMode,
@@ -95,7 +103,7 @@ export async function checkWrappedAccess(
 		validToken: settings.shareToken,
 		isAuthenticated: !!currentUser,
 		isServerMember: !!currentUser,
-		isOwner: currentUser?.id === userId || currentUser?.isAdmin === true
+		isOwner
 	};
 
 	const result = checkAccess(context);
@@ -130,7 +138,21 @@ export interface CheckTokenAccessResult {
 	year: number;
 }
 
-export async function checkTokenAccess(token: string): Promise<CheckTokenAccessResult> {
+export interface CheckTokenAccessOptions {
+	token: string;
+	currentUser?: {
+		id: number;
+		plexId: number;
+		isAdmin: boolean;
+	};
+}
+
+export async function checkTokenAccess(
+	input: string | CheckTokenAccessOptions
+): Promise<CheckTokenAccessResult> {
+	const opts: CheckTokenAccessOptions = typeof input === 'string' ? { token: input } : input;
+	const { token, currentUser } = opts;
+
 	const settings = await getShareSettingsByToken(token);
 
 	if (!settings) {
@@ -156,11 +178,19 @@ export async function checkTokenAccess(token: string): Promise<CheckTokenAccessR
 	const effectiveMode = getMoreRestrictiveMode(settings.mode, globalFloor);
 	if (effectiveMode !== ShareMode.PRIVATE_LINK) {
 		// Floor pushed the effective mode above private-link (e.g. private-oauth):
-		// token alone is no longer sufficient, direct the viewer to sign in.
+		// signed-in server members satisfy the auth floor, so the token URL still
+		// resolves for them. Only anonymous visitors are gated.
 		if (ShareModePrivacyLevel[effectiveMode] > ShareModePrivacyLevel[ShareMode.PRIVATE_LINK]) {
-			throw new ShareAccessDeniedError(
-				'This wrapped is visible only to members of this Plex server. Sign in with your Plex account to view.'
-			);
+			if (!currentUser) {
+				throw new ShareAccessDeniedError(
+					'This wrapped is visible only to members of this Plex server. Sign in with your Plex account to view.'
+				);
+			}
+			return {
+				settings: { ...settings, mode: effectiveMode },
+				userId: settings.userId,
+				year: settings.year
+			};
 		}
 		// Both per-user mode and floor are public: the page is public, so the
 		// token is meaningless; treat as a stale link.

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -31,6 +31,10 @@ export function isValidTokenFormat(token: string): boolean {
 	return uuidV4Regex.test(token);
 }
 
+export function isPureNumericId(value: string): boolean {
+	return /^\d+$/.test(value);
+}
+
 function normalizeShareModeSource(value: string | null): ShareModeSourceType {
 	const parsed = ShareModeSourceSchema.safeParse(value ?? ShareModeSource.EXPLICIT);
 	return parsed.success ? parsed.data : ShareModeSource.EXPLICIT;
@@ -130,12 +134,62 @@ export async function setGlobalShareDefaults(defaults: GlobalShareDefaults): Pro
 	});
 }
 
-export async function bulkApplyUserControl(canUserControl: boolean): Promise<number> {
-	const result = await db
-		.update(shareSettings)
-		.set({ canUserControl })
-		.returning({ id: shareSettings.id });
-	return result.length;
+export async function bulkApplyShareDefaults(): Promise<number> {
+	return db.transaction(async (tx) => {
+		const defaultsResult = await tx
+			.select({ key: appSettings.key, value: appSettings.value })
+			.from(appSettings)
+			.where(eq(appSettings.key, ShareSettingsKey.DEFAULT_SHARE_MODE))
+			.limit(1);
+
+		const allowResult = await tx
+			.select({ value: appSettings.value })
+			.from(appSettings)
+			.where(eq(appSettings.key, ShareSettingsKey.ALLOW_USER_CONTROL))
+			.limit(1);
+
+		const parsedDefault = ShareModeSchema.safeParse(defaultsResult[0]?.value);
+		const defaultMode: ShareModeType = parsedDefault.success
+			? parsedDefault.data
+			: ShareMode.PUBLIC;
+		const allowUserControl = allowResult[0]?.value === 'true';
+
+		const baseUpdate: Record<string, unknown> = {
+			mode: defaultMode,
+			modeSource: ShareModeSource.DEFAULT,
+			canUserControl: allowUserControl
+		};
+
+		if (defaultMode !== ShareMode.PRIVATE_LINK) {
+			baseUpdate.shareToken = null;
+		}
+
+		const updated = await tx.update(shareSettings).set(baseUpdate).returning({
+			id: shareSettings.id,
+			userId: shareSettings.userId,
+			year: shareSettings.year,
+			shareToken: shareSettings.shareToken
+		});
+
+		if (defaultMode === ShareMode.PRIVATE_LINK) {
+			for (const row of updated) {
+				if (!row.shareToken) {
+					await tx
+						.update(shareSettings)
+						.set({ shareToken: generateShareToken() })
+						.where(
+							and(
+								eq(shareSettings.userId, row.userId),
+								eq(shareSettings.year, row.year),
+								isNull(shareSettings.shareToken)
+							)
+						);
+				}
+			}
+		}
+
+		return updated.length;
+	});
 }
 
 export async function getServerWrappedShareMode(): Promise<ShareModeType> {

--- a/src/lib/slides/types.ts
+++ b/src/lib/slides/types.ts
@@ -30,8 +30,8 @@ export const UpdateSlideConfigSchema = z.object({
 export type UpdateSlideConfig = z.infer<typeof UpdateSlideConfigSchema>;
 
 export const CreateCustomSlideSchema = z.object({
-	title: z.string().min(1).max(200),
-	content: z.string().min(1).max(10000),
+	title: z.string().trim().min(1).max(200),
+	content: z.string().trim().min(1).max(10000),
 	enabled: z.boolean().default(true),
 	sortOrder: z.number().int().nonnegative(),
 	year: z.number().int().min(2000).max(2100).nullable().optional()
@@ -40,8 +40,8 @@ export const CreateCustomSlideSchema = z.object({
 export type CreateCustomSlide = z.infer<typeof CreateCustomSlideSchema>;
 
 export const UpdateCustomSlideSchema = z.object({
-	title: z.string().min(1).max(200).optional(),
-	content: z.string().min(1).max(10000).optional(),
+	title: z.string().trim().min(1).max(200).optional(),
+	content: z.string().trim().min(1).max(10000).optional(),
 	enabled: z.boolean().optional(),
 	sortOrder: z.number().int().nonnegative().optional(),
 	year: z.number().int().min(2000).max(2100).nullable().optional()

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -220,7 +220,15 @@ function clearFilters() {
 	searchText = '';
 	fromDate = '';
 	toDate = '';
+	// Drop the SSE buffer so previously-filtered events (e.g. captured while an
+	// ERROR-only filter was active) don't leak into the unfiltered view.
+	streamedLogs = [];
+	lastSeenStreamId = 0;
 	goto('/admin/logs', { replaceState: true, invalidateAll: true });
+	if (autoScroll) {
+		disconnectSSE();
+		connectSSE();
+	}
 }
 
 // Connect to SSE stream

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -4,6 +4,7 @@ import { env } from '$env/dynamic/private';
 import {
 	AnonymizationMode,
 	type AnonymizationModeType,
+	API_CONFIG_KEYS,
 	AppSettingsKey,
 	type ConfigSource,
 	clearCachedServerMachineId,
@@ -25,6 +26,7 @@ import {
 	PRIVACY_SETTINGS_KEYS,
 	resetCsrfWarningDismissal,
 	setAnonymizationMode,
+	setApiConfigAtomic,
 	setAppSetting,
 	setCachedServerName,
 	setPrivacySettingsAtomic,
@@ -50,7 +52,7 @@ import {
 	setLogRetentionDays
 } from '$lib/server/logging';
 import {
-	bulkApplyUserControl,
+	bulkApplyShareDefaults,
 	getGlobalAllowUserControl,
 	getGlobalDefaultShareMode,
 	getServerWrappedShareMode,
@@ -75,10 +77,6 @@ const GlobalDefaultsSchema = z.object({
 	defaultShareMode: ShareModeSchema,
 	allowUserControl: z.coerce.boolean()
 });
-const BulkUserControlSchema = z.object({
-	canUserControl: z.enum(['true', 'false']).transform((v) => v === 'true')
-});
-
 // Server-wide wrapped only supports public and private-oauth (not private-link)
 const ServerWrappedModeSchema = z.enum(['public', 'private-oauth']);
 
@@ -95,12 +93,21 @@ const ApiConfigSchema = z.object({
 	plexToken: z.string().max(512).optional(),
 	openaiApiKey: z.string().max(512).optional(),
 	openaiBaseUrl: z.string().max(512).url('Invalid URL format').optional().or(z.literal('')),
-	openaiModel: z.string().max(100).optional()
+	openaiModel: z.string().max(100).optional(),
+	apiConfigVersion: z.string()
 });
 
 const LogSettingsSchema = z.object({
-	retentionDays: z.number().min(1).max(365),
-	maxCount: z.number().min(1000).max(1000000),
+	retentionDays: z
+		.number({ error: 'Retention days must be a number' })
+		.int('Retention days must be a whole number')
+		.min(1, 'Retention days must be at least 1')
+		.max(365, 'Retention days cannot exceed 365'),
+	maxCount: z
+		.number({ error: 'Max log count must be a number' })
+		.int('Max log count must be a whole number')
+		.min(1000, 'Max log count must be at least 1000')
+		.max(1000000, 'Max log count cannot exceed 1,000,000'),
 	debugEnabled: z.boolean()
 });
 
@@ -143,7 +150,8 @@ export const load: PageServerLoad = async () => {
 		csrfWarningDismissed,
 		csrfOriginSkippedRaw,
 		trustProxyConfig,
-		privacySettingsUpdatedAt
+		privacySettingsUpdatedAt,
+		apiConfigUpdatedAt
 	] = await Promise.all([
 		getApiConfigWithSources(),
 		getUITheme(),
@@ -161,7 +169,8 @@ export const load: PageServerLoad = async () => {
 		isCsrfWarningDismissed(),
 		getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED),
 		getTrustProxyConfigWithSource(),
-		getAppSettingsUpdatedAt(PRIVACY_SETTINGS_KEYS)
+		getAppSettingsUpdatedAt(PRIVACY_SETTINGS_KEYS),
+		getAppSettingsUpdatedAt(API_CONFIG_KEYS)
 	]);
 
 	const currentYear = new Date().getFullYear();
@@ -209,6 +218,7 @@ export const load: PageServerLoad = async () => {
 		},
 		serverWrappedShareMode,
 		privacySettingsVersion: privacySettingsUpdatedAt?.toISOString() ?? '',
+		apiConfigVersion: apiConfigUpdatedAt?.toISOString() ?? '',
 		security: {
 			originValue: csrfConfig.origin.value,
 			csrfEnabled: !!csrfConfig.origin.value,
@@ -233,7 +243,8 @@ export const actions: Actions = requireAdminActions({
 			plexToken: formData.get('plexToken')?.toString() ?? '',
 			openaiApiKey: formData.get('openaiApiKey')?.toString() ?? '',
 			openaiBaseUrl: formData.get('openaiBaseUrl')?.toString() ?? '',
-			openaiModel: formData.get('openaiModel')?.toString() ?? ''
+			openaiModel: formData.get('openaiModel')?.toString() ?? '',
+			apiConfigVersion: formData.get('apiConfigVersion')?.toString() ?? ''
 		};
 
 		const parsed = ApiConfigSchema.safeParse(data);
@@ -247,29 +258,33 @@ export const actions: Actions = requireAdminActions({
 		try {
 			const apiConfig = await getApiConfigWithSources();
 
-			// Save each setting (only if provided AND not locked by ENV).
-			// Secret fields (plexToken, openaiApiKey) are blank on load to avoid
-			// leaking via hydration; an empty submission means "no change".
-			if (parsed.data.plexServerUrl && !apiConfig.plex.serverUrl.isLocked) {
-				await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, parsed.data.plexServerUrl);
-				// URL changed — the cached machineId may be stale; next membership
-				// check will re-fetch /identity against the new URL.
+			const result = await setApiConfigAtomic({
+				values: {
+					plexServerUrl: parsed.data.plexServerUrl ?? '',
+					plexToken: parsed.data.plexToken ?? '',
+					openaiApiKey: parsed.data.openaiApiKey ?? '',
+					openaiBaseUrl: parsed.data.openaiBaseUrl ?? '',
+					openaiModel: parsed.data.openaiModel ?? ''
+				},
+				locks: {
+					plexServerUrl: apiConfig.plex.serverUrl.isLocked,
+					plexToken: apiConfig.plex.token.isLocked,
+					openaiApiKey: apiConfig.openai.apiKey.isLocked,
+					openaiBaseUrl: apiConfig.openai.baseUrl.isLocked,
+					openaiModel: apiConfig.openai.model.isLocked
+				},
+				submittedVersion: parsed.data.apiConfigVersion
+			});
+
+			if (result.status === 'conflict') {
+				return fail(409, {
+					conflict: true,
+					error: 'Settings changed in another tab. Reload and try again.'
+				});
+			}
+
+			if (result.plexCredentialsChanged) {
 				await clearCachedServerMachineId();
-			}
-			if (parsed.data.plexToken && !apiConfig.plex.token.isLocked) {
-				await setAppSetting(AppSettingsKey.PLEX_TOKEN, parsed.data.plexToken);
-				// Token changed — the cached machineId was fetched with the old token;
-				// drop it so /identity runs with the new credentials.
-				await clearCachedServerMachineId();
-			}
-			if (parsed.data.openaiApiKey && !apiConfig.openai.apiKey.isLocked) {
-				await setAppSetting(AppSettingsKey.OPENAI_API_KEY, parsed.data.openaiApiKey);
-			}
-			if (parsed.data.openaiBaseUrl && !apiConfig.openai.baseUrl.isLocked) {
-				await setAppSetting(AppSettingsKey.OPENAI_BASE_URL, parsed.data.openaiBaseUrl);
-			}
-			if (parsed.data.openaiModel && !apiConfig.openai.model.isLocked) {
-				await setAppSetting(AppSettingsKey.OPENAI_MODEL, parsed.data.openaiModel);
 			}
 
 			return { success: true, message: 'API configuration updated' };
@@ -546,8 +561,8 @@ export const actions: Actions = requireAdminActions({
 		const debugEnabledStr = formData.get('debugEnabled')?.toString();
 
 		const data = {
-			retentionDays: retentionDaysStr ? parseInt(retentionDaysStr, 10) : 7,
-			maxCount: maxCountStr ? parseInt(maxCountStr, 10) : 50000,
+			retentionDays: retentionDaysStr ? Number.parseInt(retentionDaysStr, 10) : Number.NaN,
+			maxCount: maxCountStr ? Number.parseInt(maxCountStr, 10) : Number.NaN,
 			debugEnabled: debugEnabledStr === 'true'
 		};
 
@@ -601,24 +616,13 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	bulkApplyUserControl: async ({ request }) => {
-		const formData = await request.formData();
-
-		const parsed = BulkUserControlSchema.safeParse({
-			canUserControl: formData.get('canUserControl')
-		});
-		if (!parsed.success) {
-			return fail(400, {
-				error: 'Invalid input: canUserControl must be "true" or "false"'
-			});
-		}
-
+	bulkApplyShareDefaults: async () => {
 		try {
-			const count = await bulkApplyUserControl(parsed.data.canUserControl);
+			const count = await bulkApplyShareDefaults();
 			return { success: true, message: `Updated ${count} user share records` };
 		} catch (error) {
 			const message =
-				error instanceof Error ? error.message : 'Failed to apply default to existing users';
+				error instanceof Error ? error.message : 'Failed to apply defaults to existing users';
 			return fail(500, { error: message });
 		}
 	},

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -88,11 +88,19 @@ const PrivacySettingsSchema = z.object({
 	settingsVersion: z.string()
 });
 
+// Each value field is `string | undefined`:
+//   undefined = field absent from this submission (e.g. the OpenAI panel saved
+//               and didn't include Plex inputs) → service treats as no-op.
+//   ''        = field present but blank → service either clears (echoed-back
+//               keys) or no-ops (secret keys).
+//   non-empty = write.
+// The URL-validated fields accept `''` via the literal union so a cleared input
+// passes validation and reaches the service as the clear signal.
 const ApiConfigSchema = z.object({
-	plexServerUrl: z.string().max(512).url('Invalid URL format').optional().or(z.literal('')),
+	plexServerUrl: z.union([z.string().max(512).url('Invalid URL format'), z.literal('')]).optional(),
 	plexToken: z.string().max(512).optional(),
 	openaiApiKey: z.string().max(512).optional(),
-	openaiBaseUrl: z.string().max(512).url('Invalid URL format').optional().or(z.literal('')),
+	openaiBaseUrl: z.union([z.string().max(512).url('Invalid URL format'), z.literal('')]).optional(),
 	openaiModel: z.string().max(100).optional(),
 	apiConfigVersion: z.string()
 });
@@ -238,12 +246,20 @@ export const actions: Actions = requireAdminActions({
 	updateApiConfig: async ({ request }) => {
 		const formData = await request.formData();
 
+		// Distinguish "field absent from this submission" from "field submitted blank":
+		// the API config UI has two separate <form> elements (Plex panel, OpenAI panel)
+		// both targeting `?/updateApiConfig`. Saving one panel does NOT include the
+		// other panel's inputs; treating those absent fields as `''` would wipe the
+		// other panel's stored values via the echoed-back-key clear path.
+		const field = (name: string): string | undefined =>
+			formData.has(name) ? (formData.get(name)?.toString() ?? '') : undefined;
+
 		const data = {
-			plexServerUrl: formData.get('plexServerUrl')?.toString() ?? '',
-			plexToken: formData.get('plexToken')?.toString() ?? '',
-			openaiApiKey: formData.get('openaiApiKey')?.toString() ?? '',
-			openaiBaseUrl: formData.get('openaiBaseUrl')?.toString() ?? '',
-			openaiModel: formData.get('openaiModel')?.toString() ?? '',
+			plexServerUrl: field('plexServerUrl'),
+			plexToken: field('plexToken'),
+			openaiApiKey: field('openaiApiKey'),
+			openaiBaseUrl: field('openaiBaseUrl'),
+			openaiModel: field('openaiModel'),
 			apiConfigVersion: formData.get('apiConfigVersion')?.toString() ?? ''
 		};
 
@@ -260,11 +276,11 @@ export const actions: Actions = requireAdminActions({
 
 			const result = await setApiConfigAtomic({
 				values: {
-					plexServerUrl: parsed.data.plexServerUrl ?? '',
-					plexToken: parsed.data.plexToken ?? '',
-					openaiApiKey: parsed.data.openaiApiKey ?? '',
-					openaiBaseUrl: parsed.data.openaiBaseUrl ?? '',
-					openaiModel: parsed.data.openaiModel ?? ''
+					plexServerUrl: parsed.data.plexServerUrl,
+					plexToken: parsed.data.plexToken,
+					openaiApiKey: parsed.data.openaiApiKey,
+					openaiBaseUrl: parsed.data.openaiBaseUrl,
+					openaiModel: parsed.data.openaiModel
 				},
 				locks: {
 					plexServerUrl: apiConfig.plex.serverUrl.isLocked,

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -98,12 +98,12 @@ const ApiConfigSchema = z.object({
 });
 
 const LogSettingsSchema = z.object({
-	retentionDays: z
+	retentionDays: z.coerce
 		.number({ error: 'Retention days must be a number' })
 		.int('Retention days must be a whole number')
 		.min(1, 'Retention days must be at least 1')
 		.max(365, 'Retention days cannot exceed 365'),
-	maxCount: z
+	maxCount: z.coerce
 		.number({ error: 'Max log count must be a number' })
 		.int('Max log count must be a whole number')
 		.min(1000, 'Max log count must be at least 1000')
@@ -556,14 +556,10 @@ export const actions: Actions = requireAdminActions({
 	updateLogSettings: async ({ request }) => {
 		const formData = await request.formData();
 
-		const retentionDaysStr = formData.get('retentionDays')?.toString();
-		const maxCountStr = formData.get('maxCount')?.toString();
-		const debugEnabledStr = formData.get('debugEnabled')?.toString();
-
 		const data = {
-			retentionDays: retentionDaysStr ? Number.parseInt(retentionDaysStr, 10) : Number.NaN,
-			maxCount: maxCountStr ? Number.parseInt(maxCountStr, 10) : Number.NaN,
-			debugEnabled: debugEnabledStr === 'true'
+			retentionDays: formData.get('retentionDays')?.toString(),
+			maxCount: formData.get('maxCount')?.toString(),
+			debugEnabled: formData.get('debugEnabled')?.toString() === 'true'
 		};
 
 		const parsed = LogSettingsSchema.safeParse(data);

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -107,33 +107,34 @@ let selectedDefaultShareMode = $state('public');
 let allowUserControl = $state(true);
 let isBulkApplyingUserControl = $state(false);
 
-let bulkApplyUserControlDialogOpen = $state(false);
+let bulkApplyShareDefaultsDialogOpen = $state(false);
 
-async function confirmBulkApplyUserControl() {
-	bulkApplyUserControlDialogOpen = false;
+async function confirmBulkApplyShareDefaults() {
+	bulkApplyShareDefaultsDialogOpen = false;
 	isBulkApplyingUserControl = true;
 
-	const formData = new FormData();
-	formData.append('canUserControl', allowUserControl.toString());
-
 	try {
-		const response = await fetch('?/bulkApplyUserControl', {
+		const response = await fetch('?/bulkApplyShareDefaults', {
 			method: 'POST',
-			body: formData
+			body: new FormData()
 		});
 		const result = deserialize(await response.text());
 
-		if (result.type === 'success' && result.data) {
-			handleFormToast(result.data as { success: boolean; message: string });
+		if (result.type === 'success') {
+			const payload = (result.data ?? {
+				success: true,
+				message: 'Defaults applied to all users.'
+			}) as { success: boolean; message: string };
+			handleFormToast(payload);
 		} else if (result.type === 'failure') {
 			handleFormToast({
-				error: (result.data as { error?: string })?.error ?? 'Failed to apply default.'
+				error: (result.data as { error?: string })?.error ?? 'Failed to apply defaults.'
 			});
 		} else if (result.type === 'error') {
-			handleFormToast({ error: result.error?.message ?? 'Failed to apply default.' });
+			handleFormToast({ error: result.error?.message ?? 'Failed to apply defaults.' });
 		}
 	} catch (error) {
-		const message = error instanceof Error ? error.message : 'Failed to apply default.';
+		const message = error instanceof Error ? error.message : 'Failed to apply defaults.';
 		handleFormToast({ error: message });
 	} finally {
 		isBulkApplyingUserControl = false;
@@ -538,6 +539,7 @@ const logFieldErrors = $derived(
 					</div>
 
 					<form method="POST" action="?/updateApiConfig" use:enhance class="panel-form">
+						<input type="hidden" name="apiConfigVersion" value={data.apiConfigVersion} />
 						<div class="form-field">
 							<div class="field-header">
 								<label for="plexServerUrl">Server URL</label>
@@ -717,6 +719,7 @@ const logFieldErrors = $derived(
 					</p>
 
 					<form method="POST" action="?/updateApiConfig" use:enhance class="panel-form">
+						<input type="hidden" name="apiConfigVersion" value={data.apiConfigVersion} />
 						<div class="form-field">
 							<div class="field-header">
 								<label for="openaiApiKey">API Key</label>
@@ -1342,14 +1345,14 @@ const logFieldErrors = $derived(
 						type="button"
 						class="btn-secondary"
 						disabled={isBulkApplyingUserControl}
-						onclick={() => (bulkApplyUserControlDialogOpen = true)}
+						onclick={() => (bulkApplyShareDefaultsDialogOpen = true)}
 					>
 						{#if isBulkApplyingUserControl}
 							<Loader2 class="btn-icon spinning" />
 							Applying...
 						{:else}
 							<Users class="btn-icon" />
-							Apply current default to all existing users
+							Apply current defaults to all existing users
 						{/if}
 					</button>
 				</section>
@@ -2192,20 +2195,21 @@ const logFieldErrors = $derived(
 	</AlertDialog.Content>
 </AlertDialog.Root>
 
-<AlertDialog.Root bind:open={bulkApplyUserControlDialogOpen}>
+<AlertDialog.Root bind:open={bulkApplyShareDefaultsDialogOpen}>
 	<AlertDialog.Content>
 		<AlertDialog.Header>
-			<AlertDialog.Title>Apply default to all users?</AlertDialog.Title>
+			<AlertDialog.Title>Apply current defaults to all users?</AlertDialog.Title>
 			<AlertDialog.Description>
-				This will overwrite the per-user "can control" setting for every existing user. Future users
-				will still receive the current default.
+				This resets every existing user's share mode and "can control" setting back to the current
+				server defaults. Per-user customizations will be lost. Future users continue to receive
+				the current defaults.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
 			<AlertDialog.Cancel disabled={isBulkApplyingUserControl}>Cancel</AlertDialog.Cancel>
 			<AlertDialog.Action
 				disabled={isBulkApplyingUserControl}
-				onclick={confirmBulkApplyUserControl}
+				onclick={confirmBulkApplyShareDefaults}
 			>
 				{isBulkApplyingUserControl ? 'Applying…' : 'Apply to all users'}
 			</AlertDialog.Action>

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -59,6 +59,21 @@ let editorContent = $state('');
 let editorYear = $state<number | null>(null);
 let editorEnabled = $state(true);
 let previewHtml = $state('');
+let editorTriggerRef: HTMLElement | null = null;
+let editorTitleInputRef: HTMLInputElement | null = $state(null);
+
+$effect(() => {
+	if (!showEditor) return;
+	const handler = (e: KeyboardEvent) => {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			closeEditor();
+		}
+	};
+	document.addEventListener('keydown', handler);
+	queueMicrotask(() => editorTitleInputRef?.focus());
+	return () => document.removeEventListener('keydown', handler);
+});
 
 // Delete confirmation state
 let deletingSlideId = $state<number | null>(null);
@@ -117,6 +132,7 @@ const unifiedSlides = $derived.by(() => {
 
 // Open editor for new slide
 function openNewEditor() {
+	editorTriggerRef = (document.activeElement as HTMLElement) ?? null;
 	editingSlide = null;
 	editorTitle = '';
 	editorContent = '';
@@ -128,6 +144,7 @@ function openNewEditor() {
 
 // Open editor for existing slide
 function openEditEditor(slide: (typeof data.customSlides)[0]) {
+	editorTriggerRef = (document.activeElement as HTMLElement) ?? null;
 	editingSlide = slide;
 	editorTitle = slide.title;
 	editorContent = slide.content;
@@ -141,6 +158,9 @@ function openEditEditor(slide: (typeof data.customSlides)[0]) {
 function closeEditor() {
 	showEditor = false;
 	editingSlide = null;
+	const trigger = editorTriggerRef;
+	editorTriggerRef = null;
+	queueMicrotask(() => trigger?.focus());
 }
 
 // Handle drag start
@@ -474,8 +494,8 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			<div
 				class="modal"
 				onclick={(e) => e.stopPropagation()}
-				onkeydown={(e) => e.key === 'Escape' && closeEditor()}
 				role="dialog"
+				aria-modal="true"
 				aria-labelledby="editor-title"
 				tabindex="-1"
 			>
@@ -517,6 +537,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 							type="text"
 							id="title"
 							name="title"
+							bind:this={editorTitleInputRef}
 							bind:value={editorTitle}
 							required
 							placeholder="Enter slide title"

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -306,6 +306,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 		/* Users Table */
 		.users-table-wrapper {
 			overflow-x: auto;
+			max-width: 100%;
 		}
 
 		.users-table {

--- a/src/routes/api/onboarding/test-connection/+server.ts
+++ b/src/routes/api/onboarding/test-connection/+server.ts
@@ -47,13 +47,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 		if (!parseResult.success) {
 			const errorMessage = parseResult.error.issues[0]?.message ?? 'Invalid request';
-			return json({ success: false, error: errorMessage });
+			return json({ success: false, error: errorMessage }, { status: 400 });
 		}
 
 		const { url } = parseResult.data;
 		const accessToken = parseResult.data.accessToken ?? parseResult.data.token;
 		if (!accessToken) {
-			return json({ success: false, error: 'Access token is required' });
+			return json({ success: false, error: 'Access token is required' }, { status: 400 });
 		}
 
 		// Normalize URL - remove trailing slash
@@ -78,10 +78,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			// Check for authentication errors
 			if (response.status === 401) {
 				logger.debug('Connection test failed: Authentication failed', 'Onboarding');
-				return json({
-					success: false,
-					error: 'Authentication failed - the access token may be invalid'
-				});
+				return json(
+					{
+						success: false,
+						error: 'Authentication failed - the access token may be invalid'
+					},
+					{ status: 401 }
+				);
 			}
 
 			if (!response.ok) {
@@ -89,10 +92,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 					`Connection test failed: ${response.status} ${response.statusText}`,
 					'Onboarding'
 				);
-				return json({
-					success: false,
-					error: `Server returned error: ${response.status} ${response.statusText}`
-				});
+				return json(
+					{
+						success: false,
+						error: `Server returned error: ${response.status} ${response.statusText}`
+					},
+					{ status: 502 }
+				);
 			}
 
 			// Parse and validate response
@@ -101,10 +107,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 			if (!identityResult.success) {
 				logger.debug('Connection test failed: Not a valid Plex server response', 'Onboarding');
-				return json({
-					success: false,
-					error: 'This does not appear to be a Plex Media Server'
-				});
+				return json(
+					{
+						success: false,
+						error: 'This does not appear to be a Plex Media Server'
+					},
+					{ status: 502 }
+				);
 			}
 
 			const { machineIdentifier, friendlyName } = identityResult.data.MediaContainer;
@@ -121,17 +130,23 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			if (fetchError instanceof Error) {
 				const errorMessage = classifyConnectionError(fetchError);
 				logger.debug(`Connection test failed: ${errorMessage}`, 'Onboarding');
-				return json({
-					success: false,
-					error: errorMessage
-				});
+				return json(
+					{
+						success: false,
+						error: errorMessage
+					},
+					{ status: 502 }
+				);
 			}
 
 			logger.debug('Connection test failed: Unknown error', 'Onboarding');
-			return json({
-				success: false,
-				error: 'Connection failed'
-			});
+			return json(
+				{
+					success: false,
+					error: 'Connection failed'
+				},
+				{ status: 502 }
+			);
 		} finally {
 			// Keep the timer armed until after response.json() + parsing complete so
 			// CONNECTION_TIMEOUT_MS caps the whole /identity call, not just the
@@ -148,9 +163,12 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			`Test connection error: ${err instanceof Error ? err.message : String(err)}`,
 			'Onboarding'
 		);
-		return json({
-			success: false,
-			error: 'An unexpected error occurred'
-		});
+		return json(
+			{
+				success: false,
+				error: 'An unexpected error occurred'
+			},
+			{ status: 500 }
+		);
 	}
 };

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -288,7 +288,13 @@ export const actions: Actions = {
 		try {
 			const formData = await request.formData();
 
-			// Parse form data
+			// Parse form data. Hidden AI inputs are always rendered (so the form
+			// submits in one click) but emit empty strings when the toggle is off;
+			// coerce those to undefined so optional() and enum() schemas match.
+			const optionalString = (key: string): string | undefined => {
+				const raw = formData.get(key)?.toString().trim();
+				return raw ? raw : undefined;
+			};
 			const rawData = {
 				uiTheme: formData.get('uiTheme'),
 				wrappedTheme: formData.get('wrappedTheme'),
@@ -298,11 +304,11 @@ export const actions: Actions = {
 				allowUserControl: formData.get('allowUserControl'),
 				enabledSlides: formData.get('enabledSlides'),
 				enableFunFacts: formData.get('enableFunFacts'),
-				funFactFrequency: formData.get('funFactFrequency') ?? undefined,
-				openaiApiKey: formData.get('openaiApiKey') ?? undefined,
-				openaiBaseUrl: formData.get('openaiBaseUrl')?.toString().trim() ?? undefined,
-				openaiModel: formData.get('openaiModel')?.toString().trim() ?? undefined,
-				aiPersona: formData.get('aiPersona') ?? undefined
+				funFactFrequency: optionalString('funFactFrequency'),
+				openaiApiKey: optionalString('openaiApiKey'),
+				openaiBaseUrl: optionalString('openaiBaseUrl'),
+				openaiModel: optionalString('openaiModel'),
+				aiPersona: optionalString('aiPersona')
 			};
 
 			// Validate

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -270,13 +270,15 @@ function getThemeColors(themeValue: string) {
 				<input type="hidden" name="allowUserControl" value={allowUserControl} />
 				<input type="hidden" name="enabledSlides" value={enabledSlidesString} />
 				<input type="hidden" name="enableFunFacts" value={enableFunFacts} />
-				{#if enableFunFacts}
-					<input type="hidden" name="funFactFrequency" value={funFactFrequency} />
-					<input type="hidden" name="openaiApiKey" value={openaiApiKey} />
-					<input type="hidden" name="openaiBaseUrl" value={openaiBaseUrl} />
-					<input type="hidden" name="openaiModel" value={openaiModel} />
-					<input type="hidden" name="aiPersona" value={aiPersona} />
-				{/if}
+				<input
+					type="hidden"
+					name="funFactFrequency"
+					value={enableFunFacts ? funFactFrequency : ''}
+				/>
+				<input type="hidden" name="openaiApiKey" value={enableFunFacts ? openaiApiKey : ''} />
+				<input type="hidden" name="openaiBaseUrl" value={enableFunFacts ? openaiBaseUrl : ''} />
+				<input type="hidden" name="openaiModel" value={enableFunFacts ? openaiModel : ''} />
+				<input type="hidden" name="aiPersona" value={enableFunFacts ? aiPersona : ''} />
 
 				<!-- Carousel Content -->
 				<div class="carousel-content" bind:this={contentRef}>
@@ -1191,8 +1193,19 @@ function getThemeColors(themeValue: string) {
 
 		.radio-card input {
 			position: absolute;
-			opacity: 0;
-			pointer-events: none;
+			width: 1px;
+			height: 1px;
+			padding: 0;
+			margin: -1px;
+			overflow: hidden;
+			clip: rect(0, 0, 0, 0);
+			white-space: nowrap;
+			border: 0;
+		}
+
+		.radio-card:focus-within .radio-card-content {
+			outline: 2px solid hsl(var(--primary));
+			outline-offset: 2px;
 		}
 
 		.radio-card-content {

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -40,11 +40,17 @@ import type { Actions, PageServerLoad } from './$types';
 
 async function resolveUserIdFromIdentifier(
 	identifier: string,
-	year: number
+	year: number,
+	currentUser?: App.Locals['user']
 ): Promise<number | null> {
 	if (isValidTokenFormat(identifier)) {
 		try {
-			const tokenResult = await checkTokenAccess(identifier);
+			// Forward currentUser so floor-elevated token URLs (e.g. global floor
+			// raised above PRIVATE_LINK to PRIVATE_OAUTH) still resolve for signed-in
+			// viewers. Mirrors what `load` does above; without it, the action helpers
+			// would reject any signed-in owner/admin trying to mutate share settings
+			// through a token URL once the floor is raised.
+			const tokenResult = await checkTokenAccess({ token: identifier, currentUser });
 			return tokenResult.year === year ? tokenResult.userId : null;
 		} catch (err) {
 			if (err instanceof InvalidShareTokenError || err instanceof ShareAccessDeniedError) {
@@ -262,7 +268,7 @@ export const actions: Actions = {
 			return fail(400, { error: 'Invalid year' });
 		}
 
-		const userId = await resolveUserIdFromIdentifier(params.identifier, year);
+		const userId = await resolveUserIdFromIdentifier(params.identifier, year, locals.user);
 		if (!userId) {
 			return fail(400, { error: 'Invalid user identifier' });
 		}
@@ -315,7 +321,7 @@ export const actions: Actions = {
 			return fail(400, { error: 'Invalid year' });
 		}
 
-		const userId = await resolveUserIdFromIdentifier(params.identifier, year);
+		const userId = await resolveUserIdFromIdentifier(params.identifier, year, locals.user);
 		if (!userId) {
 			return fail(400, { error: 'Invalid user identifier' });
 		}

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -59,7 +59,7 @@ async function resolveUserIdFromIdentifier(
 	}
 
 	const userId = Number(identifier);
-	return Number.isFinite(userId) && userId > 0 ? userId : null;
+	return Number.isSafeInteger(userId) && userId > 0 ? userId : null;
 }
 
 export const load: PageServerLoad = async ({ params, locals, parent }) => {
@@ -101,7 +101,7 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 			error(404, "We couldn't find a Wrapped page for that link.");
 		}
 		const parsedId = Number(identifier);
-		if (!Number.isFinite(parsedId) || parsedId <= 0) {
+		if (!Number.isSafeInteger(parsedId) || parsedId <= 0) {
 			error(404, "We couldn't find a Wrapped page for that link.");
 		}
 		userId = parsedId;

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -11,6 +11,7 @@ import {
 	ensureShareToken,
 	getGlobalDefaultShareMode,
 	getOrCreateShareSettings,
+	isPureNumericId,
 	isValidTokenFormat,
 	regenerateShareToken,
 	updateShareSettings
@@ -53,8 +54,12 @@ async function resolveUserIdFromIdentifier(
 		}
 	}
 
-	const userId = parseInt(identifier, 10);
-	return Number.isNaN(userId) || userId <= 0 ? null : userId;
+	if (!isPureNumericId(identifier)) {
+		return null;
+	}
+
+	const userId = Number(identifier);
+	return Number.isFinite(userId) && userId > 0 ? userId : null;
 }
 
 export const load: PageServerLoad = async ({ params, locals, parent }) => {
@@ -72,7 +77,10 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	if (isValidTokenFormat(identifier)) {
 		accessedViaToken = true;
 		try {
-			const tokenResult = await checkTokenAccess(identifier);
+			const tokenResult = await checkTokenAccess({
+				token: identifier,
+				currentUser: locals.user
+			});
 			userId = tokenResult.userId;
 
 			// Verify year matches the token's year
@@ -89,8 +97,11 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 			throw err;
 		}
 	} else {
-		const parsedId = parseInt(identifier, 10);
-		if (Number.isNaN(parsedId) || parsedId <= 0) {
+		if (!isPureNumericId(identifier)) {
+			error(404, "We couldn't find a Wrapped page for that link.");
+		}
+		const parsedId = Number(identifier);
+		if (!Number.isFinite(parsedId) || parsedId <= 0) {
 			error(404, "We couldn't find a Wrapped page for that link.");
 		}
 		userId = parsedId;
@@ -168,24 +179,20 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 
 	const globalFloorForUrl = await getGlobalDefaultShareMode();
 	const effectiveModeForUrl = getMoreRestrictiveMode(shareSettings.mode, globalFloorForUrl);
-	// Resolve the share token for the URL, minting one lazily if needed (e.g. when
-	// the global floor raises the effective mode to private-link but the per-user
-	// row was created under a less-restrictive mode and has no token yet).
-	const resolvedShareToken =
-		effectiveModeForUrl === ShareMode.PRIVATE_LINK
-			? (shareSettings.shareToken ?? (await ensureShareToken(userId, year)))
-			: null;
+	const ownerOrAdmin = isOwner || isAdmin;
+	const needsTokenForUrl = effectiveModeForUrl === ShareMode.PRIVATE_LINK;
+	// Owner/admin keep their canonical token even when the floor raises the
+	// effective mode above PRIVATE_LINK, so the share modal stays stable
+	// across reloads. Lazy-mint only when PRIVATE_LINK is actually reachable.
+	const rawTokenForOwner = ownerOrAdmin
+		? (shareSettings.shareToken ?? (needsTokenForUrl ? await ensureShareToken(userId, year) : null))
+		: null;
+	const resolvedShareToken = needsTokenForUrl
+		? (rawTokenForOwner ?? shareSettings.shareToken ?? (await ensureShareToken(userId, year)))
+		: null;
 	const urlIdentifier = resolvedShareToken ?? userId;
 
-	// Only owner/admin sees the raw token, and only when the effective mode is
-	// actually private-link. Anonymous and non-owner viewers never receive it,
-	// even if the row still holds one (defense-in-depth against capture/replay).
-	// Use resolvedShareToken (not the stale shareSettings.shareToken) so that a
-	// freshly-minted token is correctly surfaced to the owner/admin.
-	const exposedShareToken =
-		(isOwner || isAdmin) && effectiveModeForUrl === ShareMode.PRIVATE_LINK
-			? resolvedShareToken
-			: null;
+	const exposedShareToken = ownerOrAdmin ? rawTokenForOwner : null;
 	const signedStats = await signStatsThumbnails(stats, {
 		kind: 'user',
 		year,

--- a/tests/unit/admin/settings.service.test.ts
+++ b/tests/unit/admin/settings.service.test.ts
@@ -969,10 +969,10 @@ describe('Admin Settings Service', () => {
 
 			const result = await setApiConfigAtomic({
 				values: {
-					plexServerUrl: '',
-					plexToken: '',
-					openaiApiKey: '',
-					openaiBaseUrl: '',
+					plexServerUrl: undefined,
+					plexToken: undefined,
+					openaiApiKey: undefined,
+					openaiBaseUrl: undefined,
 					openaiModel: 'gpt-5-mini'
 				},
 				locks: allUnlocked,
@@ -988,10 +988,10 @@ describe('Admin Settings Service', () => {
 
 			const result = await setApiConfigAtomic({
 				values: {
-					plexServerUrl: '',
-					plexToken: '',
-					openaiApiKey: '',
-					openaiBaseUrl: '',
+					plexServerUrl: undefined,
+					plexToken: undefined,
+					openaiApiKey: undefined,
+					openaiBaseUrl: undefined,
 					openaiModel: 'gpt-5-mini'
 				},
 				locks: allUnlocked,
@@ -1007,8 +1007,8 @@ describe('Admin Settings Service', () => {
 					plexServerUrl: 'http://plex.example.com:32400',
 					plexToken: 'tok-x',
 					openaiApiKey: 'sk-x',
-					openaiBaseUrl: '',
-					openaiModel: ''
+					openaiBaseUrl: undefined,
+					openaiModel: undefined
 				},
 				locks: {
 					plexServerUrl: true,
@@ -1027,15 +1027,16 @@ describe('Admin Settings Service', () => {
 			expect(await getAppSetting(AppSettingsKey.OPENAI_API_KEY)).toBe('sk-x');
 		});
 
-		it('treats empty values as no-change', async () => {
+		it('treats undefined values as no-change (absent fields are not touched)', async () => {
 			await setAppSetting(AppSettingsKey.OPENAI_API_KEY, 'sk-existing');
+			await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://plex.example.com:32400');
 
 			const result = await setApiConfigAtomic({
 				values: {
-					plexServerUrl: '',
-					plexToken: '',
-					openaiApiKey: '',
-					openaiBaseUrl: '',
+					plexServerUrl: undefined,
+					plexToken: undefined,
+					openaiApiKey: undefined,
+					openaiBaseUrl: undefined,
 					openaiModel: 'gpt-5-mini'
 				},
 				locks: allUnlocked,
@@ -1045,7 +1046,131 @@ describe('Admin Settings Service', () => {
 			expect(result.status).toBe('ok');
 			expect(result.plexCredentialsChanged).toBe(false);
 			expect(await getAppSetting(AppSettingsKey.OPENAI_API_KEY)).toBe('sk-existing');
+			expect(await getAppSetting(AppSettingsKey.PLEX_SERVER_URL)).toBe(
+				'http://plex.example.com:32400'
+			);
 			expect(await getAppSetting(AppSettingsKey.OPENAI_MODEL)).toBe('gpt-5-mini');
+		});
+
+		// Regression: an OpenAI-panel save must not wipe Plex rows. The two panels
+		// are separate <form> elements both targeting `?/updateApiConfig`, so the
+		// submission omits the other panel's inputs entirely (formData.has === false).
+		it('does not touch Plex rows when only OpenAI fields are submitted', async () => {
+			await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://plex.example.com:32400');
+			await setAppSetting(AppSettingsKey.PLEX_TOKEN, 'plex-secret');
+
+			const result = await setApiConfigAtomic({
+				values: {
+					plexServerUrl: undefined,
+					plexToken: undefined,
+					openaiApiKey: 'sk-new',
+					openaiBaseUrl: 'https://api.example.com',
+					openaiModel: 'gpt-4o'
+				},
+				locks: allUnlocked,
+				submittedVersion: new Date(Date.now() + 60_000).toISOString()
+			});
+
+			expect(result.status).toBe('ok');
+			expect(result.plexCredentialsChanged).toBe(false);
+			expect(await getAppSetting(AppSettingsKey.PLEX_SERVER_URL)).toBe(
+				'http://plex.example.com:32400'
+			);
+			expect(await getAppSetting(AppSettingsKey.PLEX_TOKEN)).toBe('plex-secret');
+			expect(await getAppSetting(AppSettingsKey.OPENAI_API_KEY)).toBe('sk-new');
+			expect(await getAppSetting(AppSettingsKey.OPENAI_MODEL)).toBe('gpt-4o');
+		});
+
+		it('clears echoed-back keys when submitted as empty string', async () => {
+			await setAppSetting(AppSettingsKey.OPENAI_BASE_URL, 'https://api.example.com');
+			await setAppSetting(AppSettingsKey.OPENAI_MODEL, 'gpt-4o');
+
+			const result = await setApiConfigAtomic({
+				values: {
+					plexServerUrl: undefined,
+					plexToken: undefined,
+					openaiApiKey: undefined,
+					openaiBaseUrl: '',
+					openaiModel: ''
+				},
+				locks: allUnlocked,
+				submittedVersion: new Date(Date.now() + 60_000).toISOString()
+			});
+
+			expect(result.status).toBe('ok');
+			expect(await getAppSetting(AppSettingsKey.OPENAI_BASE_URL)).toBeNull();
+			expect(await getAppSetting(AppSettingsKey.OPENAI_MODEL)).toBeNull();
+		});
+
+		it('treats empty string for secret keys as no-op (never clears stored secret)', async () => {
+			await setAppSetting(AppSettingsKey.PLEX_TOKEN, 'plex-secret');
+			await setAppSetting(AppSettingsKey.OPENAI_API_KEY, 'sk-existing');
+
+			const result = await setApiConfigAtomic({
+				values: {
+					plexServerUrl: undefined,
+					plexToken: '',
+					openaiApiKey: '',
+					openaiBaseUrl: undefined,
+					openaiModel: undefined
+				},
+				locks: allUnlocked,
+				submittedVersion: new Date(Date.now() + 60_000).toISOString()
+			});
+
+			expect(result.status).toBe('ok');
+			expect(await getAppSetting(AppSettingsKey.PLEX_TOKEN)).toBe('plex-secret');
+			expect(await getAppSetting(AppSettingsKey.OPENAI_API_KEY)).toBe('sk-existing');
+		});
+
+		// Regression: a clear-only mutation in tab A must advance the OCC version
+		// so that tab B (holding the pre-clear version) cannot resurrect the value.
+		it('advances the OCC version when a clear is the only mutation', async () => {
+			await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://plex.example.com:32400');
+			await setAppSetting(AppSettingsKey.OPENAI_BASE_URL, 'https://api.example.com');
+
+			const versionBeforeClear = await getAppSettingsUpdatedAt([
+				AppSettingsKey.PLEX_SERVER_URL,
+				AppSettingsKey.PLEX_TOKEN,
+				AppSettingsKey.OPENAI_API_KEY,
+				AppSettingsKey.OPENAI_BASE_URL,
+				AppSettingsKey.OPENAI_MODEL,
+				AppSettingsKey.API_CONFIG_VERSION
+			]);
+
+			// Allow at least 1ms for updatedAt comparison to be meaningful.
+			await new Promise((r) => setTimeout(r, 5));
+
+			// Tab A submits the version it loaded and clears OPENAI_BASE_URL only.
+			const tabA = await setApiConfigAtomic({
+				values: {
+					plexServerUrl: undefined,
+					plexToken: undefined,
+					openaiApiKey: undefined,
+					openaiBaseUrl: '',
+					openaiModel: undefined
+				},
+				locks: allUnlocked,
+				submittedVersion: versionBeforeClear?.toISOString() ?? ''
+			});
+			expect(tabA.status).toBe('ok');
+			expect(await getAppSetting(AppSettingsKey.OPENAI_BASE_URL)).toBeNull();
+
+			// Tab B still holds the pre-clear version. It must now lose OCC.
+			const tabB = await setApiConfigAtomic({
+				values: {
+					plexServerUrl: undefined,
+					plexToken: undefined,
+					openaiApiKey: undefined,
+					openaiBaseUrl: 'https://api.example.com',
+					openaiModel: undefined
+				},
+				locks: allUnlocked,
+				submittedVersion: versionBeforeClear?.toISOString() ?? ''
+			});
+			expect(tabB.status).toBe('conflict');
+			// Tab B's resurrection of the cleared value must NOT have happened.
+			expect(await getAppSetting(AppSettingsKey.OPENAI_BASE_URL)).toBeNull();
 		});
 	});
 });

--- a/tests/unit/admin/settings.service.test.ts
+++ b/tests/unit/admin/settings.service.test.ts
@@ -31,6 +31,7 @@ import {
 	isPlexConfigured,
 	resetCsrfWarningDismissal,
 	setAnonymizationMode,
+	setApiConfigAtomic,
 	setAppSetting,
 	setCachedServerName,
 	setCurrentTheme,
@@ -926,6 +927,125 @@ describe('Admin Settings Service', () => {
 				const dismissed = await isCsrfWarningDismissed();
 				expect(dismissed).toBe(false);
 			});
+		});
+	});
+
+	describe('setApiConfigAtomic', () => {
+		const allUnlocked = {
+			plexServerUrl: false,
+			plexToken: false,
+			openaiApiKey: false,
+			openaiBaseUrl: false,
+			openaiModel: false
+		};
+
+		it('writes all provided values when version is fresh', async () => {
+			const result = await setApiConfigAtomic({
+				values: {
+					plexServerUrl: 'http://plex.example.com:32400',
+					plexToken: 'tok-1',
+					openaiApiKey: 'sk-test',
+					openaiBaseUrl: 'https://api.example.com',
+					openaiModel: 'gpt-4o'
+				},
+				locks: allUnlocked,
+				submittedVersion: new Date(Date.now() + 60_000).toISOString()
+			});
+
+			expect(result.status).toBe('ok');
+			expect(result.plexCredentialsChanged).toBe(true);
+			expect(await getAppSetting(AppSettingsKey.PLEX_SERVER_URL)).toBe(
+				'http://plex.example.com:32400'
+			);
+			expect(await getAppSetting(AppSettingsKey.PLEX_TOKEN)).toBe('tok-1');
+			expect(await getAppSetting(AppSettingsKey.OPENAI_API_KEY)).toBe('sk-test');
+			expect(await getAppSetting(AppSettingsKey.OPENAI_BASE_URL)).toBe('https://api.example.com');
+			expect(await getAppSetting(AppSettingsKey.OPENAI_MODEL)).toBe('gpt-4o');
+		});
+
+		it('returns conflict when submitted version is stale', async () => {
+			await setAppSetting(AppSettingsKey.OPENAI_MODEL, 'gpt-4o');
+			const stale = new Date(Date.now() - 60_000).toISOString();
+
+			const result = await setApiConfigAtomic({
+				values: {
+					plexServerUrl: '',
+					plexToken: '',
+					openaiApiKey: '',
+					openaiBaseUrl: '',
+					openaiModel: 'gpt-5-mini'
+				},
+				locks: allUnlocked,
+				submittedVersion: stale
+			});
+
+			expect(result.status).toBe('conflict');
+			expect(await getAppSetting(AppSettingsKey.OPENAI_MODEL)).toBe('gpt-4o');
+		});
+
+		it('returns conflict when submitted version is empty and rows exist', async () => {
+			await setAppSetting(AppSettingsKey.OPENAI_MODEL, 'gpt-4o');
+
+			const result = await setApiConfigAtomic({
+				values: {
+					plexServerUrl: '',
+					plexToken: '',
+					openaiApiKey: '',
+					openaiBaseUrl: '',
+					openaiModel: 'gpt-5-mini'
+				},
+				locks: allUnlocked,
+				submittedVersion: ''
+			});
+
+			expect(result.status).toBe('conflict');
+		});
+
+		it('skips locked fields silently', async () => {
+			const result = await setApiConfigAtomic({
+				values: {
+					plexServerUrl: 'http://plex.example.com:32400',
+					plexToken: 'tok-x',
+					openaiApiKey: 'sk-x',
+					openaiBaseUrl: '',
+					openaiModel: ''
+				},
+				locks: {
+					plexServerUrl: true,
+					plexToken: true,
+					openaiApiKey: false,
+					openaiBaseUrl: false,
+					openaiModel: false
+				},
+				submittedVersion: new Date(Date.now() + 60_000).toISOString()
+			});
+
+			expect(result.status).toBe('ok');
+			expect(result.plexCredentialsChanged).toBe(false);
+			expect(await getAppSetting(AppSettingsKey.PLEX_SERVER_URL)).toBeNull();
+			expect(await getAppSetting(AppSettingsKey.PLEX_TOKEN)).toBeNull();
+			expect(await getAppSetting(AppSettingsKey.OPENAI_API_KEY)).toBe('sk-x');
+		});
+
+		it('treats empty values as no-change', async () => {
+			await setAppSetting(AppSettingsKey.OPENAI_API_KEY, 'sk-existing');
+
+			const result = await setApiConfigAtomic({
+				values: {
+					plexServerUrl: '',
+					plexToken: '',
+					openaiApiKey: '',
+					openaiBaseUrl: '',
+					openaiModel: 'gpt-5-mini'
+				},
+				locks: allUnlocked,
+				submittedVersion: new Date(Date.now() + 60_000).toISOString()
+			});
+
+			expect(result.status).toBe('ok');
+			expect(result.plexCredentialsChanged).toBe(false);
+			expect(await getAppSetting(AppSettingsKey.OPENAI_API_KEY)).toBe('sk-existing');
+			expect(await getAppSetting(AppSettingsKey.OPENAI_MODEL)).toBe('gpt-5-mini');
 		});
 	});
 });

--- a/tests/unit/admin/settings.service.test.ts
+++ b/tests/unit/admin/settings.service.test.ts
@@ -1172,5 +1172,104 @@ describe('Admin Settings Service', () => {
 			// Tab B's resurrection of the cleared value must NOT have happened.
 			expect(await getAppSetting(AppSettingsKey.OPENAI_BASE_URL)).toBeNull();
 		});
+
+		// Regression: clearing PLEX_SERVER_URL must flag plexCredentialsChanged so
+		// the caller evicts the cached machineId — otherwise stale cache survives
+		// until the next non-empty credential change.
+		describe('plexCredentialsChanged flag', () => {
+			it('is true when PLEX_SERVER_URL is cleared (empty string)', async () => {
+				await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://plex.example.com:32400');
+
+				const result = await setApiConfigAtomic({
+					values: {
+						plexServerUrl: '',
+						plexToken: undefined,
+						openaiApiKey: undefined,
+						openaiBaseUrl: undefined,
+						openaiModel: undefined
+					},
+					locks: allUnlocked,
+					submittedVersion: new Date(Date.now() + 60_000).toISOString()
+				});
+
+				expect(result.status).toBe('ok');
+				expect(result.plexCredentialsChanged).toBe(true);
+				expect(await getAppSetting(AppSettingsKey.PLEX_SERVER_URL)).toBeNull();
+			});
+
+			it('is false when PLEX_SERVER_URL is undefined (cross-panel save)', async () => {
+				const result = await setApiConfigAtomic({
+					values: {
+						plexServerUrl: undefined,
+						plexToken: undefined,
+						openaiApiKey: 'sk-new',
+						openaiBaseUrl: undefined,
+						openaiModel: undefined
+					},
+					locks: allUnlocked,
+					submittedVersion: new Date(Date.now() + 60_000).toISOString()
+				});
+
+				expect(result.status).toBe('ok');
+				expect(result.plexCredentialsChanged).toBe(false);
+			});
+
+			it('is true when PLEX_SERVER_URL is set to a new value', async () => {
+				const result = await setApiConfigAtomic({
+					values: {
+						plexServerUrl: 'http://plex.example.com:32400',
+						plexToken: undefined,
+						openaiApiKey: undefined,
+						openaiBaseUrl: undefined,
+						openaiModel: undefined
+					},
+					locks: allUnlocked,
+					submittedVersion: new Date(Date.now() + 60_000).toISOString()
+				});
+
+				expect(result.status).toBe('ok');
+				expect(result.plexCredentialsChanged).toBe(true);
+				expect(await getAppSetting(AppSettingsKey.PLEX_SERVER_URL)).toBe(
+					'http://plex.example.com:32400'
+				);
+			});
+
+			it('is false when PLEX_SERVER_URL clear is locked (env-driven)', async () => {
+				const result = await setApiConfigAtomic({
+					values: {
+						plexServerUrl: '',
+						plexToken: undefined,
+						openaiApiKey: undefined,
+						openaiBaseUrl: undefined,
+						openaiModel: undefined
+					},
+					locks: { ...allUnlocked, plexServerUrl: true },
+					submittedVersion: new Date(Date.now() + 60_000).toISOString()
+				});
+
+				expect(result.status).toBe('ok');
+				expect(result.plexCredentialsChanged).toBe(false);
+			});
+
+			it('is false when only PLEX_TOKEN is submitted as empty (writeSecret no-op)', async () => {
+				await setAppSetting(AppSettingsKey.PLEX_TOKEN, 'plex-secret');
+
+				const result = await setApiConfigAtomic({
+					values: {
+						plexServerUrl: undefined,
+						plexToken: '',
+						openaiApiKey: undefined,
+						openaiBaseUrl: undefined,
+						openaiModel: undefined
+					},
+					locks: allUnlocked,
+					submittedVersion: new Date(Date.now() + 60_000).toISOString()
+				});
+
+				expect(result.status).toBe('ok');
+				expect(result.plexCredentialsChanged).toBe(false);
+				expect(await getAppSetting(AppSettingsKey.PLEX_TOKEN)).toBe('plex-secret');
+			});
+		});
 	});
 });

--- a/tests/unit/onboarding/test-connection-endpoint.test.ts
+++ b/tests/unit/onboarding/test-connection-endpoint.test.ts
@@ -78,9 +78,77 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 			url: 'http://plex.local:32400'
 		});
 
-		expect(response.status).toBe(200);
+		expect(response.status).toBe(400);
 		const body = (await response.json()) as { success: boolean; error?: string };
 		expect(body.success).toBe(false);
 		expect(body.error).toContain('Access token');
+	});
+
+	it('returns 400 for invalid request schema', async () => {
+		const response = await runPost(adminLocals, { url: 'not-a-url', accessToken: 'abc' });
+		expect(response.status).toBe(400);
+		const body = (await response.json()) as { success: boolean };
+		expect(body.success).toBe(false);
+	});
+
+	it('returns 401 when Plex responds 401', async () => {
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			new Response('Unauthorized', { status: 401 })
+		);
+
+		const response = await runPost(adminLocals, {
+			url: 'http://plex.local:32400',
+			accessToken: 'bad'
+		});
+
+		expect(response.status).toBe(401);
+		const body = (await response.json()) as { success: boolean; error?: string };
+		expect(body.success).toBe(false);
+		expect(body.error).toContain('Authentication failed');
+	});
+
+	it('returns 502 for non-OK upstream', async () => {
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(new Response('boom', { status: 503 }));
+
+		const response = await runPost(adminLocals, {
+			url: 'http://plex.local:32400',
+			accessToken: 'abc'
+		});
+
+		expect(response.status).toBe(502);
+		const body = (await response.json()) as { success: boolean };
+		expect(body.success).toBe(false);
+	});
+
+	it('returns 502 for non-Plex schema mismatch', async () => {
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify({ unexpected: true }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			})
+		);
+
+		const response = await runPost(adminLocals, {
+			url: 'http://plex.local:32400',
+			accessToken: 'abc'
+		});
+
+		expect(response.status).toBe(502);
+		const body = (await response.json()) as { success: boolean; error?: string };
+		expect(body.success).toBe(false);
+		expect(body.error).toContain('Plex Media Server');
+	});
+
+	it('returns 502 when fetch throws', async () => {
+		fetchSpy = spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
+
+		const response = await runPost(adminLocals, {
+			url: 'http://plex.local:32400',
+			accessToken: 'abc'
+		});
+
+		expect(response.status).toBe(502);
+		const body = (await response.json()) as { success: boolean };
+		expect(body.success).toBe(false);
 	});
 });

--- a/tests/unit/sharing/access-control.test.ts
+++ b/tests/unit/sharing/access-control.test.ts
@@ -422,6 +422,50 @@ describe('Sharing Access Control', () => {
 					expect(error).toBeInstanceOf(InvalidShareTokenError);
 				}
 			});
+
+			it('throws InvalidShareTokenError (404 anti-enumeration) when private-link is reached without a token by a non-owner', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: false
+				});
+
+				try {
+					await checkWrappedAccess({ userId, year });
+					expect.unreachable('Should have thrown InvalidShareTokenError');
+				} catch (error) {
+					expect(error).toBeInstanceOf(InvalidShareTokenError);
+				}
+			});
+
+			it('does not throw for the owner accessing private-link without a token', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: false
+				});
+
+				const result = await checkWrappedAccess({
+					userId,
+					year,
+					currentUser: { id: userId, plexId: 100, isAdmin: false }
+				});
+
+				expect(result.accessReason).toBe('owner');
+			});
+
+			it('does not throw for an admin accessing private-link without a token', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: false
+				});
+
+				const result = await checkWrappedAccess({
+					userId,
+					year,
+					currentUser: { id: 999, plexId: 999, isAdmin: true }
+				});
+
+				expect(result.accessReason).toBe('owner');
+			});
 		});
 	});
 
@@ -533,7 +577,7 @@ describe('Sharing Access Control', () => {
 		});
 
 		describe('global floor enforcement', () => {
-			it('throws ShareAccessDeniedError when floor is raised to private-oauth', async () => {
+			it('throws ShareAccessDeniedError when floor is raised to private-oauth and viewer is anonymous', async () => {
 				const token = generateShareToken();
 
 				await setGlobalShareDefaults({
@@ -554,6 +598,53 @@ describe('Sharing Access Control', () => {
 				} catch (error) {
 					expect(error).toBeInstanceOf(ShareAccessDeniedError);
 				}
+			});
+
+			it('allows token access when floor is raised to private-oauth and viewer is a signed-in member', async () => {
+				const token = generateShareToken();
+
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_OAUTH,
+					allowUserControl: false
+				});
+				await db.insert(shareSettings).values({
+					userId,
+					year,
+					mode: ShareMode.PRIVATE_LINK,
+					shareToken: token,
+					canUserControl: false
+				});
+
+				const result = await checkTokenAccess({
+					token,
+					currentUser: { id: 999, plexId: 12345, isAdmin: false }
+				});
+
+				expect(result.userId).toBe(userId);
+				expect(result.year).toBe(year);
+			});
+
+			it('allows token access for an admin viewer when floor is raised', async () => {
+				const token = generateShareToken();
+
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_OAUTH,
+					allowUserControl: false
+				});
+				await db.insert(shareSettings).values({
+					userId,
+					year,
+					mode: ShareMode.PRIVATE_LINK,
+					shareToken: token,
+					canUserControl: false
+				});
+
+				const result = await checkTokenAccess({
+					token,
+					currentUser: { id: 7, plexId: 1007, isAdmin: true }
+				});
+
+				expect(result.userId).toBe(userId);
 			});
 
 			it('allows token access when floor is public', async () => {

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import { db } from '$lib/server/db/client';
 import { appSettings, shareSettings } from '$lib/server/db/schema';
 import {
+	bulkApplyShareDefaults,
 	deleteShareSettings,
 	generateShareToken,
 	getAllUserShareSettings,
@@ -13,6 +14,7 @@ import {
 	getShareSettingsByToken,
 	getShareSettingsReadOnly,
 	getUserLogoPreference,
+	isPureNumericId,
 	isValidTokenFormat,
 	regenerateShareToken,
 	setGlobalShareDefaults,
@@ -61,6 +63,23 @@ describe('Sharing Service', () => {
 			expect(isValidTokenFormat('not-a-uuid')).toBe(false);
 			expect(isValidTokenFormat('550e8400-e29b-51d4-a716-446655440000')).toBe(false); // Wrong version
 			expect(isValidTokenFormat('550e8400-e29b-41d4')).toBe(false); // Too short
+		});
+
+		it('isPureNumericId accepts non-empty digit strings', () => {
+			expect(isPureNumericId('1')).toBe(true);
+			expect(isPureNumericId('42')).toBe(true);
+			expect(isPureNumericId('1000000')).toBe(true);
+		});
+
+		it('isPureNumericId rejects mixed, signed, or empty strings', () => {
+			expect(isPureNumericId('')).toBe(false);
+			expect(isPureNumericId('2abc')).toBe(false);
+			expect(isPureNumericId('2a155c58-MANGLED-0000-0000-000000000000')).toBe(false);
+			expect(isPureNumericId('-5')).toBe(false);
+			expect(isPureNumericId('+5')).toBe(false);
+			expect(isPureNumericId(' 5')).toBe(false);
+			expect(isPureNumericId('5 ')).toBe(false);
+			expect(isPureNumericId('1.0')).toBe(false);
 		});
 	});
 
@@ -287,6 +306,115 @@ describe('Sharing Service', () => {
 
 				const settings = await getShareSettings(1, 2024);
 				expect(settings?.shareToken).toBe(token);
+			});
+		});
+
+		describe('bulkApplyShareDefaults', () => {
+			it('resets every existing row to the current defaults (PUBLIC + allow=true)', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: true
+				});
+
+				await db.insert(shareSettings).values([
+					{
+						userId: 1,
+						year: 2024,
+						mode: ShareMode.PRIVATE_LINK,
+						modeSource: ShareModeSource.EXPLICIT,
+						shareToken: generateShareToken(),
+						canUserControl: false
+					},
+					{
+						userId: 2,
+						year: 2024,
+						mode: ShareMode.PRIVATE_OAUTH,
+						modeSource: ShareModeSource.EXPLICIT,
+						shareToken: null,
+						canUserControl: false
+					}
+				]);
+
+				const count = await bulkApplyShareDefaults();
+				expect(count).toBe(2);
+
+				const rows = await db.select().from(shareSettings);
+				for (const row of rows) {
+					expect(row.mode).toBe(ShareMode.PUBLIC);
+					expect(row.modeSource).toBe(ShareModeSource.DEFAULT);
+					expect(row.canUserControl).toBe(true);
+					expect(row.shareToken).toBeNull();
+				}
+			});
+
+			it('mints a token for every row when default is PRIVATE_LINK', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: false
+				});
+
+				await db.insert(shareSettings).values([
+					{
+						userId: 1,
+						year: 2024,
+						mode: ShareMode.PUBLIC,
+						modeSource: ShareModeSource.EXPLICIT,
+						shareToken: null,
+						canUserControl: true
+					},
+					{
+						userId: 2,
+						year: 2024,
+						mode: ShareMode.PRIVATE_OAUTH,
+						modeSource: ShareModeSource.EXPLICIT,
+						shareToken: null,
+						canUserControl: true
+					}
+				]);
+
+				const count = await bulkApplyShareDefaults();
+				expect(count).toBe(2);
+
+				const rows = await db.select().from(shareSettings);
+				for (const row of rows) {
+					expect(row.mode).toBe(ShareMode.PRIVATE_LINK);
+					expect(row.modeSource).toBe(ShareModeSource.DEFAULT);
+					expect(row.canUserControl).toBe(false);
+					expect(row.shareToken).not.toBeNull();
+					expect(isValidTokenFormat(row.shareToken!)).toBe(true);
+				}
+			});
+
+			it('preserves existing tokens when default is PRIVATE_LINK and the row already has one', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: false
+				});
+
+				const stashedToken = generateShareToken();
+				await db.insert(shareSettings).values({
+					userId: 1,
+					year: 2024,
+					mode: ShareMode.PRIVATE_LINK,
+					modeSource: ShareModeSource.EXPLICIT,
+					shareToken: stashedToken,
+					canUserControl: true
+				});
+
+				await bulkApplyShareDefaults();
+
+				const row = await db.select().from(shareSettings).limit(1);
+				expect(row[0]?.shareToken).toBe(stashedToken);
+			});
+
+			it('returns 0 when there are no share rows', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: true
+				});
+
+				const count = await bulkApplyShareDefaults();
+				expect(count).toBe(0);
 			});
 		});
 	});

--- a/tests/unit/sharing/wrapped-identifier-loader.test.ts
+++ b/tests/unit/sharing/wrapped-identifier-loader.test.ts
@@ -11,7 +11,7 @@ import {
 } from '$lib/server/db/schema';
 import { setGlobalShareDefaults } from '$lib/server/sharing/service';
 import { ShareMode, ShareModeSource } from '$lib/server/sharing/types';
-import { load } from '../../../src/routes/wrapped/[year]/u/[identifier]/+page.server';
+import { actions, load } from '../../../src/routes/wrapped/[year]/u/[identifier]/+page.server';
 
 type LoadArgs = Parameters<typeof load>[0];
 
@@ -406,5 +406,80 @@ describe('wrapped/[year]/u/[identifier] loader: shareToken payload gating', () =
 		});
 
 		expect(data.shareSettings.shareToken).toBe(TOKEN);
+	});
+});
+
+/**
+ * Regression test for the resolveUserIdFromIdentifier currentUser-forwarding fix.
+ *
+ * When a signed-in owner/admin invokes updateShareMode or regenerateToken on a
+ * token URL while the global floor has raised the effective mode above
+ * private-link (e.g. private-oauth), the helper used to call
+ * `checkTokenAccess(identifier)` (bare string), which omitted currentUser and
+ * triggered the floor branch's `if (!currentUser)` guard, causing the action
+ * to fail with "Invalid user identifier". The fix forwards locals.user.
+ */
+describe('wrapped/[year]/u/[identifier] actions: token URL + floor-elevated mode', () => {
+	const USER_ID = 42;
+	const TOKEN = '880e8400-e29b-41d4-a716-446655440333';
+	const YEAR = 2024;
+
+	type UpdateShareModeAction = NonNullable<typeof actions.updateShareMode>;
+
+	beforeEach(async () => {
+		await db.delete(shareSettings);
+		await db.delete(appSettings);
+		await db.delete(users);
+		await db.delete(cachedStats);
+		await db.delete(playHistory);
+		await db.delete(slideConfig);
+
+		await seedUser(USER_ID, 100042, 200042);
+		await seedShareSettings({
+			userId: USER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: TOKEN
+		});
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_OAUTH,
+			allowUserControl: true
+		});
+	});
+
+	async function invokeUpdateShareMode(params: {
+		identifier: string;
+		mode: (typeof ShareMode)[keyof typeof ShareMode];
+		currentUser?: TestUser;
+	}) {
+		const formData = new FormData();
+		formData.set('mode', params.mode);
+		const request = new Request('https://obzorarr.example/wrapped', {
+			method: 'POST',
+			body: formData
+		});
+		const updateShareMode = actions.updateShareMode as UpdateShareModeAction;
+		return updateShareMode({
+			request,
+			params: { year: String(YEAR), identifier: params.identifier },
+			locals: params.currentUser ? { user: params.currentUser } : {}
+		} as unknown as Parameters<UpdateShareModeAction>[0]);
+	}
+
+	it('owner accessing via token URL with floor-elevated mode resolves successfully (does not 400)', async () => {
+		const result = await invokeUpdateShareMode({
+			identifier: TOKEN,
+			mode: ShareMode.PRIVATE_LINK,
+			currentUser: {
+				id: USER_ID,
+				plexId: 100042,
+				username: `user-${USER_ID}`,
+				isAdmin: false
+			}
+		});
+
+		// Without the fix this would be: { status: 400, data: { error: 'Invalid user identifier' } }
+		const status = (result as { status?: number }).status;
+		expect(status).not.toBe(400);
 	});
 });

--- a/tests/unit/sharing/wrapped-identifier-loader.test.ts
+++ b/tests/unit/sharing/wrapped-identifier-loader.test.ts
@@ -166,6 +166,90 @@ describe('wrapped/[year]/u/[identifier] loader: cross-year token isolation', () 
  * Anonymous viewers, authenticated non-owners, and even owners viewing in a
  * widened mode must receive shareToken: null in the payload.
  */
+describe('wrapped/[year]/u/[identifier] loader: identifier validation (F-303)', () => {
+	const USER_ID = 2;
+
+	beforeEach(async () => {
+		await db.delete(shareSettings);
+		await db.delete(appSettings);
+		await db.delete(users);
+		await db.delete(cachedStats);
+		await db.delete(playHistory);
+		await db.delete(slideConfig);
+
+		await seedUser(USER_ID, 100002, 200002);
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PUBLIC,
+			allowUserControl: false
+		});
+	});
+
+	async function expectStatus(
+		identifier: string,
+		expectedStatus: number,
+		params: { availableYears?: number[] } = {}
+	): Promise<void> {
+		try {
+			await invokeLoad({
+				year: ORIGIN_YEAR,
+				identifier,
+				availableYears: params.availableYears ?? [ORIGIN_YEAR]
+			});
+			expect.unreachable(`Expected status ${expectedStatus} for identifier "${identifier}"`);
+		} catch (err) {
+			const status = (err as { status?: number }).status;
+			expect(status).toBe(expectedStatus);
+		}
+	}
+
+	it('returns 404 for a mangled UUID that parseInt would coerce to a numeric prefix', async () => {
+		await expectStatus('2a155c58-MANGLED-0000-0000-000000000000', 404);
+	});
+
+	it('returns 404 for a numeric-prefixed alphanumeric identifier', async () => {
+		await expectStatus('2abc', 404);
+	});
+
+	it('returns 404 for a whitespace identifier', async () => {
+		await expectStatus(' ', 404);
+		await expectStatus('   ', 404);
+	});
+
+	it('returns 404 for a negative numeric identifier', async () => {
+		await expectStatus('-5', 404);
+	});
+
+	it('resolves a valid numeric identifier to the matching user', async () => {
+		const data = await invokeLoad({
+			year: ORIGIN_YEAR,
+			identifier: String(USER_ID),
+			availableYears: [ORIGIN_YEAR]
+		});
+		expect(data.userId).toBe(USER_ID);
+	});
+
+	it('resolves a valid UUID share token to the matching user', async () => {
+		const VALID_TOKEN = '550e8400-e29b-41d4-a716-446655441234';
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		await seedShareSettings({
+			userId: USER_ID,
+			year: ORIGIN_YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: VALID_TOKEN
+		});
+
+		const data = await invokeLoad({
+			year: ORIGIN_YEAR,
+			identifier: VALID_TOKEN,
+			availableYears: [ORIGIN_YEAR]
+		});
+		expect(data.userId).toBe(USER_ID);
+	});
+});
+
 describe('wrapped/[year]/u/[identifier] loader: shareToken payload gating', () => {
 	const USER_ID = 42;
 	const ADMIN_ID = 7;
@@ -293,10 +377,11 @@ describe('wrapped/[year]/u/[identifier] loader: shareToken payload gating', () =
 		expect(data.shareSettings.shareToken).toBe(TOKEN);
 	});
 
-	it('returns null for the owner when the global floor pushes effectiveMode above private-link', async () => {
-		// Stored as private-link/explicit (token preserved through toShareSettings),
-		// but the global floor of private-oauth raises the EFFECTIVE mode above
-		// private-link. The defense-in-depth gate at the loader must still strip.
+	it('exposes the canonical token to the owner even when the floor raises effectiveMode above private-link', async () => {
+		// F-302: when the global floor (private-oauth) raises the effective mode
+		// above the stored private-link, the owner must still see the canonical
+		// share token so the share modal stays stable across reloads. Anonymous
+		// viewers and non-owners are still gated (covered by tests above).
 		await seedShareSettings({
 			userId: USER_ID,
 			year: YEAR,
@@ -320,6 +405,6 @@ describe('wrapped/[year]/u/[identifier] loader: shareToken payload gating', () =
 			}
 		});
 
-		expect(data.shareSettings.shareToken).toBeNull();
+		expect(data.shareSettings.shareToken).toBe(TOKEN);
 	});
 });


### PR DESCRIPTION
## Summary

Addresses every finding raised in QA dogfood run `OBZ-20260502-102506` (1 critical, 2 high, 9 medium, 8 low) with surgical, minimal-change fixes. Work was sequenced into four logical bundles so the test suite stays green at every step.

## Sharing & access-control

- **F-303 (CRITICAL) — Mangled UUID resolves to wrong user.** `parseInt("2a155c58-MANGLED-...", 10)` returned `2`, so a malformed share-token URL rendered user-id 2's wrapped page. Added `isPureNumericId()` next to `isValidTokenFormat()` and replaced both `parseInt` fallbacks in `src/routes/wrapped/[year]/u/[identifier]/+page.server.ts` with strict regex validation that throws `error(404)` for any identifier that is neither a valid token nor pure digits.
- **F-301 (HIGH) — Token URL returns 403 to authenticated members.** Extended `checkTokenAccess` to accept an options bag (`{ token, currentUser }`) and short-circuit success when the floor pushes the effective mode above PRIVATE_LINK and the caller is signed in. The legacy `string` overload is preserved for back-compat callers.
- **F-302 (HIGH) — Share modal reverts to numeric URL after reload.** Loosened the `exposedShareToken` gate so the owner/admin always receive the canonical share token, even when the privacy floor raises the effective mode. The anonymous sanitization in `toShareSettings` is unchanged — security boundary is non-owner exposure, not floor-pushed mode.
- **F-304 (MEDIUM) — Anti-enumeration deviation.** `checkWrappedAccess` now raises `InvalidShareTokenError` early when `effectiveMode === PRIVATE_LINK && !shareToken && !isOwner`, restoring the 404-not-403 anti-enumeration behaviour for admin private-link visits.
- **F-305 (MEDIUM) — Public radio not disabled below floor (admin modal).** `ShareModal.svelte` now applies `disabled` and the `below-floor` class to radio inputs that the privacy floor forbids, mirroring the existing dashboard pattern.
- **F-402 (LOW) — Apply current default doesn't reset `canUserControl`.** Replaced `bulkApplyUserControl` with `bulkApplyShareDefaults()`, a single transaction that resets every row's mode + `canUserControl` + `modeSource = DEFAULT` and reconciles tokens (nulled when default is not PRIVATE_LINK; minted for any row missing one when default is PRIVATE_LINK).

## Form / UI / validation

- **F-101 (MEDIUM) — Privacy radio cards inert to synthetic clicks.** Replaced the `position: absolute; opacity: 0; pointer-events: none` hack with the standard sr-only pattern (`width: 1px; height: 1px; clip: rect(0 0 0 0)`) so synthetic and CDP clicks toggle state. Added a `:focus-visible` outline rule for keyboard a11y.
- **F-102 (MEDIUM) — Onboarding "Next" doesn't advance.** Confirmed root-caused by the F-101 CSS issue; no additional changes needed.
- **F-103 (LOW) — "Save & Continue" needs a second click on AI step.** Hidden inputs now always render with conditional values (`enableFunFacts ? funFactFrequency : ''`); the server action uses an `optionalString` helper that coerces empty strings to `undefined` so `z.enum().optional()` parsing succeeds.
- **F-201 (MEDIUM) — Apply-to-All silent toast.** `confirmBulkApplyShareDefaults` now falls back to a default success payload (`result.data ?? { success: true, message: 'Defaults applied to all users.' }`) so the toast surfaces even when the action returns an empty body.
- **F-202 (MEDIUM) — Logs Clear All inconsistent state.** `clearFilters()` now resets `streamedLogs = []`, `lastSeenStreamId = 0`, then reconnects the SSE stream when `autoScroll` is enabled, mirroring the existing `refreshAfterLogMutation` pattern.
- **F-601 (MEDIUM) — Whitespace-only slide title accepted.** Added `.trim()` before `.min(1)` on `title` and `content` in both `CreateCustomSlideSchema` and `UpdateCustomSlideSchema` (`src/lib/slides/types.ts`).
- **F-604 (MEDIUM) — Custom slide modal a11y.** Added `aria-modal="true"` to the dialog, a global Escape listener via `$effect`, focus-return to the original trigger via `queueMicrotask`, and auto-focus on the title input when the modal opens.
- **F-605 (LOW) — Out-of-range System logging values accepted.** Tightened `LogSettingsSchema` with `.int(...)` plus per-bound error messages, and switched to NaN-on-empty parsing so the schema rejects floats, NaN, and empty input with usable per-field error text. Existing `.field-error` markup surfaces the messages.

## API / concurrency

- **F-501 (LOW) — `test-connection` HTTP 200 on failure.** Each failure path in `/api/onboarding/test-connection` now returns the correct status:
  - 400 for zod parse failure / missing access token
  - 401 for upstream Plex 401
  - 502 for upstream non-OK, non-Plex schema mismatch, or fetch errors
  - 500 for unexpected outer-catch errors
  - The single existing consumer (`/onboarding/plex`) already reads the body unconditionally, so no client changes were required.
- **F-602 (MEDIUM) — Concurrent admin settings lost-update.** Added `setApiConfigAtomic({ values, locks, submittedVersion })` to `settings.service.ts`, mirroring `setPrivacySettingsAtomic`. The load now returns `apiConfigVersion` (ISO timestamp from `getAppSettingsUpdatedAt(API_CONFIG_KEYS)`), both Plex and OpenAI forms post it back as a hidden `apiConfigVersion` input, and a stale version returns `fail(409, { conflict: true, error: 'Settings changed in another tab. Reload and try again.' })`. `clearCachedServerMachineId()` runs **after** transaction commit and only when Plex credentials actually changed.

## Responsive + spec deviations

- **F-603 (LOW) — `/admin/users` table overflow at 390px.** Added `max-width: 100%` to `.users-table-wrapper` so flex/grid parents don't expand past the viewport.
- **F-306 / F-307 (LOW) — Server wrapped Share / Restart buttons clipped.** Buttons render unconditionally in source; suspected viewport clipping. Changed `.summary-page` from `overflow: hidden` to `overflow-x: hidden; overflow-y: auto` and added bottom padding so the actions row stays reachable on short viewports.
- **F-401 (LOW) — `/admin/*` redirect target.** Re-verified: `authorizationHandle` already redirects to `/`. The `/dashboard` URL QA observed comes from the root `+page.server.ts` redirecting authenticated non-admins. **Closed as not-a-bug.**

## Out of scope

The following exploratory smells from the QA report are intentionally not addressed in this PR and should be tracked as follow-up issues if desired: future-year handling (#1), admin-username leak on server-public (#4), `gpt-5-mini` default (#6), noisy CSRF warn (#7).

## Test plan

- [x] `bun run check` — type/Svelte check clean (0 errors, 0 warnings, 1633 files)
- [x] `bun run lint` — Biome lint clean (318 files)
- [x] `bun run test` — **1429 tests pass**, 17,664+ expect() calls, ~2.4s
- [x] New unit coverage:
  - `tests/unit/sharing/wrapped-identifier-loader.test.ts` — mangled UUID, `"2abc"`, whitespace, negative, valid identifier cases
  - `tests/unit/sharing/access-control.test.ts` — F-301 (signed-in member, admin) and F-304 (anti-enumeration 404, owner success, admin success)
  - `tests/unit/sharing/service.test.ts` — `bulkApplyShareDefaults` covering PUBLIC default, PRIVATE_LINK minting, token preservation, empty case
  - `tests/unit/admin/settings.service.test.ts` — `setApiConfigAtomic` covering fresh-write, stale-version conflict, empty-version conflict, lock skipping, no-change behaviour
  - `tests/unit/onboarding/test-connection-endpoint.test.ts` — 400 / 401 / 502 (upstream / schema / fetch error) status mappings
- [ ] Manual dev-server walk-through of the share-token, onboarding, admin settings, slides editor, and logs flows once merged