### PR TITLE
fix: disable live sync during tests

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -18,6 +18,7 @@ mock.module('$env/dynamic/private', () => ({
 	env: {
 		PLEX_SERVER_URL: 'http://test-plex-server:32400',
 		PLEX_TOKEN: 'test-plex-token',
+		ENABLE_LIVE_SYNC: 'false',
 		OPENAI_API_KEY: '',
 		OPENAI_API_URL: '',
 		OPENAI_MODEL: ''


### PR DESCRIPTION
## Summary

This PR fixes the CI failure observed in GitHub Actions run 25301963222, job 74170365413. The failing test was `Plex OAuth Module > pollPinForToken > polls until token is available`, where the expected mocked fetch call count was `3` but CI observed `4`.

The extra fetch came from test cross-talk: the landing lookup action triggers live sync as fire-and-forget work for public wrapped lookups. In the shared Bun test process, that background sync could continue running after the landing lookup test finished and then race with the Plex OAuth test, which temporarily replaces `globalThis.fetch`.

## Change

- Sets `ENABLE_LIVE_SYNC` to `false` in the shared `$env/dynamic/private` test mock.
- Keeps production behavior unchanged: live sync still defaults to enabled unless configured otherwise outside the test environment.
- Prevents background live sync from leaking asynchronous Plex fetches across unit test boundaries.

## Verification

Ran the following locally:

```bash
bun test --env-file=.env.test tests/unit/landing-lookup.test.ts tests/unit/auth/plex-oauth.test.ts
bun run check
bun run test
bun run check:biome
```

Results:

- Targeted landing lookup and Plex OAuth tests passed.
- `bun run check` completed with 0 Svelte diagnostics.
- Full test suite passed: 1478 tests, 0 failures.
- Biome check passed with no fixes applied.
