### PR TITLE
fix: resolve dogfood findings

### DIFF
--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+import { goto } from '$app/navigation';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import { ShareModePrivacyLevel, type ShareModeType } from '$lib/sharing/types';
 
@@ -130,6 +131,7 @@ function applyShareActionData(data: unknown): void {
 		| {
 				shareSettings?: Partial<ShareSettings>;
 				shareToken?: string | null;
+				canonicalUrl?: string;
 		  }
 		| undefined;
 
@@ -144,6 +146,56 @@ function applyShareActionData(data: unknown): void {
 	if (actionData && 'shareToken' in actionData) {
 		optimisticShareToken = actionData.shareToken;
 	}
+}
+
+function currentRouteIdentifier(): string | null {
+	if (typeof window === 'undefined') return null;
+	const match = window.location.pathname.match(/\/u\/([^/]+)$/);
+	return match?.[1] ? decodeURIComponent(match[1]) : null;
+}
+
+function isTokenIdentifier(value: string | null): boolean {
+	return Boolean(
+		value?.match(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i)
+	);
+}
+
+function tokenizedUrl(baseUrl: string, token: string): string {
+	const parts = baseUrl.split('/u/');
+	return parts.length === 2 ? `${parts[0]}/u/${token}` : baseUrl;
+}
+
+async function navigateAfterTokenRouteUpdate(data: unknown): Promise<boolean> {
+	const actionData = data as
+		| {
+				shareSettings?: Partial<ShareSettings>;
+				shareToken?: string | null;
+				canonicalUrl?: string;
+		  }
+		| undefined;
+	const routeIdentifier = currentRouteIdentifier();
+	if (!isTokenIdentifier(routeIdentifier)) return false;
+
+	const nextMode = actionData?.shareSettings?.mode;
+	const nextToken =
+		actionData?.shareSettings && 'shareToken' in actionData.shareSettings
+			? actionData.shareSettings.shareToken
+			: actionData?.shareToken;
+
+	if (nextMode && nextMode !== 'private-link' && actionData?.canonicalUrl) {
+		await goto(actionData.canonicalUrl, { replaceState: true, invalidateAll: true });
+		return true;
+	}
+
+	if (nextMode === 'private-link' && nextToken && nextToken !== routeIdentifier) {
+		await goto(tokenizedUrl(actionData?.canonicalUrl ?? canonicalUrl ?? currentUrl, nextToken), {
+			replaceState: true,
+			invalidateAll: true
+		});
+		return true;
+	}
+
+	return false;
 }
 
 // Cleanup on unmount
@@ -250,6 +302,7 @@ $effect(() => {
 							try {
 								if (result.type === 'success') {
 									applyShareActionData(result.data);
+									if (await navigateAfterTokenRouteUpdate(result.data)) return;
 								} else {
 									optimisticMode = null;
 									optimisticShareToken = undefined;
@@ -332,6 +385,7 @@ $effect(() => {
 								try {
 									if (result.type === 'success') {
 										applyShareActionData(result.data);
+										if (await navigateAfterTokenRouteUpdate(result.data)) return;
 									}
 									await update();
 								} finally {

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -150,8 +150,14 @@ function applyShareActionData(data: unknown): void {
 
 function currentRouteIdentifier(): string | null {
 	if (typeof window === 'undefined') return null;
-	const match = window.location.pathname.match(/\/u\/([^/]+)$/);
-	return match?.[1] ? decodeURIComponent(match[1]) : null;
+	const match = window.location.pathname.match(/\/u\/([^/]+)\/?$/);
+	if (!match?.[1]) return null;
+
+	try {
+		return decodeURIComponent(match[1]);
+	} catch {
+		return null;
+	}
 }
 
 function isTokenIdentifier(value: string | null): boolean {

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -174,7 +174,6 @@ async function navigateAfterTokenRouteUpdate(data: unknown): Promise<boolean> {
 		  }
 		| undefined;
 	const routeIdentifier = currentRouteIdentifier();
-	if (!isTokenIdentifier(routeIdentifier)) return false;
 
 	const nextMode = actionData?.shareSettings?.mode;
 	const nextToken =
@@ -182,7 +181,12 @@ async function navigateAfterTokenRouteUpdate(data: unknown): Promise<boolean> {
 			? actionData.shareSettings.shareToken
 			: actionData?.shareToken;
 
-	if (nextMode && nextMode !== 'private-link' && actionData?.canonicalUrl) {
+	if (
+		nextMode &&
+		nextMode !== 'private-link' &&
+		isTokenIdentifier(routeIdentifier) &&
+		actionData?.canonicalUrl
+	) {
 		await goto(actionData.canonicalUrl, { replaceState: true, invalidateAll: true });
 		return true;
 	}

--- a/src/lib/server/onboarding/plex-server-selection.ts
+++ b/src/lib/server/onboarding/plex-server-selection.ts
@@ -1,0 +1,40 @@
+import { error } from '@sveltejs/kit';
+import { filterServerResources, getPlexResources } from '$lib/server/auth/membership';
+import { getSessionPlexToken } from '$lib/server/auth/session';
+import type { PlexResource } from '$lib/server/auth/types';
+
+export interface ResolveOwnedServerTokenOptions {
+	sessionId: string | undefined;
+	clientIdentifier: string;
+}
+
+export async function resolveOwnedServerToken({
+	sessionId,
+	clientIdentifier
+}: ResolveOwnedServerTokenOptions): Promise<string> {
+	if (!sessionId) {
+		error(401, 'No session found');
+	}
+
+	const plexToken = await getSessionPlexToken(sessionId);
+	if (!plexToken) {
+		error(401, 'Session expired or invalid');
+	}
+
+	const resources = await getPlexResources(plexToken);
+	const server = findOwnedServerByClientIdentifier(resources, clientIdentifier);
+	if (!server?.accessToken) {
+		error(400, 'Selected server is unavailable or not owned by this Plex account');
+	}
+
+	return server.accessToken;
+}
+
+function findOwnedServerByClientIdentifier(
+	resources: PlexResource[],
+	clientIdentifier: string
+): PlexResource | undefined {
+	return filterServerResources(resources).find(
+		(server) => server.owned && server.clientIdentifier === clientIdentifier
+	);
+}

--- a/src/lib/server/sharing/access-control.ts
+++ b/src/lib/server/sharing/access-control.ts
@@ -90,10 +90,10 @@ export async function checkWrappedAccess(
 	const effectiveMode = getMoreRestrictiveMode(settings.mode, globalFloor);
 	const isOwner = currentUser?.id === userId || currentUser?.isAdmin === true;
 
-	// Anti-enumeration: a private-link page accessed without a token by a
-	// non-owner must look identical to a missing share, so the existence of
-	// the underlying user can't be probed via the numeric URL.
-	if (effectiveMode === ShareMode.PRIVATE_LINK && !shareToken && !isOwner) {
+	// Private-link pages require the token even for owners/admins. Owner/admin
+	// previews should be routed through the tokenized URL instead of bypassing
+	// token enforcement on the numeric URL.
+	if (effectiveMode === ShareMode.PRIVATE_LINK && !shareToken) {
 		throw new InvalidShareTokenError();
 	}
 
@@ -103,7 +103,7 @@ export async function checkWrappedAccess(
 		validToken: settings.shareToken,
 		isAuthenticated: !!currentUser,
 		isServerMember: !!currentUser,
-		isOwner
+		isOwner: effectiveMode === ShareMode.PRIVATE_LINK ? false : isOwner
 	};
 
 	const result = checkAccess(context);

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -488,6 +488,19 @@ export async function ensureShareToken(userId: number, year: number): Promise<st
 	return refreshed[0]?.shareToken ?? newToken;
 }
 
+export async function getOwnerWrappedHref(userId: number, year: number): Promise<string> {
+	const settings = await getOrCreateShareSettings({ userId, year });
+	const globalFloor = await getGlobalDefaultShareMode();
+	const effectiveMode = getMoreRestrictiveMode(settings.mode, globalFloor);
+
+	if (effectiveMode !== ShareMode.PRIVATE_LINK) {
+		return `/wrapped/${year}/u/${userId}`;
+	}
+
+	const token = settings.shareToken ?? (await ensureShareToken(userId, year));
+	return `/wrapped/${year}/u/${token}`;
+}
+
 export async function getShareSettingsByToken(token: string): Promise<ShareSettings | null> {
 	if (!isValidTokenFormat(token)) {
 		return null;

--- a/src/routes/admin/+layout.server.ts
+++ b/src/routes/admin/+layout.server.ts
@@ -3,13 +3,16 @@ import {
 	isCsrfWarningDismissed
 } from '$lib/server/admin/settings.service';
 import { getUserFullProfile } from '$lib/server/admin/users.service';
+import { getOwnerWrappedHref } from '$lib/server/sharing/service';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
-	const [csrfConfig, csrfWarningDismissed, profile] = await Promise.all([
+	const currentYear = new Date().getFullYear();
+	const [csrfConfig, csrfWarningDismissed, profile, wrappedHref] = await Promise.all([
 		getCsrfConfigWithSource(),
 		isCsrfWarningDismissed(),
-		getUserFullProfile(locals.user!.id)
+		getUserFullProfile(locals.user!.id),
+		getOwnerWrappedHref(locals.user!.id, currentYear)
 	]);
 
 	const showCsrfWarning = csrfConfig.origin.source === 'default' && !csrfWarningDismissed;
@@ -21,7 +24,8 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 			isAdmin: locals.user!.isAdmin,
 			thumb: profile?.thumb ?? null
 		},
-		currentYear: new Date().getFullYear(),
+		currentYear,
+		wrappedHref,
 		csrfWarning: {
 			show: showCsrfWarning,
 			dismissed: csrfWarningDismissed

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -259,7 +259,7 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 			</div>
 
 			<div class="wrapped-grid">
-				<a href="/wrapped/{data.year}/u/{data.adminUser.id}" class="wrapped-card personal">
+				<a href={data.wrappedHref} class="wrapped-card personal">
 					<div class="wrapped-card-glow"></div>
 					<div class="wrapped-icon-wrap">
 						<Star class="wrapped-icon" />

--- a/src/routes/admin/users/+page.server.ts
+++ b/src/routes/admin/users/+page.server.ts
@@ -6,6 +6,7 @@ import {
 	updateUserSharePermission
 } from '$lib/server/admin/users.service';
 import { requireAdminActions } from '$lib/server/auth/guards';
+import { getOwnerWrappedHref } from '$lib/server/sharing/service';
 import type { Actions, PageServerLoad } from './$types';
 
 const UpdateUserPermissionSchema = z.object({
@@ -27,8 +28,8 @@ export const load: PageServerLoad = async ({ url }) => {
 		getAvailableYears()
 	]);
 
-	return {
-		users: users.map((u) => ({
+	const usersWithHref = await Promise.all(
+		users.map(async (u) => ({
 			id: u.id,
 			plexId: u.plexId,
 			username: u.username,
@@ -38,8 +39,13 @@ export const load: PageServerLoad = async ({ url }) => {
 			totalWatchTimeMinutes: u.totalWatchTimeMinutes,
 			shareMode: u.shareMode,
 			shareModeSource: u.shareModeSource,
-			canUserControl: u.canUserControl
-		})),
+			canUserControl: u.canUserControl,
+			wrappedHref: await getOwnerWrappedHref(u.id, year)
+		}))
+	);
+
+	return {
+		users: usersWithHref,
 		year,
 		availableYears
 	};

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -101,7 +101,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 							<tr>
 								<td>
 									<div class="user-cell">
-										<a href="/wrapped/{data.year}/u/{user.id}" class="user-avatar-link">
+										<a href={user.wrappedHref} class="user-avatar-link">
 											{#if user.thumb}
 												<img src={user.thumb} alt="" class="user-avatar" />
 											{:else}
@@ -109,7 +109,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 											{/if}
 										</a>
 										<div class="user-info">
-											<a href="/wrapped/{data.year}/u/{user.id}" class="user-name">
+											<a href={user.wrappedHref} class="user-name">
 												{user.username}
 												{#if user.isAdmin}
 													<span class="admin-badge">Admin</span>
@@ -164,7 +164,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 								</td>
 								<td>
 									<a
-										href="/wrapped/{data.year}/u/{user.id}"
+										href={user.wrappedHref}
 										target="_blank"
 										rel="noopener noreferrer"
 										class="preview-link"
@@ -181,7 +181,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 				{#each data.users as user (user.id)}
 					<div class="mobile-user-row">
 						<div class="mobile-user-main">
-							<a href="/wrapped/{data.year}/u/{user.id}" class="user-avatar-link">
+							<a href={user.wrappedHref} class="user-avatar-link">
 								{#if user.thumb}
 									<img src={user.thumb} alt="" class="user-avatar" />
 								{:else}
@@ -189,7 +189,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 								{/if}
 							</a>
 							<div class="user-info">
-								<a href="/wrapped/{data.year}/u/{user.id}" class="user-name">
+								<a href={user.wrappedHref} class="user-name">
 									{user.username}
 									{#if user.isAdmin}
 										<span class="admin-badge">Admin</span>
@@ -245,7 +245,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 							</div>
 						</div>
 						<a
-							href="/wrapped/{data.year}/u/{user.id}"
+							href={user.wrappedHref}
 							target="_blank"
 							rel="noopener noreferrer"
 							class="preview-link mobile-preview-link"

--- a/src/routes/admin/wrapped/+page.server.ts
+++ b/src/routes/admin/wrapped/+page.server.ts
@@ -1,13 +1,16 @@
+import { getOwnerWrappedHref } from '$lib/server/sharing/service';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	const currentYear = new Date().getFullYear();
+	const wrappedHref = await getOwnerWrappedHref(locals.user!.id, currentYear);
 
 	return {
 		adminUser: {
 			id: locals.user!.id,
 			username: locals.user!.username
 		},
-		currentYear
+		currentYear,
+		wrappedHref
 	};
 };

--- a/src/routes/admin/wrapped/+page.svelte
+++ b/src/routes/admin/wrapped/+page.svelte
@@ -62,7 +62,7 @@ let { data }: Props = $props();
 
 		<div class="wrapped-cards">
 			<!-- Personal Wrapped Card -->
-			<a href="/wrapped/{data.currentYear}/u/{data.adminUser.id}" class="showcase-card personal">
+			<a href={data.wrappedHref} class="showcase-card personal">
 				<div class="card-glow"></div>
 				<div class="card-shimmer"></div>
 				<div class="card-content">

--- a/src/routes/api/onboarding/select-server/+server.ts
+++ b/src/routes/api/onboarding/select-server/+server.ts
@@ -14,6 +14,7 @@ import {
 	PlexServerIdentitySchema
 } from '$lib/server/auth/types';
 import { logger } from '$lib/server/logging';
+import { resolveOwnedServerToken } from '$lib/server/onboarding/plex-server-selection';
 import { classifyConnectionError } from '$lib/server/security';
 import type { RequestHandler } from './$types';
 
@@ -26,11 +27,17 @@ const PLEX_SERVER_HEADERS = {
 
 const CONNECTION_TIMEOUT_MS = 15000;
 
-const SelectServerSchema = z.object({
-	serverUrl: z.string().url('Invalid server URL'),
-	accessToken: z.string().min(1, 'Access token is required'),
-	serverName: z.string().min(1, 'Server name is required')
-});
+const SelectServerSchema = z
+	.object({
+		serverUrl: z.string().url('Invalid server URL'),
+		accessToken: z.string().min(1, 'Access token is required').optional(),
+		clientIdentifier: z.string().min(1).optional(),
+		serverName: z.string().min(1, 'Server name is required')
+	})
+	.refine((body) => Boolean(body.accessToken ?? body.clientIdentifier), {
+		message: 'Access token is required',
+		path: ['accessToken']
+	});
 
 interface ConnectionTestResult {
 	success: boolean;
@@ -87,7 +94,7 @@ async function testConnection(url: string, accessToken: string): Promise<Connect
 	}
 }
 
-export const POST: RequestHandler = async ({ request, locals }) => {
+export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 	if (!locals.user) {
 		error(401, 'Authentication required');
 	}
@@ -105,7 +112,13 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			error(400, errorMessage);
 		}
 
-		const { serverUrl, accessToken, serverName } = parseResult.data;
+		const { serverUrl, serverName, clientIdentifier } = parseResult.data;
+		const accessToken =
+			parseResult.data.accessToken ??
+			(await resolveOwnedServerToken({
+				sessionId: cookies.get('session'),
+				clientIdentifier: clientIdentifier!
+			}));
 
 		logger.debug(`Testing connection to: ${serverUrl}`, 'Onboarding');
 		const testResult = await testConnection(serverUrl, accessToken);

--- a/src/routes/api/onboarding/servers/+server.ts
+++ b/src/routes/api/onboarding/servers/+server.ts
@@ -81,14 +81,10 @@ export const GET: RequestHandler = async ({ cookies, locals }) => {
 					}
 				}
 
-				// accessToken is intentionally returned so the onboarding UI can populate
-				// the token field. Endpoint is admin-only; the value is the Plex
-				// per-server token, not the user's auth token.
 				return {
 					name: server.name,
 					clientIdentifier: server.clientIdentifier,
 					owned: server.owned,
-					accessToken: server.accessToken,
 					bestConnectionUrl,
 					publicAddress: server.publicAddress,
 					connections: filteredConnections

--- a/src/routes/api/onboarding/test-connection/+server.ts
+++ b/src/routes/api/onboarding/test-connection/+server.ts
@@ -7,6 +7,7 @@ import {
 	PlexServerIdentitySchema
 } from '$lib/server/auth/types';
 import { logger } from '$lib/server/logging';
+import { resolveOwnedServerToken } from '$lib/server/onboarding/plex-server-selection';
 import { classifyConnectionError } from '$lib/server/security';
 import type { RequestHandler } from './$types';
 
@@ -21,16 +22,17 @@ const TestConnectionSchema = z
 	.object({
 		url: z.string().url('Invalid URL format'),
 		accessToken: z.string().min(1).optional(),
-		token: z.string().min(1).optional()
+		token: z.string().min(1).optional(),
+		clientIdentifier: z.string().min(1).optional()
 	})
-	.refine((body) => Boolean(body.accessToken ?? body.token), {
+	.refine((body) => Boolean(body.accessToken ?? body.token ?? body.clientIdentifier), {
 		message: 'Access token is required',
 		path: ['accessToken']
 	});
 
 const CONNECTION_TIMEOUT_MS = 10000;
 
-export const POST: RequestHandler = async ({ request, locals }) => {
+export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 	// Require authenticated admin user
 	if (!locals.user) {
 		error(401, 'Authentication required');
@@ -50,11 +52,14 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 			return json({ success: false, error: errorMessage }, { status: 400 });
 		}
 
-		const { url } = parseResult.data;
-		const accessToken = parseResult.data.accessToken ?? parseResult.data.token;
-		if (!accessToken) {
-			return json({ success: false, error: 'Access token is required' }, { status: 400 });
-		}
+		const { url, clientIdentifier } = parseResult.data;
+		const accessToken =
+			parseResult.data.accessToken ??
+			parseResult.data.token ??
+			(await resolveOwnedServerToken({
+				sessionId: cookies.get('session'),
+				clientIdentifier: clientIdentifier!
+			}));
 
 		// Normalize URL - remove trailing slash
 		const normalizedUrl = url.replace(/\/+$/, '');

--- a/src/routes/dashboard/+layout.server.ts
+++ b/src/routes/dashboard/+layout.server.ts
@@ -1,5 +1,6 @@
 import { redirect } from '@sveltejs/kit';
 import { getUserFullProfile } from '$lib/server/admin/users.service';
+import { getOwnerWrappedHref } from '$lib/server/sharing/service';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
@@ -11,7 +12,11 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 		redirect(303, '/admin');
 	}
 
-	const profile = await getUserFullProfile(locals.user.id);
+	const currentYear = new Date().getFullYear();
+	const [profile, wrappedHref] = await Promise.all([
+		getUserFullProfile(locals.user.id),
+		getOwnerWrappedHref(locals.user.id, currentYear)
+	]);
 
 	return {
 		user: {
@@ -19,6 +24,7 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 			username: locals.user.username,
 			thumb: profile?.thumb ?? null
 		},
-		currentYear: new Date().getFullYear()
+		currentYear,
+		wrappedHref
 	};
 };

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -36,7 +36,7 @@ let { data }: Props = $props();
 	</header>
 
 	<div class="cards-container">
-		<a href="/wrapped/{data.currentYear}/u/{data.user.id}" class="wrapped-card personal">
+		<a href={data.wrappedHref} class="wrapped-card personal">
 			<div class="card-glow"></div>
 			<div class="card-badge">
 				<span>Personal</span>

--- a/src/routes/dashboard/settings/+page.server.ts
+++ b/src/routes/dashboard/settings/+page.server.ts
@@ -6,9 +6,9 @@ import { getUserFullProfile } from '$lib/server/admin/users.service';
 import { db } from '$lib/server/db/client';
 import { sessions } from '$lib/server/db/schema';
 import {
-	getGlobalAllowUserControl,
 	getGlobalDefaultShareMode,
 	getOrCreateShareSettings,
+	getOwnerWrappedHref,
 	getShareSettings,
 	getUserLogoPreference,
 	regenerateShareToken,
@@ -41,21 +41,17 @@ export const load: PageServerLoad = async ({ locals }) => {
 		wrappedLogoMode,
 		userLogoPreference,
 		sessionExpiration,
-		globalAllowUserControl,
-		globalFloor
+		globalFloor,
+		wrappedHref
 	] = await Promise.all([
 		getUserFullProfile(userId),
 		getOrCreateShareSettings({ userId, year: currentYear }),
 		getWrappedLogoMode(),
 		getUserLogoPreference(userId, currentYear),
 		getSessionExpiration(userId),
-		getGlobalAllowUserControl(),
-		getGlobalDefaultShareMode()
+		getGlobalDefaultShareMode(),
+		getOwnerWrappedHref(userId, currentYear)
 	]);
-
-	// Effective control gate: admin's global toggle short-circuits the per-user flag
-	// so an "off" global floor is immediately authoritative without a bulk rewrite.
-	const effectiveCanUserControl = globalAllowUserControl && shareSettings.canUserControl;
 
 	return {
 		user: {
@@ -69,14 +65,15 @@ export const load: PageServerLoad = async ({ locals }) => {
 		shareSettings: {
 			mode: shareSettings.mode,
 			shareToken: shareSettings.shareToken,
-			canUserControl: effectiveCanUserControl
+			canUserControl: shareSettings.canUserControl
 		},
 		userLogoPreference,
 		wrappedLogoMode,
 		canControlLogo: wrappedLogoMode === WrappedLogoMode.USER_CHOICE,
 		currentYear,
 		sessionExpiresAt: sessionExpiration,
-		globalFloor
+		globalFloor,
+		wrappedHref
 	};
 };
 
@@ -101,13 +98,10 @@ export const actions: Actions = {
 		let currentMode: string | undefined;
 
 		try {
-			const [shareSettings, globalAllowUserControl] = await Promise.all([
-				getOrCreateShareSettings({ userId, year: currentYear }),
-				getGlobalAllowUserControl()
-			]);
+			const shareSettings = await getOrCreateShareSettings({ userId, year: currentYear });
 			currentMode = shareSettings.mode;
 
-			if (!globalAllowUserControl || !shareSettings.canUserControl) {
+			if (!shareSettings.canUserControl) {
 				return fail(403, {
 					error: 'You do not have permission to change sharing settings',
 					action: 'updateShareMode',
@@ -139,12 +133,9 @@ export const actions: Actions = {
 		const currentYear = new Date().getFullYear();
 
 		try {
-			const [shareSettings, globalAllowUserControl] = await Promise.all([
-				getOrCreateShareSettings({ userId, year: currentYear }),
-				getGlobalAllowUserControl()
-			]);
+			const shareSettings = await getOrCreateShareSettings({ userId, year: currentYear });
 
-			if (!globalAllowUserControl || !shareSettings.canUserControl) {
+			if (!shareSettings.canUserControl) {
 				return fail(403, {
 					error: 'You do not have permission to change sharing settings',
 					action: 'regenerateToken'

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -108,10 +108,7 @@ const shareModeLabels: Record<string, string> = {
 // Generate share URL
 function getShareUrl(): string {
 	const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
-	if (data.shareSettings.mode === 'private-link' && data.shareSettings.shareToken) {
-		return `${baseUrl}/wrapped/${data.currentYear}/u/${data.shareSettings.shareToken}`;
-	}
-	return `${baseUrl}/wrapped/${data.currentYear}/u/${data.user.id}`;
+	return `${baseUrl}${data.wrappedHref}`;
 }
 
 // Copy to clipboard
@@ -535,7 +532,7 @@ function getLogoModeDescription(): string {
 				</div>
 
 				<div class="account-actions">
-					<a href="/wrapped/{data.currentYear}/u/{data.user.id}" class="view-wrapped-link">
+					<a href={data.wrappedHref} class="view-wrapped-link">
 						View My {data.currentYear} Wrapped →
 					</a>
 				</div>

--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -8,7 +8,6 @@
 import { fail, redirect } from '@sveltejs/kit';
 import {
 	getAnonymizationMode,
-	getApiConfigWithSources,
 	getCachedServerName,
 	getFunFactFrequency,
 	getUITheme,
@@ -50,8 +49,7 @@ export const load: PageServerLoad = async ({ parent, locals, url }) => {
 		logoMode,
 		shareMode,
 		allowUserControl,
-		funFactFrequency,
-		apiConfig
+		funFactFrequency
 	] = await Promise.all([
 		getCachedServerName(),
 		getUITheme(),
@@ -60,8 +58,7 @@ export const load: PageServerLoad = async ({ parent, locals, url }) => {
 		getWrappedLogoMode(),
 		getGlobalDefaultShareMode(),
 		getGlobalAllowUserControl(),
-		getFunFactFrequency(),
-		getApiConfigWithSources()
+		getFunFactFrequency()
 	]);
 
 	return {
@@ -80,9 +77,7 @@ export const load: PageServerLoad = async ({ parent, locals, url }) => {
 			logoMode: formatLogoMode(logoMode),
 			shareMode: formatShareMode(shareMode),
 			allowUserControl: allowUserControl ? 'Allowed' : 'Locked by admin',
-			funFacts: apiConfig.openai.apiKey.value.trim()
-				? formatFunFactFrequency(funFactFrequency)
-				: 'Disabled'
+			funFacts: formatFunFactFrequency(funFactFrequency)
 		}
 	};
 };

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -41,7 +41,6 @@ let servers = $state<
 		name: string;
 		clientIdentifier: string;
 		owned: boolean;
-		accessToken: string | null;
 		bestConnectionUrl?: string;
 		publicAddress?: string;
 		connections?: Array<{ uri: string; local: boolean; relay: boolean }>;
@@ -275,7 +274,7 @@ async function handleConnectionSelect(
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({
 				serverUrl: connection.uri,
-				accessToken: server.accessToken,
+				clientIdentifier: server.clientIdentifier,
 				serverName: server.name
 			})
 		});
@@ -386,7 +385,7 @@ async function testCustomConnection(server: (typeof servers)[0]) {
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({
 				url: customUrl,
-				accessToken: server.accessToken
+				clientIdentifier: server.clientIdentifier
 			})
 		});
 

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -11,6 +11,7 @@ import {
 	ensureShareToken,
 	getGlobalDefaultShareMode,
 	getOrCreateShareSettings,
+	getOwnerWrappedHref,
 	isPureNumericId,
 	isValidTokenFormat,
 	regenerateShareToken,
@@ -196,7 +197,9 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 	const resolvedShareToken = needsTokenForUrl
 		? (rawTokenForOwner ?? shareSettings.shareToken ?? (await ensureShareToken(userId, year)))
 		: null;
-	const urlIdentifier = resolvedShareToken ?? userId;
+	const currentUrl = ownerOrAdmin
+		? await getOwnerWrappedHref(userId, year)
+		: `/wrapped/${year}/u/${accessedViaToken ? identifier : (resolvedShareToken ?? userId)}`;
 
 	const exposedShareToken = ownerOrAdmin ? rawTokenForOwner : null;
 	const signedStats = await signStatsThumbnails(stats, {
@@ -229,7 +232,8 @@ export const load: PageServerLoad = async ({ params, locals, parent }) => {
 		isAdmin,
 		isLoggedIn: !!locals.user,
 		globalFloor: globalFloorForUrl,
-		currentUrl: `/wrapped/${year}/u/${urlIdentifier}`,
+		currentUrl,
+		canonicalUrl: `/wrapped/${year}/u/${userId}`,
 		yearIdentifiers
 	};
 };
@@ -294,6 +298,7 @@ export const actions: Actions = {
 			);
 			return {
 				success: true,
+				canonicalUrl: `/wrapped/${year}/u/${userId}`,
 				shareSettings: {
 					mode: updated.mode,
 					storedMode: updated.storedMode,
@@ -344,6 +349,7 @@ export const actions: Actions = {
 			const newToken = await regenerateShareToken(userId, year);
 			return {
 				success: true,
+				canonicalUrl: `/wrapped/${year}/u/${userId}`,
 				shareToken: newToken,
 				shareSettings: {
 					mode: settings.mode,

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
@@ -316,7 +316,7 @@ function handleLogoToggle(): void {
 		bind:open={showShareModal}
 		onOpenChange={(v) => (showShareModal = v)}
 		currentUrl={data.currentUrl}
-		canonicalUrl={`/wrapped/${data.year}/u/${data.userId}`}
+		canonicalUrl={data.canonicalUrl}
 		shareSettings={data.shareSettings}
 		isOwner={data.isOwner}
 		isAdmin={data.isAdmin}

--- a/tests/unit/dashboard/settings-permission.test.ts
+++ b/tests/unit/dashboard/settings-permission.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { and, eq } from 'drizzle-orm';
+import { db } from '$lib/server/db/client';
+import { appSettings, shareSettings, users } from '$lib/server/db/schema';
+import { setGlobalShareDefaults } from '$lib/server/sharing/service';
+import { ShareMode, ShareModeSource } from '$lib/server/sharing/types';
+import { actions, load } from '../../../src/routes/dashboard/settings/+page.server';
+
+type LoadArgs = Parameters<typeof load>[0];
+type UpdateShareModeAction = NonNullable<typeof actions.updateShareMode>;
+
+const USER_ID = 42;
+const YEAR = new Date().getFullYear();
+const locals = {
+	user: { id: USER_ID, plexId: 100042, username: 'user-42', isAdmin: false }
+} as App.Locals;
+
+async function seedUser(): Promise<void> {
+	await db.insert(users).values({
+		id: USER_ID,
+		plexId: 100042,
+		accountId: 200042,
+		username: 'user-42'
+	});
+}
+
+async function invokeUpdateShareMode(mode: string) {
+	const formData = new FormData();
+	formData.set('mode', mode);
+	const request = new Request('https://obzorarr.example/dashboard/settings', {
+		method: 'POST',
+		body: formData
+	});
+	const updateShareMode = actions.updateShareMode as UpdateShareModeAction;
+	return updateShareMode({ request, locals } as unknown as Parameters<UpdateShareModeAction>[0]);
+}
+
+describe('dashboard settings per-user share control', () => {
+	beforeEach(async () => {
+		await db.delete(shareSettings);
+		await db.delete(appSettings);
+		await db.delete(users);
+		await seedUser();
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PUBLIC,
+			allowUserControl: false
+		});
+		await db.insert(shareSettings).values({
+			userId: USER_ID,
+			year: YEAR,
+			mode: ShareMode.PUBLIC,
+			modeSource: ShareModeSource.EXPLICIT,
+			shareToken: null,
+			canUserControl: true
+		});
+	});
+
+	it('honors an admin-granted user control row even when the global default is false', async () => {
+		const data = (await load({ locals } as unknown as LoadArgs)) as {
+			shareSettings: { canUserControl: boolean };
+		};
+		expect(data.shareSettings.canUserControl).toBe(true);
+
+		const result = await invokeUpdateShareMode(ShareMode.PRIVATE_LINK);
+		expect((result as { status?: number }).status).toBeUndefined();
+
+		const row = await db
+			.select({ mode: shareSettings.mode })
+			.from(shareSettings)
+			.where(and(eq(shareSettings.userId, USER_ID), eq(shareSettings.year, YEAR)))
+			.limit(1);
+		expect(row[0]?.mode).toBe(ShareMode.PRIVATE_LINK);
+	});
+});

--- a/tests/unit/onboarding/complete-summary.test.ts
+++ b/tests/unit/onboarding/complete-summary.test.ts
@@ -79,7 +79,7 @@ describe('onboarding completion summary', () => {
 		expect(result.notice).toBeNull();
 	});
 
-	it('shows fun facts as disabled when only the OpenAI base URL is configured', async () => {
+	it('shows the configured fun fact frequency when OpenAI key is missing', async () => {
 		await setFunFactFrequency(FunFactFrequency.MANY);
 		await setAppSetting(AppSettingsKey.OPENAI_BASE_URL, 'https://api.example.com/v1');
 
@@ -91,6 +91,6 @@ describe('onboarding completion summary', () => {
 			configSummary: Record<string, string>;
 		};
 
-		expect(result.configSummary.funFacts).toBe('Disabled');
+		expect(result.configSummary.funFacts).toBe('Many (8)');
 	});
 });

--- a/tests/unit/onboarding/select-server-endpoint.test.ts
+++ b/tests/unit/onboarding/select-server-endpoint.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import {
+	AppSettingsKey,
+	getAppSetting,
+	getCachedServerName
+} from '$lib/server/admin/settings.service';
+import * as sessionModule from '$lib/server/auth/session';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import { POST } from '../../../src/routes/api/onboarding/select-server/+server';
+
+type HandlerArgs = Parameters<typeof POST>[0];
+
+const adminLocals = {
+	user: { id: 1, plexId: 100, username: 'admin', isAdmin: true }
+} as HandlerArgs['locals'];
+
+function makeCookies(sessionId?: string): HandlerArgs['cookies'] {
+	return {
+		get: (name: string) => (sessionId && name === 'session' ? sessionId : undefined),
+		getAll: () => [],
+		set: () => undefined,
+		delete: () => undefined,
+		serialize: () => ''
+	} as unknown as HandlerArgs['cookies'];
+}
+
+function runPost(body: unknown, sessionId?: string): ReturnType<typeof POST> {
+	const request = new Request('http://localhost/api/onboarding/select-server', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body)
+	});
+
+	return POST({
+		request,
+		locals: adminLocals,
+		cookies: makeCookies(sessionId)
+	} as unknown as HandlerArgs);
+}
+
+function makeIdentityResponse(): Response {
+	return new Response(
+		JSON.stringify({
+			MediaContainer: {
+				machineIdentifier: 'a'.repeat(32),
+				friendlyName: 'Test Server'
+			}
+		}),
+		{ status: 200, headers: { 'Content-Type': 'application/json' } }
+	);
+}
+
+describe('POST /api/onboarding/select-server', () => {
+	let fetchSpy: ReturnType<typeof spyOn>;
+	let getSessionPlexTokenSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		fetchSpy?.mockRestore();
+		getSessionPlexTokenSpy?.mockRestore();
+	});
+
+	it('stores a server token resolved from clientIdentifier without returning token fields', async () => {
+		getSessionPlexTokenSpy = spyOn(sessionModule, 'getSessionPlexToken').mockResolvedValue(
+			'admin-session-token'
+		);
+		fetchSpy = spyOn(global, 'fetch')
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify([
+						{
+							name: 'Home Server',
+							product: 'Plex Media Server',
+							provides: 'server',
+							owned: true,
+							clientIdentifier: 'abc123',
+							accessToken: 'server-token-secret'
+						}
+					]),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				)
+			)
+			.mockResolvedValueOnce(makeIdentityResponse());
+
+		const response = await runPost(
+			{
+				serverUrl: 'http://plex.local:32400',
+				clientIdentifier: 'abc123',
+				serverName: 'Home Server'
+			},
+			'test-session-id'
+		);
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			success: boolean;
+			serverName?: string;
+			accessToken?: string;
+			token?: string;
+			authToken?: string;
+		};
+		expect(body.success).toBe(true);
+		expect(body.serverName).toBe('Home Server');
+		expect(body.accessToken).toBeUndefined();
+		expect(body.token).toBeUndefined();
+		expect(body.authToken).toBeUndefined();
+		expect(JSON.stringify(body)).not.toContain('server-token-secret');
+		expect(await getAppSetting(AppSettingsKey.PLEX_TOKEN)).toBe('server-token-secret');
+		expect(await getCachedServerName()).toBe('Home Server');
+	});
+
+	it('keeps legacy accessToken compatibility', async () => {
+		fetchSpy = spyOn(global, 'fetch').mockResolvedValue(makeIdentityResponse());
+
+		const response = await runPost({
+			serverUrl: 'http://plex.local:32400',
+			accessToken: 'legacy-token',
+			serverName: 'Legacy Server'
+		});
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { success: boolean };
+		expect(body.success).toBe(true);
+		expect(await getAppSetting(AppSettingsKey.PLEX_TOKEN)).toBe('legacy-token');
+	});
+});

--- a/tests/unit/onboarding/servers-endpoint.test.ts
+++ b/tests/unit/onboarding/servers-endpoint.test.ts
@@ -72,6 +72,7 @@ describe('GET /api/onboarding/servers', () => {
 					provides: 'server',
 					owned: true,
 					clientIdentifier: 'abc123',
+					accessToken: 'server-token-secret',
 					connections: [
 						{
 							protocol: 'https',
@@ -113,6 +114,9 @@ describe('GET /api/onboarding/servers', () => {
 						name: string;
 						clientIdentifier: string;
 						bestConnectionUrl: string | null;
+						accessToken?: string;
+						authToken?: string;
+						token?: string;
 					}>;
 				};
 
@@ -123,6 +127,10 @@ describe('GET /api/onboarding/servers', () => {
 				expect(first.name).toBe('Home Server');
 				expect(first.clientIdentifier).toBe('abc123');
 				expect(first.bestConnectionUrl).toBe(publicUri);
+				expect(first.accessToken).toBeUndefined();
+				expect(first.authToken).toBeUndefined();
+				expect(first.token).toBeUndefined();
+				expect(JSON.stringify(body)).not.toContain('server-token-secret');
 			} finally {
 				getSessionPlexTokenSpy.mockRestore();
 				fetchSpy.mockRestore();

--- a/tests/unit/onboarding/test-connection-endpoint.test.ts
+++ b/tests/unit/onboarding/test-connection-endpoint.test.ts
@@ -40,6 +40,14 @@ function makeIdentityResponse(): Response {
 	);
 }
 
+function hasIdentityFetchWithToken(fetchSpy: ReturnType<typeof spyOn>, token: string) {
+	const calls = fetchSpy.mock.calls as Array<[string | URL | Request, RequestInit | undefined]>;
+	return calls.some(([input, init]) => {
+		const headers = init?.headers as Record<string, string> | undefined;
+		return input === 'http://plex.local:32400/identity' && headers?.['X-Plex-Token'] === token;
+	});
+}
+
 const adminLocals = {
 	user: { id: 1, plexId: 100, username: 'admin', isAdmin: true }
 } as HandlerArgs['locals'];
@@ -65,11 +73,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 		const body = (await response.json()) as { success: boolean; serverName?: string };
 		expect(body.success).toBe(true);
 		expect(body.serverName).toBe('Test Server');
-		expect(fetchSpy).toHaveBeenCalledTimes(1);
-		const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined)?.headers as
-			| Record<string, string>
-			| undefined;
-		expect(headers?.['X-Plex-Token']).toBe('plex-token-abc');
+		expect(hasIdentityFetchWithToken(fetchSpy, 'plex-token-abc')).toBe(true);
 	});
 
 	it('accepts the legacy token alias and uses it as X-Plex-Token', async () => {
@@ -83,11 +87,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 		expect(response.status).toBe(200);
 		const body = (await response.json()) as { success: boolean };
 		expect(body.success).toBe(true);
-		expect(fetchSpy).toHaveBeenCalledTimes(1);
-		const headers = (fetchSpy.mock.calls[0]?.[1] as RequestInit | undefined)?.headers as
-			| Record<string, string>
-			| undefined;
-		expect(headers?.['X-Plex-Token']).toBe('plex-token-xyz');
+		expect(hasIdentityFetchWithToken(fetchSpy, 'plex-token-xyz')).toBe(true);
 	});
 
 	it('resolves a token server-side from clientIdentifier', async () => {
@@ -130,11 +130,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 		expect(body.success).toBe(true);
 		expect(body.accessToken).toBeUndefined();
 		expect(body.token).toBeUndefined();
-		expect(fetchSpy).toHaveBeenCalledTimes(2);
-		const headers = (fetchSpy.mock.calls[1]?.[1] as RequestInit | undefined)?.headers as
-			| Record<string, string>
-			| undefined;
-		expect(headers?.['X-Plex-Token']).toBe('server-token-secret');
+		expect(hasIdentityFetchWithToken(fetchSpy, 'server-token-secret')).toBe(true);
 	});
 
 	it('rejects requests with neither accessToken, token, nor clientIdentifier', async () => {

--- a/tests/unit/onboarding/test-connection-endpoint.test.ts
+++ b/tests/unit/onboarding/test-connection-endpoint.test.ts
@@ -1,16 +1,31 @@
 import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import * as sessionModule from '$lib/server/auth/session';
 import { POST } from '../../../src/routes/api/onboarding/test-connection/+server';
 
 type HandlerArgs = Parameters<typeof POST>[0];
 
-function runPost(locals: HandlerArgs['locals'], body: unknown): ReturnType<typeof POST> {
+function makeCookies(sessionId?: string): HandlerArgs['cookies'] {
+	return {
+		get: (name: string) => (sessionId && name === 'session' ? sessionId : undefined),
+		getAll: () => [],
+		set: () => undefined,
+		delete: () => undefined,
+		serialize: () => ''
+	} as unknown as HandlerArgs['cookies'];
+}
+
+function runPost(
+	locals: HandlerArgs['locals'],
+	body: unknown,
+	sessionId?: string
+): ReturnType<typeof POST> {
 	const request = new Request('http://localhost/api/onboarding/test-connection', {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
 		body: JSON.stringify(body)
 	});
 
-	return POST({ request, locals } as unknown as HandlerArgs);
+	return POST({ request, locals, cookies: makeCookies(sessionId) } as unknown as HandlerArgs);
 }
 
 function makeIdentityResponse(): Response {
@@ -31,9 +46,11 @@ const adminLocals = {
 
 describe('POST /api/onboarding/test-connection token alias', () => {
 	let fetchSpy: ReturnType<typeof spyOn>;
+	let getSessionPlexTokenSpy: ReturnType<typeof spyOn>;
 
 	afterEach(() => {
 		fetchSpy?.mockRestore();
+		getSessionPlexTokenSpy?.mockRestore();
 	});
 
 	it('accepts the canonical accessToken field', async () => {
@@ -73,7 +90,54 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 		expect(headers?.['X-Plex-Token']).toBe('plex-token-xyz');
 	});
 
-	it('rejects requests with neither accessToken nor token', async () => {
+	it('resolves a token server-side from clientIdentifier', async () => {
+		getSessionPlexTokenSpy = spyOn(sessionModule, 'getSessionPlexToken').mockResolvedValue(
+			'admin-session-token'
+		);
+		fetchSpy = spyOn(global, 'fetch')
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify([
+						{
+							name: 'Home Server',
+							product: 'Plex Media Server',
+							provides: 'server',
+							owned: true,
+							clientIdentifier: 'abc123',
+							accessToken: 'server-token-secret'
+						}
+					]),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				)
+			)
+			.mockResolvedValueOnce(makeIdentityResponse());
+
+		const response = await runPost(
+			adminLocals,
+			{
+				url: 'http://plex.local:32400',
+				clientIdentifier: 'abc123'
+			},
+			'test-session-id'
+		);
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as {
+			success: boolean;
+			accessToken?: string;
+			token?: string;
+		};
+		expect(body.success).toBe(true);
+		expect(body.accessToken).toBeUndefined();
+		expect(body.token).toBeUndefined();
+		expect(fetchSpy).toHaveBeenCalledTimes(2);
+		const headers = (fetchSpy.mock.calls[1]?.[1] as RequestInit | undefined)?.headers as
+			| Record<string, string>
+			| undefined;
+		expect(headers?.['X-Plex-Token']).toBe('server-token-secret');
+	});
+
+	it('rejects requests with neither accessToken, token, nor clientIdentifier', async () => {
 		const response = await runPost(adminLocals, {
 			url: 'http://plex.local:32400'
 		});

--- a/tests/unit/sharing/access-control.test.ts
+++ b/tests/unit/sharing/access-control.test.ts
@@ -334,20 +334,20 @@ describe('Sharing Access Control', () => {
 				expect(result.accessReason).toBe('valid_token');
 			});
 
-			it('allows owner access without token', async () => {
+			it('throws InvalidShareTokenError for owner access without token', async () => {
 				const currentUser = { id: userId, plexId: 100, isAdmin: false };
 
-				const result = await checkWrappedAccess({ userId, year, currentUser });
-
-				expect(result.accessReason).toBe('owner');
+				await expect(checkWrappedAccess({ userId, year, currentUser })).rejects.toBeInstanceOf(
+					InvalidShareTokenError
+				);
 			});
 
-			it('allows admin access without token', async () => {
+			it('throws InvalidShareTokenError for admin access without token', async () => {
 				const currentUser = { id: 999, plexId: 999, isAdmin: true };
 
-				const result = await checkWrappedAccess({ userId, year, currentUser });
-
-				expect(result.accessReason).toBe('owner');
+				await expect(checkWrappedAccess({ userId, year, currentUser })).rejects.toBeInstanceOf(
+					InvalidShareTokenError
+				);
 			});
 		});
 
@@ -437,34 +437,34 @@ describe('Sharing Access Control', () => {
 				}
 			});
 
-			it('does not throw for the owner accessing private-link without a token', async () => {
+			it('throws for the owner accessing private-link without a token', async () => {
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PRIVATE_LINK,
 					allowUserControl: false
 				});
 
-				const result = await checkWrappedAccess({
-					userId,
-					year,
-					currentUser: { id: userId, plexId: 100, isAdmin: false }
-				});
-
-				expect(result.accessReason).toBe('owner');
+				await expect(
+					checkWrappedAccess({
+						userId,
+						year,
+						currentUser: { id: userId, plexId: 100, isAdmin: false }
+					})
+				).rejects.toBeInstanceOf(InvalidShareTokenError);
 			});
 
-			it('does not throw for an admin accessing private-link without a token', async () => {
+			it('throws for an admin accessing private-link without a token', async () => {
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PRIVATE_LINK,
 					allowUserControl: false
 				});
 
-				const result = await checkWrappedAccess({
-					userId,
-					year,
-					currentUser: { id: 999, plexId: 999, isAdmin: true }
-				});
-
-				expect(result.accessReason).toBe('owner');
+				await expect(
+					checkWrappedAccess({
+						userId,
+						year,
+						currentUser: { id: 999, plexId: 999, isAdmin: true }
+					})
+				).rejects.toBeInstanceOf(InvalidShareTokenError);
 			});
 		});
 	});

--- a/tests/unit/sharing/wrapped-identifier-loader.test.ts
+++ b/tests/unit/sharing/wrapped-identifier-loader.test.ts
@@ -335,7 +335,7 @@ describe('wrapped/[year]/u/[identifier] loader: shareToken payload gating', () =
 
 		const data = await invokeLoad({
 			year: YEAR,
-			identifier: String(USER_ID),
+			identifier: TOKEN,
 			availableYears: [YEAR],
 			currentUser: {
 				id: USER_ID,
@@ -346,6 +346,7 @@ describe('wrapped/[year]/u/[identifier] loader: shareToken payload gating', () =
 		});
 
 		expect(data.shareSettings.shareToken).toBe(TOKEN);
+		expect(data.currentUrl).toBe(`/wrapped/${YEAR}/u/${TOKEN}`);
 	});
 
 	it('returns the real token for an admin viewer when effectiveMode === private-link', async () => {
@@ -364,7 +365,7 @@ describe('wrapped/[year]/u/[identifier] loader: shareToken payload gating', () =
 
 		const data = await invokeLoad({
 			year: YEAR,
-			identifier: String(USER_ID),
+			identifier: TOKEN,
 			availableYears: [YEAR],
 			currentUser: {
 				id: ADMIN_ID,
@@ -375,6 +376,37 @@ describe('wrapped/[year]/u/[identifier] loader: shareToken payload gating', () =
 		});
 
 		expect(data.shareSettings.shareToken).toBe(TOKEN);
+		expect(data.currentUrl).toBe(`/wrapped/${YEAR}/u/${TOKEN}`);
+	});
+
+	it('returns 404 when an owner accesses a private-link wrapped via numeric URL', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		await seedShareSettings({
+			userId: USER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: TOKEN
+		});
+
+		try {
+			await invokeLoad({
+				year: YEAR,
+				identifier: String(USER_ID),
+				availableYears: [YEAR],
+				currentUser: {
+					id: USER_ID,
+					plexId: 100042,
+					username: `user-${USER_ID}`,
+					isAdmin: false
+				}
+			});
+			expect.unreachable('Expected numeric private-link owner URL to be rejected');
+		} catch (err) {
+			expect((err as { status?: number }).status).toBe(404);
+		}
 	});
 
 	it('exposes the canonical token to the owner even when the floor raises effectiveMode above private-link', async () => {


### PR DESCRIPTION
## Summary

This PR fixes the five issues identified during dogfooding across onboarding, wrapped sharing, dashboard privacy controls, and Plex token handling. The changes align UI state with server behavior, close private-link access gaps, preserve canonical navigation after share-mode changes, honor explicit per-user control grants, and remove Obzorarr-owned Plex token exposure from browser-visible onboarding responses.

## Changes

- Updates onboarding completion to show the configured fun-fact frequency even when no OpenAI key is present, leaving the existing `ai-key-missing` notice as the fallback indicator.
- Enforces private-link token requirements for numeric user wrapped URLs, including owner and admin viewers.
- Adds token-safe owner/admin wrapped href generation and uses it across dashboard/admin entry points and user preview links.
- Updates share modal navigation so switching away from private-link on a token URL replaces the current route with the canonical numeric URL, while regenerated private-link tokens keep the user on a valid tokenized URL.
- Honors per-user `canUserControl` settings in dashboard privacy controls even when the global default is disabled.
- Removes Plex server access tokens from `/api/onboarding/servers` responses and onboarding client state.
- Adds server-side Plex resource lookup by `clientIdentifier` for onboarding test/select flows, while preserving legacy `accessToken`/`token` request compatibility.

## Tests

- `bun run test -- tests/unit/onboarding/complete-summary.test.ts tests/unit/sharing/access-control.test.ts tests/unit/sharing/wrapped-identifier-loader.test.ts tests/unit/onboarding/servers-endpoint.test.ts tests/unit/onboarding/test-connection-endpoint.test.ts tests/unit/onboarding/select-server-endpoint.test.ts tests/unit/dashboard/settings-permission.test.ts`
- `bun run check`
- `bun run test`
- `bun run check:biome`