### PR TITLE
fix: address 5 QA findings from run OBZ-20260502-181123

### DIFF
--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -152,6 +152,18 @@ $effect(() => {
 		clearTimeout(copyTimeout);
 	};
 });
+
+// Reset optimistic state when the modal transitions from closed to open
+// so a freshly-loaded shareSettings prop (e.g., token rotated elsewhere) is
+// not shadowed by stale optimistic values from a prior session.
+let prevOpen = false;
+$effect(() => {
+	if (open && !prevOpen) {
+		optimisticMode = null;
+		optimisticShareToken = undefined;
+	}
+	prevOpen = open;
+});
 </script>
 
 <AlertDialog.Root bind:open onOpenChange={handleOpenChange}>

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -245,8 +245,11 @@ $effect(() => {
 								await update();
 							} finally {
 								isUpdating = false;
-								optimisticMode = null;
-								optimisticShareToken = undefined;
+								// Intentionally do NOT reset optimisticMode/optimisticShareToken here.
+								// On success: applyShareActionData() set them to the server's value, so
+								// clearing them between this finally and the next $derived re-evaluation
+								// causes a brief all-unchecked render frame for the radio group.
+								// On failure: the else branch above already cleared them inline.
 							}
 						};
 					}}

--- a/src/lib/server/admin/zod-helpers.ts
+++ b/src/lib/server/admin/zod-helpers.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+/**
+ * Optional string that trims surrounding whitespace and treats empty-after-trim
+ * as `undefined`. Use for free-text settings inputs (API keys, model names,
+ * server names) where a whitespace-only submission should not be persisted as a
+ * meaningful value — it would silently break downstream API calls otherwise.
+ */
+export function optionalTrimmed(maxLen: number) {
+	return z
+		.string()
+		.max(maxLen)
+		.optional()
+		.transform((s) => {
+			if (s == null) return undefined;
+			const trimmed = s.trim();
+			return trimmed === '' ? undefined : trimmed;
+		});
+}

--- a/src/lib/server/security/csrf-handle.ts
+++ b/src/lib/server/security/csrf-handle.ts
@@ -13,7 +13,10 @@ const STATE_CHANGING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
 
 let startupLogged = false;
 
-function getOriginFromRequest(request: Request): string | null {
+// Exported so admin actions (e.g. updateCsrfOrigin) can predict the same
+// origin csrfHandle compares against, rather than rederiving from
+// `request.url` which is the immutable raw URL behind a reverse proxy.
+export function getOriginFromRequest(request: Request): string | null {
 	const origin = request.headers.get('origin');
 	if (origin) return origin;
 

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -714,6 +714,7 @@ $effect(() => {
 			max-width: 1200px;
 			margin: 0 auto;
 			padding: 2rem;
+			min-width: 0;
 		}
 
 		.page-header {
@@ -815,7 +816,7 @@ $effect(() => {
 
 		.filters-grid {
 			display: grid;
-			grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+			grid-template-columns: repeat(auto-fit, minmax(min(200px, 100%), 1fr));
 			gap: 1rem;
 		}
 
@@ -823,6 +824,7 @@ $effect(() => {
 			display: flex;
 			flex-direction: column;
 			gap: 0.5rem;
+			min-width: 0;
 		}
 
 		.filter-label {
@@ -839,6 +841,8 @@ $effect(() => {
 			border-radius: var(--radius);
 			color: hsl(var(--foreground));
 			font-size: 0.875rem;
+			min-width: 0;
+			width: 100%;
 		}
 
 		.level-checkboxes {

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -757,7 +757,11 @@ export const actions: Actions = requireAdminActions({
 		}
 
 		const formData = await request.formData();
-		const csrfOrigin = formData.get('csrfOrigin')?.toString() ?? '';
+		// Trim once at extraction so whitespace-only inputs (e.g. '   ') route to the
+		// clear branch alongside literal '' rather than failing schema validation with
+		// a confusing "Invalid origin URL" 400 — mirrors the trimmedUrlOrEmpty pattern
+		// used for ApiConfigSchema URL fields above.
+		const csrfOrigin = (formData.get('csrfOrigin')?.toString() ?? '').trim();
 		const confirmMismatch = formData.get('confirmMismatch')?.toString() === 'true';
 
 		if (csrfOrigin) {

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -52,6 +52,7 @@ import {
 	setLogMaxCount,
 	setLogRetentionDays
 } from '$lib/server/logging';
+import { getOriginFromRequest } from '$lib/server/security/csrf-handle';
 import {
 	bulkApplyShareDefaults,
 	getGlobalAllowUserControl,
@@ -748,7 +749,7 @@ export const actions: Actions = requireAdminActions({
 		};
 	},
 
-	updateCsrfOrigin: async ({ request }) => {
+	updateCsrfOrigin: async ({ request, url }) => {
 		const csrfConfig = await getCsrfConfigWithSource();
 		if (csrfConfig.origin.isLocked) {
 			return fail(400, {
@@ -777,7 +778,13 @@ export const actions: Actions = requireAdminActions({
 			// path, query, or fragment — exactly what the CSRF middleware compares against
 			// the browser's Origin header.
 			const normalizedOrigin = parsed.data.csrfOrigin;
-			const requestOrigin = new URL(request.url).origin;
+			// Use the same source-of-truth that csrfHandle compares against (Origin
+			// header, falling back to Referer). Behind a reverse proxy `request.url`
+			// is the immutable raw internal URL — comparing against that would
+			// trigger a spurious mismatch warning even when the operator correctly
+			// matches the public-facing origin. Fall back to `event.url.origin`
+			// (proxy-rewritten by `proxyHandle`) when neither header is present.
+			const requestOrigin = getOriginFromRequest(request) ?? url.origin;
 			const isMismatch = normalizedOrigin.toLowerCase() !== requestOrigin.toLowerCase();
 
 			// Refuse to write a mismatched origin without explicit confirmation: silently

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -147,6 +147,14 @@ const CsrfOriginSchema = z.object({
 		.refine((url) => url.startsWith('http://') || url.startsWith('https://'), {
 			message: 'Origin must start with http:// or https://'
 		})
+		.transform((url) => {
+			try {
+				const parsed = new URL(url);
+				return parsed.origin;
+			} catch {
+				return url;
+			}
+		})
 });
 
 const TrustProxySchema = z.object({
@@ -761,7 +769,10 @@ export const actions: Actions = requireAdminActions({
 				});
 			}
 
-			const normalizedOrigin = csrfOrigin.replace(/\/$/, '');
+			// `URL.origin` returns canonical scheme://host[:port] with no trailing slash,
+			// path, query, or fragment — exactly what the CSRF middleware compares against
+			// the browser's Origin header.
+			const normalizedOrigin = parsed.data.csrfOrigin;
 			const requestOrigin = new URL(request.url).origin;
 			const isMismatch = normalizedOrigin.toLowerCase() !== requestOrigin.toLowerCase();
 

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -105,15 +105,23 @@ const PrivacySettingsSchema = z.object({
 //   - Echoed-back keys (openaiModel, openaiBaseUrl) get `.trim()` on the inner
 //     string so whitespace-only inputs become the canonical clear signal `''`,
 //     preserving the user's ability to clear by blanking the field.
+// Trim before the union so whitespace-only inputs (e.g. '   ') collapse to ''
+// and match the literal-empty branch — without preprocess, .trim() on the URL
+// branch would still leave the original untrimmed string for the literal('')
+// check, causing whitespace-only submissions to fail validation instead of
+// being treated as the documented "clear" signal.
+const trimmedUrlOrEmpty = z
+	.preprocess(
+		(v) => (typeof v === 'string' ? v.trim() : v),
+		z.union([z.string().max(512).url('Invalid URL format'), z.literal('')])
+	)
+	.optional();
+
 const ApiConfigSchema = z.object({
-	plexServerUrl: z
-		.union([z.string().trim().max(512).url('Invalid URL format'), z.literal('')])
-		.optional(),
+	plexServerUrl: trimmedUrlOrEmpty,
 	plexToken: optionalTrimmed(512),
 	openaiApiKey: optionalTrimmed(512),
-	openaiBaseUrl: z
-		.union([z.string().trim().max(512).url('Invalid URL format'), z.literal('')])
-		.optional(),
+	openaiBaseUrl: trimmedUrlOrEmpty,
 	openaiModel: z.string().trim().max(100).optional(),
 	apiConfigVersion: z.string()
 });

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -40,6 +40,7 @@ import {
 	type WrappedLogoModeType
 } from '$lib/server/admin/settings.service';
 import { getAvailableYears } from '$lib/server/admin/users.service';
+import { optionalTrimmed } from '$lib/server/admin/zod-helpers';
 import { requireAdminActions } from '$lib/server/auth/guards';
 import { testOpenAIConnection } from '$lib/server/funfacts/test-connection';
 import {
@@ -96,12 +97,24 @@ const PrivacySettingsSchema = z.object({
 //   non-empty = write.
 // The URL-validated fields accept `''` via the literal union so a cleared input
 // passes validation and reaches the service as the clear signal.
+//
+// Whitespace handling:
+//   - Secret keys (plexToken, openaiApiKey) use `optionalTrimmed(...)`: empty,
+//     whitespace-only, and absent all collapse to `undefined` (no-op). Prevents
+//     a stray "  " press from being persisted as the secret.
+//   - Echoed-back keys (openaiModel, openaiBaseUrl) get `.trim()` on the inner
+//     string so whitespace-only inputs become the canonical clear signal `''`,
+//     preserving the user's ability to clear by blanking the field.
 const ApiConfigSchema = z.object({
-	plexServerUrl: z.union([z.string().max(512).url('Invalid URL format'), z.literal('')]).optional(),
-	plexToken: z.string().max(512).optional(),
-	openaiApiKey: z.string().max(512).optional(),
-	openaiBaseUrl: z.union([z.string().max(512).url('Invalid URL format'), z.literal('')]).optional(),
-	openaiModel: z.string().max(100).optional(),
+	plexServerUrl: z
+		.union([z.string().trim().max(512).url('Invalid URL format'), z.literal('')])
+		.optional(),
+	plexToken: optionalTrimmed(512),
+	openaiApiKey: optionalTrimmed(512),
+	openaiBaseUrl: z
+		.union([z.string().trim().max(512).url('Invalid URL format'), z.literal('')])
+		.optional(),
+	openaiModel: z.string().trim().max(100).optional(),
 	apiConfigVersion: z.string()
 });
 
@@ -729,6 +742,7 @@ export const actions: Actions = requireAdminActions({
 
 		const formData = await request.formData();
 		const csrfOrigin = formData.get('csrfOrigin')?.toString() ?? '';
+		const confirmMismatch = formData.get('confirmMismatch')?.toString() === 'true';
 
 		if (csrfOrigin) {
 			const parsed = CsrfOriginSchema.safeParse({ csrfOrigin });
@@ -739,16 +753,30 @@ export const actions: Actions = requireAdminActions({
 				});
 			}
 
+			const normalizedOrigin = csrfOrigin.replace(/\/$/, '');
+			const requestOrigin = new URL(request.url).origin;
+			const isMismatch = normalizedOrigin.toLowerCase() !== requestOrigin.toLowerCase();
+
+			// Refuse to write a mismatched origin without explicit confirmation: silently
+			// persisting a mismatch would lock this browser out of all admin POSTs with
+			// no in-UI recovery path (would require env override or direct DB surgery).
+			if (isMismatch && !confirmMismatch) {
+				return fail(409, {
+					requireConfirmation: true,
+					attemptedOrigin: normalizedOrigin,
+					requestOrigin,
+					csrfMismatchMessage: `Saving "${normalizedOrigin}" while loaded from "${requestOrigin}" will lock this browser out of all admin POST operations. Recovery would require restarting the server with ORIGIN=<correct> env or editing the app_settings table directly. Confirm to proceed anyway.`
+				});
+			}
+
 			try {
-				const normalizedOrigin = csrfOrigin.replace(/\/$/, '');
-				const requestOrigin = new URL(request.url).origin;
 				await setAppSetting(AppSettingsKey.CSRF_ORIGIN, normalizedOrigin);
 
-				if (normalizedOrigin.toLowerCase() !== requestOrigin.toLowerCase()) {
+				if (isMismatch) {
 					return {
 						success: true,
 						warning: true,
-						message: `CSRF origin saved, but it does not match your current origin (${requestOrigin}). You may get locked out of the admin panel.`
+						message: `CSRF origin saved to "${normalizedOrigin}". Your current browser origin is "${requestOrigin}" — you may now be locked out.`
 					};
 				}
 

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -243,6 +243,17 @@ $effect(() => {
 	handleFormToast(form);
 });
 
+// Open the CSRF mismatch confirmation dialog when the server signals it.
+// The fail(409) payload deliberately omits success/error/warning so handleFormToast
+// stays silent — the dialog is the UI response.
+$effect(() => {
+	if (form && 'requireConfirmation' in form && form.requireConfirmation) {
+		const f = form as { attemptedOrigin?: string };
+		pendingCsrfOrigin = f.attemptedOrigin ?? null;
+		csrfMismatchDialogOpen = true;
+	}
+});
+
 // Cache clearing dialog state
 let cacheDialogOpen = $state(false);
 let pendingCacheYear = $state<number | undefined>(undefined);
@@ -460,6 +471,16 @@ let trustProxySource = $state<'env' | 'db' | 'default'>('default');
 let trustProxyLocked = $state(false);
 let isSavingTrustProxy = $state(false);
 
+// CSRF mismatch confirmation dialog state. Server returns fail(409,
+// { requireConfirmation: true, attemptedOrigin, ... }) when the submitted
+// origin doesn't match the request origin; we surface it as a confirm
+// dialog rather than silently writing a value that would lock the user out.
+let csrfMismatchDialogOpen = $state(false);
+let pendingCsrfOrigin = $state<string | null>(null);
+let isConfirmingCsrfMismatch = $state(false);
+let isSavingOpenAI = $state(false);
+let isSavingPlex = $state(false);
+
 // Sync CSRF state from data
 $effect(() => {
 	csrfOriginValue = data.security.originValue;
@@ -538,7 +559,21 @@ const logFieldErrors = $derived(
 						</div>
 					</div>
 
-					<form method="POST" action="?/updateApiConfig" use:enhance class="panel-form">
+					<form
+						method="POST"
+						action="?/updateApiConfig"
+						use:enhance={() => {
+							isSavingPlex = true;
+							return async ({ update }) => {
+								try {
+									await update();
+								} finally {
+									isSavingPlex = false;
+								}
+							};
+						}}
+						class="panel-form"
+					>
 						<input type="hidden" name="apiConfigVersion" value={data.apiConfigVersion} />
 						<div class="form-field">
 							<div class="field-header">
@@ -627,9 +662,14 @@ const logFieldErrors = $derived(
 
 						<div class="plex-actions">
 							{#if !plexServerUrlLocked || !plexTokenLocked}
-								<button type="submit" class="btn-primary">
-									<Check class="btn-icon" />
-									Save Plex Settings
+								<button type="submit" class="btn-primary" disabled={isSavingPlex}>
+									{#if isSavingPlex}
+										<Loader2 class="btn-icon spinning" />
+										Saving…
+									{:else}
+										<Check class="btn-icon" />
+										Save Plex Settings
+									{/if}
 								</button>
 							{/if}
 
@@ -718,7 +758,21 @@ const logFieldErrors = $derived(
 						Configure AI-powered fun facts generation. Leave empty to use predefined templates.
 					</p>
 
-					<form method="POST" action="?/updateApiConfig" use:enhance class="panel-form">
+					<form
+						method="POST"
+						action="?/updateApiConfig"
+						use:enhance={() => {
+							isSavingOpenAI = true;
+							return async ({ update }) => {
+								try {
+									await update();
+								} finally {
+									isSavingOpenAI = false;
+								}
+							};
+						}}
+						class="panel-form"
+					>
 						<input type="hidden" name="apiConfigVersion" value={data.apiConfigVersion} />
 						<div class="form-field">
 							<div class="field-header">
@@ -836,9 +890,14 @@ const logFieldErrors = $derived(
 
 						<div class="panel-actions">
 							{#if !openaiApiKeyLocked || !openaiBaseUrlLocked || !openaiModelLocked}
-								<button type="submit" class="btn-primary">
-									<Check class="btn-icon" />
-									Save OpenAI Settings
+								<button type="submit" class="btn-primary" disabled={isSavingOpenAI}>
+									{#if isSavingOpenAI}
+										<Loader2 class="btn-icon spinning" />
+										Saving…
+									{:else}
+										<Check class="btn-icon" />
+										Save OpenAI Settings
+									{/if}
 								</button>
 							{/if}
 
@@ -1472,8 +1531,13 @@ const logFieldErrors = $derived(
 										use:enhance={() => {
 											isSavingCsrf = true;
 											return async ({ result, update }) => {
-												isSavingCsrf = false;
-												await update({ reset: result.type !== 'failure' });
+												try {
+													// Don't reset the input on failure (incl. fail(409) confirmation
+													// requirement) so the user can confirm without retyping.
+													await update({ reset: result.type !== 'failure' });
+												} finally {
+													isSavingCsrf = false;
+												}
 											};
 										}}
 									>
@@ -2189,6 +2253,53 @@ const logFieldErrors = $derived(
 					{:else}
 						Clear CSRF Origin
 					{/if}
+				</AlertDialog.Action>
+			</form>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
+
+<!-- CSRF Mismatch Confirmation Dialog -->
+<AlertDialog.Root bind:open={csrfMismatchDialogOpen}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Confirm risky CSRF change</AlertDialog.Title>
+			<AlertDialog.Description>
+				{(form as { csrfMismatchMessage?: string } | null | undefined)?.csrfMismatchMessage ??
+					'Saving this CSRF origin may lock you out of admin POST operations.'}
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel
+				disabled={isConfirmingCsrfMismatch}
+				onclick={() => {
+					csrfMismatchDialogOpen = false;
+					pendingCsrfOrigin = null;
+				}}
+			>
+				Cancel
+			</AlertDialog.Cancel>
+			<form
+				method="POST"
+				action="?/updateCsrfOrigin"
+				use:enhance={() => {
+					isConfirmingCsrfMismatch = true;
+					return async ({ update }) => {
+						try {
+							await update({ reset: false });
+						} finally {
+							isConfirmingCsrfMismatch = false;
+							csrfMismatchDialogOpen = false;
+							pendingCsrfOrigin = null;
+						}
+					};
+				}}
+				style="display: contents;"
+			>
+				<input type="hidden" name="csrfOrigin" value={pendingCsrfOrigin ?? ''} />
+				<input type="hidden" name="confirmMismatch" value="true" />
+				<AlertDialog.Action type="submit" disabled={isConfirmingCsrfMismatch}>
+					{isConfirmingCsrfMismatch ? 'Saving…' : 'Save anyway'}
 				</AlertDialog.Action>
 			</form>
 		</AlertDialog.Footer>

--- a/tests/unit/admin/csrf-action.test.ts
+++ b/tests/unit/admin/csrf-action.test.ts
@@ -22,6 +22,7 @@ function createRequest(opts: {
 	csrfOrigin?: string;
 	confirmMismatch?: boolean;
 	requestUrl?: string;
+	originHeader?: string | null;
 }): Request {
 	const formData = new FormData();
 	if (opts.csrfOrigin !== undefined) {
@@ -30,15 +31,25 @@ function createRequest(opts: {
 	if (opts.confirmMismatch) {
 		formData.set('confirmMismatch', 'true');
 	}
-	return new Request(opts.requestUrl ?? `${ORIGIN}/admin/settings?/updateCsrfOrigin`, {
+	const requestUrl = opts.requestUrl ?? `${ORIGIN}/admin/settings?/updateCsrfOrigin`;
+	const headers: HeadersInit = {};
+	// Default to setting Origin: ORIGIN so tests exercise the same source-of-truth
+	// (browser Origin header) that csrfHandle uses. Pass `originHeader: null` to
+	// omit it explicitly; pass a string to override.
+	if (opts.originHeader !== null) {
+		headers.Origin = opts.originHeader ?? ORIGIN;
+	}
+	return new Request(requestUrl, {
 		method: 'POST',
-		body: formData
+		body: formData,
+		headers
 	});
 }
 
-async function runUpdate(request: Request) {
+async function runUpdate(request: Request, urlOverride?: string) {
 	const action = actions.updateCsrfOrigin as UpdateCsrfOriginAction;
-	return action({ request, locals: adminLocals } as Parameters<UpdateCsrfOriginAction>[0]);
+	const url = new URL(urlOverride ?? request.url);
+	return action({ request, url, locals: adminLocals } as Parameters<UpdateCsrfOriginAction>[0]);
 }
 
 describe('admin updateCsrfOrigin action', () => {
@@ -145,6 +156,47 @@ describe('admin updateCsrfOrigin action', () => {
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
 
 		await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
+	});
+
+	it('uses the browser Origin header for the mismatch check, not request.url', async () => {
+		// Behind a reverse proxy, request.url is the immutable raw internal URL
+		// (e.g. http://localhost:3000) while the browser's Origin header carries
+		// the public-facing origin (e.g. https://app.example.com). The mismatch
+		// check must use the Origin header so it predicts the same comparison
+		// csrfHandle will perform. Saving the public origin while the request
+		// arrives at the internal URL must NOT trip the lockout warning.
+		const publicOrigin = 'https://app.example.com';
+		const internalUrl = 'http://localhost:3000/admin/settings?/updateCsrfOrigin';
+		const result = await runUpdate(
+			createRequest({
+				csrfOrigin: publicOrigin,
+				requestUrl: internalUrl,
+				originHeader: publicOrigin
+			})
+		);
+
+		expect(result).toEqual({ success: true, message: 'CSRF origin updated' });
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(publicOrigin);
+	});
+
+	it('falls back to event.url.origin (proxy-rewritten) when Origin/Referer headers are absent', async () => {
+		// proxyHandle rewrites event.url to the public-facing origin. When a
+		// request arrives without Origin or Referer (unusual for a browser POST
+		// but possible), we should use event.url.origin as the fallback rather
+		// than request.url which is the raw internal URL.
+		const publicOrigin = 'https://app.example.com';
+		const internalUrl = 'http://localhost:3000/admin/settings?/updateCsrfOrigin';
+		const result = await runUpdate(
+			createRequest({
+				csrfOrigin: publicOrigin,
+				requestUrl: internalUrl,
+				originHeader: null
+			}),
+			`${publicOrigin}/admin/settings?/updateCsrfOrigin`
+		);
+
+		expect(result).toEqual({ success: true, message: 'CSRF origin updated' });
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(publicOrigin);
 	});
 
 	it('treats whitespace-only csrfOrigin as a clear request, not invalid input', async () => {

--- a/tests/unit/admin/csrf-action.test.ts
+++ b/tests/unit/admin/csrf-action.test.ts
@@ -146,4 +146,18 @@ describe('admin updateCsrfOrigin action', () => {
 
 		await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
 	});
+
+	it('treats whitespace-only csrfOrigin as a clear request, not invalid input', async () => {
+		// Whitespace-only inputs should route to the clear branch (same as '') rather
+		// than failing schema validation with a confusing "Invalid origin URL" 400.
+		await setAppSetting(AppSettingsKey.CSRF_ORIGIN, ORIGIN);
+		await setAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED, 'true');
+
+		const result = await runUpdate(createRequest({ csrfOrigin: '   ' }));
+
+		expect((result as { success: boolean }).success).toBe(true);
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
+
+		await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
+	});
 });

--- a/tests/unit/admin/csrf-action.test.ts
+++ b/tests/unit/admin/csrf-action.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { env } from '$env/dynamic/private';
+import {
+	AppSettingsKey,
+	deleteAppSetting,
+	getAppSetting,
+	setAppSetting
+} from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import { actions } from '../../../src/routes/admin/settings/+page.server';
+
+const ORIGIN = 'http://localhost:5173';
+
+type UpdateCsrfOriginAction = NonNullable<typeof actions.updateCsrfOrigin>;
+
+const adminLocals = {
+	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
+} as unknown as App.Locals;
+
+function createRequest(opts: {
+	csrfOrigin?: string;
+	confirmMismatch?: boolean;
+	requestUrl?: string;
+}): Request {
+	const formData = new FormData();
+	if (opts.csrfOrigin !== undefined) {
+		formData.set('csrfOrigin', opts.csrfOrigin);
+	}
+	if (opts.confirmMismatch) {
+		formData.set('confirmMismatch', 'true');
+	}
+	return new Request(opts.requestUrl ?? `${ORIGIN}/admin/settings?/updateCsrfOrigin`, {
+		method: 'POST',
+		body: formData
+	});
+}
+
+async function runUpdate(request: Request) {
+	const action = actions.updateCsrfOrigin as UpdateCsrfOriginAction;
+	return action({ request, locals: adminLocals } as Parameters<UpdateCsrfOriginAction>[0]);
+}
+
+describe('admin updateCsrfOrigin action', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+	});
+
+	it('returns fail(409) and does NOT call setAppSetting when origin mismatches and confirmMismatch is absent', async () => {
+		const result = (await runUpdate(
+			createRequest({ csrfOrigin: 'http://tampered.example.com:5173' })
+		)) as { status: number; data: Record<string, unknown> };
+
+		expect(result.status).toBe(409);
+		expect(result.data.requireConfirmation).toBe(true);
+		expect(result.data.attemptedOrigin).toBe('http://tampered.example.com:5173');
+		expect(result.data.requestOrigin).toBe(ORIGIN);
+		expect(typeof result.data.csrfMismatchMessage).toBe('string');
+		// Critically, no DB write should have happened.
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
+	});
+
+	it('writes to DB and returns success+warning when confirmMismatch=true on mismatch', async () => {
+		const result = await runUpdate(
+			createRequest({
+				csrfOrigin: 'http://tampered.example.com:5173',
+				confirmMismatch: true
+			})
+		);
+
+		expect(result).toMatchObject({ success: true, warning: true });
+		expect(typeof (result as { message?: string }).message).toBe('string');
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(
+			'http://tampered.example.com:5173'
+		);
+	});
+
+	it('writes to DB and returns plain success when origin matches request origin', async () => {
+		const result = await runUpdate(createRequest({ csrfOrigin: ORIGIN }));
+
+		expect(result).toEqual({ success: true, message: 'CSRF origin updated' });
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
+	});
+
+	it('normalizes trailing slash before persisting', async () => {
+		const result = await runUpdate(createRequest({ csrfOrigin: `${ORIGIN}/` }));
+
+		expect(result).toEqual({ success: true, message: 'CSRF origin updated' });
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
+	});
+
+	it('returns fail(400) for invalid URL', async () => {
+		const result = (await runUpdate(createRequest({ csrfOrigin: 'not-a-url' }))) as {
+			status: number;
+			data: Record<string, unknown>;
+		};
+
+		expect(result.status).toBe(400);
+		expect(result.data.error).toBe('Invalid origin URL');
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
+	});
+
+	it('returns fail(400) when env-locked (ORIGIN env var set)', async () => {
+		// $env/dynamic/private is mock.module()-ed at setup time and the underlying
+		// `env` object reference is shared across importers — mutate it in place,
+		// then restore. process.env doesn't reach the SvelteKit-mocked module.
+		const dynamicEnv = env as Record<string, string | undefined>;
+		const previous = dynamicEnv.ORIGIN;
+		dynamicEnv.ORIGIN = 'http://locked.example.com';
+		try {
+			const result = (await runUpdate(createRequest({ csrfOrigin: ORIGIN }))) as {
+				status: number;
+				data: { error: string };
+			};
+
+			expect(result.status).toBe(400);
+			expect(result.data.error).toMatch(/environment variable/i);
+			expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
+		} finally {
+			if (previous === undefined) delete dynamicEnv.ORIGIN;
+			else dynamicEnv.ORIGIN = previous;
+		}
+	});
+
+	it('refuses to clear origin when no ORIGIN env and skip flag not set', async () => {
+		await setAppSetting(AppSettingsKey.CSRF_ORIGIN, ORIGIN);
+
+		const result = (await runUpdate(createRequest({ csrfOrigin: '' }))) as {
+			status: number;
+			data: { error: string };
+		};
+
+		expect(result.status).toBe(400);
+		expect(result.data.error).toMatch(/Cannot clear CSRF origin/);
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
+	});
+
+	it('clears origin when CSRF skip flag is set', async () => {
+		await setAppSetting(AppSettingsKey.CSRF_ORIGIN, ORIGIN);
+		await setAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED, 'true');
+
+		const result = await runUpdate(createRequest({ csrfOrigin: '' }));
+
+		expect((result as { success: boolean }).success).toBe(true);
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
+
+		await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
+	});
+});

--- a/tests/unit/admin/zod-helpers.test.ts
+++ b/tests/unit/admin/zod-helpers.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+import { optionalTrimmed } from '$lib/server/admin/zod-helpers';
+
+describe('optionalTrimmed', () => {
+	const schema = optionalTrimmed(100);
+
+	it('returns undefined for undefined input', () => {
+		expect(schema.parse(undefined)).toBeUndefined();
+	});
+
+	it('returns undefined for empty string', () => {
+		expect(schema.parse('')).toBeUndefined();
+	});
+
+	it('returns undefined for whitespace-only input', () => {
+		expect(schema.parse('   ')).toBeUndefined();
+	});
+
+	it('returns undefined for tab/newline-only input', () => {
+		expect(schema.parse('\t\n  ')).toBeUndefined();
+	});
+
+	it('trims surrounding whitespace', () => {
+		expect(schema.parse('  sk-abc  ')).toBe('sk-abc');
+	});
+
+	it('preserves valid input', () => {
+		expect(schema.parse('gpt-5-mini')).toBe('gpt-5-mini');
+	});
+
+	it('rejects strings exceeding max length (counted before trim)', () => {
+		expect(() => schema.parse('x'.repeat(101))).toThrow();
+	});
+});


### PR DESCRIPTION
## Summary

Addresses the five actionable findings remaining from E2E dogfooding run **OBZ-20260502-181123** after Phase 6 reconciliation. Per user decision F-001/F-002/F-003 are closed as wontfix (agent-browser hit-test artifacts against standards-compliant accessible HTML), and F-006/F-007/F-008 were refuted as Phase 2 false positives.

| ID | Severity | Surface | Fix |
|---|---|---|---|
| F-005 | CRITICAL | Server action + UI | Mismatched CSRF origin now requires explicit confirmation; cannot self-lockout from a single tab anymore |
| F-012 | MEDIUM | CSS | `/admin/logs` collapses to single-column at narrow viewports instead of overflowing |
| F-009 | LOW | Component | `ShareModal` no longer flashes all-radio-unchecked between optimistic and server values |
| F-010 | LOW | Zod schemas | Whitespace-only secrets/model strings no longer persist or break downstream API calls |
| F-011 | LOW | UI | "Save OpenAI Settings" / "Save Plex Settings" debounce while in-flight |

## Changes

### F-005 - CSRF self-lockout requires explicit confirmation (CRITICAL)

Files: `src/routes/admin/settings/+page.server.ts`, `src/routes/admin/settings/+page.svelte`, `tests/unit/admin/csrf-action.test.ts` (new).

Previously, `updateCsrfOrigin` unconditionally wrote the new origin to the DB and then displayed a warning toast on mismatch. The admin was already locked out of all subsequent admin POST operations by the time the toast appeared, with no in-UI recovery path.

The action now returns `fail(409, { requireConfirmation: true, attemptedOrigin, requestOrigin, csrfMismatchMessage })` when the normalized submitted origin does not match the request origin and `confirmMismatch=true` is not in the form data. **No DB write happens on the unconfirmed path.** The fail payload deliberately omits `error`/`success`/`warning` so the existing `handleFormToast` stays silent - the dialog is the UI response.

Client-side, a new `AlertDialog` opens via a `$effect` watching `form.requireConfirmation`, displays the server's `csrfMismatchMessage`, and offers Cancel / Save anyway. Save anyway submits a hidden form with the same `csrfOrigin` plus `confirmMismatch=true`. The original save form's `use:enhance` callback was switched to try/finally so `isSavingCsrf` always resets, and `update({ reset: result.type !== 'failure' })` preserves the typed value through the 409 so the user can confirm without retyping.

### F-010 - Zod schemas trim whitespace (LOW)

Files: `src/lib/server/admin/zod-helpers.ts` (new), `src/routes/admin/settings/+page.server.ts`, `tests/unit/admin/zod-helpers.test.ts` (new).

New helper `optionalTrimmed(maxLen)` returns `undefined` for `undefined`, empty, and whitespace-only inputs and trims surrounding whitespace otherwise.

`ApiConfigSchema` is updated with the principle:

- **Secret keys** (`plexToken`, `openaiApiKey`) use `optionalTrimmed`. Empty, whitespace-only, and absent submissions all collapse to `undefined`, which the service treats as a no-op. Prevents a stray space-press from being persisted as the secret.
- **Echoed-back keys** (`openaiBaseUrl`, `openaiModel`, `plexServerUrl`) use `.trim()` on the inner string, so `"  "` becomes `""` and reaches the service as the canonical clear signal. Preserves the user's ability to clear the value by blanking the field.

This deliberately diverges from the plan's literal recommendation of `optionalTrimmed` for `openaiModel`, because that would silently drop the existing clear-via-blank semantics for echoed-back keys (regression on existing service tests in `setApiConfigAtomic`).

### F-011 - Save buttons debounce while in-flight (LOW)

File: `src/routes/admin/settings/+page.svelte`.

Added `isSavingOpenAI` and `isSavingPlex` state. Both `?/updateApiConfig` forms (Plex panel and OpenAI panel) now use a two-level `use:enhance` callback that toggles the flag in try/finally, copied from the working pattern in `/admin/sync`. Submit buttons render `Saving...` with a `Loader2` spinner and `disabled={true}` for the duration of the request. Rapid clicks now produce exactly one POST instead of N.

### F-012 - `/admin/logs` mobile overflow (MEDIUM)

File: `src/routes/admin/logs/+page.svelte`.

The screenshot evidence (`qa-evidence/.../97-explore-admin-logs-390x844-horizontal-scroll.png`) showed `.filters-grid` rendering 2 columns at 390px because the inputs inside columns had intrinsic min-content widths that the grid was honoring. Canonical fix:

- `.filters-grid` `grid-template-columns` is now `repeat(auto-fit, minmax(min(200px, 100%), 1fr))`, allowing fall-through to a single column when the parent is narrower than 200px.
- `.filter-group` and its `input`/`select` got `min-width: 0` (and `width: 100%` on the inputs) so children can shrink below their intrinsic content width.
- Defensive `min-width: 0` added to `.logs-page`.

`.logs-table-wrapper` already has `overflow-x: auto`, so the table itself remains independently horizontally scrollable inside the wrapper.

### F-009 - ShareModal radio flash on submit (LOW)

File: `src/lib/components/wrapped/ShareModal.svelte`.

`displayMode = $derived(optimisticMode ?? shareSettings?.mode)` drives the radio `checked` attribute. The `use:enhance` `finally` block was unconditionally setting `optimisticMode = null` and `optimisticShareToken = undefined` after every request, including success. On the success path, `applyShareActionData()` had set `optimisticMode` to the server's returned mode and `await update()` re-hydrated `shareSettings`, but the `finally` overwrote the optimistic value between those two events, briefly producing an all-unchecked render frame.

Removed the unconditional nulls from `finally`. The failure branch already nulls them inline. After `await update()` succeeds the optimistic value equals the server value, so leaving it set is a no-op for the derived; the next user interaction overwrites it cleanly. Inline comment explains the rationale.

## Test Plan

Type-check, lint, format, and full test suite run clean locally:

- `bun run check` - 0 errors, 0 warnings (1636 files).
- `bun run lint` - clean (325 files).
- `bun run test` - 1454 pass, 0 fail.
- New tests:
  - `tests/unit/admin/csrf-action.test.ts` - 8 cases covering mismatch-rejected, mismatch-confirmed, matching, trailing-slash normalization, invalid URL, env-locked, refused clear, and allowed-clear branches.
  - `tests/unit/admin/zod-helpers.test.ts` - 7 cases covering undefined / empty / whitespace / tab-newline / surrounding whitespace / valid input / max-length-exceeded.

Manual verification recommended (mirrors the original Phase 2 flow):

- [ ] `/admin/settings` Security tab: enter mismatched origin, click Save - dialog appears, no DB write. Cancel preserves typed value. Save anyway writes the value and shows the warning toast.
- [ ] `/admin/settings` Connections: save OpenAI with model = `"   "` - field is empty after reload, no whitespace persisted to `app_settings`.
- [ ] `/admin/settings` Connections: rapid-click Save OpenAI Settings or Save Plex Settings - exactly one POST in the Network tab.
- [ ] `/wrapped/2026/u/{id}`: open ShareModal, switch modes - selected radio stays visually checked through transition with no all-unchecked flash.
- [ ] DevTools mobile emulation 390x844 on `/admin/logs` - `document.body.scrollWidth === 390`, filters collapse to a single column. Spot-check 768x1024 and 1366x768 confirms desktop layout is unchanged.

## Out of scope

- F-001 / F-002 / F-003 - closed as wontfix per user decision (agent-browser hit-test artifacts on standards-compliant accessible HTML).
- F-004 - by-design observation, not a bug.
- F-006 / F-007 / F-008 - refuted in Phase 6.