### PR TITLE
fix(qa): address dogfood findings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -66,6 +66,7 @@
 			"**",
 			"!**/build",
 			"!**/.svelte-kit",
+			"!**/.omc",
 			"!**/node_modules",
 			"!**/data",
 			"!**/dogfood-output",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"lint": "biome lint .",
 		"lint:fix": "biome lint --write .",
 		"check:biome": "biome check .",
+		"dogfood:scrub": "bun run scripts/scrub-dogfood-output.ts",
 		"db:generate": "drizzle-kit generate",
 		"db:migrate": "bun run scripts/migrate.ts",
 		"db:studio": "drizzle-kit studio",

--- a/scripts/scrub-dogfood-output.ts
+++ b/scripts/scrub-dogfood-output.ts
@@ -31,6 +31,7 @@ type Secret = {
 	key: (typeof SECRET_KEYS)[number];
 	value: string;
 	placeholder: string;
+	pathPlaceholder: string;
 };
 
 function parseEnv(content: string): Map<string, string> {
@@ -100,7 +101,7 @@ function redactedPath(filePath: string, secrets: Secret[]): { filePath: string; 
 
 	for (const secret of secrets) {
 		if (!nextPath.includes(secret.value)) continue;
-		nextPath = nextPath.split(secret.value).join(secret.placeholder);
+		nextPath = nextPath.split(secret.value).join(secret.pathPlaceholder);
 		found.add(secret.key);
 	}
 
@@ -116,7 +117,7 @@ if (!(await envFile.exists())) {
 const envValues = parseEnv(await envFile.text());
 const secrets = SECRET_KEYS.map((key) => {
 	const value = envValues.get(key)?.trim() ?? '';
-	return value ? { key, value, placeholder: `<${key}>` } : null;
+	return value ? { key, value, placeholder: `<${key}>`, pathPlaceholder: `__${key}__` } : null;
 })
 	.filter((secret): secret is Secret => secret !== null)
 	.sort((a, b) => b.value.length - a.value.length);

--- a/scripts/scrub-dogfood-output.ts
+++ b/scripts/scrub-dogfood-output.ts
@@ -133,12 +133,12 @@ for (const filePath of files) {
 	let currentPath = filePath;
 	const pathResult = redactedPath(filePath, secrets);
 	if (pathResult.keys.length > 0) {
-		findings.push({ file: filePath, keys: pathResult.keys, type: 'filename' });
 		if (writeChanges) {
 			await mkdir(path.dirname(pathResult.filePath), { recursive: true });
 			await rename(filePath, pathResult.filePath);
 			currentPath = pathResult.filePath;
 		}
+		findings.push({ file: currentPath, keys: pathResult.keys, type: 'filename' });
 	}
 
 	if (!(await isLikelyTextFile(currentPath))) continue;

--- a/scripts/scrub-dogfood-output.ts
+++ b/scripts/scrub-dogfood-output.ts
@@ -1,0 +1,169 @@
+import { lstat, readdir, rename, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const SECRET_KEYS = [
+	'PLEX_SERVER_URL',
+	'PLEX_TOKEN',
+	'PLEX_ADMIN_USER_EMAIL',
+	'PLEX_ADMIN_USER_PASSWORD',
+	'PLEX_TEST_USER_EMAIL',
+	'PLEX_TEST_USER_PASSWORD'
+] as const;
+
+const TEXT_EXTENSIONS = new Set([
+	'.csv',
+	'.html',
+	'.json',
+	'.log',
+	'.md',
+	'.txt',
+	'.tsv',
+	'.xml',
+	'.yaml',
+	'.yml'
+]);
+
+const envPath = path.resolve(process.cwd(), '.env');
+const outputRoot = path.resolve(process.cwd(), 'dogfood-output');
+const writeChanges = Bun.argv.includes('--write');
+
+type Secret = {
+	key: (typeof SECRET_KEYS)[number];
+	value: string;
+	placeholder: string;
+};
+
+function parseEnv(content: string): Map<string, string> {
+	const values = new Map<string, string>();
+	for (const line of content.split(/\r?\n/)) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith('#')) continue;
+
+		const equalsIndex = trimmed.indexOf('=');
+		if (equalsIndex === -1) continue;
+
+		const key = trimmed.slice(0, equalsIndex).trim();
+		let value = trimmed.slice(equalsIndex + 1).trim();
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
+		values.set(key, value);
+	}
+	return values;
+}
+
+function redactText(text: string, secrets: Secret[]): { text: string; keys: string[] } {
+	let redacted = text;
+	const found = new Set<string>();
+
+	for (const secret of secrets) {
+		if (!redacted.includes(secret.value)) continue;
+		redacted = redacted.split(secret.value).join(secret.placeholder);
+		found.add(secret.key);
+	}
+
+	return { text: redacted, keys: [...found] };
+}
+
+async function listFiles(dir: string): Promise<string[]> {
+	const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+	const files: string[] = [];
+
+	for (const entry of entries) {
+		const fullPath = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...(await listFiles(fullPath)));
+		} else if (entry.isFile()) {
+			files.push(fullPath);
+		}
+	}
+
+	return files;
+}
+
+async function isLikelyTextFile(filePath: string): Promise<boolean> {
+	if (TEXT_EXTENSIONS.has(path.extname(filePath).toLowerCase())) return true;
+
+	const stat = await lstat(filePath);
+	if (stat.size > 1024 * 1024) return false;
+
+	const bytes = new Uint8Array(await Bun.file(filePath).slice(0, 4096).arrayBuffer());
+	return !bytes.includes(0);
+}
+
+function redactedPath(filePath: string, secrets: Secret[]): { filePath: string; keys: string[] } {
+	let nextPath = filePath;
+	const found = new Set<string>();
+
+	for (const secret of secrets) {
+		if (!nextPath.includes(secret.value)) continue;
+		nextPath = nextPath.split(secret.value).join(secret.placeholder);
+		found.add(secret.key);
+	}
+
+	return { filePath: nextPath, keys: [...found] };
+}
+
+const envFile = Bun.file(envPath);
+if (!(await envFile.exists())) {
+	console.error('No .env file found; cannot compare dogfood artifacts against runtime secrets.');
+	process.exit(1);
+}
+
+const envValues = parseEnv(await envFile.text());
+const secrets = SECRET_KEYS.map((key) => {
+	const value = envValues.get(key)?.trim() ?? '';
+	return value ? { key, value, placeholder: `<${key}>` } : null;
+})
+	.filter((secret): secret is Secret => secret !== null)
+	.sort((a, b) => b.value.length - a.value.length);
+
+if (secrets.length === 0) {
+	console.error('No configured secret values found in .env.');
+	process.exit(1);
+}
+
+const files = await listFiles(outputRoot);
+const findings: Array<{ file: string; keys: string[]; type: 'content' | 'filename' }> = [];
+
+for (const filePath of files) {
+	let currentPath = filePath;
+	const pathResult = redactedPath(filePath, secrets);
+	if (pathResult.keys.length > 0) {
+		findings.push({ file: filePath, keys: pathResult.keys, type: 'filename' });
+		if (writeChanges) {
+			await rename(filePath, pathResult.filePath);
+			currentPath = pathResult.filePath;
+		}
+	}
+
+	if (!(await isLikelyTextFile(currentPath))) continue;
+
+	const original = await Bun.file(currentPath).text();
+	const result = redactText(original, secrets);
+	if (result.keys.length === 0) continue;
+
+	findings.push({ file: currentPath, keys: result.keys, type: 'content' });
+	if (writeChanges) {
+		await writeFile(currentPath, result.text);
+	}
+}
+
+if (findings.length === 0) {
+	console.log('No configured .env secrets found in dogfood-output text artifacts or filenames.');
+	process.exit(0);
+}
+
+for (const finding of findings) {
+	console.log(
+		`${writeChanges ? 'Redacted' : 'Found'} ${finding.type} secret(s) ${finding.keys.join(', ')} in ${path.relative(process.cwd(), finding.file)}`
+	);
+}
+
+if (!writeChanges) {
+	console.error('Run `bun run dogfood:scrub -- --write` to redact text artifacts.');
+	process.exit(1);
+}

--- a/scripts/scrub-dogfood-output.ts
+++ b/scripts/scrub-dogfood-output.ts
@@ -70,7 +70,7 @@ function redactText(text: string, secrets: Secret[]): { text: string; keys: stri
 }
 
 async function listFiles(dir: string): Promise<string[]> {
-	const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+	const entries = await readdir(dir, { withFileTypes: true });
 	const files: string[] = [];
 
 	for (const entry of entries) {

--- a/scripts/scrub-dogfood-output.ts
+++ b/scripts/scrub-dogfood-output.ts
@@ -1,4 +1,4 @@
-import { lstat, readdir, rename, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, readdir, rename, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 const SECRET_KEYS = [
@@ -95,7 +95,7 @@ async function isLikelyTextFile(filePath: string): Promise<boolean> {
 }
 
 function redactedPath(filePath: string, secrets: Secret[]): { filePath: string; keys: string[] } {
-	let nextPath = filePath;
+	let nextPath = path.relative(outputRoot, filePath);
 	const found = new Set<string>();
 
 	for (const secret of secrets) {
@@ -104,7 +104,7 @@ function redactedPath(filePath: string, secrets: Secret[]): { filePath: string; 
 		found.add(secret.key);
 	}
 
-	return { filePath: nextPath, keys: [...found] };
+	return { filePath: path.join(outputRoot, nextPath), keys: [...found] };
 }
 
 const envFile = Bun.file(envPath);
@@ -135,6 +135,7 @@ for (const filePath of files) {
 	if (pathResult.keys.length > 0) {
 		findings.push({ file: filePath, keys: pathResult.keys, type: 'filename' });
 		if (writeChanges) {
+			await mkdir(path.dirname(pathResult.filePath), { recursive: true });
 			await rename(filePath, pathResult.filePath);
 			currentPath = pathResult.filePath;
 		}

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -98,6 +98,30 @@ async function fetchPin(redirectUrl?: string): Promise<PinResponse> {
 	return (await response.json()) as PinResponse;
 }
 
+export function sanitizeCompletedLoginResponse(result: unknown): CompletedLoginResponse | null {
+	if (!result || typeof result !== 'object' || !('user' in result)) return null;
+
+	const raw = result as {
+		user?: { username?: unknown; isAdmin?: unknown };
+		redirectTo?: unknown;
+	};
+	if (!raw.user || typeof raw.user.isAdmin !== 'boolean') return null;
+
+	const sanitized: CompletedLoginResponse = {
+		user: {
+			isAdmin: raw.user.isAdmin
+		}
+	};
+	if (typeof raw.user.username === 'string') {
+		sanitized.user.username = raw.user.username;
+	}
+	if (raw.redirectTo === '/admin' || raw.redirectTo === '/dashboard') {
+		sanitized.redirectTo = raw.redirectTo;
+	}
+
+	return sanitized;
+}
+
 function storePinForRedirect(
 	pinId: number,
 	context: PlexLoginContext,
@@ -192,15 +216,16 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 						return;
 					}
 
-					const result = (await pollResponse.json()) as { pending: true } | CompletedLoginResponse;
+					const result = (await pollResponse.json()) as unknown;
 					if (finished) return;
 
-					if ('user' in result && result.user) {
+					const completedLogin = sanitizeCompletedLoginResponse(result);
+					if (completedLogin) {
 						callbackInProgress = true;
 						cleanup();
 
 						try {
-							await opts.onSuccess(result.user);
+							await opts.onSuccess(completedLogin.user);
 							succeeded = true;
 						} catch (err) {
 							if (cancelled || succeeded || timedOut || pinExpired) return;

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { animate } from 'motion';
+import { tick } from 'svelte';
 import { prefersReducedMotion } from 'svelte/motion';
 import type { SlideMessagingContext } from '$lib/components/slides/messaging-context';
 import { createPersonalContext } from '$lib/components/slides/messaging-context';
@@ -38,6 +39,7 @@ let {
 const EDGE_ZONE_PERCENT = 0.15;
 const SWIPE_THRESHOLD = 50;
 const ANIMATION_DURATION = 450;
+type AnimationHandle = { stop: () => void; finished: Promise<void> };
 
 const navigation = createSlideState();
 let initialized = $state(false);
@@ -65,18 +67,15 @@ let showPreviousSlide = $state(false);
 let previousSlideIndex = $state(-1);
 
 let mounted = $state(true);
-let activeEnterAnim: { stop: () => void; finished: Promise<void> } | null = $state(null);
+let activeEnterAnim: AnimationHandle | null = $state(null);
+let activeExitAnim: AnimationHandle | null = $state(null);
 let transitionTimeout: ReturnType<typeof setTimeout> | null = $state(null);
+let transitionToken = 0;
 
 $effect(() => {
 	return () => {
 		mounted = false;
-		if (activeEnterAnim) {
-			activeEnterAnim.stop();
-		}
-		if (transitionTimeout) {
-			clearTimeout(transitionTimeout);
-		}
+		clearTransitionHandles();
 	};
 });
 
@@ -85,6 +84,41 @@ const previousSlide = $derived(previousSlideIndex >= 0 ? slides[previousSlideInd
 
 function emitSlideChange(): void {
 	onSlideChange?.(navigation.currentSlide);
+}
+
+function clearTransitionHandles(): void {
+	if (transitionTimeout) {
+		clearTimeout(transitionTimeout);
+		transitionTimeout = null;
+	}
+	if (activeEnterAnim) {
+		activeEnterAnim.stop();
+		activeEnterAnim = null;
+	}
+	if (activeExitAnim) {
+		activeExitAnim.stop();
+		activeExitAnim = null;
+	}
+}
+
+function startNavigation(direction: 'forward' | 'backward', move: () => boolean): void {
+	if (isTransitioning) return;
+
+	const fromSlide = navigation.currentSlide;
+	previousSlideIndex = fromSlide;
+	showPreviousSlide = true;
+	isTransitioning = true;
+
+	if (!move()) {
+		showPreviousSlide = false;
+		previousSlideIndex = -1;
+		isTransitioning = false;
+		return;
+	}
+
+	const token = ++transitionToken;
+	emitSlideChange();
+	void animateTransition(direction, token);
 }
 
 function goToNext(): void {
@@ -96,36 +130,27 @@ function goToNext(): void {
 		return;
 	}
 
-	previousSlideIndex = navigation.currentSlide;
-	showPreviousSlide = true;
-	isTransitioning = true;
-
-	navigation.goToNext();
-	emitSlideChange();
-	animateTransition('forward');
+	startNavigation('forward', () => navigation.goToNext());
 }
 
 function goToPrevious(): void {
 	if (isTransitioning || !navigation.canGoPrevious) return;
 
-	previousSlideIndex = navigation.currentSlide;
-	showPreviousSlide = true;
-	isTransitioning = true;
-
-	navigation.goToPrevious();
-	emitSlideChange();
-	animateTransition('backward');
+	startNavigation('backward', () => navigation.goToPrevious());
 }
 
-function animateTransition(direction: 'forward' | 'backward'): void {
+async function animateTransition(direction: 'forward' | 'backward', token: number): Promise<void> {
+	navigation.startAnimation();
+	await tick();
+
+	if (!mounted || token !== transitionToken) return;
+
 	const shouldAnimate = !prefersReducedMotion.current;
 
 	if (!shouldAnimate || !currentSlideEl) {
-		finishTransition();
+		finishTransition(token);
 		return;
 	}
-
-	navigation.startAnimation();
 
 	const enterFrom =
 		direction === 'forward' ? 'translateX(80%) scale(0.98)' : 'translateX(-80%) scale(0.98)';
@@ -134,18 +159,11 @@ function animateTransition(direction: 'forward' | 'backward'): void {
 
 	const slideEl = currentSlideEl;
 	if (!slideEl) {
-		finishTransition();
+		finishTransition(token);
 		return;
 	}
 
-	if (activeEnterAnim) {
-		activeEnterAnim.stop();
-		activeEnterAnim = null;
-	}
-	if (transitionTimeout) {
-		clearTimeout(transitionTimeout);
-		transitionTimeout = null;
-	}
+	clearTransitionHandles();
 
 	const enterKeyframes = {
 		opacity: [0, 1],
@@ -170,54 +188,41 @@ function animateTransition(direction: 'forward' | 'backward'): void {
 			opacity: [1, 0],
 			transform: ['translateX(0) scale(1)', exitTo]
 		} as Record<string, unknown>;
-		(animate as (el: Element, kf: Record<string, unknown>, opts: Record<string, unknown>) => void)(
-			prevEl,
-			exitKeyframes,
-			{
-				duration: ANIMATION_DURATION / 1000,
-				easing: EASING_PRESETS.organic
-			}
-		);
+		activeExitAnim = (
+			animate as (
+				el: Element,
+				kf: Record<string, unknown>,
+				opts: Record<string, unknown>
+			) => AnimationHandle
+		)(prevEl, exitKeyframes, {
+			duration: ANIMATION_DURATION / 1000,
+			easing: EASING_PRESETS.organic
+		});
 	}
 
 	transitionTimeout = setTimeout(() => {
-		if (isTransitioning) {
-			finishTransition();
+		if (isTransitioning && token === transitionToken) {
+			finishTransition(token);
 		}
 	}, ANIMATION_DURATION + 100);
 
 	enterAnim.finished
 		.then(() => {
-			if (transitionTimeout) {
-				clearTimeout(transitionTimeout);
-				transitionTimeout = null;
-			}
-			if (mounted && isTransitioning) {
-				finishTransition();
+			if (mounted && isTransitioning && token === transitionToken) {
+				finishTransition(token);
 			}
 		})
 		.catch(() => {
-			if (transitionTimeout) {
-				clearTimeout(transitionTimeout);
-				transitionTimeout = null;
-			}
-			if (mounted && isTransitioning) {
-				finishTransition();
+			if (mounted && isTransitioning && token === transitionToken) {
+				finishTransition(token);
 			}
 		});
 }
 
-function finishTransition(): void {
-	if (!isTransitioning) return;
+function finishTransition(token = transitionToken): void {
+	if (!isTransitioning || token !== transitionToken) return;
 
-	if (transitionTimeout) {
-		clearTimeout(transitionTimeout);
-		transitionTimeout = null;
-	}
-	if (activeEnterAnim) {
-		activeEnterAnim.stop();
-		activeEnterAnim = null;
-	}
+	clearTransitionHandles();
 
 	showPreviousSlide = false;
 	previousSlideIndex = -1;
@@ -304,23 +309,13 @@ function handleKeyDown(event: KeyboardEvent): void {
 		case 'Home':
 			event.preventDefault();
 			if (navigation.currentSlide !== 0) {
-				previousSlideIndex = navigation.currentSlide;
-				showPreviousSlide = true;
-				isTransitioning = true;
-				navigation.goToFirst();
-				emitSlideChange();
-				animateTransition('backward');
+				startNavigation('backward', () => navigation.goToFirst());
 			}
 			break;
 		case 'End':
 			event.preventDefault();
 			if (!navigation.isLast) {
-				previousSlideIndex = navigation.currentSlide;
-				showPreviousSlide = true;
-				isTransitioning = true;
-				navigation.goToLast();
-				emitSlideChange();
-				animateTransition('forward');
+				startNavigation('forward', () => navigation.goToLast());
 			}
 			break;
 	}

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -603,21 +603,22 @@ $effect(() => {
 				</table>
 			</div>
 
-			{#if data.hasMore && visibleLogs.length > 0}
-				{@const lastLog = visibleLogs[visibleLogs.length - 1]}
-				{#if lastLog}
-					<div class="load-more">
-						<a
-							href="/admin/logs?cursor={lastLog.id}&{$page.url.searchParams.toString()}"
-							class="load-more-button"
-						>
-							Load More
-						</a>
-					</div>
-				{/if}
+		{/if}
+
+		{#if data.hasMore && data.logs.length > 0}
+			{@const lastLog = data.logs[data.logs.length - 1]}
+			{#if lastLog}
+				<div class="load-more">
+					<a
+						href="/admin/logs?cursor={lastLog.id}&{$page.url.searchParams.toString()}"
+						class="load-more-button"
+					>
+						Load More
+					</a>
+				</div>
 			{/if}
 		{/if}
-	</section>
+		</section>
 
 	<!-- Settings Info -->
 	<section class="section settings-info">

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -83,12 +83,22 @@ const filteredStreamedLogs = $derived(
 	})
 );
 
-// Combined logs (filtered streamed + server-filtered)
+function matchesVisibleFilters(log: LogEntry): boolean {
+	if (selectedLevels.length > 0 && !selectedLevels.includes(log.level)) return false;
+	if (selectedSource && log.source !== selectedSource) return false;
+	if (searchText && !log.message.toLowerCase().includes(searchText.toLowerCase())) return false;
+	if (data.filters?.fromTimestamp && log.timestamp < data.filters.fromTimestamp) return false;
+	if (data.filters?.toTimestamp && log.timestamp > data.filters.toTimestamp) return false;
+	return true;
+}
+
+// Combined logs (filtered streamed + server-filtered), then narrowed by live local inputs.
 const allLogs = $derived([...filteredStreamedLogs, ...data.logs]);
+const visibleLogs = $derived(allLogs.filter(matchesVisibleFilters));
 
 const visibleLevelCounts = $derived.by(() => {
 	const counts: Record<LogLevelType, number> = { DEBUG: 0, INFO: 0, WARN: 0, ERROR: 0 };
-	for (const log of allLogs) {
+	for (const log of visibleLogs) {
 		counts[log.level] += 1;
 	}
 	return counts;
@@ -102,7 +112,7 @@ const visibleSources = $derived.by(() => {
 	return Array.from(sources).sort();
 });
 
-const visibleTotalCount = $derived(allLogs.length);
+const visibleTotalCount = $derived(visibleLogs.length);
 
 // Available log levels
 const logLevels: LogLevelType[] = ['DEBUG', 'INFO', 'WARN', 'ERROR'];
@@ -538,7 +548,7 @@ $effect(() => {
 			</span>
 		</div>
 
-		{#if allLogs.length === 0}
+		{#if visibleLogs.length === 0}
 			<p class="empty-message">No logs found matching your filters.</p>
 		{:else}
 			<div class="logs-table-wrapper">
@@ -553,7 +563,7 @@ $effect(() => {
 						</tr>
 					</thead>
 					<tbody>
-						{#each allLogs as log (log.id)}
+						{#each visibleLogs as log (log.id)}
 							<tr class={getLevelClass(log.level)}>
 								<td class="col-time">
 									<span class="time-relative">{formatRelativeTime(log.timestamp)}</span>
@@ -593,8 +603,8 @@ $effect(() => {
 				</table>
 			</div>
 
-			{#if data.hasMore && allLogs.length > 0}
-				{@const lastLog = allLogs[allLogs.length - 1]}
+			{#if data.hasMore && visibleLogs.length > 0}
+				{@const lastLog = visibleLogs[visibleLogs.length - 1]}
 				{#if lastLog}
 					<div class="load-more">
 						<a

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -77,9 +77,10 @@ const AnonymizationSchema = z.enum(['real', 'anonymous', 'hybrid']);
 const WrappedLogoModeSchema = z.enum(['always_show', 'always_hide', 'user_choice']);
 
 const ShareModeSchema = z.enum(['public', 'private-oauth', 'private-link']);
+const BooleanStringSchema = z.enum(['true', 'false']).transform((value) => value === 'true');
 const GlobalDefaultsSchema = z.object({
 	defaultShareMode: ShareModeSchema,
-	allowUserControl: z.coerce.boolean()
+	allowUserControl: BooleanStringSchema
 });
 // Server-wide wrapped only supports public and private-oauth (not private-link)
 const ServerWrappedModeSchema = z.enum(['public', 'private-oauth']);
@@ -92,7 +93,7 @@ const ServerWrappedSettingsSchema = z.object({
 
 const UserDefaultsSettingsSchema = z.object({
 	defaultShareMode: ShareModeSchema,
-	allowUserControl: z.coerce.boolean(),
+	allowUserControl: BooleanStringSchema,
 	settingsVersion: z.string()
 });
 
@@ -646,7 +647,7 @@ export const actions: Actions = requireAdminActions({
 
 		const data = {
 			defaultShareMode: formData.get('defaultShareMode'),
-			allowUserControl: formData.get('allowUserControl') === 'true'
+			allowUserControl: formData.get('allowUserControl')
 		};
 
 		const parsed = GlobalDefaultsSchema.safeParse(data);
@@ -742,7 +743,7 @@ export const actions: Actions = requireAdminActions({
 
 		const data = {
 			defaultShareMode: formData.get('defaultShareMode'),
-			allowUserControl: formData.get('allowUserControl') === 'true',
+			allowUserControl: formData.get('allowUserControl'),
 			settingsVersion: formData.get('settingsVersion')?.toString() ?? ''
 		};
 

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -44,7 +44,6 @@ import { goto } from '$app/navigation';
 import { page } from '$app/stores';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import * as Tabs from '$lib/components/ui/tabs';
-import * as Tooltip from '$lib/components/ui/tooltip';
 import { handleFormToast } from '$lib/utils/form-toast';
 import type { ActionData, PageData } from './$types';
 
@@ -155,6 +154,8 @@ let openaiApiKeyLocked = $state(false);
 let openaiBaseUrlLocked = $state(false);
 let openaiModelLocked = $state(false);
 let csrfOriginLocked = $state(false);
+let csrfHelpOpen = $state(false);
+let trustProxyHelpOpen = $state(false);
 
 // Secret fields: true when a value is stored server-side (DB or ENV).
 // Used to display a placeholder without exposing the raw value.
@@ -1456,37 +1457,23 @@ const logFieldErrors = $derived(
 
 		<!-- Security Tab -->
 		{#if activeTab === 'security'}
-			<Tooltip.Provider delayDuration={200}>
-				<div class="security-content">
+			<div class="security-content">
 					<!-- CSRF Protection Panel -->
 					<section class="panel csrf-panel">
 						<div class="panel-header">
 							<div class="panel-title">
 								<ShieldCheck class="panel-icon security" />
 								<h2>CSRF Protection</h2>
-								<Tooltip.Root>
-									<Tooltip.Trigger>
-										<span
-											role="button"
-											tabindex="0"
-											class="help-trigger"
-											aria-label="Learn how CSRF protection works"
-										>
-											<CircleHelp />
-										</span>
-									</Tooltip.Trigger>
-									<Tooltip.Content side="right" sideOffset={8} class="csrf-tooltip">
-										<div class="csrf-tooltip-inner">
-											<strong>How CSRF Protection Works</strong>
-											<p>
-												When ORIGIN is set, Obzorarr validates that all state-changing requests
-												(POST, PUT, PATCH, DELETE) originate from your domain. Combined with
-												SameSite cookies, this provides robust protection without additional reverse
-												proxy configuration.
-											</p>
-										</div>
-									</Tooltip.Content>
-								</Tooltip.Root>
+								<button
+									type="button"
+									class="help-trigger"
+									aria-label="Learn how CSRF protection works"
+									aria-expanded={csrfHelpOpen}
+									aria-controls="csrf-help-panel"
+									onclick={() => (csrfHelpOpen = !csrfHelpOpen)}
+								>
+									<CircleHelp />
+								</button>
 							</div>
 							<div class="connection-status" class:connected={data.security.csrfEnabled}>
 								<span class="status-dot"></span>
@@ -1499,6 +1486,17 @@ const logFieldErrors = $derived(
 							Cross-Site Request Forgery protection prevents malicious websites from making
 							unauthorized requests on behalf of authenticated users.
 						</p>
+						{#if csrfHelpOpen}
+							<div id="csrf-help-panel" class="security-help-panel">
+								<strong>How CSRF Protection Works</strong>
+								<p>
+									When ORIGIN is set, Obzorarr validates that all state-changing requests
+									(POST, PUT, PATCH, DELETE) originate from your domain. Combined with SameSite
+									cookies, this provides robust protection without additional reverse proxy
+									configuration.
+								</p>
+							</div>
+						{/if}
 
 						<div class="panel-form">
 							<div class="form-field">
@@ -1699,30 +1697,16 @@ const logFieldErrors = $derived(
 							<div class="panel-title">
 								<ShieldCheck class="panel-icon security" />
 								<h2>Reverse Proxy Header Trust</h2>
-								<Tooltip.Root>
-									<Tooltip.Trigger>
-										<span
-											role="button"
-											tabindex="0"
-											class="help-trigger"
-											aria-label="Learn how reverse-proxy header trust works"
-										>
-											<CircleHelp />
-										</span>
-									</Tooltip.Trigger>
-									<Tooltip.Content side="right" sideOffset={8} class="csrf-tooltip">
-										<div class="csrf-tooltip-inner">
-											<strong>How Reverse-Proxy Header Trust Works</strong>
-											<p>
-												When enabled, Obzorarr trusts <code>X-Forwarded-Proto</code> and
-												<code>X-Forwarded-Host</code> from the upstream proxy and uses them to
-												build absolute URLs. Enable ONLY if your reverse proxy strips inbound
-												forwarded headers from clients — otherwise an attacker can poison the
-												app's view of its own host and protocol.
-											</p>
-										</div>
-									</Tooltip.Content>
-								</Tooltip.Root>
+								<button
+									type="button"
+									class="help-trigger"
+									aria-label="Learn how reverse-proxy header trust works"
+									aria-expanded={trustProxyHelpOpen}
+									aria-controls="trust-proxy-help-panel"
+									onclick={() => (trustProxyHelpOpen = !trustProxyHelpOpen)}
+								>
+									<CircleHelp />
+								</button>
 							</div>
 							<div class="connection-status" class:connected={trustProxyValue}>
 								<span class="status-dot"></span>
@@ -1734,6 +1718,18 @@ const logFieldErrors = $derived(
 							Trust <code>X-Forwarded-Proto</code> and <code>X-Forwarded-Host</code> from the
 							upstream reverse proxy. Default: off.
 						</p>
+						{#if trustProxyHelpOpen}
+							<div id="trust-proxy-help-panel" class="security-help-panel">
+								<strong>How Reverse-Proxy Header Trust Works</strong>
+								<p>
+									When enabled, Obzorarr trusts <code>X-Forwarded-Proto</code> and
+									<code>X-Forwarded-Host</code> from the upstream proxy and uses them to build
+									absolute URLs. Enable only if your reverse proxy strips inbound forwarded
+									headers from clients; otherwise an attacker can poison the app's view of its own
+									host and protocol.
+								</p>
+							</div>
+						{/if}
 
 						<div class="panel-form">
 							<div class="form-field">
@@ -1872,8 +1868,7 @@ const logFieldErrors = $derived(
 							</div>
 						{/if}
 					</div>
-				</div>
-			</Tooltip.Provider>
+			</div>
 		{/if}
 
 		<!-- Data Tab -->
@@ -3520,16 +3515,6 @@ const logFieldErrors = $derived(
 			color: hsl(var(--muted-foreground));
 		}
 
-		/* Help Trigger - Whisper-quiet info hint */
-		.panel-title :global([data-slot='tooltip-trigger']) {
-			all: unset;
-			display: inline-flex;
-			align-items: center;
-			vertical-align: middle;
-			margin-left: 0.375rem;
-			cursor: pointer;
-		}
-
 		.help-trigger {
 			all: unset;
 			display: inline-flex;
@@ -3551,6 +3536,28 @@ const logFieldErrors = $derived(
 		.help-trigger :global(svg) {
 			width: 15px;
 			height: 15px;
+		}
+
+		.security-help-panel {
+			margin: 0.75rem 0 1.25rem;
+			padding: 0.875rem 1rem;
+			border: 1px solid hsl(var(--border) / 0.65);
+			border-radius: 8px;
+			background: hsl(var(--muted) / 0.25);
+			color: hsl(var(--muted-foreground));
+			font-size: 0.875rem;
+			line-height: 1.55;
+		}
+
+		.security-help-panel strong {
+			display: block;
+			margin-bottom: 0.35rem;
+			color: hsl(var(--foreground));
+			font-size: 0.875rem;
+		}
+
+		.security-help-panel p {
+			margin: 0;
 		}
 
 		/* Documentation - Compact Collapsible */

--- a/src/routes/admin/slides/+page.server.ts
+++ b/src/routes/admin/slides/+page.server.ts
@@ -333,7 +333,10 @@ export const actions: Actions = requireAdminActions({
 
 		// Parse custom count if provided
 		let customCount: number | undefined;
-		if (mode === FunFactFrequency.CUSTOM && customCountStr) {
+		if (mode === FunFactFrequency.CUSTOM) {
+			if (typeof customCountStr !== 'string' || customCountStr.trim() === '') {
+				return fail(400, { error: 'Custom count must be between 1 and 15' });
+			}
 			customCount = parseInt(customCountStr as string, 10);
 			if (Number.isNaN(customCount) || customCount < 1 || customCount > 15) {
 				return fail(400, { error: 'Custom count must be between 1 and 15' });

--- a/src/routes/admin/slides/+page.server.ts
+++ b/src/routes/admin/slides/+page.server.ts
@@ -334,11 +334,15 @@ export const actions: Actions = requireAdminActions({
 		// Parse custom count if provided
 		let customCount: number | undefined;
 		if (mode === FunFactFrequency.CUSTOM) {
-			if (typeof customCountStr !== 'string' || customCountStr.trim() === '') {
+			if (typeof customCountStr !== 'string') {
 				return fail(400, { error: 'Custom count must be between 1 and 15' });
 			}
-			customCount = parseInt(customCountStr as string, 10);
-			if (Number.isNaN(customCount) || customCount < 1 || customCount > 15) {
+			const customCountToken = customCountStr.trim();
+			if (!/^\d+$/.test(customCountToken)) {
+				return fail(400, { error: 'Custom count must be between 1 and 15' });
+			}
+			customCount = Number(customCountToken);
+			if (!Number.isInteger(customCount) || customCount < 1 || customCount > 15) {
 				return fail(400, { error: 'Custom count must be between 1 and 15' });
 			}
 		}

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { ActionResult } from '@sveltejs/kit';
+import { untrack } from 'svelte';
 import { deserialize, enhance } from '$app/forms';
 import type { SlideType } from '$lib/components/slides/types';
 import { DEFAULT_SLIDE_ORDER } from '$lib/components/slides/types';
@@ -41,14 +42,21 @@ const SLIDE_NAMES: Record<SlideType, string> = {
 	custom: 'Custom Slide'
 };
 
-// Fun Fact frequency state (synced from server data)
-let selectedFrequencyMode = $state<typeof data.funFactFrequency.mode>('normal');
-let customCount = $state(0);
+// Fun Fact frequency state (synced from server data only when server data changes)
+let selectedFrequencyMode = $state<typeof data.funFactFrequency.mode>(
+	untrack(() => data.funFactFrequency.mode)
+);
+let customCount = $state(untrack(() => data.funFactFrequency.count));
+let syncedFrequencyKey = $state('');
 
-// Sync state from data before DOM updates
-$effect.pre(() => {
+// Avoid resetting the radio while the user is selecting Custom before submit.
+$effect(() => {
+	const frequencyKey = `${data.funFactFrequency.mode}:${data.funFactFrequency.count}`;
+	if (frequencyKey === syncedFrequencyKey) return;
+
 	selectedFrequencyMode = data.funFactFrequency.mode;
 	customCount = data.funFactFrequency.count;
+	syncedFrequencyKey = frequencyKey;
 });
 
 // State for custom slide editor
@@ -423,39 +431,37 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 				};
 			}}
 		>
-			<!-- svelte-ignore a11y_click_events_have_key_events -->
-			<!-- svelte-ignore a11y_no_static_element_interactions -->
-			<div class="frequency-options" onclick={(e) => e.stopPropagation()}>
+			<div class="frequency-options">
 				<label class="frequency-option">
 					<input type="radio" name="mode" value="few" bind:group={selectedFrequencyMode} />
-						<span class="frequency-label">
-							<span class="frequency-name">Few</span>
-							<span class="frequency-desc">2 fun facts</span>
-						</span>
+					<span class="frequency-label">
+						<span class="frequency-name">Few</span>
+						<span class="frequency-desc">2 fun facts</span>
+					</span>
 				</label>
 
 				<label class="frequency-option">
 					<input type="radio" name="mode" value="normal" bind:group={selectedFrequencyMode} />
-						<span class="frequency-label">
-							<span class="frequency-name">Normal</span>
-							<span class="frequency-desc">4 fun facts</span>
-						</span>
+					<span class="frequency-label">
+						<span class="frequency-name">Normal</span>
+						<span class="frequency-desc">4 fun facts</span>
+					</span>
 				</label>
 
 				<label class="frequency-option">
 					<input type="radio" name="mode" value="many" bind:group={selectedFrequencyMode} />
-						<span class="frequency-label">
-							<span class="frequency-name">Many</span>
-							<span class="frequency-desc">8 fun facts</span>
-						</span>
+					<span class="frequency-label">
+						<span class="frequency-name">Many</span>
+						<span class="frequency-desc">8 fun facts</span>
+					</span>
 				</label>
 
 				<label class="frequency-option">
 					<input type="radio" name="mode" value="custom" bind:group={selectedFrequencyMode} />
-						<span class="frequency-label">
-							<span class="frequency-name">Custom</span>
-							<span class="frequency-desc">1-15 fun facts</span>
-						</span>
+					<span class="frequency-label">
+						<span class="frequency-name">Custom</span>
+						<span class="frequency-desc">1-15 fun facts</span>
+					</span>
 				</label>
 			</div>
 

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -177,6 +177,84 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 					</tbody>
 				</table>
 			</div>
+			<div class="mobile-users-list">
+				{#each data.users as user (user.id)}
+					<div class="mobile-user-row">
+						<div class="mobile-user-main">
+							<a href="/wrapped/{data.year}/u/{user.id}" class="user-avatar-link">
+								{#if user.thumb}
+									<img src={user.thumb} alt="" class="user-avatar" />
+								{:else}
+									<span class="user-avatar placeholder">&#9787;</span>
+								{/if}
+							</a>
+							<div class="user-info">
+								<a href="/wrapped/{data.year}/u/{user.id}" class="user-name">
+									{user.username}
+									{#if user.isAdmin}
+										<span class="admin-badge">Admin</span>
+									{/if}
+								</a>
+								{#if user.email}
+									<span class="user-email">{user.email}</span>
+								{/if}
+							</div>
+						</div>
+						<div class="mobile-user-meta">
+							<div class="mobile-meta-item">
+								<span class="mobile-meta-label">Watch Time</span>
+								<span class="watch-time">{formatWatchTime(user.totalWatchTimeMinutes)}</span>
+							</div>
+							<div class="mobile-meta-item">
+								<span class="mobile-meta-label">Share Mode</span>
+								<span
+									class="share-mode"
+									class:public={user.shareModeSource !== 'default' && user.shareMode === 'public'}
+									class:oauth={user.shareModeSource !== 'default' &&
+										user.shareMode === 'private-oauth'}
+									class:link={user.shareModeSource !== 'default' &&
+										user.shareMode === 'private-link'}
+								>
+									{getShareModeLabel(user.shareMode, user.shareModeSource)}
+								</span>
+							</div>
+							<div class="mobile-meta-item">
+								<span class="mobile-meta-label">Can Control</span>
+								<form
+									method="POST"
+									action="?/updateUserPermission"
+									use:enhance
+									class="permission-form"
+								>
+									<input type="hidden" name="userId" value={user.id} />
+									<input type="hidden" name="year" value={data.year} />
+									<input
+										type="hidden"
+										name="canUserControl"
+										value={user.canUserControl ? 'false' : 'true'}
+									/>
+									<button
+										type="submit"
+										class="toggle-button"
+										class:enabled={user.canUserControl}
+										title={user.canUserControl ? 'Click to revoke control' : 'Click to grant control'}
+									>
+										{user.canUserControl ? 'Yes' : 'No'}
+									</button>
+								</form>
+							</div>
+						</div>
+						<a
+							href="/wrapped/{data.year}/u/{user.id}"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="preview-link mobile-preview-link"
+						>
+							Preview Wrapped
+						</a>
+					</div>
+				{/each}
+			</div>
 		{/if}
 	</section>
 
@@ -209,6 +287,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 			max-width: 1000px;
 			margin: 0 auto;
 			padding: 2rem;
+			min-width: 0;
 		}
 
 		.page-header {
@@ -271,6 +350,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 			border-radius: var(--radius);
 			padding: 1.5rem;
 			margin-bottom: 1.5rem;
+			min-width: 0;
 		}
 
 		.section h2 {
@@ -306,7 +386,10 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 		/* Users Table */
 		.users-table-wrapper {
 			overflow-x: auto;
+			width: 100%;
 			max-width: 100%;
+			min-width: 0;
+			-webkit-overflow-scrolling: touch;
 		}
 
 		.users-table {
@@ -364,6 +447,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 		.user-info {
 			display: flex;
 			flex-direction: column;
+			min-width: 0;
 		}
 
 		.user-name {
@@ -381,6 +465,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 		.user-email {
 			font-size: 0.75rem;
 			color: hsl(var(--muted-foreground));
+			overflow-wrap: anywhere;
 		}
 
 		.admin-badge {
@@ -460,6 +545,64 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 			text-decoration: underline;
 		}
 
+		.mobile-users-list {
+			display: none;
+		}
+
+		.mobile-user-row {
+			display: flex;
+			flex-direction: column;
+			gap: 0.875rem;
+			padding: 1rem 0;
+			border-bottom: 1px solid hsl(var(--border));
+			min-width: 0;
+		}
+
+		.mobile-user-row:first-child {
+			padding-top: 0;
+		}
+
+		.mobile-user-row:last-child {
+			padding-bottom: 0;
+			border-bottom: 0;
+		}
+
+		.mobile-user-main {
+			display: flex;
+			align-items: center;
+			gap: 0.75rem;
+			min-width: 0;
+		}
+
+		.mobile-user-main .user-info {
+			flex: 1;
+		}
+
+		.mobile-user-meta {
+			display: grid;
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+			gap: 0.75rem;
+			align-items: start;
+		}
+
+		.mobile-meta-item {
+			display: flex;
+			flex-direction: column;
+			gap: 0.35rem;
+			min-width: 0;
+		}
+
+		.mobile-meta-label {
+			color: hsl(var(--muted-foreground));
+			font-size: 0.6875rem;
+			font-weight: 600;
+			text-transform: uppercase;
+		}
+
+		.mobile-preview-link {
+			align-self: flex-start;
+		}
+
 		.empty-message {
 			color: hsl(var(--muted-foreground));
 			text-align: center;
@@ -494,18 +637,41 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 				padding: 1rem;
 			}
 
-			.users-table {
-				font-size: 0.75rem;
+			.page-header-row {
+				flex-direction: column;
+				align-items: stretch;
 			}
 
-			.users-table th,
-			.users-table td {
-				padding: 0.5rem;
+			.section {
+				padding: 1rem;
+			}
+
+			.users-table-wrapper {
+				display: none;
+			}
+
+			.mobile-users-list {
+				display: block;
 			}
 
 			.user-avatar {
-				width: 28px;
-				height: 28px;
+				width: 32px;
+				height: 32px;
+			}
+
+			.user-name {
+				max-width: 100%;
+				overflow-wrap: anywhere;
+			}
+
+			.legend-item {
+				align-items: flex-start;
+			}
+		}
+
+		@media (max-width: 430px) {
+			.mobile-user-meta {
+				grid-template-columns: 1fr;
 			}
 		}
 </style>

--- a/src/routes/auth/plex/redirect/+page.svelte
+++ b/src/routes/auth/plex/redirect/+page.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { browser } from '$app/environment';
-import { LOGIN_TIMEOUT_MS, PIN_STORAGE_KEY, POLL_INTERVAL_MS } from '$lib/client/plex-login';
+import {
+	LOGIN_TIMEOUT_MS,
+	PIN_STORAGE_KEY,
+	POLL_INTERVAL_MS,
+	sanitizeCompletedLoginResponse
+} from '$lib/client/plex-login';
 import type { PageData } from './$types';
 
 type Status = 'loading' | 'success' | 'error' | 'cancelled';
@@ -104,12 +109,11 @@ async function pollForLogin(
 			throw new Error(errData.message || 'Failed to check authentication status');
 		}
 
-		const result = (await response.json()) as
-			| { pending: true }
-			| { user: { isAdmin: boolean }; redirectTo?: string };
+		const result = (await response.json()) as unknown;
 
-		if ('user' in result && result.user) {
-			return result;
+		const completedLogin = sanitizeCompletedLoginResponse(result);
+		if (completedLogin) {
+			return completedLogin;
 		}
 	}
 

--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -7,15 +7,13 @@
 
 import { fail, redirect } from '@sveltejs/kit';
 import {
-	AppSettingsKey,
 	getAnonymizationMode,
-	getAppSetting,
+	getApiConfigWithSources,
 	getCachedServerName,
 	getFunFactFrequency,
 	getUITheme,
 	getWrappedLogoMode,
-	getWrappedTheme,
-	hasOpenAIEnvConfig
+	getWrappedTheme
 } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
 import { completeOnboarding } from '$lib/server/onboarding';
@@ -52,8 +50,7 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 		shareMode,
 		allowUserControl,
 		funFactFrequency,
-		openaiApiKey,
-		openaiBaseUrl
+		apiConfig
 	] = await Promise.all([
 		getCachedServerName(),
 		getUITheme(),
@@ -63,8 +60,7 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 		getGlobalDefaultShareMode(),
 		getGlobalAllowUserControl(),
 		getFunFactFrequency(),
-		getAppSetting(AppSettingsKey.OPENAI_API_KEY),
-		getAppSetting(AppSettingsKey.OPENAI_BASE_URL)
+		getApiConfigWithSources()
 	]);
 
 	return {
@@ -82,10 +78,9 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 			logoMode: formatLogoMode(logoMode),
 			shareMode: formatShareMode(shareMode),
 			allowUserControl: allowUserControl ? 'Allowed' : 'Locked by admin',
-			funFacts:
-				hasOpenAIEnvConfig() || openaiApiKey || openaiBaseUrl
-					? formatFunFactFrequency(funFactFrequency)
-					: 'Disabled'
+			funFacts: apiConfig.openai.apiKey.value.trim()
+				? formatFunFactFrequency(funFactFrequency)
+				: 'Disabled'
 		}
 	};
 };

--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -7,14 +7,19 @@
 
 import { fail, redirect } from '@sveltejs/kit';
 import {
+	AppSettingsKey,
 	getAnonymizationMode,
+	getAppSetting,
 	getCachedServerName,
+	getFunFactFrequency,
 	getUITheme,
-	getWrappedTheme
+	getWrappedLogoMode,
+	getWrappedTheme,
+	hasOpenAIEnvConfig
 } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
 import { completeOnboarding } from '$lib/server/onboarding';
-import { getGlobalDefaultShareMode } from '$lib/server/sharing/service';
+import { getGlobalAllowUserControl, getGlobalDefaultShareMode } from '$lib/server/sharing/service';
 import { getPlayHistoryCount, getSyncProgress, isSyncRunning } from '$lib/server/sync';
 import type { Actions, PageServerLoad } from './$types';
 
@@ -38,12 +43,28 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 	const historyCount = await getPlayHistoryCount();
 
 	// Get configured settings for summary
-	const [serverName, uiTheme, wrappedTheme, anonymizationMode, shareMode] = await Promise.all([
+	const [
+		serverName,
+		uiTheme,
+		wrappedTheme,
+		anonymizationMode,
+		logoMode,
+		shareMode,
+		allowUserControl,
+		funFactFrequency,
+		openaiApiKey,
+		openaiBaseUrl
+	] = await Promise.all([
 		getCachedServerName(),
 		getUITheme(),
 		getWrappedTheme(),
 		getAnonymizationMode(),
-		getGlobalDefaultShareMode()
+		getWrappedLogoMode(),
+		getGlobalDefaultShareMode(),
+		getGlobalAllowUserControl(),
+		getFunFactFrequency(),
+		getAppSetting(AppSettingsKey.OPENAI_API_KEY),
+		getAppSetting(AppSettingsKey.OPENAI_BASE_URL)
 	]);
 
 	return {
@@ -58,7 +79,13 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 			uiTheme: formatThemeName(uiTheme),
 			wrappedTheme: formatThemeName(wrappedTheme),
 			anonymizationMode: formatAnonymizationMode(anonymizationMode),
-			shareMode: formatShareMode(shareMode)
+			logoMode: formatLogoMode(logoMode),
+			shareMode: formatShareMode(shareMode),
+			allowUserControl: allowUserControl ? 'Allowed' : 'Locked by admin',
+			funFacts:
+				hasOpenAIEnvConfig() || openaiApiKey || openaiBaseUrl
+					? formatFunFactFrequency(funFactFrequency)
+					: 'Disabled'
 		}
 	};
 };
@@ -95,6 +122,20 @@ function formatShareMode(mode: string): string {
 		'private-link': 'Private Link'
 	};
 	return modes[mode] || mode;
+}
+
+function formatLogoMode(mode: string): string {
+	const modes: Record<string, string> = {
+		always_show: 'Always Show',
+		always_hide: 'Always Hide',
+		user_choice: 'User Choice'
+	};
+	return modes[mode] || mode;
+}
+
+function formatFunFactFrequency(config: { mode: string; count: number }): string {
+	if (config.mode === 'custom') return `Custom (${config.count})`;
+	return `${formatThemeName(config.mode)} (${config.count})`;
 }
 
 /**

--- a/src/routes/onboarding/complete/+page.svelte
+++ b/src/routes/onboarding/complete/+page.svelte
@@ -52,14 +52,34 @@ const summaryItems = $derived([
 		value: data.configSummary.uiTheme
 	},
 	{
+		icon: 'palette',
+		label: 'Wrapped Theme',
+		value: data.configSummary.wrappedTheme
+	},
+	{
 		icon: 'shield',
 		label: 'Privacy Mode',
 		value: data.configSummary.anonymizationMode
 	},
 	{
+		icon: 'shield',
+		label: 'Logo Mode',
+		value: data.configSummary.logoMode
+	},
+	{
 		icon: 'share',
 		label: 'Default Sharing',
 		value: data.configSummary.shareMode
+	},
+	{
+		icon: 'share',
+		label: 'User Control',
+		value: data.configSummary.allowUserControl
+	},
+	{
+		icon: 'sparkles',
+		label: 'Fun Facts',
+		value: data.configSummary.funFacts
 	}
 ]);
 </script>
@@ -132,6 +152,12 @@ const summaryItems = $derived([
 										<circle cx="18" cy="19" r="3" />
 										<line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
 										<line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+									</svg>
+								{:else if item.icon === 'sparkles'}
+									<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+										<path d="M12 3l1.4 4.2L18 8.6l-4.6 1.4L12 15l-1.4-5L6 8.6l4.6-1.4L12 3z" />
+										<path d="M19 14l.8 2.2L22 17l-2.2.8L19 20l-.8-2.2L16 17l2.2-.8L19 14z" />
+										<path d="M5 14l.8 2.2L8 17l-2.2.8L5 20l-.8-2.2L2 17l2.2-.8L5 14z" />
 									</svg>
 								{/if}
 							</div>

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -267,9 +267,9 @@ function getThemeColors(themeValue: string) {
 				<input type="hidden" name="anonymizationMode" value={anonymizationMode} />
 				<input type="hidden" name="logoMode" value={wrappedLogoMode} />
 				<input type="hidden" name="defaultShareMode" value={defaultShareMode} />
-				<input type="hidden" name="allowUserControl" value={allowUserControl} />
+				<input type="hidden" name="allowUserControl" value={allowUserControl ? 'true' : 'false'} />
 				<input type="hidden" name="enabledSlides" value={enabledSlidesString} />
-				<input type="hidden" name="enableFunFacts" value={enableFunFacts} />
+				<input type="hidden" name="enableFunFacts" value={enableFunFacts ? 'true' : 'false'} />
 				<input
 					type="hidden"
 					name="funFactFrequency"

--- a/tests/unit/admin/settings-actions.test.ts
+++ b/tests/unit/admin/settings-actions.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import {
+	getAppSettingsUpdatedAt,
+	USER_DEFAULTS_SETTINGS_KEYS
+} from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import { getGlobalAllowUserControl, getGlobalDefaultShareMode } from '$lib/server/sharing/service';
+import { actions } from '../../../src/routes/admin/settings/+page.server';
+
+type UpdateUserDefaultsAction = NonNullable<typeof actions.updateUserDefaults>;
+
+const adminLocals = {
+	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
+} as unknown as App.Locals;
+
+function createUserDefaultsRequest(overrides: Record<string, string> = {}): Request {
+	const formData = new FormData();
+	formData.set('defaultShareMode', 'private-oauth');
+	formData.set('allowUserControl', 'false');
+	formData.set('settingsVersion', '');
+
+	for (const [key, value] of Object.entries(overrides)) {
+		formData.set(key, value);
+	}
+
+	return new Request('http://localhost/admin/settings?/updateUserDefaults', {
+		method: 'POST',
+		body: formData
+	});
+}
+
+async function runUpdateUserDefaults(request: Request) {
+	const updateUserDefaults = actions.updateUserDefaults as UpdateUserDefaultsAction;
+	return updateUserDefaults({
+		request,
+		locals: adminLocals
+	} as Parameters<UpdateUserDefaultsAction>[0]);
+}
+
+describe('admin settings actions', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+	});
+
+	it('persists explicit false and true allowUserControl values', async () => {
+		await expect(runUpdateUserDefaults(createUserDefaultsRequest())).resolves.toMatchObject({
+			success: true
+		});
+		expect(await getGlobalDefaultShareMode()).toBe('private-oauth');
+		expect(await getGlobalAllowUserControl()).toBe(false);
+
+		const updatedAt = await getAppSettingsUpdatedAt(USER_DEFAULTS_SETTINGS_KEYS);
+		expect(updatedAt).not.toBeNull();
+
+		await expect(
+			runUpdateUserDefaults(
+				createUserDefaultsRequest({
+					defaultShareMode: 'public',
+					allowUserControl: 'true',
+					settingsVersion: (updatedAt as Date).toISOString()
+				})
+			)
+		).resolves.toMatchObject({ success: true });
+
+		expect(await getGlobalDefaultShareMode()).toBe('public');
+		expect(await getGlobalAllowUserControl()).toBe(true);
+	});
+
+	it('rejects checkbox-style boolean values instead of silently coercing them', async () => {
+		const result = await runUpdateUserDefaults(
+			createUserDefaultsRequest({ allowUserControl: 'on' })
+		);
+
+		expect(result).toMatchObject({
+			status: 400,
+			data: {
+				error: 'Invalid input'
+			}
+		});
+	});
+});

--- a/tests/unit/admin/slides-actions.test.ts
+++ b/tests/unit/admin/slides-actions.test.ts
@@ -36,7 +36,7 @@ describe('admin slides actions', () => {
 		await db.delete(appSettings);
 	});
 
-	for (const customCount of ['0', '16', '']) {
+	for (const customCount of ['0', '16', '', '1abc', '1.5']) {
 		it(`rejects invalid custom fun fact count ${customCount || '<empty>'}`, async () => {
 			const result = await runSetFunFactFrequency(
 				createFrequencyRequest(FunFactFrequency.CUSTOM, customCount)

--- a/tests/unit/admin/slides-actions.test.ts
+++ b/tests/unit/admin/slides-actions.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { FunFactFrequency, getFunFactFrequency } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import { actions } from '../../../src/routes/admin/slides/+page.server';
+
+type SetFunFactFrequencyAction = NonNullable<typeof actions.setFunFactFrequency>;
+
+const adminLocals = {
+	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
+} as unknown as App.Locals;
+
+function createFrequencyRequest(mode: string, customCount?: string): Request {
+	const formData = new FormData();
+	formData.set('mode', mode);
+	if (customCount !== undefined) {
+		formData.set('customCount', customCount);
+	}
+
+	return new Request('http://localhost/admin/slides?/setFunFactFrequency', {
+		method: 'POST',
+		body: formData
+	});
+}
+
+async function runSetFunFactFrequency(request: Request) {
+	const setFrequency = actions.setFunFactFrequency as SetFunFactFrequencyAction;
+	return setFrequency({
+		request,
+		locals: adminLocals
+	} as Parameters<SetFunFactFrequencyAction>[0]);
+}
+
+describe('admin slides actions', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+	});
+
+	for (const customCount of ['0', '16', '']) {
+		it(`rejects invalid custom fun fact count ${customCount || '<empty>'}`, async () => {
+			const result = await runSetFunFactFrequency(
+				createFrequencyRequest(FunFactFrequency.CUSTOM, customCount)
+			);
+
+			expect(result).toMatchObject({
+				status: 400,
+				data: {
+					error: 'Custom count must be between 1 and 15'
+				}
+			});
+		});
+	}
+
+	for (const [customCount, expectedCount] of [
+		['1', 1],
+		['15', 15]
+	] as const) {
+		it(`accepts custom fun fact count ${customCount}`, async () => {
+			await expect(
+				runSetFunFactFrequency(createFrequencyRequest(FunFactFrequency.CUSTOM, customCount))
+			).resolves.toMatchObject({
+				success: true,
+				funFactFrequency: {
+					mode: FunFactFrequency.CUSTOM,
+					count: expectedCount
+				}
+			});
+
+			expect(await getFunFactFrequency()).toEqual({
+				mode: FunFactFrequency.CUSTOM,
+				count: expectedCount
+			});
+		});
+	}
+});

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test';
+
+async function readSource(path: string): Promise<string> {
+	return Bun.file(path).text();
+}
+
+describe('admin UI source regressions', () => {
+	it('uses the effective visible log collection for empty filtered results', async () => {
+		const source = await readSource('src/routes/admin/logs/+page.svelte');
+
+		expect(source).toContain(
+			'const visibleLogs = $derived(allLogs.filter(matchesVisibleFilters));'
+		);
+		expect(source).toContain('{#if visibleLogs.length === 0}');
+		expect(source).not.toContain('{#if allLogs.length === 0}');
+	});
+
+	it('renders security help as real disclosure buttons', async () => {
+		const source = await readSource('src/routes/admin/settings/+page.svelte');
+
+		expect(source).toContain('aria-expanded={csrfHelpOpen}');
+		expect(source).toContain('aria-controls="csrf-help-panel"');
+		expect(source).toContain('aria-expanded={trustProxyHelpOpen}');
+		expect(source).toContain('aria-controls="trust-proxy-help-panel"');
+		expect(source).not.toContain('role="button"');
+	});
+
+	it('keeps the users table desktop-only and renders a mobile list', async () => {
+		const source = await readSource('src/routes/admin/users/+page.svelte');
+
+		expect(source).toContain('class="mobile-users-list"');
+		expect(source).toContain('.users-table-wrapper');
+		expect(source).toContain('display: none;');
+		expect(source).toContain('@media (max-width: 430px)');
+	});
+
+	it('does not reset custom fun fact frequency selection on every local click', async () => {
+		const source = await readSource('src/routes/admin/slides/+page.svelte');
+
+		expect(source).toContain('syncedFrequencyKey');
+		expect(source).toContain('frequencyKey === syncedFrequencyKey');
+		expect(source).not.toContain('class="frequency-options" onclick');
+	});
+
+	it('guards wrapped story transitions against stale rapid navigation', async () => {
+		const source = await readSource('src/lib/components/wrapped/StoryMode.svelte');
+
+		expect(source).toContain('let transitionToken = 0;');
+		expect(source).toContain('async function animateTransition');
+		expect(source).toContain('await tick();');
+		expect(source).toContain('token === transitionToken');
+		expect(source).toContain('function startNavigation');
+	});
+});

--- a/tests/unit/onboarding/complete-summary.test.ts
+++ b/tests/unit/onboarding/complete-summary.test.ts
@@ -57,4 +57,18 @@ describe('onboarding completion summary', () => {
 			funFacts: 'Custom (7)'
 		});
 	});
+
+	it('shows fun facts as disabled when only the OpenAI base URL is configured', async () => {
+		await setFunFactFrequency(FunFactFrequency.MANY);
+		await setAppSetting(AppSettingsKey.OPENAI_BASE_URL, 'https://api.example.com/v1');
+
+		const result = (await load({
+			parent: async () => ({}),
+			locals: adminLocals
+		} as Parameters<typeof load>[0])) as {
+			configSummary: Record<string, string>;
+		};
+
+		expect(result.configSummary.funFacts).toBe('Disabled');
+	});
 });

--- a/tests/unit/onboarding/complete-summary.test.ts
+++ b/tests/unit/onboarding/complete-summary.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import {
+	AnonymizationMode,
+	AppSettingsKey,
+	FunFactFrequency,
+	setAnonymizationMode,
+	setAppSetting,
+	setCachedServerName,
+	setFunFactFrequency,
+	setUITheme,
+	setWrappedLogoMode,
+	setWrappedTheme,
+	ThemePresets,
+	WrappedLogoMode
+} from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings, playHistory, syncStatus } from '$lib/server/db/schema';
+import { setGlobalShareDefaults } from '$lib/server/sharing/service';
+import { load } from '../../../src/routes/onboarding/complete/+page.server';
+
+const adminLocals = {
+	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
+} as unknown as App.Locals;
+
+describe('onboarding completion summary', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		await db.delete(playHistory);
+		await db.delete(syncStatus);
+	});
+
+	it('reflects the persisted onboarding configuration', async () => {
+		await setCachedServerName('QA Plex');
+		await setUITheme(ThemePresets.SUPABASE);
+		await setWrappedTheme(ThemePresets.DOOM_64);
+		await setAnonymizationMode(AnonymizationMode.HYBRID);
+		await setWrappedLogoMode(WrappedLogoMode.USER_CHOICE);
+		await setGlobalShareDefaults({ defaultShareMode: 'private-link', allowUserControl: true });
+		await setFunFactFrequency(FunFactFrequency.CUSTOM, 7);
+		await setAppSetting(AppSettingsKey.OPENAI_API_KEY, 'test-openai-key');
+
+		const result = (await load({
+			parent: async () => ({}),
+			locals: adminLocals
+		} as Parameters<typeof load>[0])) as {
+			configSummary: Record<string, string>;
+		};
+
+		expect(result.configSummary).toEqual({
+			serverName: 'QA Plex',
+			uiTheme: 'Supabase',
+			wrappedTheme: 'Doom 64',
+			anonymizationMode: 'Hybrid',
+			logoMode: 'User Choice',
+			shareMode: 'Private Link',
+			allowUserControl: 'Allowed',
+			funFacts: 'Custom (7)'
+		});
+	});
+});

--- a/tests/unit/onboarding/settings-actions.test.ts
+++ b/tests/unit/onboarding/settings-actions.test.ts
@@ -1,4 +1,23 @@
-import { describe, expect, it } from 'bun:test';
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { isRedirect } from '@sveltejs/kit';
+import {
+	AnonymizationMode,
+	AppSettingsKey,
+	FunFactFrequency,
+	getAnonymizationMode,
+	getAppSetting,
+	getFunFactFrequency,
+	getUITheme,
+	getWrappedLogoMode,
+	getWrappedTheme,
+	ThemePresets,
+	WrappedLogoMode
+} from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings, slideConfig } from '$lib/server/db/schema';
+import { getOnboardingStep, OnboardingSteps } from '$lib/server/onboarding';
+import { getGlobalAllowUserControl, getGlobalDefaultShareMode } from '$lib/server/sharing/service';
+import { initializeDefaultSlideConfig } from '$lib/server/slides/config.service';
 import { actions } from '../../../src/routes/onboarding/settings/+page.server';
 
 const ORIGIN = 'http://localhost:5173';
@@ -40,7 +59,25 @@ async function runSaveSettings(request: Request) {
 	} as Parameters<SaveSettingsAction>[0]);
 }
 
+async function expectRedirect(run: () => Promise<unknown>, location: string) {
+	try {
+		await run();
+		throw new Error('Expected action to redirect');
+	} catch (error) {
+		expect(isRedirect(error)).toBe(true);
+		if (!isRedirect(error)) throw error;
+		expect(error.status).toBe(303);
+		expect(error.location).toBe(location);
+	}
+}
+
 describe('onboarding settings actions', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		await db.delete(slideConfig);
+		await initializeDefaultSlideConfig();
+	});
+
 	it('fails with 400 when enableFunFacts is true and openaiApiKey is missing', async () => {
 		const request = createSettingsRequest({
 			enableFunFacts: 'true',
@@ -59,6 +96,46 @@ describe('onboarding settings actions', () => {
 		});
 		expect((result as { data: { error: string } }).data.error).toContain(
 			'OpenAI API key is required'
+		);
+	});
+
+	it('persists non-default settings before redirecting to completion', async () => {
+		const request = createSettingsRequest({
+			uiTheme: ThemePresets.SUPABASE,
+			wrappedTheme: ThemePresets.DOOM_64,
+			anonymizationMode: AnonymizationMode.HYBRID,
+			logoMode: WrappedLogoMode.USER_CHOICE,
+			defaultShareMode: 'private-link',
+			allowUserControl: 'true',
+			enableFunFacts: 'false'
+		});
+
+		await expectRedirect(() => runSaveSettings(request), '/onboarding/complete');
+
+		expect(await getUITheme()).toBe(ThemePresets.SUPABASE);
+		expect(await getWrappedTheme()).toBe(ThemePresets.DOOM_64);
+		expect(await getAnonymizationMode()).toBe(AnonymizationMode.HYBRID);
+		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.USER_CHOICE);
+		expect(await getGlobalDefaultShareMode()).toBe('private-link');
+		expect(await getGlobalAllowUserControl()).toBe(true);
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.COMPLETE);
+	});
+
+	it('persists enabled fun fact frequency when AI credentials are supplied', async () => {
+		const request = createSettingsRequest({
+			enableFunFacts: 'true',
+			funFactFrequency: FunFactFrequency.MANY,
+			openaiApiKey: 'test-openai-key',
+			openaiBaseUrl: 'https://api.openai.example/v1',
+			openaiModel: 'test-model'
+		});
+
+		await expectRedirect(() => runSaveSettings(request), '/onboarding/complete');
+
+		expect(await getFunFactFrequency()).toEqual({ mode: FunFactFrequency.MANY, count: 8 });
+		expect(await getAppSetting(AppSettingsKey.OPENAI_API_KEY)).toBe('test-openai-key');
+		expect(await getAppSetting(AppSettingsKey.OPENAI_BASE_URL)).toBe(
+			'https://api.openai.example/v1'
 		);
 	});
 });

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -1,11 +1,56 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import {
 	PIN_STORAGE_KEY,
+	sanitizeCompletedLoginResponse,
 	startPlexLoginPopup,
 	startPlexLoginRedirect
 } from '$lib/client/plex-login';
 
 const originalFetch = globalThis.fetch;
+
+describe('sanitizeCompletedLoginResponse', () => {
+	it('keeps only browser-safe login fields', () => {
+		const sanitized = sanitizeCompletedLoginResponse({
+			user: {
+				id: 1,
+				plexId: 123,
+				username: 'alice',
+				email: 'alice@example.com',
+				isAdmin: true,
+				authToken: 'plex-user-token',
+				services: [{ accessToken: 'service-token' }]
+			},
+			redirectTo: '/admin',
+			authToken: 'raw-auth-token',
+			accessToken: 'raw-access-token',
+			resources: [{ clientIdentifier: 'server-id' }]
+		});
+
+		expect(sanitized).toEqual({
+			user: {
+				username: 'alice',
+				isAdmin: true
+			},
+			redirectTo: '/admin'
+		});
+
+		const responseText = JSON.stringify(sanitized);
+		for (const forbidden of [
+			'authToken',
+			'plexToken',
+			'plexId',
+			'email',
+			'services',
+			'accessToken',
+			'clientIdentifier',
+			'resources',
+			'raw-auth-token',
+			'service-token'
+		]) {
+			expect(responseText).not.toContain(forbidden);
+		}
+	});
+});
 
 interface MemoryStorage {
 	store: Map<string, string>;


### PR DESCRIPTION
## Summary

Addresses the Obzorarr dogfood findings with scoped fixes across onboarding, admin settings, slides, wrapped navigation, auth response handling, logs, users, and QA artifact hygiene.

## Changes

- Expand onboarding completion summaries so they reflect persisted appearance, privacy, sharing, user-control, logo, and fun fact settings.
- Normalize admin and onboarding boolean form values to explicit true/false strings and add server-side validation coverage.
- Repair custom fun fact frequency selection and validate custom counts at the route action boundary.
- Harden wrapped Story Mode transitions against rapid navigation by tokenizing transitions and cleaning up stale animation handles.
- Sanitize browser-facing Plex login completion payloads before popup and redirect flows consume them.
- Show a real empty state for filtered log results.
- Replace security tooltip-only help affordances with accessible disclosure buttons.
- Add a mobile users layout to avoid page-level horizontal overflow.
- Add a dogfood artifact scrub command and exclude local .omc state from Biome checks.

## Validation

- bun run check
- bun run check:biome
- bun run test
- bun run dogfood:scrub
- git diff --check

## Operational note

The QA finding about a temporarily captured Plex token still requires manual token rotation by an operator. The new scrub command verifies dogfood text artifacts and filenames against configured .env secret values.