### PR TITLE
fix: address 9 QA findings from run OBZ-20260502-222013

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,10 @@
 # Obzorarr Environment Configuration
+#
+# Values containing & * # $ ! or other shell-special characters
+# MUST be wrapped in single quotes or escaped, e.g.:
+#   PLEX_TOKEN='abc&def$ghi'
+# Do NOT use double quotes (they preserve $ expansion).
+# `source .env` works only with quoted values; `dotenv-cli` is more robust.
 
 # =============================================================================
 # REQUIRED

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ All requests pass through `sequence(...)` in this order:
 
 - **CSRF** is origin-based, configured from DB (`app_settings`) first, then `ORIGIN` env var. SvelteKit's built-in origin check is disabled (`trustedOrigins: ['*']` in `svelte.config.js`) because this app sits behind a reverse proxy; protection comes from the custom `csrfHandle` + SameSite=Lax cookies.
 - **CSP** is set in `svelte.config.js` with `mode: 'nonce'`.
-- **`authorizationHandle`** gates `/admin` to `locals.user.isAdmin`. The root `+page.server.ts` redirects logged-in users to `/admin` or `/dashboard`.
+- **`authorizationHandle`** gates `/admin` to `locals.user.isAdmin`. Non-admins are redirected to `/dashboard` (logged in) or `/` (anonymous). The root `+page.server.ts` redirects logged-in users to `/admin` or `/dashboard`.
 - **`DEV_BYPASS_AUTH`** (dev only) short-circuits auth by creating a hardcoded `DEV_SESSION_ID`. Tuned with `DEV_BYPASS_USER` (empty/`random`/plexId/username) and optional `DEV_PLEX_TOKEN` for onboarding testing. See `src/lib/server/auth/dev-bypass.ts`.
 
 ### Authentication

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -207,7 +207,8 @@ const onboardingHandle: Handle = async ({ event, resolve }) => {
 const authorizationHandle: Handle = async ({ event, resolve }) => {
 	if (isAdminRouteId(event.route.id)) {
 		if (!event.locals.user || !event.locals.user.isAdmin) {
-			return redirectResponse(event, '/');
+			const fallback = event.locals.user ? '/dashboard' : '/';
+			return redirectResponse(event, fallback);
 		}
 	}
 

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -278,7 +278,7 @@ $effect(() => {
 									type="radio"
 									name="mode"
 									value={mode}
-									checked={displayMode === mode}
+									checked={isUpdating ? optimisticMode === mode : displayMode === mode}
 									disabled={isUpdating || isBelowFloor(mode as ShareModeType)}
 									onchange={(e) => {
 										optimisticMode = mode as ShareModeType;

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -323,6 +323,11 @@ $effect(() => {
 						action="?/regenerateToken"
 						use:enhance={() => {
 							isUpdating = true;
+							// Seed optimisticMode with the current mode so the radio group's
+							// `checked={isUpdating ? optimisticMode === mode : ...}` expression
+							// keeps the correct option selected for the round-trip duration.
+							// The regenerate action does not change the mode, so we mirror it.
+							optimisticMode = shareSettings?.mode ?? null;
 							return async ({ result, update }) => {
 								try {
 									if (result.type === 'success') {

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -123,12 +123,20 @@ export async function getAppSettingsUpdatedAt(keys: readonly string[]): Promise<
 }
 
 /**
- * Keys covered by the privacy settings panel. Exported so the route can use
- * the same constant for loading the current version timestamp.
+ * Keys covered by the "Server-wide Wrapped" privacy form (anonymization +
+ * server-wide share mode). Each form has its own optimistic-locking version so
+ * a stale value on one form doesn't false-409 the other.
  */
-export const PRIVACY_SETTINGS_KEYS = [
+export const SERVER_WRAPPED_SETTINGS_KEYS = [
 	AppSettingsKey.ANONYMIZATION_MODE,
-	ShareSettingsKey.SERVER_WRAPPED_SHARE_MODE,
+	ShareSettingsKey.SERVER_WRAPPED_SHARE_MODE
+] as const;
+
+/**
+ * Keys covered by the "User Sharing Defaults" privacy form (per-user default
+ * share mode + allow-user-control flag).
+ */
+export const USER_DEFAULTS_SETTINGS_KEYS = [
 	ShareSettingsKey.DEFAULT_SHARE_MODE,
 	ShareSettingsKey.ALLOW_USER_CONTROL
 ] as const;
@@ -152,22 +160,21 @@ export const API_CONFIG_KEYS = [
 ] as const;
 
 /**
- * Atomically validates that the privacy settings have not changed since
- * `submittedVersion` and, if so, writes all four values in a single SQLite
- * transaction. Returns `'conflict'` when the submitted version is stale.
+ * Atomically validates that the "Server-wide Wrapped" settings (anonymization
+ * mode + server-wide share mode) have not changed since `submittedVersion`
+ * and, if so, writes both values in a single SQLite transaction. Returns
+ * `'conflict'` when the submitted version is stale.
  */
-export async function setPrivacySettingsAtomic(opts: {
+export async function setServerWrappedSettingsAtomic(opts: {
 	anonymizationMode: AnonymizationModeType;
 	serverWrappedShareMode: string;
-	defaultShareMode: string;
-	allowUserControl: boolean;
 	submittedVersion: string;
 }): Promise<'ok' | 'conflict'> {
 	return db.transaction(async (tx) => {
 		const rows = await tx
 			.select({ updatedAt: appSettings.updatedAt })
 			.from(appSettings)
-			.where(inArray(appSettings.key, PRIVACY_SETTINGS_KEYS as unknown as string[]));
+			.where(inArray(appSettings.key, SERVER_WRAPPED_SETTINGS_KEYS as unknown as string[]));
 
 		if (rows.length > 0) {
 			let maxMs = 0;
@@ -206,6 +213,41 @@ export async function setPrivacySettingsAtomic(opts: {
 				target: appSettings.key,
 				set: { value: opts.serverWrappedShareMode, updatedAt: now }
 			});
+
+		return 'ok';
+	});
+}
+
+/**
+ * Atomically validates that the "User Sharing Defaults" settings (default
+ * share mode + allow-user-control flag) have not changed since
+ * `submittedVersion` and, if so, writes both values in a single SQLite
+ * transaction. Returns `'conflict'` when the submitted version is stale.
+ */
+export async function setUserDefaultsAtomic(opts: {
+	defaultShareMode: string;
+	allowUserControl: boolean;
+	submittedVersion: string;
+}): Promise<'ok' | 'conflict'> {
+	return db.transaction(async (tx) => {
+		const rows = await tx
+			.select({ updatedAt: appSettings.updatedAt })
+			.from(appSettings)
+			.where(inArray(appSettings.key, USER_DEFAULTS_SETTINGS_KEYS as unknown as string[]));
+
+		if (rows.length > 0) {
+			let maxMs = 0;
+			for (const row of rows) {
+				const t = row.updatedAt.getTime();
+				if (t > maxMs) maxMs = t;
+			}
+			const submittedMs = opts.submittedVersion ? Date.parse(opts.submittedVersion) : Number.NaN;
+			if (Number.isNaN(submittedMs) || submittedMs < maxMs) {
+				return 'conflict';
+			}
+		}
+
+		const now = new Date();
 
 		await tx
 			.insert(appSettings)

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -23,19 +23,21 @@ import {
 	getWrappedLogoMode,
 	getWrappedTheme,
 	isCsrfWarningDismissed,
-	PRIVACY_SETTINGS_KEYS,
 	resetCsrfWarningDismissal,
+	SERVER_WRAPPED_SETTINGS_KEYS,
 	setAnonymizationMode,
 	setApiConfigAtomic,
 	setAppSetting,
 	setCachedServerName,
-	setPrivacySettingsAtomic,
+	setServerWrappedSettingsAtomic,
 	setUITheme,
+	setUserDefaultsAtomic,
 	setWrappedLogoMode,
 	setWrappedTheme,
 	ThemePresets,
 	type ThemePresetType,
 	toSafeConfigValue,
+	USER_DEFAULTS_SETTINGS_KEYS,
 	WrappedLogoMode,
 	type WrappedLogoModeType
 } from '$lib/server/admin/settings.service';
@@ -82,9 +84,13 @@ const GlobalDefaultsSchema = z.object({
 // Server-wide wrapped only supports public and private-oauth (not private-link)
 const ServerWrappedModeSchema = z.enum(['public', 'private-oauth']);
 
-const PrivacySettingsSchema = z.object({
+const ServerWrappedSettingsSchema = z.object({
 	anonymizationMode: AnonymizationSchema,
 	serverWrappedShareMode: ServerWrappedModeSchema,
+	settingsVersion: z.string()
+});
+
+const UserDefaultsSettingsSchema = z.object({
 	defaultShareMode: ShareModeSchema,
 	allowUserControl: z.coerce.boolean(),
 	settingsVersion: z.string()
@@ -188,7 +194,8 @@ export const load: PageServerLoad = async () => {
 		csrfWarningDismissed,
 		csrfOriginSkippedRaw,
 		trustProxyConfig,
-		privacySettingsUpdatedAt,
+		serverWrappedSettingsUpdatedAt,
+		userDefaultsSettingsUpdatedAt,
 		apiConfigUpdatedAt
 	] = await Promise.all([
 		getApiConfigWithSources(),
@@ -207,7 +214,8 @@ export const load: PageServerLoad = async () => {
 		isCsrfWarningDismissed(),
 		getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED),
 		getTrustProxyConfigWithSource(),
-		getAppSettingsUpdatedAt(PRIVACY_SETTINGS_KEYS),
+		getAppSettingsUpdatedAt(SERVER_WRAPPED_SETTINGS_KEYS),
+		getAppSettingsUpdatedAt(USER_DEFAULTS_SETTINGS_KEYS),
 		getAppSettingsUpdatedAt(API_CONFIG_KEYS)
 	]);
 
@@ -255,7 +263,8 @@ export const load: PageServerLoad = async () => {
 			allowUserControl
 		},
 		serverWrappedShareMode,
-		privacySettingsVersion: privacySettingsUpdatedAt?.toISOString() ?? '',
+		serverWrappedSettingsVersion: serverWrappedSettingsUpdatedAt?.toISOString() ?? '',
+		userDefaultsSettingsVersion: userDefaultsSettingsUpdatedAt?.toISOString() ?? '',
 		apiConfigVersion: apiConfigUpdatedAt?.toISOString() ?? '',
 		security: {
 			originValue: csrfConfig.origin.value,
@@ -690,18 +699,16 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	updatePrivacySettings: async ({ request }) => {
+	updateServerWrappedSettings: async ({ request }) => {
 		const formData = await request.formData();
 
 		const data = {
 			anonymizationMode: formData.get('anonymizationMode'),
 			serverWrappedShareMode: formData.get('serverWrappedShareMode'),
-			defaultShareMode: formData.get('defaultShareMode'),
-			allowUserControl: formData.get('allowUserControl') === 'true',
 			settingsVersion: formData.get('settingsVersion')?.toString() ?? ''
 		};
 
-		const parsed = PrivacySettingsSchema.safeParse(data);
+		const parsed = ServerWrappedSettingsSchema.safeParse(data);
 		if (!parsed.success) {
 			return fail(400, {
 				error: 'Invalid input',
@@ -710,9 +717,45 @@ export const actions: Actions = requireAdminActions({
 		}
 
 		try {
-			const result = await setPrivacySettingsAtomic({
+			const result = await setServerWrappedSettingsAtomic({
 				anonymizationMode: parsed.data.anonymizationMode as AnonymizationModeType,
 				serverWrappedShareMode: parsed.data.serverWrappedShareMode,
+				submittedVersion: parsed.data.settingsVersion
+			});
+
+			if (result === 'conflict') {
+				return fail(409, {
+					error: 'Settings changed in another tab. Please reload.'
+				});
+			}
+
+			return { success: true, message: 'Server-wide wrapped settings updated' };
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : 'Failed to update server-wide wrapped settings';
+			return fail(500, { error: message });
+		}
+	},
+
+	updateUserDefaults: async ({ request }) => {
+		const formData = await request.formData();
+
+		const data = {
+			defaultShareMode: formData.get('defaultShareMode'),
+			allowUserControl: formData.get('allowUserControl') === 'true',
+			settingsVersion: formData.get('settingsVersion')?.toString() ?? ''
+		};
+
+		const parsed = UserDefaultsSettingsSchema.safeParse(data);
+		if (!parsed.success) {
+			return fail(400, {
+				error: 'Invalid input',
+				fieldErrors: parsed.error.flatten().fieldErrors
+			});
+		}
+
+		try {
+			const result = await setUserDefaultsAtomic({
 				defaultShareMode: parsed.data.defaultShareMode,
 				allowUserControl: parsed.data.allowUserControl,
 				submittedVersion: parsed.data.settingsVersion
@@ -724,9 +767,10 @@ export const actions: Actions = requireAdminActions({
 				});
 			}
 
-			return { success: true, message: 'Privacy settings updated' };
+			return { success: true, message: 'User sharing defaults updated' };
 		} catch (error) {
-			const message = error instanceof Error ? error.message : 'Failed to update privacy settings';
+			const message =
+				error instanceof Error ? error.message : 'Failed to update user sharing defaults';
 			return fail(500, { error: message });
 		}
 	},

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -1171,259 +1171,287 @@ const logFieldErrors = $derived(
 
 		<!-- Privacy Tab -->
 		{#if activeTab === 'privacy'}
-			<form method="POST" action="?/updatePrivacySettings" use:enhance class="privacy-content">
-				<input type="hidden" name="settingsVersion" value={data.privacySettingsVersion} />
-				<!-- User Identity Section -->
-				<section class="panel privacy-panel">
-					<div class="panel-header">
-						<div class="panel-title">
-							<Users class="panel-icon" />
-							<h2>User Identity</h2>
+			<div class="privacy-content">
+				<!-- Form 1: Server-wide Wrapped (anonymization + server-wide share mode) -->
+				<form method="POST" action="?/updateServerWrappedSettings" use:enhance>
+					<input
+						type="hidden"
+						name="settingsVersion"
+						value={data.serverWrappedSettingsVersion}
+					/>
+
+					<!-- User Identity Section -->
+					<section class="panel privacy-panel">
+						<div class="panel-header">
+							<div class="panel-title">
+								<Users class="panel-icon" />
+								<h2>User Identity</h2>
+							</div>
 						</div>
-					</div>
-					<p class="panel-description">Control how usernames appear in server-wide statistics.</p>
-
-					<h3 class="subsection-title">
-						<VenetianMask class="subsection-icon" />
-						Anonymization Mode
-					</h3>
-
-					<div class="option-cards">
-						<label class="option-card" class:selected={selectedAnonymization === 'real'}>
-							<input
-								type="radio"
-								name="anonymizationMode"
-								value="real"
-								bind:group={selectedAnonymization}
-							/>
-							<div class="option-icon">
-								<UserCheck />
-							</div>
-							<div class="option-content">
-								<span class="option-title">Real Names</span>
-								<span class="option-desc">{anonymizationDescriptions.real}</span>
-							</div>
-							{#if selectedAnonymization === 'real'}
-								<div class="option-check"><Check /></div>
-							{/if}
-						</label>
-
-						<label class="option-card" class:selected={selectedAnonymization === 'anonymous'}>
-							<input
-								type="radio"
-								name="anonymizationMode"
-								value="anonymous"
-								bind:group={selectedAnonymization}
-							/>
-							<div class="option-icon">
-								<VenetianMask />
-							</div>
-							<div class="option-content">
-								<span class="option-title">Anonymous</span>
-								<span class="option-desc">{anonymizationDescriptions.anonymous}</span>
-							</div>
-							{#if selectedAnonymization === 'anonymous'}
-								<div class="option-check"><Check /></div>
-							{/if}
-						</label>
-
-						<label class="option-card" class:selected={selectedAnonymization === 'hybrid'}>
-							<input
-								type="radio"
-								name="anonymizationMode"
-								value="hybrid"
-								bind:group={selectedAnonymization}
-							/>
-							<div class="option-icon">
-								<Users />
-							</div>
-							<div class="option-content">
-								<span class="option-title">Hybrid</span>
-								<span class="option-desc">{anonymizationDescriptions.hybrid}</span>
-							</div>
-							{#if selectedAnonymization === 'hybrid'}
-								<div class="option-check"><Check /></div>
-							{/if}
-						</label>
-					</div>
-
-				</section>
-
-				<!-- Sharing Access Section -->
-				<section class="panel privacy-panel">
-					<div class="panel-header">
-						<div class="panel-title">
-							<Globe class="panel-icon" />
-							<h2>Sharing Access</h2>
-						</div>
-					</div>
-					<p class="panel-description">Configure access controls for wrapped pages.</p>
-
-					<h3 class="subsection-title">
-						<Server class="subsection-icon" />
-						Server-Wide Wrapped Access
-					</h3>
-					<p class="subsection-hint">
-						Control who can access the server-wide Year in Review at <code
-							>/wrapped/{data.currentYear}</code
-						>.
-					</p>
-
-					<div class="option-cards two-col">
-						<label class="option-card" class:selected={selectedServerWrappedMode === 'public'}>
-							<input
-								type="radio"
-								name="serverWrappedShareMode"
-								value="public"
-								bind:group={selectedServerWrappedMode}
-							/>
-							<div class="option-icon">
-								<Globe />
-							</div>
-							<div class="option-content">
-								<span class="option-title">Public</span>
-								<span class="option-desc">Anyone can view</span>
-							</div>
-							{#if selectedServerWrappedMode === 'public'}
-								<div class="option-check"><Check /></div>
-							{/if}
-						</label>
-
-						<label
-							class="option-card"
-							class:selected={selectedServerWrappedMode === 'private-oauth'}
-						>
-							<input
-								type="radio"
-								name="serverWrappedShareMode"
-								value="private-oauth"
-								bind:group={selectedServerWrappedMode}
-							/>
-							<div class="option-icon">
-								<Lock />
-							</div>
-							<div class="option-content">
-								<span class="option-title">Private OAuth</span>
-								<span class="option-desc">Server members only</span>
-							</div>
-							{#if selectedServerWrappedMode === 'private-oauth'}
-								<div class="option-check"><Check /></div>
-							{/if}
-						</label>
-					</div>
-
-					<h3 class="subsection-title">
-						<Users class="subsection-icon" />
-						User Sharing Defaults
-					</h3>
-					<p class="subsection-hint">
-						Minimum privacy level for user wrapped pages. Users cannot choose less restrictive
-						settings.
-					</p>
-
-					<div class="option-cards three-col">
-						<label class="option-card" class:selected={selectedDefaultShareMode === 'public'}>
-							<input
-								type="radio"
-								name="defaultShareMode"
-								value="public"
-								bind:group={selectedDefaultShareMode}
-							/>
-							<div class="option-icon">
-								<Globe />
-							</div>
-							<div class="option-content">
-								<span class="option-title">Public</span>
-								<span class="option-desc">Least restrictive</span>
-							</div>
-							{#if selectedDefaultShareMode === 'public'}
-								<div class="option-check"><Check /></div>
-							{/if}
-						</label>
-
-						<label class="option-card" class:selected={selectedDefaultShareMode === 'private-link'}>
-							<input
-								type="radio"
-								name="defaultShareMode"
-								value="private-link"
-								bind:group={selectedDefaultShareMode}
-							/>
-							<div class="option-icon">
-								<Link />
-							</div>
-							<div class="option-content">
-								<span class="option-title">Private Link</span>
-								<span class="option-desc">Secret share link</span>
-							</div>
-							{#if selectedDefaultShareMode === 'private-link'}
-								<div class="option-check"><Check /></div>
-							{/if}
-						</label>
-
-						<label
-							class="option-card"
-							class:selected={selectedDefaultShareMode === 'private-oauth'}
-						>
-							<input
-								type="radio"
-								name="defaultShareMode"
-								value="private-oauth"
-								bind:group={selectedDefaultShareMode}
-							/>
-							<div class="option-icon">
-								<Lock />
-							</div>
-							<div class="option-content">
-								<span class="option-title">Private OAuth</span>
-								<span class="option-desc">Most restrictive</span>
-							</div>
-							{#if selectedDefaultShareMode === 'private-oauth'}
-								<div class="option-check"><Check /></div>
-							{/if}
-						</label>
-					</div>
-
-					<!-- User Control Toggle -->
-					<div class="toggle-option">
-						<label class="toggle-label">
-							<input
-								type="checkbox"
-								name="allowUserControlCheckbox"
-								bind:checked={allowUserControl}
-							/>
-							<span class="toggle-switch"></span>
-							<span class="toggle-text">Allow users to control their own sharing settings</span>
-						</label>
-						<p class="toggle-hint">
-							When enabled, users can adjust privacy but cannot go below the minimum set above.
+						<p class="panel-description">
+							Control how usernames appear in server-wide statistics.
 						</p>
+
+						<h3 class="subsection-title">
+							<VenetianMask class="subsection-icon" />
+							Anonymization Mode
+						</h3>
+
+						<div class="option-cards">
+							<label class="option-card" class:selected={selectedAnonymization === 'real'}>
+								<input
+									type="radio"
+									name="anonymizationMode"
+									value="real"
+									bind:group={selectedAnonymization}
+								/>
+								<div class="option-icon">
+									<UserCheck />
+								</div>
+								<div class="option-content">
+									<span class="option-title">Real Names</span>
+									<span class="option-desc">{anonymizationDescriptions.real}</span>
+								</div>
+								{#if selectedAnonymization === 'real'}
+									<div class="option-check"><Check /></div>
+								{/if}
+							</label>
+
+							<label class="option-card" class:selected={selectedAnonymization === 'anonymous'}>
+								<input
+									type="radio"
+									name="anonymizationMode"
+									value="anonymous"
+									bind:group={selectedAnonymization}
+								/>
+								<div class="option-icon">
+									<VenetianMask />
+								</div>
+								<div class="option-content">
+									<span class="option-title">Anonymous</span>
+									<span class="option-desc">{anonymizationDescriptions.anonymous}</span>
+								</div>
+								{#if selectedAnonymization === 'anonymous'}
+									<div class="option-check"><Check /></div>
+								{/if}
+							</label>
+
+							<label class="option-card" class:selected={selectedAnonymization === 'hybrid'}>
+								<input
+									type="radio"
+									name="anonymizationMode"
+									value="hybrid"
+									bind:group={selectedAnonymization}
+								/>
+								<div class="option-icon">
+									<Users />
+								</div>
+								<div class="option-content">
+									<span class="option-title">Hybrid</span>
+									<span class="option-desc">{anonymizationDescriptions.hybrid}</span>
+								</div>
+								{#if selectedAnonymization === 'hybrid'}
+									<div class="option-check"><Check /></div>
+								{/if}
+							</label>
+						</div>
+					</section>
+
+					<!-- Server-Wide Wrapped Access Section -->
+					<section class="panel privacy-panel">
+						<div class="panel-header">
+							<div class="panel-title">
+								<Server class="panel-icon" />
+								<h2>Server-Wide Wrapped Access</h2>
+							</div>
+						</div>
+						<p class="panel-description">
+							Control who can access the server-wide Year in Review at <code
+								>/wrapped/{data.currentYear}</code
+							>.
+						</p>
+
+						<div class="option-cards two-col">
+							<label class="option-card" class:selected={selectedServerWrappedMode === 'public'}>
+								<input
+									type="radio"
+									name="serverWrappedShareMode"
+									value="public"
+									bind:group={selectedServerWrappedMode}
+								/>
+								<div class="option-icon">
+									<Globe />
+								</div>
+								<div class="option-content">
+									<span class="option-title">Public</span>
+									<span class="option-desc">Anyone can view</span>
+								</div>
+								{#if selectedServerWrappedMode === 'public'}
+									<div class="option-check"><Check /></div>
+								{/if}
+							</label>
+
+							<label
+								class="option-card"
+								class:selected={selectedServerWrappedMode === 'private-oauth'}
+							>
+								<input
+									type="radio"
+									name="serverWrappedShareMode"
+									value="private-oauth"
+									bind:group={selectedServerWrappedMode}
+								/>
+								<div class="option-icon">
+									<Lock />
+								</div>
+								<div class="option-content">
+									<span class="option-title">Private OAuth</span>
+									<span class="option-desc">Server members only</span>
+								</div>
+								{#if selectedServerWrappedMode === 'private-oauth'}
+									<div class="option-check"><Check /></div>
+								{/if}
+							</label>
+						</div>
+					</section>
+
+					<!-- Sticky Save Button (Server settings) -->
+					<div class="sticky-save">
+						<button type="submit" class="btn-primary btn-large">
+							<Shield class="btn-icon" />
+							Save Server Settings
+						</button>
 					</div>
-					<input type="hidden" name="allowUserControl" value={allowUserControl.toString()} />
+				</form>
 
-					<button
-						type="button"
-						class="btn-secondary"
-						disabled={isBulkApplyingUserControl}
-						onclick={() => (bulkApplyShareDefaultsDialogOpen = true)}
-					>
-						{#if isBulkApplyingUserControl}
-							<Loader2 class="btn-icon spinning" />
-							Applying...
-						{:else}
-							<Users class="btn-icon" />
-							Apply current defaults to all existing users
-						{/if}
-					</button>
-				</section>
+				<!-- Form 2: User Sharing Defaults (defaultShareMode + allowUserControl) -->
+				<form method="POST" action="?/updateUserDefaults" use:enhance>
+					<input
+						type="hidden"
+						name="settingsVersion"
+						value={data.userDefaultsSettingsVersion}
+					/>
 
-				<!-- Sticky Save Button -->
-				<div class="sticky-save">
-					<button type="submit" class="btn-primary btn-large">
-						<Shield class="btn-icon" />
-						Save Privacy Settings
-					</button>
-				</div>
-			</form>
+					<!-- User Sharing Defaults Section -->
+					<section class="panel privacy-panel">
+						<div class="panel-header">
+							<div class="panel-title">
+								<Users class="panel-icon" />
+								<h2>User Sharing Defaults</h2>
+							</div>
+						</div>
+						<p class="panel-description">
+							Minimum privacy level for user wrapped pages. Users cannot choose less restrictive
+							settings.
+						</p>
+
+						<div class="option-cards three-col">
+							<label class="option-card" class:selected={selectedDefaultShareMode === 'public'}>
+								<input
+									type="radio"
+									name="defaultShareMode"
+									value="public"
+									bind:group={selectedDefaultShareMode}
+								/>
+								<div class="option-icon">
+									<Globe />
+								</div>
+								<div class="option-content">
+									<span class="option-title">Public</span>
+									<span class="option-desc">Least restrictive</span>
+								</div>
+								{#if selectedDefaultShareMode === 'public'}
+									<div class="option-check"><Check /></div>
+								{/if}
+							</label>
+
+							<label
+								class="option-card"
+								class:selected={selectedDefaultShareMode === 'private-link'}
+							>
+								<input
+									type="radio"
+									name="defaultShareMode"
+									value="private-link"
+									bind:group={selectedDefaultShareMode}
+								/>
+								<div class="option-icon">
+									<Link />
+								</div>
+								<div class="option-content">
+									<span class="option-title">Private Link</span>
+									<span class="option-desc">Secret share link</span>
+								</div>
+								{#if selectedDefaultShareMode === 'private-link'}
+									<div class="option-check"><Check /></div>
+								{/if}
+							</label>
+
+							<label
+								class="option-card"
+								class:selected={selectedDefaultShareMode === 'private-oauth'}
+							>
+								<input
+									type="radio"
+									name="defaultShareMode"
+									value="private-oauth"
+									bind:group={selectedDefaultShareMode}
+								/>
+								<div class="option-icon">
+									<Lock />
+								</div>
+								<div class="option-content">
+									<span class="option-title">Private OAuth</span>
+									<span class="option-desc">Most restrictive</span>
+								</div>
+								{#if selectedDefaultShareMode === 'private-oauth'}
+									<div class="option-check"><Check /></div>
+								{/if}
+							</label>
+						</div>
+
+						<!-- User Control Toggle -->
+						<div class="toggle-option">
+							<label class="toggle-label">
+								<input
+									type="checkbox"
+									name="allowUserControlCheckbox"
+									bind:checked={allowUserControl}
+								/>
+								<span class="toggle-switch"></span>
+								<span class="toggle-text">Allow users to control their own sharing settings</span>
+							</label>
+							<p class="toggle-hint">
+								When enabled, users can adjust privacy but cannot go below the minimum set above.
+							</p>
+						</div>
+						<input type="hidden" name="allowUserControl" value={allowUserControl.toString()} />
+
+						<button
+							type="button"
+							class="btn-secondary"
+							disabled={isBulkApplyingUserControl}
+							onclick={() => (bulkApplyShareDefaultsDialogOpen = true)}
+						>
+							{#if isBulkApplyingUserControl}
+								<Loader2 class="btn-icon spinning" />
+								Applying...
+							{:else}
+								<Users class="btn-icon" />
+								Apply current defaults to all existing users
+							{/if}
+						</button>
+					</section>
+
+					<!-- Sticky Save Button (User defaults) -->
+					<div class="sticky-save">
+						<button type="submit" class="btn-primary btn-large">
+							<Shield class="btn-icon" />
+							Save User Defaults
+						</button>
+					</div>
+				</form>
+			</div>
 		{/if}
 
 		<!-- Security Tab -->
@@ -3173,7 +3201,7 @@ const logFieldErrors = $derived(
 			padding: 0 1.25rem;
 		}
 
-		.subsection-hint code {
+		.panel-description code {
 			padding: 0.125rem 0.375rem;
 			background: hsl(var(--muted));
 			border-radius: 4px;

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -627,6 +627,7 @@ async function goToPage(page: number) {
 						class:completed={sync.status === 'completed'}
 						class:failed={sync.status === 'failed'}
 						class:running={sync.status === 'running'}
+						class:cancelled={sync.status === 'cancelled'}
 					>
 						<div class="history-status-indicator">
 							{#if sync.status === 'completed'}
@@ -639,6 +640,12 @@ async function goToPage(page: number) {
 								<svg viewBox="0 0 24 24" fill="currentColor">
 									<path
 										d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm-1-7v2h2v-2h-2zm0-8v6h2V7h-2z"
+									/>
+								</svg>
+							{:else if sync.status === 'cancelled'}
+								<svg viewBox="0 0 24 24" fill="currentColor">
+									<path
+										d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm5 13.59L15.59 17 12 13.41 8.41 17 7 15.59 10.59 12 7 8.41 8.41 7 12 10.59 15.59 7 17 8.41 13.41 12 17 15.59z"
 									/>
 								</svg>
 							{:else}
@@ -1647,6 +1654,10 @@ async function goToPage(page: number) {
 
 		.history-item.running .history-status-indicator {
 			color: hsl(var(--primary));
+		}
+
+		.history-item.cancelled .history-status-indicator {
+			color: hsl(var(--muted-foreground));
 		}
 
 		.running-indicator {

--- a/src/routes/api/onboarding/servers/+server.ts
+++ b/src/routes/api/onboarding/servers/+server.ts
@@ -81,6 +81,9 @@ export const GET: RequestHandler = async ({ cookies, locals }) => {
 					}
 				}
 
+				// accessToken is intentionally returned so the onboarding UI can populate
+				// the token field. Endpoint is admin-only; the value is the Plex
+				// per-server token, not the user's auth token.
 				return {
 					name: server.name,
 					clientIdentifier: server.clientIdentifier,

--- a/src/routes/api/onboarding/test-connection/+server.ts
+++ b/src/routes/api/onboarding/test-connection/+server.ts
@@ -112,7 +112,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 						success: false,
 						error: 'This does not appear to be a Plex Media Server'
 					},
-					{ status: 502 }
+					{ status: 422 }
 				);
 			}
 
@@ -135,7 +135,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 						success: false,
 						error: errorMessage
 					},
-					{ status: 502 }
+					{ status: 503 }
 				);
 			}
 
@@ -145,7 +145,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 					success: false,
 					error: 'Connection failed'
 				},
-				{ status: 502 }
+				{ status: 503 }
 			);
 		} finally {
 			// Keep the timer armed until after response.json() + parsing complete so

--- a/src/routes/api/onboarding/test-connection/+server.ts
+++ b/src/routes/api/onboarding/test-connection/+server.ts
@@ -101,8 +101,22 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 				);
 			}
 
-			// Parse and validate response
-			const data = await response.json();
+			// Parse and validate response. A non-JSON body (e.g. an HTML gateway page
+			// from a non-Plex service) means the endpoint is reachable but is not a
+			// Plex Media Server — surface that as 422, not as a 503 connectivity error.
+			let data: unknown;
+			try {
+				data = await response.json();
+			} catch {
+				logger.debug('Connection test failed: Response body was not valid JSON', 'Onboarding');
+				return json(
+					{
+						success: false,
+						error: 'This does not appear to be a Plex Media Server'
+					},
+					{ status: 422 }
+				);
+			}
 			const identityResult = PlexServerIdentitySchema.safeParse(data);
 
 			if (!identityResult.success) {

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -871,6 +871,7 @@ function getLogoModeDescription(): string {
 			padding: 1rem 1.25rem;
 			background: hsl(210 60% 50% / 0.1);
 			border: 1px solid hsl(210 60% 50% / 0.25);
+			border-left: 3px solid hsl(var(--primary));
 			border-radius: var(--radius);
 			margin-bottom: 1rem;
 		}
@@ -886,7 +887,8 @@ function getLogoModeDescription(): string {
 
 		.info-content strong {
 			display: block;
-			font-size: 0.875rem;
+			font-size: 0.9375rem;
+			font-weight: 600;
 			color: hsl(var(--foreground));
 			margin-bottom: 0.25rem;
 		}

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -331,6 +331,13 @@ export const actions: Actions = {
 				}
 			}
 
+			if (data.enableFunFacts && !openaiApiKey) {
+				return fail(400, {
+					error:
+						'OpenAI API key is required when AI Fun Facts is enabled. Add a key or disable the toggle.'
+				});
+			}
+
 			// Save all settings in parallel
 			await Promise.all([
 				// Appearance

--- a/tests/unit/onboarding/settings-actions.test.ts
+++ b/tests/unit/onboarding/settings-actions.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test';
+import { actions } from '../../../src/routes/onboarding/settings/+page.server';
+
+const ORIGIN = 'http://localhost:5173';
+type SaveSettingsAction = NonNullable<typeof actions.saveSettings>;
+
+const adminLocals = {
+	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
+} as unknown as App.Locals;
+
+function createSettingsRequest(overrides: Record<string, string> = {}): Request {
+	const formData = new FormData();
+	// Required by SettingsSchema
+	formData.set('uiTheme', 'modern-minimal');
+	formData.set('wrappedTheme', 'modern-minimal');
+	formData.set('anonymizationMode', 'real');
+	formData.set('logoMode', 'always_show');
+	formData.set('defaultShareMode', 'public');
+	formData.set('allowUserControl', 'false');
+	formData.set('enabledSlides', '');
+	formData.set('enableFunFacts', 'false');
+
+	for (const [key, value] of Object.entries(overrides)) {
+		formData.set(key, value);
+	}
+
+	return new Request(`${ORIGIN}/onboarding/settings`, {
+		method: 'POST',
+		headers: { origin: ORIGIN },
+		body: formData
+	});
+}
+
+async function runSaveSettings(request: Request) {
+	const saveSettings = actions.saveSettings as SaveSettingsAction;
+	return saveSettings({
+		request,
+		locals: adminLocals,
+		url: new URL(request.url)
+	} as Parameters<SaveSettingsAction>[0]);
+}
+
+describe('onboarding settings actions', () => {
+	it('fails with 400 when enableFunFacts is true and openaiApiKey is missing', async () => {
+		const request = createSettingsRequest({
+			enableFunFacts: 'true',
+			funFactFrequency: 'normal',
+			openaiApiKey: '   ' // whitespace-only -> coerced to undefined by optionalString trim
+		});
+
+		const result = await runSaveSettings(request);
+
+		expect(result).toMatchObject({
+			status: 400,
+			data: {
+				error:
+					'OpenAI API key is required when AI Fun Facts is enabled. Add a key or disable the toggle.'
+			}
+		});
+		expect((result as { data: { error: string } }).data.error).toContain(
+			'OpenAI API key is required'
+		);
+	});
+});

--- a/tests/unit/onboarding/test-connection-endpoint.test.ts
+++ b/tests/unit/onboarding/test-connection-endpoint.test.ts
@@ -139,6 +139,22 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 		expect(body.error).toContain('Plex Media Server');
 	});
 
+	it('returns 422 when response body is not valid JSON', async () => {
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
+			new Response('<html>Gateway</html>', { status: 200 })
+		);
+
+		const response = await runPost(adminLocals, {
+			url: 'http://plex.local:32400',
+			accessToken: 'abc'
+		});
+
+		expect(response.status).toBe(422);
+		const body = (await response.json()) as { success: boolean; error?: string };
+		expect(body.success).toBe(false);
+		expect(body.error).toContain('Plex Media Server');
+	});
+
 	it('returns 503 when fetch throws', async () => {
 		fetchSpy = spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
 

--- a/tests/unit/onboarding/test-connection-endpoint.test.ts
+++ b/tests/unit/onboarding/test-connection-endpoint.test.ts
@@ -120,7 +120,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 		expect(body.success).toBe(false);
 	});
 
-	it('returns 502 for non-Plex schema mismatch', async () => {
+	it('returns 422 for non-Plex schema mismatch', async () => {
 		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(
 			new Response(JSON.stringify({ unexpected: true }), {
 				status: 200,
@@ -133,13 +133,13 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 			accessToken: 'abc'
 		});
 
-		expect(response.status).toBe(502);
+		expect(response.status).toBe(422);
 		const body = (await response.json()) as { success: boolean; error?: string };
 		expect(body.success).toBe(false);
 		expect(body.error).toContain('Plex Media Server');
 	});
 
-	it('returns 502 when fetch throws', async () => {
+	it('returns 503 when fetch throws', async () => {
 		fetchSpy = spyOn(global, 'fetch').mockRejectedValue(new Error('network down'));
 
 		const response = await runPost(adminLocals, {
@@ -147,7 +147,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 			accessToken: 'abc'
 		});
 
-		expect(response.status).toBe(502);
+		expect(response.status).toBe(503);
 		const body = (await response.json()) as { success: boolean };
 		expect(body.success).toBe(false);
 	});


### PR DESCRIPTION
## Summary

Addresses every actionable finding from the E2E QA dogfood run `OBZ-20260502-222013` (0 critical, 0 high, 2 medium, 5 low, 4 info). Two findings closed as documentation/no-op (`F-006`, `F-009`) since the existing code already behaved correctly; `F-008` left as recommendation per the plan; `F-011` deferred to a manual verification task (could not reproduce in Phase 2).

## Findings fixed

### F-001 [MEDIUM] — Onboarding silent fail when AI Fun Facts toggled on without OpenAI key

`SettingsSchema.openaiApiKey` is `.optional()`, so an empty key passed validation and every AI write no-op'd, leaving the user with `enableFunFacts=true` but no key configured. Added an explicit `fail(400)` guard between `parseResult` and the writes in `src/routes/onboarding/settings/+page.server.ts`. Surfaces an inline sonner toast via the existing `handleFormToast` pipeline.

### F-002 [MEDIUM] — Cancelled syncs not visually distinguished in admin sync history

The sync engine writes `status: 'cancelled'` and the type already includes it, but the history-row template only branched `completed | failed | else=running`. Added a `cancelled` class binding, an X-icon SVG branch, and a muted-foreground CSS rule in `src/routes/admin/sync/+page.svelte`. Cancelled rows now read as user-aborted (neutral) rather than failed (red).

### F-003 [LOW/OPS] — `.env` parse error on `&` and `$` in passwords

Bit Phase 1: zsh chokes on unquoted `&` and silently expands `$VAR`-shaped substrings. Added a header note to `.env.example` explaining single-quote escaping rules and warning against double quotes.

### F-004 [LOW] — ShareModal radio briefly shows all-unchecked after mode change

The `displayMode` derived (`optimisticMode ?? shareSettings?.mode`) became ambiguous between `await update()` re-running `load()` and the next `$derived` tick, causing a visible flicker. Pinned the radio's `checked` attribute to `optimisticMode === mode` while `isUpdating`; falls back to normal `displayMode` logic once `isUpdating` settles.

### F-005 [LOW/UX] — Privacy save bundled per-user defaults and server-wrapped share mode

Phase 3 inadvertently flipped `server_wrapped_share_mode` while changing `default_share_mode` because both were saved by a single form action. Refactored the Privacy tab and service layer:

- `setPrivacySettingsAtomic` → split into `setServerWrappedSettingsAtomic` (anonymization + server-wide share mode) and `setUserDefaultsAtomic` (default share mode + allow-user-control).
- `PRIVACY_SETTINGS_KEYS` → `SERVER_WRAPPED_SETTINGS_KEYS` and `USER_DEFAULTS_SETTINGS_KEYS`. Each helper checks `updatedAt` only on the keys it writes, so a stale version on one form doesn't false-409 the other.
- `updatePrivacySettings` action → `updateServerWrappedSettings` and `updateUserDefaults` actions in `src/routes/admin/settings/+page.server.ts`.
- The single Privacy form in `src/routes/admin/settings/+page.svelte` is now two intent-grouped forms with separate save buttons and OCC version inputs.

The onboarding-wizard `saveSettings` action calls the lower-level `setGlobalShareDefaults` / `setAnonymizationMode` directly, so it does not depend on the changed function and is unaffected.

### F-006 [LOW/SPEC] — Non-admin redirect to `/dashboard`, not `/`

`authorizationHandle` redirected non-admins to `/`, where the root `+page.server.ts` re-redirected them to `/dashboard`. Optimized to redirect logged-in non-admins straight to `/dashboard` (saves one HTTP round-trip; matches observed behavior). Anonymous users still land on `/`. CLAUDE.md updated to reflect the actual behavior.

### F-007 [LOW] — Locked-by-admin banner visually weak

The `info-banner` element already existed but was easy to miss after the form disappeared. Added a 3px primary-color left accent border, bumped the strong text to `0.9375rem` / `font-weight: 600`. Applied via shared `.info-banner` styles, so both banner instances on the dashboard settings page benefit.

### F-009 [INFO/BY-DESIGN] — `/api/onboarding/servers` returns Plex `accessToken`

Endpoint is correctly admin-gated and the token is needed by the onboarding UI to populate the per-server token field. Closed as by-design with a clarifying comment in `src/routes/api/onboarding/servers/+server.ts`.

### F-010 [INFO] — `test-connection` returns 502 for unreachable URLs

Three return paths used `502`. Distinguished them in `src/routes/api/onboarding/test-connection/+server.ts`:

- Got an HTTP response from upstream but it was non-OK: still **502** (semantically a bad gateway response).
- Got a response but it didn't parse as a Plex identity: **422** (body is unprocessable).
- Fetch threw (DNS failure, connection refused, timeout): **503** (upstream unavailable, not a bad gateway).

Response body envelope is unchanged. Test expectations updated.

## Closed without code change

- **F-008 [INFO]** — Default rate-limit bucket of 30 req/min on landing page is generous but functional. Plan recommends leaving as-is until product defines a target.
- **F-011 [INFO/UNCONFIRMED]** — Phase 1 onboarding-settings radio unresponsive could not be reproduced in Phase 2; deferred to a manual cold-start verification task per the plan.

## Test plan

- [x] `bun run check` — 0 errors, 0 warnings (1636 files).
- [x] `bun run lint` — clean (318 files, no fixes applied).
- [x] `bun run test` — 1457 pass, 0 fail (20164 expect calls); coverage 85.01% line / 84.23% function (above 80% threshold).
- [x] Updated `tests/unit/onboarding/test-connection-endpoint.test.ts` to match new status codes (422 / 503).
- [ ] Manual: reset DB, walk onboarding to AI step, toggle on without OpenAI key — expect inline error toast (F-001).
- [ ] Manual: start large backfill on `/admin/sync`, cancel, confirm muted X-icon row in history (F-002).
- [ ] Manual: open ShareModal, cycle modes rapidly, confirm no unchecked-flicker frame (F-004).
- [ ] Manual: change only "User Sharing Defaults" on `/admin/settings?tab=privacy`, save, confirm `server_wrapped_share_mode` unchanged in DB (F-005).
- [ ] Manual: log in as non-admin, navigate to `/admin`, confirm single 303 to `/dashboard` (F-006).
- [ ] Manual: admin disables `allow_user_control`, confirm banner is the prominent visual element on `/dashboard/settings` (F-007).
- [ ] Manual: `curl -X POST /api/onboarding/test-connection -d '{"url":"http://does-not-exist.invalid:32400","accessToken":"x"}'` returns 503 (F-010).
- [ ] Manual: cold-start onboarding repro for F-011; if reproducible, file a fresh focused issue.