### PR TITLE
fix: resolve dogfood qa regressions

### DIFF
--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -12,6 +12,7 @@ import User from '@lucide/svelte/icons/user';
 import Users from '@lucide/svelte/icons/users';
 import X from '@lucide/svelte/icons/x';
 import type { Component, Snippet } from 'svelte';
+import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
 import { page } from '$app/stores';
@@ -58,7 +59,23 @@ const isActive = $derived((href: string) => {
 
 // Mobile sidebar state
 let sidebarOpen = $state(false);
+let isMobileSidebar = $state(false);
+let sidebarHiddenFromMobile = $derived(isMobileSidebar && !sidebarOpen);
 let adminAvatarError = $state(false);
+
+$effect(() => {
+	if (!browser) return;
+
+	const query = window.matchMedia('(max-width: 768px)');
+	const syncMobileState = () => {
+		isMobileSidebar = query.matches;
+	};
+
+	syncMobileState();
+	query.addEventListener('change', syncMobileState);
+
+	return () => query.removeEventListener('change', syncMobileState);
+});
 
 // Reset avatar error when thumb URL changes so a new URL gets a fresh load attempt
 $effect(() => {
@@ -125,7 +142,12 @@ function handleCsrfWarningDismissed() {
 	{/if}
 
 	<!-- Sidebar -->
-	<aside class="sidebar" class:open={sidebarOpen}>
+	<aside
+		class="sidebar"
+		class:open={sidebarOpen}
+		inert={sidebarHiddenFromMobile}
+		aria-hidden={sidebarHiddenFromMobile ? 'true' : undefined}
+	>
 		<div class="sidebar-header">
 			<div class="sidebar-branding">
 				<Logo size="md" />

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -547,11 +547,18 @@ function handleCsrfWarningDismissed() {
 
 			.sidebar {
 				transform: translateX(-100%);
-				transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+				visibility: hidden;
+				pointer-events: none;
+				transition:
+					transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+					visibility 0s linear 0.3s;
 			}
 
 			.sidebar.open {
 				transform: translateX(0);
+				visibility: visible;
+				pointer-events: auto;
+				transition-delay: 0s;
 			}
 
 			.main-content {

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -93,7 +93,18 @@ function matchesVisibleFilters(log: LogEntry): boolean {
 }
 
 // Combined logs (filtered streamed + server-filtered), then narrowed by live local inputs.
-const allLogs = $derived([...filteredStreamedLogs, ...data.logs]);
+const allLogs = $derived.by(() => {
+	const seen = new Set<number>();
+	const merged: LogEntry[] = [];
+
+	for (const log of [...filteredStreamedLogs, ...data.logs]) {
+		if (seen.has(log.id)) continue;
+		seen.add(log.id);
+		merged.push(log);
+	}
+
+	return merged;
+});
 const visibleLogs = $derived(allLogs.filter(matchesVisibleFilters));
 
 const visibleLevelCounts = $derived.by(() => {
@@ -503,15 +514,29 @@ $effect(() => {
 				action={exportAction}
 				use:enhance={() => {
 					return async ({ result }) => {
-						if (result.type === 'success' && result.data?.exportData) {
+						if (result.type === 'success' && typeof result.data?.exportData === 'string') {
 							const blob = new Blob([result.data.exportData as string], { type: 'application/json' });
 							const url = URL.createObjectURL(blob);
 							const a = document.createElement('a');
 							a.href = url;
 							a.download = (result.data.exportFilename as string) || 'logs-export.json';
+							document.body.append(a);
 							a.click();
-							setTimeout(() => URL.revokeObjectURL(url), 100);
+							a.remove();
+							setTimeout(() => URL.revokeObjectURL(url), 1000);
+							return;
 						}
+
+						if (result.type === 'failure') {
+							const message =
+								typeof result.data?.error === 'string'
+									? result.data.error
+									: 'Failed to export logs';
+							toast.error(message);
+							return;
+						}
+
+						toast.error('Failed to export logs');
 					};
 				}}
 				class="inline-form"

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -46,7 +46,9 @@ let selectedFrequencyMode = $state<typeof data.funFactFrequency.mode>(
 	untrack(() => data.funFactFrequency.mode)
 );
 let customCount = $state(untrack(() => data.funFactFrequency.count));
-let syncedFrequencyKey = $state('');
+let syncedFrequencyKey = $state(
+	untrack(() => `${data.funFactFrequency.mode}:${data.funFactFrequency.count}`)
+);
 
 // Avoid resetting the radio while the user is selecting Custom before submit.
 $effect(() => {
@@ -431,6 +433,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 						const frequency = result.data.funFactFrequency as typeof data.funFactFrequency;
 						selectedFrequencyMode = frequency.mode;
 						customCount = frequency.count;
+						syncedFrequencyKey = `${frequency.mode}:${frequency.count}`;
 					}
 					await update();
 				};

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -333,6 +333,7 @@ function getThemeColors(themeValue: string) {
 											type="button"
 											class="theme-swatch"
 											class:selected={uiTheme === option.value}
+											aria-pressed={uiTheme === option.value}
 											onclick={() => (uiTheme = option.value)}
 											style="--swatch-primary: {colors.primary}; --swatch-accent: {colors.accent}; --swatch-bg: {colors.bg}"
 										>
@@ -358,6 +359,7 @@ function getThemeColors(themeValue: string) {
 											type="button"
 											class="theme-swatch"
 											class:selected={wrappedTheme === option.value}
+											aria-pressed={wrappedTheme === option.value}
 											onclick={() => (wrappedTheme = option.value)}
 											style="--swatch-primary: {colors.primary}; --swatch-accent: {colors.accent}; --swatch-bg: {colors.bg}"
 										>

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -77,6 +77,10 @@ describe('admin UI source regressions', () => {
 		);
 		expect(source).toContain('inert={sidebarHiddenFromMobile}');
 		expect(source).toContain("aria-hidden={sidebarHiddenFromMobile ? 'true' : undefined}");
+		expect(source).toContain('visibility: hidden;');
+		expect(source).toContain('pointer-events: none;');
+		expect(source).toContain('visibility: visible;');
+		expect(source).toContain('pointer-events: auto;');
 	});
 
 	it('guards wrapped story transitions against stale rapid navigation', async () => {

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -8,11 +8,24 @@ describe('admin UI source regressions', () => {
 	it('uses the effective visible log collection for empty filtered results', async () => {
 		const source = await readSource('src/routes/admin/logs/+page.svelte');
 
+		expect(source).toContain('const allLogs = $derived.by(() => {');
+		expect(source).toContain('const seen = new Set<number>();');
+		expect(source).toContain('if (seen.has(log.id)) continue;');
 		expect(source).toContain(
 			'const visibleLogs = $derived(allLogs.filter(matchesVisibleFilters));'
 		);
 		expect(source).toContain('{#if visibleLogs.length === 0}');
 		expect(source).not.toContain('{#if allLogs.length === 0}');
+	});
+
+	it('exports logs through a temporary document anchor and reports failures', async () => {
+		const source = await readSource('src/routes/admin/logs/+page.svelte');
+
+		expect(source).toContain('document.body.append(a);');
+		expect(source).toContain('a.click();');
+		expect(source).toContain('a.remove();');
+		expect(source).toContain('setTimeout(() => URL.revokeObjectURL(url), 1000);');
+		expect(source).toContain("toast.error('Failed to export logs');");
 	});
 
 	it('renders security help as real disclosure buttons', async () => {
@@ -38,8 +51,32 @@ describe('admin UI source regressions', () => {
 		const source = await readSource('src/routes/admin/slides/+page.svelte');
 
 		expect(source).toContain('syncedFrequencyKey');
+		expect(source).toContain(
+			'untrack(() => `$' + '{data.funFactFrequency.mode}:$' + '{data.funFactFrequency.count}`)'
+		);
 		expect(source).toContain('frequencyKey === syncedFrequencyKey');
+		expect(source).toContain(
+			'syncedFrequencyKey = `$' + '{frequency.mode}:$' + '{frequency.count}`;'
+		);
 		expect(source).not.toContain('class="frequency-options" onclick');
+	});
+
+	it('marks onboarding theme swatches as pressed when selected', async () => {
+		const source = await readSource('src/routes/onboarding/settings/+page.svelte');
+
+		expect(source).toContain('aria-pressed={uiTheme === option.value}');
+		expect(source).toContain('aria-pressed={wrappedTheme === option.value}');
+	});
+
+	it('removes the closed mobile admin sidebar from the accessibility tree and tab order', async () => {
+		const source = await readSource('src/routes/admin/+layout.svelte');
+
+		expect(source).toContain("window.matchMedia('(max-width: 768px)')");
+		expect(source).toContain(
+			'let sidebarHiddenFromMobile = $derived(isMobileSidebar && !sidebarOpen);'
+		);
+		expect(source).toContain('inert={sidebarHiddenFromMobile}');
+		expect(source).toContain("aria-hidden={sidebarHiddenFromMobile ? 'true' : undefined}");
 	});
 
 	it('guards wrapped story transitions against stale rapid navigation', async () => {

--- a/tests/unit/security/admin-guards.test.ts
+++ b/tests/unit/security/admin-guards.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 import { isAdminRouteId, requireAdminAction } from '$lib/server/auth/guards';
 
+async function readSource(path: string): Promise<string> {
+	return Bun.file(path).text();
+}
+
 describe('admin auth guards', () => {
 	it('identifies decoded admin route ids instead of relying on raw pathnames', () => {
 		expect(isAdminRouteId('/admin')).toBe(true);
@@ -18,5 +22,12 @@ describe('admin auth guards', () => {
 		expect(
 			requireAdminAction({ user: { id: 1, plexId: 1, username: 'u', isAdmin: true } })
 		).toBeNull();
+	});
+
+	it('keeps logged-in non-admin admin-route probes redirected to dashboard', async () => {
+		const source = await readSource('src/hooks.server.ts');
+
+		expect(source).toContain("const fallback = event.locals.user ? '/dashboard' : '/';");
+		expect(source).toContain('return redirectResponse(event, fallback);');
 	});
 });

--- a/tests/unit/sharing/wrapped-identifier-loader.test.ts
+++ b/tests/unit/sharing/wrapped-identifier-loader.test.ts
@@ -409,6 +409,37 @@ describe('wrapped/[year]/u/[identifier] loader: shareToken payload gating', () =
 		}
 	});
 
+	it('returns 404 when an admin accesses a private-link wrapped via numeric URL', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		await seedShareSettings({
+			userId: USER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: TOKEN
+		});
+		await seedUser(ADMIN_ID, 100008, 200008);
+
+		try {
+			await invokeLoad({
+				year: YEAR,
+				identifier: String(USER_ID),
+				availableYears: [YEAR],
+				currentUser: {
+					id: ADMIN_ID,
+					plexId: 100008,
+					username: `user-${ADMIN_ID}`,
+					isAdmin: true
+				}
+			});
+			expect.unreachable('Expected numeric private-link admin URL to be rejected');
+		} catch (err) {
+			expect((err as { status?: number }).status).toBe(404);
+		}
+	});
+
 	it('exposes the canonical token to the owner even when the floor raises effectiveMode above private-link', async () => {
 		// F-302: when the global floor (private-oauth) raises the effective mode
 		// above the stored private-link, the owner must still see the canonical


### PR DESCRIPTION
## Summary

This PR resolves the actionable dogfood findings around admin UI accessibility, log export behavior, fun fact frequency state, live log rendering, and private-link wrapped access regressions. It preserves the documented product and security decisions that private-link user wrapped URLs require tokens and logged-in non-admin `/admin/*` probes redirect to `/dashboard`.

## Changes

- Adds `aria-pressed` state to onboarding Dashboard Theme and Wrapped Presentation Theme swatches so selected state is exposed to assistive technology.
- Fixes the admin Logs JSON export enhanced handler by appending the temporary download anchor to `document.body`, clicking it, removing it, delaying blob URL revocation, and showing failure toasts when the export action fails or returns missing data.
- De-duplicates the merged live SSE and server log list by `log.id`, keeping streamed entries first, to avoid duplicate keyed each-block warnings.
- Stabilizes admin Slides Fun Fact Frequency local state by initializing the synced key from server data and updating it after successful saves.
- Removes the closed mobile admin sidebar from the accessibility tree and tab order with mobile-only `inert` and `aria-hidden` handling, while preserving desktop sidebar keyboard access.
- Adds regression coverage for the UI source contracts, non-admin admin redirect behavior, and private-link numeric wrapped URL rejection for admins.

## Preserved Decisions

- Private-link wrapped pages still require tokenized URLs; numeric `/wrapped/{year}/u/{userId}` URLs remain rejected under effective `private-link`, including owner and admin access.
- Logged-in non-admin `/admin/*` access continues to redirect to `/dashboard`, matching the repository route guidance.
- Obzorarr-origin Plex login completion responses remain browser-safe and do not include Plex tokens, email fields, service resources, or raw OAuth payloads. Any `AUTH_COMPLETE` console payload from `app.plex.tv` is third-party/upstream output, not an Obzorarr response leak.

## Verification

- `bun test tests/unit/plex-login.test.ts tests/unit/auth/login-completion.test.ts tests/unit/admin/ui-source-regressions.test.ts tests/unit/security/admin-guards.test.ts tests/unit/sharing/wrapped-identifier-loader.test.ts`
- `bun run check`
- `bun run check:biome`
- `bun run test`

## Notes

Browser smoke checks from the dogfood plan were not run in this environment because the required in-app browser Node REPL control tool was not exposed in the session. The covered regressions are backed by targeted source and loader tests plus the full project test suite.