### PR TITLE
fix: secure onboarding claim and credentialed urls

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -61,7 +61,6 @@ const COOKIE_OPTIONS = {
 
 let devBypassLogged = false;
 let settingsConflictsCleared = false;
-let bootstrapBannerChecked = false;
 
 const initializationHandle: Handle = async ({ event, resolve }) => {
 	if (!settingsConflictsCleared) {
@@ -79,14 +78,11 @@ const initializationHandle: Handle = async ({ event, resolve }) => {
 			logger.error(`Failed to clear conflicting DB settings: ${errorMessage}`, 'Startup');
 		}
 	}
-	if (!bootstrapBannerChecked) {
-		bootstrapBannerChecked = true;
-		try {
-			await printOnboardingBootstrapBanner(event.url.origin);
-		} catch (error) {
-			const errorMessage = error instanceof Error ? error.message : String(error);
-			logger.error(`Failed to prepare onboarding bootstrap token: ${errorMessage}`, 'Startup');
-		}
+	try {
+		await printOnboardingBootstrapBanner(event.url.origin);
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		logger.error(`Failed to prepare onboarding bootstrap token: ${errorMessage}`, 'Startup');
 	}
 	return resolve(event);
 };

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -19,7 +19,11 @@ import {
 } from '$lib/server/auth/session';
 import { SESSION_DURATION_MS } from '$lib/server/auth/types';
 import { logger } from '$lib/server/logging';
-import { getOnboardingStep, requiresOnboarding } from '$lib/server/onboarding';
+import {
+	getOnboardingStep,
+	printOnboardingBootstrapBanner,
+	requiresOnboarding
+} from '$lib/server/onboarding';
 import {
 	applySecurityHeaders,
 	csrfHandle,
@@ -57,6 +61,7 @@ const COOKIE_OPTIONS = {
 
 let devBypassLogged = false;
 let settingsConflictsCleared = false;
+let bootstrapBannerChecked = false;
 
 const initializationHandle: Handle = async ({ event, resolve }) => {
 	if (!settingsConflictsCleared) {
@@ -72,6 +77,15 @@ const initializationHandle: Handle = async ({ event, resolve }) => {
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			logger.error(`Failed to clear conflicting DB settings: ${errorMessage}`, 'Startup');
+		}
+	}
+	if (!bootstrapBannerChecked) {
+		bootstrapBannerChecked = true;
+		try {
+			await printOnboardingBootstrapBanner(event.url.origin);
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error);
+			logger.error(`Failed to prepare onboarding bootstrap token: ${errorMessage}`, 'Startup');
 		}
 	}
 	return resolve(event);

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -79,7 +79,7 @@ const initializationHandle: Handle = async ({ event, resolve }) => {
 		}
 	}
 	try {
-		await printOnboardingBootstrapBanner(event.url.origin);
+		await printOnboardingBootstrapBanner();
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error);
 		logger.error(`Failed to prepare onboarding bootstrap token: ${errorMessage}`, 'Startup');

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -2,12 +2,18 @@ import { and, between, eq, inArray, sql } from 'drizzle-orm';
 import { env } from '$env/dynamic/private';
 import { db } from '$lib/server/db/client';
 import { appSettings, cachedStats, playHistory, shareSettings } from '$lib/server/db/schema';
+import {
+	envAllowsInsecureLocalPlexHttp,
+	normalizePlexServerUrl,
+	shouldPersistPlexInsecureLocalHttpOptIn
+} from '$lib/server/security/credentialed-url';
 import { ShareMode, ShareModeSource, ShareSettingsKey } from '$lib/server/sharing/types';
 import { createYearFilter } from '$lib/server/stats/utils';
 
 export const AppSettingsKey = {
 	PLEX_SERVER_URL: 'plex_server_url',
 	PLEX_TOKEN: 'plex_token',
+	PLEX_ALLOW_INSECURE_LOCAL_HTTP: 'plex_allow_insecure_local_http',
 	OPENAI_API_KEY: 'openai_api_key',
 	OPENAI_BASE_URL: 'openai_base_url',
 	OPENAI_MODEL: 'openai_model',
@@ -35,6 +41,9 @@ export const AppSettingsKey = {
 	ENABLE_LIVE_SYNC: 'enable_live_sync',
 	ONBOARDING_COMPLETED: 'onboarding_completed',
 	ONBOARDING_CURRENT_STEP: 'onboarding_current_step',
+	ONBOARDING_CLAIMED: 'onboarding_claimed',
+	ONBOARDING_CLAIM_PROOF_HASH: 'onboarding_claim_proof_hash',
+	ONBOARDING_CLAIMED_AT: 'onboarding_claimed_at',
 	CSRF_ORIGIN: 'csrf_origin',
 	CSRF_ORIGIN_SKIPPED: 'csrf_origin_skipped',
 	CSRF_WARNING_DISMISSED: 'csrf_warning_dismissed',
@@ -153,6 +162,7 @@ export const USER_DEFAULTS_SETTINGS_KEYS = [
 export const API_CONFIG_KEYS = [
 	AppSettingsKey.PLEX_SERVER_URL,
 	AppSettingsKey.PLEX_TOKEN,
+	AppSettingsKey.PLEX_ALLOW_INSECURE_LOCAL_HTTP,
 	AppSettingsKey.OPENAI_API_KEY,
 	AppSettingsKey.OPENAI_BASE_URL,
 	AppSettingsKey.OPENAI_MODEL,
@@ -340,6 +350,7 @@ export async function setUserDefaultsAtomic(opts: {
 export interface SetApiConfigInput {
 	plexServerUrl: string | undefined;
 	plexToken: string | undefined;
+	plexAllowInsecureLocalHttp?: boolean;
 	openaiApiKey: string | undefined;
 	openaiBaseUrl: string | undefined;
 	openaiModel: string | undefined;
@@ -460,6 +471,22 @@ export async function setApiConfigAtomic(opts: {
 			opts.values.plexServerUrl,
 			opts.locks.plexServerUrl
 		);
+		if (opts.values.plexServerUrl !== undefined && !opts.locks.plexServerUrl) {
+			if (opts.values.plexServerUrl === '') {
+				await tx
+					.delete(appSettings)
+					.where(eq(appSettings.key, AppSettingsKey.PLEX_ALLOW_INSECURE_LOCAL_HTTP));
+			} else if (
+				opts.values.plexAllowInsecureLocalHttp &&
+				shouldPersistPlexInsecureLocalHttpOptIn(opts.values.plexServerUrl)
+			) {
+				await upsert(AppSettingsKey.PLEX_ALLOW_INSECURE_LOCAL_HTTP, 'true');
+			} else {
+				await tx
+					.delete(appSettings)
+					.where(eq(appSettings.key, AppSettingsKey.PLEX_ALLOW_INSECURE_LOCAL_HTTP));
+			}
+		}
 		await writeSecret(AppSettingsKey.PLEX_TOKEN, opts.values.plexToken, opts.locks.plexToken);
 		await writeSecret(
 			AppSettingsKey.OPENAI_API_KEY,
@@ -896,6 +923,11 @@ export function hasOpenAIEnvConfig(): boolean {
 	return Boolean(env.OPENAI_API_KEY || env.OPENAI_API_URL || env.OPENAI_MODEL);
 }
 
+export async function isPlexInsecureLocalHttpAllowed(): Promise<boolean> {
+	if (envAllowsInsecureLocalPlexHttp()) return true;
+	return (await getAppSetting(AppSettingsKey.PLEX_ALLOW_INSECURE_LOCAL_HTTP)) === 'true';
+}
+
 export interface PlexConfig {
 	serverUrl: string;
 	token: string;
@@ -908,8 +940,13 @@ export interface PlexConfig {
  */
 export async function getPlexConfig(): Promise<PlexConfig> {
 	const config = await getApiConfigWithSources();
+	const serverUrl = config.plex.serverUrl.value
+		? normalizePlexServerUrl(config.plex.serverUrl.value, {
+				allowInsecureLocalHttp: await isPlexInsecureLocalHttpAllowed()
+			})
+		: '';
 	return {
-		serverUrl: config.plex.serverUrl.value,
+		serverUrl,
 		token: config.plex.token.value
 	};
 }

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -3,6 +3,7 @@ import { env } from '$env/dynamic/private';
 import { db } from '$lib/server/db/client';
 import { appSettings, cachedStats, playHistory, shareSettings } from '$lib/server/db/schema';
 import {
+	CredentialedUrlError,
 	envAllowsInsecureLocalPlexHttp,
 	normalizePlexServerUrl,
 	shouldPersistPlexInsecureLocalHttpOptIn
@@ -940,11 +941,16 @@ export interface PlexConfig {
  */
 export async function getPlexConfig(): Promise<PlexConfig> {
 	const config = await getApiConfigWithSources();
-	const serverUrl = config.plex.serverUrl.value
-		? normalizePlexServerUrl(config.plex.serverUrl.value, {
+	let serverUrl = '';
+	if (config.plex.serverUrl.value) {
+		try {
+			serverUrl = normalizePlexServerUrl(config.plex.serverUrl.value, {
 				allowInsecureLocalHttp: await isPlexInsecureLocalHttpAllowed()
-			})
-		: '';
+			});
+		} catch (err) {
+			if (!(err instanceof CredentialedUrlError)) throw err;
+		}
+	}
 	return {
 		serverUrl,
 		token: config.plex.token.value

--- a/src/lib/server/auth/login-completion.ts
+++ b/src/lib/server/auth/login-completion.ts
@@ -4,7 +4,11 @@ import { getApiConfigWithSources } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { users } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logging';
-import { requiresOnboarding } from '$lib/server/onboarding';
+import {
+	OnboardingClaimRequiredError,
+	requireActiveOnboardingClaim,
+	requiresOnboarding
+} from '$lib/server/onboarding';
 import { requireServerMembership, verifyServerOwnership } from './membership';
 import { clearPinTransaction, getPinTransactionForRequest } from './pin-transactions';
 import { checkPinStatus, getPlexUserInfo } from './plex-oauth';
@@ -45,6 +49,12 @@ export async function createSessionFromPlexToken(
 	let accountId: number;
 
 	if (isOnboarding && !hasServerConfigured) {
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch {
+			throw new OnboardingClaimRequiredError();
+		}
+
 		const ownership = await verifyServerOwnership(authToken);
 
 		if (!ownership.isOwner) {

--- a/src/lib/server/auth/login-completion.ts
+++ b/src/lib/server/auth/login-completion.ts
@@ -4,7 +4,11 @@ import { getApiConfigWithSources } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { users } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logging';
-import { requireActiveOnboardingClaim, requiresOnboarding } from '$lib/server/onboarding';
+import {
+	type OnboardingClaimCookieContext,
+	requireActiveOnboardingClaim,
+	requiresOnboarding
+} from '$lib/server/onboarding';
 import { requireServerMembership, verifyServerOwnership } from './membership';
 import { clearPinTransaction, getPinTransactionForRequest } from './pin-transactions';
 import { checkPinStatus, getPlexUserInfo } from './plex-oauth';
@@ -33,7 +37,8 @@ export type PinLoginResult = { pending: true } | CompletedLogin;
 
 export async function createSessionFromPlexToken(
 	authToken: string,
-	cookies: Cookies
+	cookies: Cookies,
+	context: OnboardingClaimCookieContext = {}
 ): Promise<CompletedLogin> {
 	const plexUser = await getPlexUserInfo(authToken);
 
@@ -45,7 +50,7 @@ export async function createSessionFromPlexToken(
 	let accountId: number;
 
 	if (isOnboarding && !hasServerConfigured) {
-		await requireActiveOnboardingClaim(cookies);
+		await requireActiveOnboardingClaim(cookies, context);
 
 		const ownership = await verifyServerOwnership(authToken);
 
@@ -120,7 +125,8 @@ export async function createSessionFromPlexToken(
 
 export async function completePlexPinLogin(
 	pinId: number,
-	cookies: Cookies
+	cookies: Cookies,
+	context: OnboardingClaimCookieContext = {}
 ): Promise<PinLoginResult> {
 	const transaction = await getPinTransactionForRequest(pinId, cookies);
 	if (!transaction) {
@@ -137,7 +143,7 @@ export async function completePlexPinLogin(
 		return { pending: true };
 	}
 
-	const completed = await createSessionFromPlexToken(pinStatus.authToken, cookies);
+	const completed = await createSessionFromPlexToken(pinStatus.authToken, cookies, context);
 	try {
 		await clearPinTransaction(cookies, transaction.state);
 	} catch (err) {

--- a/src/lib/server/auth/login-completion.ts
+++ b/src/lib/server/auth/login-completion.ts
@@ -4,11 +4,7 @@ import { getApiConfigWithSources } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { users } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logging';
-import {
-	OnboardingClaimRequiredError,
-	requireActiveOnboardingClaim,
-	requiresOnboarding
-} from '$lib/server/onboarding';
+import { requireActiveOnboardingClaim, requiresOnboarding } from '$lib/server/onboarding';
 import { requireServerMembership, verifyServerOwnership } from './membership';
 import { clearPinTransaction, getPinTransactionForRequest } from './pin-transactions';
 import { checkPinStatus, getPlexUserInfo } from './plex-oauth';
@@ -49,11 +45,7 @@ export async function createSessionFromPlexToken(
 	let accountId: number;
 
 	if (isOnboarding && !hasServerConfigured) {
-		try {
-			await requireActiveOnboardingClaim(cookies);
-		} catch {
-			throw new OnboardingClaimRequiredError();
-		}
+		await requireActiveOnboardingClaim(cookies);
 
 		const ownership = await verifyServerOwnership(authToken);
 

--- a/src/lib/server/funfacts/service.ts
+++ b/src/lib/server/funfacts/service.ts
@@ -3,7 +3,10 @@ import {
 	getApiConfigWithSources,
 	getAppSetting
 } from '$lib/server/admin/settings.service';
-import { normalizeOpenAIBaseUrl } from '$lib/server/security/credentialed-url';
+import {
+	CredentialedUrlError,
+	normalizeOpenAIBaseUrl
+} from '$lib/server/security/credentialed-url';
 import type { ServerStats, Stats, UserStats } from '$lib/server/stats/types';
 import { isUserStats } from '$lib/server/stats/types';
 import { buildEnhancedPrompt, enrichContext } from './ai';
@@ -20,6 +23,28 @@ import type {
 } from './types';
 import { AIGenerationError } from './types';
 
+const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_OPENAI_MODEL = 'gpt-5-mini';
+
+function resolveOpenAIBaseUrl(rawBaseUrl: string): {
+	baseUrl: string;
+	isValid: boolean;
+	error?: CredentialedUrlError;
+} {
+	if (!rawBaseUrl) {
+		return { baseUrl: DEFAULT_OPENAI_BASE_URL, isValid: true };
+	}
+
+	try {
+		return { baseUrl: normalizeOpenAIBaseUrl(rawBaseUrl), isValid: true };
+	} catch (error) {
+		if (error instanceof CredentialedUrlError) {
+			return { baseUrl: DEFAULT_OPENAI_BASE_URL, isValid: false, error };
+		}
+		throw error;
+	}
+}
+
 export async function getFunFactsConfig(): Promise<FunFactsConfig> {
 	const [apiConfig, persona] = await Promise.all([
 		getApiConfigWithSources(),
@@ -28,14 +53,23 @@ export async function getFunFactsConfig(): Promise<FunFactsConfig> {
 
 	const apiKey = apiConfig.openai.apiKey.value.trim();
 	const rawBaseUrl = apiConfig.openai.baseUrl.value.trim();
-	const baseUrl = rawBaseUrl ? normalizeOpenAIBaseUrl(rawBaseUrl) : '';
+	const {
+		baseUrl,
+		isValid: isBaseUrlValid,
+		error: baseUrlError
+	} = resolveOpenAIBaseUrl(rawBaseUrl);
 	const model = apiConfig.openai.model.value.trim();
+	const aiEnabled = Boolean(apiKey && isBaseUrlValid);
+
+	if (apiKey && baseUrlError) {
+		console.warn('Invalid OpenAI base URL configured; AI fun facts are disabled:', baseUrlError);
+	}
 
 	return {
-		aiEnabled: Boolean(apiKey),
-		openaiApiKey: apiKey || undefined,
-		openaiBaseUrl: baseUrl || 'https://api.openai.com/v1',
-		openaiModel: model || 'gpt-5-mini',
+		aiEnabled,
+		openaiApiKey: aiEnabled ? apiKey : undefined,
+		openaiBaseUrl: baseUrl,
+		openaiModel: model || DEFAULT_OPENAI_MODEL,
 		maxAIRetries: 2,
 		aiTimeoutMs: 10000,
 		aiPersona: (persona as AIPersona) ?? 'witty'
@@ -333,8 +367,8 @@ export async function generateWithAI(
 	const persona = config.aiPersona ?? 'witty';
 	const { system: systemPrompt, user: userPrompt } = buildEnhancedPrompt(context, count, persona);
 	const maxRetries = config.maxAIRetries ?? 2;
-	const baseUrl = normalizeOpenAIBaseUrl(config.openaiBaseUrl ?? 'https://api.openai.com/v1');
-	const model = config.openaiModel ?? 'gpt-5-mini';
+	const baseUrl = normalizeOpenAIBaseUrl(config.openaiBaseUrl ?? DEFAULT_OPENAI_BASE_URL);
+	const model = config.openaiModel ?? DEFAULT_OPENAI_MODEL;
 
 	let lastError: Error | null = null;
 

--- a/src/lib/server/funfacts/service.ts
+++ b/src/lib/server/funfacts/service.ts
@@ -3,6 +3,7 @@ import {
 	getApiConfigWithSources,
 	getAppSetting
 } from '$lib/server/admin/settings.service';
+import { normalizeOpenAIBaseUrl } from '$lib/server/security/credentialed-url';
 import type { ServerStats, Stats, UserStats } from '$lib/server/stats/types';
 import { isUserStats } from '$lib/server/stats/types';
 import { buildEnhancedPrompt, enrichContext } from './ai';
@@ -26,7 +27,8 @@ export async function getFunFactsConfig(): Promise<FunFactsConfig> {
 	]);
 
 	const apiKey = apiConfig.openai.apiKey.value.trim();
-	const baseUrl = apiConfig.openai.baseUrl.value.trim().replace(/\/+$/, '');
+	const rawBaseUrl = apiConfig.openai.baseUrl.value.trim();
+	const baseUrl = rawBaseUrl ? normalizeOpenAIBaseUrl(rawBaseUrl) : '';
 	const model = apiConfig.openai.model.value.trim();
 
 	return {
@@ -331,7 +333,7 @@ export async function generateWithAI(
 	const persona = config.aiPersona ?? 'witty';
 	const { system: systemPrompt, user: userPrompt } = buildEnhancedPrompt(context, count, persona);
 	const maxRetries = config.maxAIRetries ?? 2;
-	const baseUrl = config.openaiBaseUrl ?? 'https://api.openai.com/v1';
+	const baseUrl = normalizeOpenAIBaseUrl(config.openaiBaseUrl ?? 'https://api.openai.com/v1');
 	const model = config.openaiModel ?? 'gpt-5-mini';
 
 	let lastError: Error | null = null;

--- a/src/lib/server/funfacts/test-connection.ts
+++ b/src/lib/server/funfacts/test-connection.ts
@@ -1,3 +1,8 @@
+import {
+	CredentialedUrlError,
+	normalizeOpenAIBaseUrl
+} from '$lib/server/security/credentialed-url';
+
 const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_MODEL = 'gpt-5-mini';
 const TIMEOUT_MS = 10_000;
@@ -16,7 +21,15 @@ export async function testOpenAIConnection(
 		return { success: false, error: 'API key is required' };
 	}
 
-	const resolvedBaseUrl = (baseUrl?.trim() || DEFAULT_BASE_URL).replace(/\/+$/, '');
+	let resolvedBaseUrl: string;
+	try {
+		resolvedBaseUrl = normalizeOpenAIBaseUrl(baseUrl?.trim() || DEFAULT_BASE_URL);
+	} catch (err) {
+		return {
+			success: false,
+			error: err instanceof CredentialedUrlError ? err.message : 'Invalid OpenAI base URL'
+		};
+	}
 	const resolvedModel = model?.trim() || DEFAULT_MODEL;
 
 	const controller = new AbortController();

--- a/src/lib/server/onboarding/bootstrap.ts
+++ b/src/lib/server/onboarding/bootstrap.ts
@@ -70,6 +70,7 @@ export function isBootstrapTokenExpired(): boolean {
 	if (!activeBootstrapToken) return true;
 	if (Date.now() >= activeBootstrapToken.expiresAt) {
 		activeBootstrapToken = null;
+		bannerPrinted = false;
 		return true;
 	}
 	return false;
@@ -94,9 +95,8 @@ export function validateBootstrapToken(candidate: string): boolean {
 }
 
 export async function printOnboardingBootstrapBanner(origin?: string): Promise<void> {
-	if (bannerPrinted || (await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED)) === 'true')
-		return;
-	bannerPrinted = true;
+	if (bannerPrinted && !isBootstrapTokenExpired()) return;
+	if ((await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED)) === 'true') return;
 
 	const token = createBootstrapToken();
 	const setupUrl = origin ? `${origin.replace(/\/+$/, '')}/onboarding/claim` : '/onboarding/claim';
@@ -107,6 +107,7 @@ export async function printOnboardingBootstrapBanner(origin?: string): Promise<v
 	console.info(`Bootstrap token: ${token}`);
 	console.info('This token expires in 15 minutes and is not stored.');
 	console.info('');
+	bannerPrinted = true;
 }
 
 async function sha256Hex(value: string): Promise<string> {

--- a/src/lib/server/onboarding/bootstrap.ts
+++ b/src/lib/server/onboarding/bootstrap.ts
@@ -1,0 +1,221 @@
+import type { Cookies } from '@sveltejs/kit';
+import { dev } from '$app/environment';
+import {
+	AppSettingsKey,
+	deleteAppSetting,
+	getAppSetting,
+	setAppSetting
+} from '$lib/server/admin/settings.service';
+
+const BOOTSTRAP_TOKEN_TTL_MS = 15 * 60 * 1000;
+const CLAIM_TTL_SECONDS = 10 * 60;
+const CLAIM_TTL_MS = CLAIM_TTL_SECONDS * 1000;
+const TOKEN_LENGTH = 14;
+const TOKEN_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+export const ONBOARDING_CLAIM_COOKIE = 'obzorarr_onboarding_claim';
+export const ONBOARDING_CLAIM_REQUIRED_MESSAGE =
+	'Setup claim required. Open the Obzorarr server console, claim this setup session, and try again.';
+
+interface BootstrapToken {
+	value: string;
+	expiresAt: number;
+}
+
+let activeBootstrapToken: BootstrapToken | null = null;
+let bannerPrinted = false;
+
+export class OnboardingClaimRequiredError extends Error {
+	constructor(message = ONBOARDING_CLAIM_REQUIRED_MESSAGE) {
+		super(message);
+		this.name = 'OnboardingClaimRequiredError';
+	}
+}
+
+function randomTokenChar(): string {
+	const maxValid = Math.floor(256 / TOKEN_ALPHABET.length) * TOKEN_ALPHABET.length;
+	const bytes = new Uint8Array(1);
+
+	while (true) {
+		crypto.getRandomValues(bytes);
+		const value = bytes[0];
+		if (value !== undefined && value < maxValid) {
+			return TOKEN_ALPHABET[value % TOKEN_ALPHABET.length] ?? 'a';
+		}
+	}
+}
+
+export function generateBootstrapToken(): string {
+	const chars = Array.from({ length: 12 }, randomTokenChar);
+	return `${chars.slice(0, 4).join('')}-${chars.slice(4, 8).join('')}-${chars
+		.slice(8, 12)
+		.join('')}`;
+}
+
+export function createBootstrapToken(ttlMs = BOOTSTRAP_TOKEN_TTL_MS): string {
+	const value = generateBootstrapToken();
+	activeBootstrapToken = {
+		value,
+		expiresAt: Date.now() + ttlMs
+	};
+	return value;
+}
+
+export function clearBootstrapToken(): void {
+	activeBootstrapToken = null;
+	bannerPrinted = false;
+}
+
+export function isBootstrapTokenExpired(): boolean {
+	if (!activeBootstrapToken) return true;
+	if (Date.now() >= activeBootstrapToken.expiresAt) {
+		activeBootstrapToken = null;
+		return true;
+	}
+	return false;
+}
+
+function timingSafeEqualString(left: string, right: string): boolean {
+	const leftBytes = new TextEncoder().encode(left);
+	const rightBytes = new TextEncoder().encode(right);
+	if (leftBytes.length !== rightBytes.length) return false;
+
+	let diff = 0;
+	for (let i = 0; i < leftBytes.length; i++) {
+		diff |= (leftBytes[i] ?? 0) ^ (rightBytes[i] ?? 0);
+	}
+	return diff === 0;
+}
+
+export function validateBootstrapToken(candidate: string): boolean {
+	if (!activeBootstrapToken || isBootstrapTokenExpired()) return false;
+	if (candidate.length !== TOKEN_LENGTH) return false;
+	return timingSafeEqualString(candidate, activeBootstrapToken.value);
+}
+
+export async function printOnboardingBootstrapBanner(origin?: string): Promise<void> {
+	if (bannerPrinted || (await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED)) === 'true')
+		return;
+	bannerPrinted = true;
+
+	const token = createBootstrapToken();
+	const setupUrl = origin ? `${origin.replace(/\/+$/, '')}/onboarding/claim` : '/onboarding/claim';
+
+	console.info('');
+	console.info('Obzorarr initial setup requires a bootstrap claim.');
+	console.info(`Setup URL: ${setupUrl}`);
+	console.info(`Bootstrap token: ${token}`);
+	console.info('This token expires in 15 minutes and is not stored.');
+	console.info('');
+}
+
+async function sha256Hex(value: string): Promise<string> {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+	return Array.from(new Uint8Array(digest))
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('');
+}
+
+function createClaimProof(): string {
+	const bytes = new Uint8Array(32);
+	crypto.getRandomValues(bytes);
+	return Array.from(bytes)
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('');
+}
+
+function setClaimCookie(cookies: Cookies, proof: string): void {
+	cookies.set(ONBOARDING_CLAIM_COOKIE, proof, {
+		path: '/',
+		httpOnly: true,
+		secure: !dev,
+		sameSite: 'strict',
+		maxAge: CLAIM_TTL_SECONDS
+	});
+}
+
+export function clearOnboardingClaimCookie(cookies: Cookies): void {
+	cookies.delete(ONBOARDING_CLAIM_COOKIE, { path: '/' });
+}
+
+async function getActiveStoredClaimHash(): Promise<string | null> {
+	const [claimed, proofHash, claimedAt] = await Promise.all([
+		getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED),
+		getAppSetting(AppSettingsKey.ONBOARDING_CLAIM_PROOF_HASH),
+		getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT)
+	]);
+
+	if (claimed !== 'true' || !proofHash || !claimedAt) return null;
+
+	const claimedAtMs = Number(claimedAt);
+	if (!Number.isFinite(claimedAtMs) || Date.now() - claimedAtMs > CLAIM_TTL_MS) {
+		return null;
+	}
+
+	return proofHash;
+}
+
+export async function hasAnyActiveOnboardingClaim(): Promise<boolean> {
+	return (await getActiveStoredClaimHash()) !== null;
+}
+
+export async function hasActiveOnboardingClaim(cookies: Cookies): Promise<boolean> {
+	const proof = cookies.get(ONBOARDING_CLAIM_COOKIE);
+	if (!proof) return false;
+
+	const storedHash = await getActiveStoredClaimHash();
+	if (!storedHash) return false;
+
+	const cookieHash = await sha256Hex(proof);
+	return timingSafeEqualString(cookieHash, storedHash);
+}
+
+export async function renewOnboardingClaim(cookies: Cookies): Promise<boolean> {
+	const proof = cookies.get(ONBOARDING_CLAIM_COOKIE);
+	if (!proof || !(await hasActiveOnboardingClaim(cookies))) return false;
+
+	await setAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT, String(Date.now()));
+	setClaimCookie(cookies, proof);
+	return true;
+}
+
+export async function requireActiveOnboardingClaim(cookies: Cookies): Promise<void> {
+	if (!(await renewOnboardingClaim(cookies))) {
+		throw new OnboardingClaimRequiredError();
+	}
+}
+
+export async function claimOnboardingInstance(
+	cookies: Cookies,
+	token: string
+): Promise<'claimed' | 'renewed' | 'already-claimed' | 'invalid-token'> {
+	if (await renewOnboardingClaim(cookies)) {
+		return 'renewed';
+	}
+
+	if (await hasAnyActiveOnboardingClaim()) {
+		return 'already-claimed';
+	}
+
+	if (!validateBootstrapToken(token)) {
+		return 'invalid-token';
+	}
+
+	const proof = createClaimProof();
+	await Promise.all([
+		setAppSetting(AppSettingsKey.ONBOARDING_CLAIMED, 'true'),
+		setAppSetting(AppSettingsKey.ONBOARDING_CLAIM_PROOF_HASH, await sha256Hex(proof)),
+		setAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT, String(Date.now()))
+	]);
+	setClaimCookie(cookies, proof);
+	return 'claimed';
+}
+
+export async function clearOnboardingClaim(): Promise<void> {
+	await Promise.all([
+		deleteAppSetting(AppSettingsKey.ONBOARDING_CLAIMED),
+		deleteAppSetting(AppSettingsKey.ONBOARDING_CLAIM_PROOF_HASH),
+		deleteAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT)
+	]);
+	clearBootstrapToken();
+}

--- a/src/lib/server/onboarding/bootstrap.ts
+++ b/src/lib/server/onboarding/bootstrap.ts
@@ -26,6 +26,7 @@ interface BootstrapToken {
 let activeBootstrapToken: BootstrapToken | null = null;
 let bannerPrinted = false;
 let bootstrapBannerPromise: Promise<void> | null = null;
+let onboardingCompletedCached = false;
 
 export interface OnboardingClaimCookieContext {
 	requestUrl?: URL;
@@ -71,6 +72,7 @@ export function clearBootstrapToken(): void {
 	activeBootstrapToken = null;
 	bannerPrinted = false;
 	bootstrapBannerPromise = null;
+	onboardingCompletedCached = false;
 }
 
 export function isBootstrapTokenExpired(): boolean {
@@ -109,8 +111,13 @@ function getOrCreateBootstrapToken(): string {
 }
 
 async function printBootstrapBanner(): Promise<void> {
+	if (onboardingCompletedCached) return;
 	if (bannerPrinted && !isBootstrapTokenExpired()) return;
-	if ((await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED)) === 'true') return;
+	if ((await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED)) === 'true') {
+		onboardingCompletedCached = true;
+		activeBootstrapToken = null;
+		return;
+	}
 
 	const token = getOrCreateBootstrapToken();
 	const origin = await getCsrfOrigin();
@@ -126,6 +133,7 @@ async function printBootstrapBanner(): Promise<void> {
 }
 
 export async function printOnboardingBootstrapBanner(): Promise<void> {
+	if (onboardingCompletedCached) return;
 	if (bannerPrinted && !isBootstrapTokenExpired()) return;
 
 	if (!bootstrapBannerPromise) {

--- a/src/lib/server/onboarding/bootstrap.ts
+++ b/src/lib/server/onboarding/bootstrap.ts
@@ -4,6 +4,7 @@ import {
 	AppSettingsKey,
 	deleteAppSetting,
 	getAppSetting,
+	getCsrfOrigin,
 	setAppSetting
 } from '$lib/server/admin/settings.service';
 
@@ -94,11 +95,12 @@ export function validateBootstrapToken(candidate: string): boolean {
 	return timingSafeEqualString(candidate, activeBootstrapToken.value);
 }
 
-export async function printOnboardingBootstrapBanner(origin?: string): Promise<void> {
+export async function printOnboardingBootstrapBanner(): Promise<void> {
 	if (bannerPrinted && !isBootstrapTokenExpired()) return;
 	if ((await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED)) === 'true') return;
 
 	const token = createBootstrapToken();
+	const origin = await getCsrfOrigin();
 	const setupUrl = origin ? `${origin.replace(/\/+$/, '')}/onboarding/claim` : '/onboarding/claim';
 
 	console.info('');

--- a/src/lib/server/onboarding/bootstrap.ts
+++ b/src/lib/server/onboarding/bootstrap.ts
@@ -25,6 +25,11 @@ interface BootstrapToken {
 
 let activeBootstrapToken: BootstrapToken | null = null;
 let bannerPrinted = false;
+let bootstrapBannerPromise: Promise<void> | null = null;
+
+export interface OnboardingClaimCookieContext {
+	requestUrl?: URL;
+}
 
 export class OnboardingClaimRequiredError extends Error {
 	constructor(message = ONBOARDING_CLAIM_REQUIRED_MESSAGE) {
@@ -65,6 +70,7 @@ export function createBootstrapToken(ttlMs = BOOTSTRAP_TOKEN_TTL_MS): string {
 export function clearBootstrapToken(): void {
 	activeBootstrapToken = null;
 	bannerPrinted = false;
+	bootstrapBannerPromise = null;
 }
 
 export function isBootstrapTokenExpired(): boolean {
@@ -95,11 +101,18 @@ export function validateBootstrapToken(candidate: string): boolean {
 	return timingSafeEqualString(candidate, activeBootstrapToken.value);
 }
 
-export async function printOnboardingBootstrapBanner(): Promise<void> {
+function getOrCreateBootstrapToken(): string {
+	if (activeBootstrapToken && !isBootstrapTokenExpired()) {
+		return activeBootstrapToken.value;
+	}
+	return createBootstrapToken();
+}
+
+async function printBootstrapBanner(): Promise<void> {
 	if (bannerPrinted && !isBootstrapTokenExpired()) return;
 	if ((await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED)) === 'true') return;
 
-	const token = createBootstrapToken();
+	const token = getOrCreateBootstrapToken();
 	const origin = await getCsrfOrigin();
 	const setupUrl = origin ? `${origin.replace(/\/+$/, '')}/onboarding/claim` : '/onboarding/claim';
 
@@ -110,6 +123,20 @@ export async function printOnboardingBootstrapBanner(): Promise<void> {
 	console.info('This token expires in 15 minutes and is not stored.');
 	console.info('');
 	bannerPrinted = true;
+}
+
+export async function printOnboardingBootstrapBanner(): Promise<void> {
+	if (bannerPrinted && !isBootstrapTokenExpired()) return;
+
+	if (!bootstrapBannerPromise) {
+		bootstrapBannerPromise = printBootstrapBanner();
+	}
+
+	try {
+		await bootstrapBannerPromise;
+	} finally {
+		bootstrapBannerPromise = null;
+	}
 }
 
 async function sha256Hex(value: string): Promise<string> {
@@ -127,11 +154,21 @@ function createClaimProof(): string {
 		.join('');
 }
 
-function setClaimCookie(cookies: Cookies, proof: string): void {
+function shouldSecureClaimCookie(context: OnboardingClaimCookieContext = {}): boolean {
+	if (dev) return false;
+	if (context.requestUrl) return context.requestUrl.protocol === 'https:';
+	return true;
+}
+
+function setClaimCookie(
+	cookies: Cookies,
+	proof: string,
+	context: OnboardingClaimCookieContext = {}
+): void {
 	cookies.set(ONBOARDING_CLAIM_COOKIE, proof, {
 		path: '/',
 		httpOnly: true,
-		secure: !dev,
+		secure: shouldSecureClaimCookie(context),
 		sameSite: 'strict',
 		maxAge: CLAIM_TTL_SECONDS
 	});
@@ -173,26 +210,33 @@ export async function hasActiveOnboardingClaim(cookies: Cookies): Promise<boolea
 	return timingSafeEqualString(cookieHash, storedHash);
 }
 
-export async function renewOnboardingClaim(cookies: Cookies): Promise<boolean> {
+export async function renewOnboardingClaim(
+	cookies: Cookies,
+	context: OnboardingClaimCookieContext = {}
+): Promise<boolean> {
 	const proof = cookies.get(ONBOARDING_CLAIM_COOKIE);
 	if (!proof || !(await hasActiveOnboardingClaim(cookies))) return false;
 
 	await setAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT, String(Date.now()));
-	setClaimCookie(cookies, proof);
+	setClaimCookie(cookies, proof, context);
 	return true;
 }
 
-export async function requireActiveOnboardingClaim(cookies: Cookies): Promise<void> {
-	if (!(await renewOnboardingClaim(cookies))) {
+export async function requireActiveOnboardingClaim(
+	cookies: Cookies,
+	context: OnboardingClaimCookieContext = {}
+): Promise<void> {
+	if (!(await renewOnboardingClaim(cookies, context))) {
 		throw new OnboardingClaimRequiredError();
 	}
 }
 
 export async function claimOnboardingInstance(
 	cookies: Cookies,
-	token: string
+	token: string,
+	context: OnboardingClaimCookieContext = {}
 ): Promise<'claimed' | 'renewed' | 'already-claimed' | 'invalid-token'> {
-	if (await renewOnboardingClaim(cookies)) {
+	if (await renewOnboardingClaim(cookies, context)) {
 		return 'renewed';
 	}
 
@@ -210,7 +254,7 @@ export async function claimOnboardingInstance(
 		setAppSetting(AppSettingsKey.ONBOARDING_CLAIM_PROOF_HASH, await sha256Hex(proof)),
 		setAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT, String(Date.now()))
 	]);
-	setClaimCookie(cookies, proof);
+	setClaimCookie(cookies, proof, context);
 	return 'claimed';
 }
 

--- a/src/lib/server/onboarding/index.ts
+++ b/src/lib/server/onboarding/index.ts
@@ -10,6 +10,7 @@ export {
 	isBootstrapTokenExpired,
 	ONBOARDING_CLAIM_COOKIE,
 	ONBOARDING_CLAIM_REQUIRED_MESSAGE,
+	type OnboardingClaimCookieContext,
 	OnboardingClaimRequiredError,
 	printOnboardingBootstrapBanner,
 	renewOnboardingClaim,

--- a/src/lib/server/onboarding/index.ts
+++ b/src/lib/server/onboarding/index.ts
@@ -1,4 +1,23 @@
 export {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	clearOnboardingClaim,
+	clearOnboardingClaimCookie,
+	createBootstrapToken,
+	generateBootstrapToken,
+	hasActiveOnboardingClaim,
+	hasAnyActiveOnboardingClaim,
+	isBootstrapTokenExpired,
+	ONBOARDING_CLAIM_COOKIE,
+	ONBOARDING_CLAIM_REQUIRED_MESSAGE,
+	OnboardingClaimRequiredError,
+	printOnboardingBootstrapBanner,
+	renewOnboardingClaim,
+	requireActiveOnboardingClaim,
+	validateBootstrapToken
+} from './bootstrap';
+
+export {
 	completeOnboarding,
 	getNextStep,
 	getOnboardingStatus,

--- a/src/lib/server/onboarding/status.ts
+++ b/src/lib/server/onboarding/status.ts
@@ -5,8 +5,10 @@ import {
 	getAppSetting,
 	setAppSetting
 } from '$lib/server/admin/settings.service';
+import { clearOnboardingClaim } from './bootstrap';
 
 export const OnboardingSteps = {
+	CLAIM: 'claim',
 	CSRF: 'csrf',
 	PLEX: 'plex',
 	SYNC: 'sync',
@@ -40,7 +42,7 @@ export async function getOnboardingStep(): Promise<OnboardingStep> {
 		return step as OnboardingStep;
 	}
 
-	return OnboardingSteps.CSRF;
+	return OnboardingSteps.CLAIM;
 }
 
 export async function setOnboardingStep(step: OnboardingStep): Promise<void> {
@@ -50,6 +52,7 @@ export async function setOnboardingStep(step: OnboardingStep): Promise<void> {
 export async function completeOnboarding(): Promise<void> {
 	await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
 	await deleteAppSetting(AppSettingsKey.ONBOARDING_CURRENT_STEP);
+	await clearOnboardingClaim();
 	// Do NOT clear CSRF_ORIGIN_SKIPPED here. If the user skipped CSRF origin
 	// configuration during onboarding (no ORIGIN configured), clearing this flag
 	// would hard-lock the install: every POST to /admin/settings would return 403
@@ -60,6 +63,7 @@ export async function completeOnboarding(): Promise<void> {
 export async function resetOnboarding(): Promise<void> {
 	await deleteAppSetting(AppSettingsKey.ONBOARDING_COMPLETED);
 	await deleteAppSetting(AppSettingsKey.ONBOARDING_CURRENT_STEP);
+	await clearOnboardingClaim();
 }
 
 export async function isPlexConfigured(): Promise<boolean> {
@@ -83,6 +87,7 @@ export async function getOnboardingStatus(): Promise<OnboardingStatus> {
 
 export function getStepNumber(step: OnboardingStep): number {
 	const stepOrder: OnboardingStep[] = [
+		OnboardingSteps.CLAIM,
 		OnboardingSteps.CSRF,
 		OnboardingSteps.PLEX,
 		OnboardingSteps.SYNC,
@@ -94,6 +99,7 @@ export function getStepNumber(step: OnboardingStep): number {
 
 export function getNextStep(currentStep: OnboardingStep): OnboardingStep | null {
 	const stepOrder: OnboardingStep[] = [
+		OnboardingSteps.CLAIM,
 		OnboardingSteps.CSRF,
 		OnboardingSteps.PLEX,
 		OnboardingSteps.SYNC,
@@ -109,6 +115,7 @@ export function getNextStep(currentStep: OnboardingStep): OnboardingStep | null 
 
 export function getPreviousStep(currentStep: OnboardingStep): OnboardingStep | null {
 	const stepOrder: OnboardingStep[] = [
+		OnboardingSteps.CLAIM,
 		OnboardingSteps.CSRF,
 		OnboardingSteps.PLEX,
 		OnboardingSteps.SYNC,

--- a/src/lib/server/plex/server-identity.service.ts
+++ b/src/lib/server/plex/server-identity.service.ts
@@ -2,6 +2,7 @@ import {
 	clearCachedServerMachineId,
 	getApiConfigWithSources,
 	getCachedServerMachineId,
+	isPlexInsecureLocalHttpAllowed,
 	setCachedServerMachineId
 } from '$lib/server/admin/settings.service';
 import {
@@ -11,6 +12,7 @@ import {
 	PlexServerIdentitySchema
 } from '$lib/server/auth/types';
 import { logger } from '$lib/server/logging';
+import { normalizePlexServerUrl } from '$lib/server/security/credentialed-url';
 import { classifyConnectionError } from '$lib/server/security/error-sanitizer';
 
 const PLEX_SERVER_HEADERS = {
@@ -40,7 +42,17 @@ export async function fetchServerIdentity(
 		return { identity: null, errorReason: 'Plex server URL or token is not configured' };
 	}
 
-	const normalizedUrl = serverUrl.replace(/\/+$/, '');
+	let normalizedUrl: string;
+	try {
+		normalizedUrl = normalizePlexServerUrl(serverUrl, {
+			allowInsecureLocalHttp: await isPlexInsecureLocalHttpAllowed()
+		});
+	} catch (err) {
+		return {
+			identity: null,
+			errorReason: err instanceof Error ? err.message : 'Invalid Plex server URL'
+		};
+	}
 	const endpoint = `${normalizedUrl}/identity`;
 
 	const controller = new AbortController();

--- a/src/lib/server/ratelimit/types.ts
+++ b/src/lib/server/ratelimit/types.ts
@@ -31,6 +31,7 @@ export const RATE_LIMIT_CONFIGS = {
 	auth: { name: 'auth', windowMs: 300_000, maxRequests: 10 },
 	authPoll: { name: 'authPoll', windowMs: 60_000, maxRequests: 60 },
 	authRedirect: { name: 'authRedirect', windowMs: 60_000, maxRequests: 30 },
+	onboardingClaim: { name: 'onboardingClaim', windowMs: 300_000, maxRequests: 5 },
 	api: { name: 'api', windowMs: 60_000, maxRequests: 30 },
 	landingPage: { name: 'landingPage', windowMs: 60_000, maxRequests: 30 },
 	landingLookup: { name: 'landingLookup', windowMs: 60_000, maxRequests: 10 }

--- a/src/lib/server/security/credentialed-url.ts
+++ b/src/lib/server/security/credentialed-url.ts
@@ -1,0 +1,110 @@
+import { env } from '$env/dynamic/private';
+
+export const OPENAI_HTTPS_REQUIRED_MESSAGE = 'OpenAI base URL must use HTTPS.';
+export const PLEX_HTTP_OPT_IN_REQUIRED_MESSAGE =
+	'HTTP Plex URLs require a local/private host and explicit local HTTP opt-in.';
+
+export class CredentialedUrlError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'CredentialedUrlError';
+	}
+}
+
+function parseCredentialedBaseUrl(rawUrl: string): URL {
+	const trimmed = rawUrl.trim().replace(/\/+$/, '');
+	let parsed: URL;
+	try {
+		parsed = new URL(trimmed);
+	} catch {
+		throw new CredentialedUrlError('Invalid URL format');
+	}
+
+	if (parsed.username || parsed.password) {
+		throw new CredentialedUrlError('Configured base URLs must not include credentials.');
+	}
+	if (parsed.search || parsed.hash) {
+		throw new CredentialedUrlError(
+			'Configured base URLs must not include query strings or fragments.'
+		);
+	}
+
+	return parsed;
+}
+
+function parseIpv4(hostname: string): number[] | null {
+	const parts = hostname.split('.');
+	if (parts.length !== 4) return null;
+
+	const octets: number[] = [];
+	for (const part of parts) {
+		if (!/^\d{1,3}$/.test(part)) return null;
+		const value = Number(part);
+		if (!Number.isInteger(value) || value < 0 || value > 255) return null;
+		octets.push(value);
+	}
+	return octets;
+}
+
+export function isLocalOrPrivateHost(hostname: string): boolean {
+	const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+
+	if (host === 'localhost' || host.endsWith('.local') || host.endsWith('.lan')) {
+		return true;
+	}
+
+	const ipv4 = parseIpv4(host);
+	if (ipv4) {
+		const [a, b] = ipv4;
+		if (a === 10) return true;
+		if (a === 127) return true;
+		if (a === 169 && b === 254) return true;
+		if (a === 172 && b !== undefined && b >= 16 && b <= 31) return true;
+		if (a === 192 && b === 168) return true;
+		return false;
+	}
+
+	if (host === '::1') return true;
+	if (host.startsWith('fc') || host.startsWith('fd')) return true;
+	if (/^fe[89ab][0-9a-f]?:/i.test(host)) return true;
+
+	return false;
+}
+
+export function envAllowsInsecureLocalPlexHttp(): boolean {
+	return env.PLEX_ALLOW_INSECURE_LOCAL_HTTP === 'true';
+}
+
+export function normalizeOpenAIBaseUrl(rawUrl: string): string {
+	const parsed = parseCredentialedBaseUrl(rawUrl);
+	if (parsed.protocol !== 'https:') {
+		throw new CredentialedUrlError(OPENAI_HTTPS_REQUIRED_MESSAGE);
+	}
+	return parsed.toString().replace(/\/+$/, '');
+}
+
+export function normalizePlexServerUrl(
+	rawUrl: string,
+	options: { allowInsecureLocalHttp: boolean }
+): string {
+	const parsed = parseCredentialedBaseUrl(rawUrl);
+
+	if (parsed.protocol === 'https:') {
+		return parsed.toString().replace(/\/+$/, '');
+	}
+
+	if (parsed.protocol !== 'http:') {
+		throw new CredentialedUrlError('Plex server URL must use HTTP or HTTPS.');
+	}
+
+	if (!options.allowInsecureLocalHttp || !isLocalOrPrivateHost(parsed.hostname)) {
+		throw new CredentialedUrlError(PLEX_HTTP_OPT_IN_REQUIRED_MESSAGE);
+	}
+
+	return parsed.toString().replace(/\/+$/, '');
+}
+
+export function shouldPersistPlexInsecureLocalHttpOptIn(rawUrl: string): boolean {
+	const parsed = parseCredentialedBaseUrl(rawUrl);
+	return parsed.protocol === 'http:' && isLocalOrPrivateHost(parsed.hostname);
+}

--- a/src/lib/server/security/credentialed-url.ts
+++ b/src/lib/server/security/credentialed-url.ts
@@ -46,6 +46,27 @@ function parseIpv4(hostname: string): number[] | null {
 	return octets;
 }
 
+function isIpv6Literal(hostname: string): boolean {
+	if (!hostname.includes(':')) return false;
+
+	try {
+		new URL(`http://[${hostname}]`);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function isIpv6UniqueLocal(hostname: string): boolean {
+	if (!isIpv6Literal(hostname)) return false;
+
+	const firstHextet = /^([0-9a-f]{1,4}):/i.exec(hostname)?.[1];
+	if (!firstHextet) return false;
+
+	const value = Number.parseInt(firstHextet, 16);
+	return value >= 0xfc00 && value <= 0xfdff;
+}
+
 export function isLocalOrPrivateHost(hostname: string): boolean {
 	const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
 
@@ -65,7 +86,7 @@ export function isLocalOrPrivateHost(hostname: string): boolean {
 	}
 
 	if (host === '::1') return true;
-	if (host.startsWith('fc') || host.startsWith('fd')) return true;
+	if (isIpv6UniqueLocal(host)) return true;
 	if (/^fe[89ab][0-9a-f]?:/i.test(host)) return true;
 
 	return false;

--- a/src/lib/server/security/rate-limit-handle.ts
+++ b/src/lib/server/security/rate-limit-handle.ts
@@ -24,6 +24,10 @@ function getConfigForPath(path: string, method: string): RateLimitConfig {
 		return RATE_LIMIT_CONFIGS.default;
 	}
 
+	if (method === 'POST' && path === '/onboarding/claim') {
+		return RATE_LIMIT_CONFIGS.onboardingClaim;
+	}
+
 	if (path.startsWith('/auth/')) {
 		return RATE_LIMIT_CONFIGS.auth;
 	}

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -58,6 +58,7 @@ import {
 } from '$lib/server/logging';
 import {
 	CredentialedUrlError,
+	envAllowsInsecureLocalPlexHttp,
 	normalizeOpenAIBaseUrl,
 	normalizePlexServerUrl
 } from '$lib/server/security/credentialed-url';
@@ -364,7 +365,7 @@ export const actions: Actions = requireAdminActions({
 				try {
 					values.plexServerUrl = normalizePlexServerUrl(values.plexServerUrl, {
 						allowInsecureLocalHttp:
-							values.plexAllowInsecureLocalHttp || (await isPlexInsecureLocalHttpAllowed())
+							values.plexAllowInsecureLocalHttp || envAllowsInsecureLocalPlexHttp()
 					});
 				} catch (err) {
 					return fail(400, {

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -24,6 +24,7 @@ import {
 	getWrappedLogoMode,
 	getWrappedTheme,
 	isCsrfWarningDismissed,
+	isPlexInsecureLocalHttpAllowed,
 	resetCsrfWarningDismissal,
 	SERVER_WRAPPED_SETTINGS_KEYS,
 	setAnonymizationMode,
@@ -55,6 +56,11 @@ import {
 	setLogMaxCount,
 	setLogRetentionDays
 } from '$lib/server/logging';
+import {
+	CredentialedUrlError,
+	normalizeOpenAIBaseUrl,
+	normalizePlexServerUrl
+} from '$lib/server/security/credentialed-url';
 import { getOriginFromRequest } from '$lib/server/security/csrf-handle';
 import {
 	bulkApplyShareDefaults,
@@ -132,6 +138,10 @@ const trimmedUrlOrEmpty = z
 const ApiConfigSchema = z.object({
 	plexServerUrl: trimmedUrlOrEmpty,
 	plexToken: optionalTrimmed(512),
+	plexAllowInsecureLocalHttp: z
+		.enum(['true', 'false'])
+		.optional()
+		.transform((v) => v === 'true'),
 	openaiApiKey: optionalTrimmed(512),
 	openaiBaseUrl: trimmedUrlOrEmpty,
 	// `openaiModel` is echoed back; submitting blank used to silently clear the row,
@@ -203,6 +213,7 @@ export const load: PageServerLoad = async () => {
 		csrfWarningDismissed,
 		csrfOriginSkippedRaw,
 		trustProxyConfig,
+		plexAllowInsecureLocalHttp,
 		serverWrappedSettingsUpdatedAt,
 		userDefaultsSettingsUpdatedAt,
 		apiConfigUpdatedAt
@@ -223,6 +234,7 @@ export const load: PageServerLoad = async () => {
 		isCsrfWarningDismissed(),
 		getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED),
 		getTrustProxyConfigWithSource(),
+		isPlexInsecureLocalHttpAllowed(),
 		getAppSettingsUpdatedAt(SERVER_WRAPPED_SETTINGS_KEYS),
 		getAppSettingsUpdatedAt(USER_DEFAULTS_SETTINGS_KEYS),
 		getAppSettingsUpdatedAt(API_CONFIG_KEYS)
@@ -234,6 +246,7 @@ export const load: PageServerLoad = async () => {
 		settings: {
 			plexServerUrl: apiConfig.plex.serverUrl as SettingValue,
 			plexToken: toSafeConfigValue(apiConfig.plex.token) satisfies SafeSettingValue,
+			plexAllowInsecureLocalHttp,
 			openaiApiKey: toSafeConfigValue(apiConfig.openai.apiKey) satisfies SafeSettingValue,
 			openaiBaseUrl: apiConfig.openai.baseUrl as SettingValue,
 			openaiModel: apiConfig.openai.model as SettingValue
@@ -312,6 +325,7 @@ export const actions: Actions = requireAdminActions({
 		const data = {
 			plexServerUrl: field('plexServerUrl'),
 			plexToken: field('plexToken'),
+			plexAllowInsecureLocalHttp: field('plexAllowInsecureLocalHttp'),
 			openaiApiKey: field('openaiApiKey'),
 			openaiBaseUrl: field('openaiBaseUrl'),
 			openaiModel: field('openaiModel'),
@@ -337,15 +351,40 @@ export const actions: Actions = requireAdminActions({
 
 		try {
 			const apiConfig = await getApiConfigWithSources();
+			const values = {
+				plexServerUrl: parsed.data.plexServerUrl,
+				plexToken: parsed.data.plexToken,
+				plexAllowInsecureLocalHttp: parsed.data.plexAllowInsecureLocalHttp,
+				openaiApiKey: parsed.data.openaiApiKey,
+				openaiBaseUrl: parsed.data.openaiBaseUrl,
+				openaiModel: parsed.data.openaiModel
+			};
+
+			if (values.plexServerUrl && !apiConfig.plex.serverUrl.isLocked) {
+				try {
+					values.plexServerUrl = normalizePlexServerUrl(values.plexServerUrl, {
+						allowInsecureLocalHttp:
+							values.plexAllowInsecureLocalHttp || (await isPlexInsecureLocalHttpAllowed())
+					});
+				} catch (err) {
+					return fail(400, {
+						error: err instanceof CredentialedUrlError ? err.message : 'Invalid Plex server URL'
+					});
+				}
+			}
+
+			if (values.openaiBaseUrl && !apiConfig.openai.baseUrl.isLocked) {
+				try {
+					values.openaiBaseUrl = normalizeOpenAIBaseUrl(values.openaiBaseUrl);
+				} catch (err) {
+					return fail(400, {
+						error: err instanceof CredentialedUrlError ? err.message : 'Invalid OpenAI base URL'
+					});
+				}
+			}
 
 			const result = await setApiConfigAtomic({
-				values: {
-					plexServerUrl: parsed.data.plexServerUrl,
-					plexToken: parsed.data.plexToken,
-					openaiApiKey: parsed.data.openaiApiKey,
-					openaiBaseUrl: parsed.data.openaiBaseUrl,
-					openaiModel: parsed.data.openaiModel
-				},
+				values,
 				locks: {
 					plexServerUrl: apiConfig.plex.serverUrl.isLocked,
 					plexToken: apiConfig.plex.token.isLocked,
@@ -378,6 +417,7 @@ export const actions: Actions = requireAdminActions({
 		const formData = await request.formData();
 		const submittedUrl = formData.get('plexServerUrl')?.toString() ?? '';
 		const submittedToken = formData.get('plexToken')?.toString() ?? '';
+		const allowInsecureLocalHttp = formData.get('plexAllowInsecureLocalHttp') === 'true';
 
 		// The client never echoes the stored token back (to avoid hydration leaks),
 		// so a missing token field is the normal case. We fall back to the stored
@@ -386,12 +426,12 @@ export const actions: Actions = requireAdminActions({
 		// host (SSRF / secret exfil).
 		const apiConfig = await getApiConfigWithSources();
 		const storedUrl = apiConfig.plex.serverUrl.value;
-		const plexServerUrl = submittedUrl || storedUrl;
+		let plexServerUrl = submittedUrl || storedUrl;
 
 		// Normalise both URLs for comparison (strip trailing slashes).
 		const normalise = (u: string) => u.replace(/\/+$/, '');
 		const urlMatchesStored =
-			plexServerUrl && storedUrl && normalise(plexServerUrl) === normalise(storedUrl);
+			Boolean(plexServerUrl && storedUrl) && normalise(plexServerUrl) === normalise(storedUrl);
 
 		// Allow token fallback only when the URL hasn't changed from what is stored.
 		const plexToken = submittedToken || (urlMatchesStored ? apiConfig.plex.token.value : '');
@@ -404,6 +444,17 @@ export const actions: Actions = requireAdminActions({
 		}
 		if (!plexToken) {
 			return fail(400, { error: 'A Plex token is required to test the server connection' });
+		}
+
+		try {
+			plexServerUrl = normalizePlexServerUrl(plexServerUrl, {
+				allowInsecureLocalHttp:
+					allowInsecureLocalHttp || (urlMatchesStored && (await isPlexInsecureLocalHttpAllowed()))
+			});
+		} catch (err) {
+			return fail(400, {
+				error: err instanceof CredentialedUrlError ? err.message : 'Invalid Plex server URL'
+			});
 		}
 
 		try {

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -81,6 +81,7 @@ let { data, form }: { data: PageData; form: ActionData } = $props();
 // Local form state (initialized and synced via $effect)
 let plexServerUrl = $state('');
 let plexToken = $state('');
+let plexAllowInsecureLocalHttp = $state(false);
 let openaiApiKey = $state('');
 let openaiBaseUrl = $state('');
 let openaiModel = $state('');
@@ -171,10 +172,14 @@ const storedPlexServerUrl = $derived(data.settings.plexServerUrl.value);
 const plexUrlChanged = $derived(
 	(plexServerUrl ?? '').replace(/\/+$/, '') !== (storedPlexServerUrl ?? '').replace(/\/+$/, '')
 );
+const showPlexInsecureLocalHttp = $derived(
+	plexServerUrl.trim().toLowerCase().startsWith('http://')
+);
 
 // Sync local state with data (initial load and after form submission)
 $effect(() => {
 	plexServerUrl = data.settings.plexServerUrl.value;
+	plexAllowInsecureLocalHttp = data.settings.plexAllowInsecureLocalHttp;
 	// Secret fields are never hydrated with the raw value; blank input = no change.
 	plexToken = '';
 	openaiApiKey = '';
@@ -601,6 +606,18 @@ const logFieldErrors = $derived(
 							{/if}
 						</div>
 
+						{#if showPlexInsecureLocalHttp && !plexServerUrlLocked}
+							<label class="checkbox-row">
+								<input
+									type="checkbox"
+									name="plexAllowInsecureLocalHttp"
+									value="true"
+									bind:checked={plexAllowInsecureLocalHttp}
+								/>
+								<span>Allow insecure local HTTP Plex connection</span>
+							</label>
+						{/if}
+
 						<div class="form-field">
 							<div class="field-header">
 								<label for="plexToken">Authentication Token</label>
@@ -678,6 +695,10 @@ const logFieldErrors = $derived(
 									const formData = new FormData();
 									formData.set('plexServerUrl', plexServerUrl);
 									formData.set('plexToken', plexToken);
+									formData.set(
+										'plexAllowInsecureLocalHttp',
+										plexAllowInsecureLocalHttp ? 'true' : 'false'
+									);
 									try {
 										const response = await fetch('?/testPlexConnection', {
 											method: 'POST',
@@ -2650,6 +2671,21 @@ const logFieldErrors = $derived(
 			font-size: 0.75rem;
 			color: hsl(var(--muted-foreground));
 			margin-top: 0.375rem;
+		}
+
+		.checkbox-row {
+			display: flex;
+			align-items: center;
+			gap: 0.625rem;
+			margin: -0.25rem 0 1rem;
+			font-size: 0.8125rem;
+			color: hsl(var(--foreground));
+		}
+
+		.checkbox-row input {
+			width: 1rem;
+			height: 1rem;
+			accent-color: hsl(var(--primary));
 		}
 
 		.field-error {

--- a/src/routes/api/onboarding/select-server/+server.ts
+++ b/src/routes/api/onboarding/select-server/+server.ts
@@ -102,7 +102,7 @@ async function testConnection(url: string, accessToken: string): Promise<Connect
 	}
 }
 
-export const POST: RequestHandler = async ({ request, locals, cookies }) => {
+export const POST: RequestHandler = async ({ request, locals, cookies, url }) => {
 	if (!locals.user) {
 		error(401, 'Authentication required');
 	}
@@ -111,7 +111,7 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 		error(403, 'Only server owners can configure Obzorarr');
 	}
 	try {
-		await requireActiveOnboardingClaim(cookies);
+		await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 	} catch (err) {
 		if (err instanceof OnboardingClaimRequiredError) {
 			error(403, err.message);

--- a/src/routes/api/onboarding/select-server/+server.ts
+++ b/src/routes/api/onboarding/select-server/+server.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import {
 	AppSettingsKey,
 	clearCachedServerMachineId,
+	deleteAppSetting,
+	isPlexInsecureLocalHttpAllowed,
 	setAppSetting,
 	setCachedServerMachineId,
 	setCachedServerName
@@ -14,8 +16,13 @@ import {
 	PlexServerIdentitySchema
 } from '$lib/server/auth/types';
 import { logger } from '$lib/server/logging';
+import { requireActiveOnboardingClaim } from '$lib/server/onboarding';
 import { resolveOwnedServerToken } from '$lib/server/onboarding/plex-server-selection';
 import { classifyConnectionError } from '$lib/server/security';
+import {
+	normalizePlexServerUrl,
+	shouldPersistPlexInsecureLocalHttpOptIn
+} from '$lib/server/security/credentialed-url';
 import type { RequestHandler } from './$types';
 
 const PLEX_SERVER_HEADERS = {
@@ -31,6 +38,7 @@ const SelectServerSchema = z
 	.object({
 		serverUrl: z.string().url('Invalid server URL'),
 		accessToken: z.string().min(1, 'Access token is required').optional(),
+		allowInsecureLocalHttp: z.boolean().optional(),
 		clientIdentifier: z.string().min(1).optional(),
 		serverName: z.string().min(1, 'Server name is required')
 	})
@@ -102,6 +110,11 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 	if (!locals.user.isAdmin) {
 		error(403, 'Only server owners can configure Obzorarr');
 	}
+	try {
+		await requireActiveOnboardingClaim(cookies);
+	} catch (err) {
+		error(403, err instanceof Error ? err.message : 'Setup claim required');
+	}
 
 	try {
 		const body = await request.json();
@@ -112,7 +125,23 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 			error(400, errorMessage);
 		}
 
-		const { serverUrl, serverName, clientIdentifier } = parseResult.data;
+		const { serverName, clientIdentifier } = parseResult.data;
+		let serverUrl: string;
+		try {
+			serverUrl = normalizePlexServerUrl(parseResult.data.serverUrl, {
+				allowInsecureLocalHttp:
+					parseResult.data.allowInsecureLocalHttp === true ||
+					(await isPlexInsecureLocalHttpAllowed())
+			});
+		} catch (err) {
+			return json(
+				{
+					success: false,
+					error: err instanceof Error ? err.message : 'Invalid Plex server URL'
+				},
+				{ status: 400 }
+			);
+		}
 		const accessToken =
 			parseResult.data.accessToken ??
 			(await resolveOwnedServerToken({
@@ -133,6 +162,14 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 
 		await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, serverUrl);
 		await setAppSetting(AppSettingsKey.PLEX_TOKEN, accessToken);
+		if (
+			parseResult.data.allowInsecureLocalHttp === true &&
+			shouldPersistPlexInsecureLocalHttpOptIn(serverUrl)
+		) {
+			await setAppSetting(AppSettingsKey.PLEX_ALLOW_INSECURE_LOCAL_HTTP, 'true');
+		} else {
+			await deleteAppSetting(AppSettingsKey.PLEX_ALLOW_INSECURE_LOCAL_HTTP);
+		}
 		await setCachedServerName(serverName);
 		if (testResult.machineIdentifier) {
 			await setCachedServerMachineId(testResult.machineIdentifier);

--- a/src/routes/api/onboarding/select-server/+server.ts
+++ b/src/routes/api/onboarding/select-server/+server.ts
@@ -16,7 +16,7 @@ import {
 	PlexServerIdentitySchema
 } from '$lib/server/auth/types';
 import { logger } from '$lib/server/logging';
-import { requireActiveOnboardingClaim } from '$lib/server/onboarding';
+import { OnboardingClaimRequiredError, requireActiveOnboardingClaim } from '$lib/server/onboarding';
 import { resolveOwnedServerToken } from '$lib/server/onboarding/plex-server-selection';
 import { classifyConnectionError } from '$lib/server/security';
 import {
@@ -113,7 +113,10 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 	try {
 		await requireActiveOnboardingClaim(cookies);
 	} catch (err) {
-		error(403, err instanceof Error ? err.message : 'Setup claim required');
+		if (err instanceof OnboardingClaimRequiredError) {
+			error(403, err.message);
+		}
+		throw err;
 	}
 
 	try {

--- a/src/routes/api/onboarding/select-server/+server.ts
+++ b/src/routes/api/onboarding/select-server/+server.ts
@@ -4,7 +4,6 @@ import {
 	AppSettingsKey,
 	clearCachedServerMachineId,
 	deleteAppSetting,
-	isPlexInsecureLocalHttpAllowed,
 	setAppSetting,
 	setCachedServerMachineId,
 	setCachedServerName
@@ -20,6 +19,7 @@ import { OnboardingClaimRequiredError, requireActiveOnboardingClaim } from '$lib
 import { resolveOwnedServerToken } from '$lib/server/onboarding/plex-server-selection';
 import { classifyConnectionError } from '$lib/server/security';
 import {
+	envAllowsInsecureLocalPlexHttp,
 	normalizePlexServerUrl,
 	shouldPersistPlexInsecureLocalHttpOptIn
 } from '$lib/server/security/credentialed-url';
@@ -129,12 +129,12 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 		}
 
 		const { serverName, clientIdentifier } = parseResult.data;
+		const allowInsecureLocalHttp =
+			parseResult.data.allowInsecureLocalHttp === true || envAllowsInsecureLocalPlexHttp();
 		let serverUrl: string;
 		try {
 			serverUrl = normalizePlexServerUrl(parseResult.data.serverUrl, {
-				allowInsecureLocalHttp:
-					parseResult.data.allowInsecureLocalHttp === true ||
-					(await isPlexInsecureLocalHttpAllowed())
+				allowInsecureLocalHttp
 			});
 		} catch (err) {
 			return json(

--- a/src/routes/api/onboarding/servers/+server.ts
+++ b/src/routes/api/onboarding/servers/+server.ts
@@ -10,7 +10,7 @@ import { logger } from '$lib/server/logging';
 import { OnboardingClaimRequiredError, requireActiveOnboardingClaim } from '$lib/server/onboarding';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ cookies, locals }) => {
+export const GET: RequestHandler = async ({ cookies, locals, url }) => {
 	if (!locals.user) {
 		error(401, 'Authentication required');
 	}
@@ -18,7 +18,7 @@ export const GET: RequestHandler = async ({ cookies, locals }) => {
 		error(403, 'Only server owners can configure Obzorarr');
 	}
 	try {
-		await requireActiveOnboardingClaim(cookies);
+		await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 	} catch (err) {
 		if (err instanceof OnboardingClaimRequiredError) {
 			error(403, err.message);

--- a/src/routes/api/onboarding/servers/+server.ts
+++ b/src/routes/api/onboarding/servers/+server.ts
@@ -7,6 +7,7 @@ import {
 } from '$lib/server/auth/membership';
 import { getSessionPlexToken } from '$lib/server/auth/session';
 import { logger } from '$lib/server/logging';
+import { requireActiveOnboardingClaim } from '$lib/server/onboarding';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ cookies, locals }) => {
@@ -15,6 +16,11 @@ export const GET: RequestHandler = async ({ cookies, locals }) => {
 	}
 	if (!locals.user.isAdmin) {
 		error(403, 'Only server owners can configure Obzorarr');
+	}
+	try {
+		await requireActiveOnboardingClaim(cookies);
+	} catch (err) {
+		error(403, err instanceof Error ? err.message : 'Setup claim required');
 	}
 
 	const sessionId = cookies.get('session');

--- a/src/routes/api/onboarding/servers/+server.ts
+++ b/src/routes/api/onboarding/servers/+server.ts
@@ -7,7 +7,7 @@ import {
 } from '$lib/server/auth/membership';
 import { getSessionPlexToken } from '$lib/server/auth/session';
 import { logger } from '$lib/server/logging';
-import { requireActiveOnboardingClaim } from '$lib/server/onboarding';
+import { OnboardingClaimRequiredError, requireActiveOnboardingClaim } from '$lib/server/onboarding';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ cookies, locals }) => {
@@ -20,7 +20,10 @@ export const GET: RequestHandler = async ({ cookies, locals }) => {
 	try {
 		await requireActiveOnboardingClaim(cookies);
 	} catch (err) {
-		error(403, err instanceof Error ? err.message : 'Setup claim required');
+		if (err instanceof OnboardingClaimRequiredError) {
+			error(403, err.message);
+		}
+		throw err;
 	}
 
 	const sessionId = cookies.get('session');

--- a/src/routes/api/onboarding/test-connection/+server.ts
+++ b/src/routes/api/onboarding/test-connection/+server.ts
@@ -36,7 +36,7 @@ const TestConnectionSchema = z
 
 const CONNECTION_TIMEOUT_MS = 10000;
 
-export const POST: RequestHandler = async ({ request, locals, cookies }) => {
+export const POST: RequestHandler = async ({ request, locals, cookies, url }) => {
 	// Require authenticated admin user
 	if (!locals.user) {
 		error(401, 'Authentication required');
@@ -46,7 +46,7 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 		error(403, 'Only server owners can configure Obzorarr');
 	}
 	try {
-		await requireActiveOnboardingClaim(cookies);
+		await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 	} catch (err) {
 		if (err instanceof OnboardingClaimRequiredError) {
 			error(403, err.message);

--- a/src/routes/api/onboarding/test-connection/+server.ts
+++ b/src/routes/api/onboarding/test-connection/+server.ts
@@ -8,7 +8,7 @@ import {
 	PlexServerIdentitySchema
 } from '$lib/server/auth/types';
 import { logger } from '$lib/server/logging';
-import { requireActiveOnboardingClaim } from '$lib/server/onboarding';
+import { OnboardingClaimRequiredError, requireActiveOnboardingClaim } from '$lib/server/onboarding';
 import { resolveOwnedServerToken } from '$lib/server/onboarding/plex-server-selection';
 import { classifyConnectionError } from '$lib/server/security';
 import { normalizePlexServerUrl } from '$lib/server/security/credentialed-url';
@@ -48,7 +48,10 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 	try {
 		await requireActiveOnboardingClaim(cookies);
 	} catch (err) {
-		error(403, err instanceof Error ? err.message : 'Setup claim required');
+		if (err instanceof OnboardingClaimRequiredError) {
+			error(403, err.message);
+		}
+		throw err;
 	}
 
 	try {

--- a/src/routes/api/onboarding/test-connection/+server.ts
+++ b/src/routes/api/onboarding/test-connection/+server.ts
@@ -1,5 +1,6 @@
 import { error, json } from '@sveltejs/kit';
 import { z } from 'zod';
+import { isPlexInsecureLocalHttpAllowed } from '$lib/server/admin/settings.service';
 import {
 	PLEX_CLIENT_ID,
 	PLEX_PRODUCT,
@@ -7,8 +8,10 @@ import {
 	PlexServerIdentitySchema
 } from '$lib/server/auth/types';
 import { logger } from '$lib/server/logging';
+import { requireActiveOnboardingClaim } from '$lib/server/onboarding';
 import { resolveOwnedServerToken } from '$lib/server/onboarding/plex-server-selection';
 import { classifyConnectionError } from '$lib/server/security';
+import { normalizePlexServerUrl } from '$lib/server/security/credentialed-url';
 import type { RequestHandler } from './$types';
 
 const PLEX_SERVER_HEADERS = {
@@ -23,6 +26,7 @@ const TestConnectionSchema = z
 		url: z.string().url('Invalid URL format'),
 		accessToken: z.string().min(1).optional(),
 		token: z.string().min(1).optional(),
+		allowInsecureLocalHttp: z.boolean().optional(),
 		clientIdentifier: z.string().min(1).optional()
 	})
 	.refine((body) => Boolean(body.accessToken ?? body.token ?? body.clientIdentifier), {
@@ -41,6 +45,11 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 	if (!locals.user.isAdmin) {
 		error(403, 'Only server owners can configure Obzorarr');
 	}
+	try {
+		await requireActiveOnboardingClaim(cookies);
+	} catch (err) {
+		error(403, err instanceof Error ? err.message : 'Setup claim required');
+	}
 
 	try {
 		// Parse and validate request body
@@ -52,7 +61,23 @@ export const POST: RequestHandler = async ({ request, locals, cookies }) => {
 			return json({ success: false, error: errorMessage }, { status: 400 });
 		}
 
-		const { url, clientIdentifier } = parseResult.data;
+		const { clientIdentifier } = parseResult.data;
+		let url: string;
+		try {
+			url = normalizePlexServerUrl(parseResult.data.url, {
+				allowInsecureLocalHttp:
+					parseResult.data.allowInsecureLocalHttp === true ||
+					(await isPlexInsecureLocalHttpAllowed())
+			});
+		} catch (err) {
+			return json(
+				{
+					success: false,
+					error: err instanceof Error ? err.message : 'Invalid Plex server URL'
+				},
+				{ status: 400 }
+			);
+		}
 		const accessToken =
 			parseResult.data.accessToken ??
 			parseResult.data.token ??

--- a/src/routes/auth/plex/+server.ts
+++ b/src/routes/auth/plex/+server.ts
@@ -61,7 +61,7 @@ export const GET: RequestHandler = async ({ cookies, url }) => {
 	}
 };
 
-export const POST: RequestHandler = async ({ request, cookies }) => {
+export const POST: RequestHandler = async ({ request, cookies, url }) => {
 	let body: unknown;
 	try {
 		body = await request.json();
@@ -79,7 +79,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 	const { pinId } = parseResult.data;
 
 	try {
-		return json(await completePlexPinLogin(pinId, cookies));
+		return json(await completePlexPinLogin(pinId, cookies, { requestUrl: url }));
 	} catch (err) {
 		if (err instanceof PinExpiredError) {
 			error(401, {

--- a/src/routes/auth/plex/+server.ts
+++ b/src/routes/auth/plex/+server.ts
@@ -9,6 +9,7 @@ import {
 import { buildPlexOAuthUrl, requestPin } from '$lib/server/auth/plex-oauth';
 import { NotServerMemberError, PinExpiredError, PlexAuthApiError } from '$lib/server/auth/types';
 import { logger } from '$lib/server/logging';
+import { OnboardingClaimRequiredError } from '$lib/server/onboarding';
 import type { RequestHandler } from './$types';
 
 const PollRequestSchema = z.object({
@@ -97,6 +98,12 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 		}
 
 		if (err instanceof NotServerMemberError) {
+			error(403, {
+				message: err.message
+			});
+		}
+
+		if (err instanceof OnboardingClaimRequiredError) {
 			error(403, {
 				message: err.message
 			});

--- a/src/routes/auth/plex/callback/+server.ts
+++ b/src/routes/auth/plex/callback/+server.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { createSessionFromPlexToken } from '$lib/server/auth/login-completion';
 import { NotServerMemberError, PlexAuthApiError } from '$lib/server/auth/types';
 import { logger } from '$lib/server/logging';
+import { OnboardingClaimRequiredError } from '$lib/server/onboarding';
 import type { RequestHandler } from './$types';
 
 const CallbackRequestSchema = z.object({
@@ -30,6 +31,12 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 		return json(await createSessionFromPlexToken(authToken, cookies));
 	} catch (err) {
 		if (err instanceof NotServerMemberError) {
+			error(403, {
+				message: err.message
+			});
+		}
+
+		if (err instanceof OnboardingClaimRequiredError) {
 			error(403, {
 				message: err.message
 			});

--- a/src/routes/auth/plex/callback/+server.ts
+++ b/src/routes/auth/plex/callback/+server.ts
@@ -10,7 +10,7 @@ const CallbackRequestSchema = z.object({
 	authToken: z.string().min(1, 'Auth token is required')
 });
 
-export const POST: RequestHandler = async ({ request, cookies }) => {
+export const POST: RequestHandler = async ({ request, cookies, url }) => {
 	let body: unknown;
 	try {
 		body = await request.json();
@@ -28,7 +28,7 @@ export const POST: RequestHandler = async ({ request, cookies }) => {
 	const { authToken } = parseResult.data;
 
 	try {
-		return json(await createSessionFromPlexToken(authToken, cookies));
+		return json(await createSessionFromPlexToken(authToken, cookies, { requestUrl: url }));
 	} catch (err) {
 		if (err instanceof NotServerMemberError) {
 			error(403, {

--- a/src/routes/onboarding/+layout.server.ts
+++ b/src/routes/onboarding/+layout.server.ts
@@ -39,6 +39,7 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 	const serverName = hasEnvConfigValue ? await getServerName() : null;
 
 	const steps: { id: OnboardingStep; label: string }[] = [
+		{ id: OnboardingSteps.CLAIM, label: 'Claim' },
 		{ id: OnboardingSteps.CSRF, label: 'Security' },
 		{ id: OnboardingSteps.PLEX, label: 'Connect' },
 		{ id: OnboardingSteps.SYNC, label: 'Sync' },

--- a/src/routes/onboarding/claim/+page.server.ts
+++ b/src/routes/onboarding/claim/+page.server.ts
@@ -1,0 +1,34 @@
+import { fail, redirect } from '@sveltejs/kit';
+import {
+	claimOnboardingInstance,
+	OnboardingSteps,
+	setOnboardingStep
+} from '$lib/server/onboarding';
+import type { Actions, PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ parent }) => {
+	return parent();
+};
+
+export const actions: Actions = {
+	claimInstance: async ({ request, cookies }) => {
+		const formData = await request.formData();
+		const token = formData.get('token')?.toString().trim() ?? '';
+
+		const result = await claimOnboardingInstance(cookies, token);
+		switch (result) {
+			case 'claimed':
+			case 'renewed':
+				await setOnboardingStep(OnboardingSteps.CSRF);
+				redirect(303, '/onboarding/csrf');
+				break;
+			case 'already-claimed':
+				return fail(409, {
+					error:
+						'Setup is already claimed in another browser. Wait for the claim to expire and try again.'
+				});
+			case 'invalid-token':
+				return fail(400, { error: 'Invalid or expired bootstrap token' });
+		}
+	}
+};

--- a/src/routes/onboarding/claim/+page.server.ts
+++ b/src/routes/onboarding/claim/+page.server.ts
@@ -11,11 +11,11 @@ export const load: PageServerLoad = async ({ parent }) => {
 };
 
 export const actions: Actions = {
-	claimInstance: async ({ request, cookies }) => {
+	claimInstance: async ({ request, cookies, url }) => {
 		const formData = await request.formData();
 		const token = formData.get('token')?.toString().trim() ?? '';
 
-		const result = await claimOnboardingInstance(cookies, token);
+		const result = await claimOnboardingInstance(cookies, token, { requestUrl: url });
 		switch (result) {
 			case 'claimed':
 			case 'renewed':

--- a/src/routes/onboarding/claim/+page.svelte
+++ b/src/routes/onboarding/claim/+page.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+import KeyRound from '@lucide/svelte/icons/key-round';
+import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
+import type { ActionData } from './$types';
+
+let { form }: { form: ActionData } = $props();
+let token = $state('');
+</script>
+
+<OnboardingCard title="Claim Setup" subtitle="Enter the bootstrap token printed in the server console">
+	<form method="POST" action="?/claimInstance" class="claim-form">
+		<div class="icon-wrap">
+			<KeyRound size={36} strokeWidth={1.75} />
+		</div>
+
+		<div class="field">
+			<label for="bootstrap-token">Bootstrap token</label>
+			<input
+				id="bootstrap-token"
+				name="token"
+				bind:value={token}
+				autocomplete="one-time-code"
+				autocapitalize="none"
+				spellcheck="false"
+				placeholder="xxxx-xxxx-xxxx"
+				required
+			/>
+		</div>
+
+		{#if form?.error}
+			<p class="error" role="alert">{form.error}</p>
+		{/if}
+
+		<button type="submit" class="claim-button" disabled={token.trim().length === 0}>
+			Claim setup
+		</button>
+	</form>
+</OnboardingCard>
+
+<style>
+	.claim-form {
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+		width: min(100%, 28rem);
+		margin: 0 auto;
+	}
+
+	.icon-wrap {
+		width: 4rem;
+		height: 4rem;
+		border-radius: 999px;
+		display: grid;
+		place-items: center;
+		margin: 0 auto;
+		background: hsl(var(--primary) / 0.12);
+		color: hsl(var(--primary));
+		border: 1px solid hsl(var(--primary) / 0.25);
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	label {
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: hsl(var(--foreground));
+	}
+
+	input {
+		width: 100%;
+		border: 1px solid hsl(var(--border));
+		border-radius: 0.5rem;
+		background: hsl(var(--background));
+		color: hsl(var(--foreground));
+		padding: 0.85rem 1rem;
+		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+		font-size: 1rem;
+		letter-spacing: 0.04em;
+	}
+
+	input:focus {
+		outline: 2px solid hsl(var(--primary) / 0.45);
+		outline-offset: 2px;
+	}
+
+	.error {
+		margin: 0;
+		color: hsl(var(--destructive));
+		font-size: 0.875rem;
+	}
+
+	.claim-button {
+		border: 0;
+		border-radius: 0.5rem;
+		background: hsl(var(--primary));
+		color: hsl(var(--primary-foreground));
+		font-weight: 700;
+		padding: 0.85rem 1rem;
+		cursor: pointer;
+	}
+
+	.claim-button:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+</style>

--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -18,6 +18,7 @@ import { logger } from '$lib/server/logging';
 import {
 	clearOnboardingClaimCookie,
 	completeOnboarding,
+	OnboardingClaimRequiredError,
 	requireActiveOnboardingClaim
 } from '$lib/server/onboarding';
 import { getGlobalAllowUserControl, getGlobalDefaultShareMode } from '$lib/server/sharing/service';
@@ -33,9 +34,12 @@ export const load: PageServerLoad = async ({ parent, locals, url, cookies }) => 
 	}
 
 	try {
-		await requireActiveOnboardingClaim(cookies);
-	} catch {
-		redirect(303, '/onboarding/claim');
+		await requireActiveOnboardingClaim(cookies, { requestUrl: url });
+	} catch (err) {
+		if (err instanceof OnboardingClaimRequiredError) {
+			redirect(303, '/onboarding/claim');
+		}
+		throw err;
 	}
 
 	const parentData = await parent();

--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -15,7 +15,11 @@ import {
 	getWrappedTheme
 } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
-import { completeOnboarding } from '$lib/server/onboarding';
+import {
+	clearOnboardingClaimCookie,
+	completeOnboarding,
+	requireActiveOnboardingClaim
+} from '$lib/server/onboarding';
 import { getGlobalAllowUserControl, getGlobalDefaultShareMode } from '$lib/server/sharing/service';
 import { getPlayHistoryCount, getSyncProgress, isSyncRunning } from '$lib/server/sync';
 import type { Actions, PageServerLoad } from './$types';
@@ -23,15 +27,22 @@ import type { Actions, PageServerLoad } from './$types';
 /**
  * Load function - marks onboarding complete and provides summary
  */
-export const load: PageServerLoad = async ({ parent, locals, url }) => {
+export const load: PageServerLoad = async ({ parent, locals, url, cookies }) => {
 	if (!locals.user?.isAdmin) {
-		redirect(303, '/onboarding/csrf');
+		redirect(303, '/onboarding/claim');
+	}
+
+	try {
+		await requireActiveOnboardingClaim(cookies);
+	} catch {
+		redirect(303, '/onboarding/claim');
 	}
 
 	const parentData = await parent();
 	const notice = url.searchParams.get('notice');
 
 	await completeOnboarding();
+	clearOnboardingClaimCookie(cookies);
 
 	logger.info(`Onboarding completed by ${locals.user?.username || 'unknown'}`, 'Onboarding');
 

--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -11,6 +11,7 @@ import {
 	getOnboardingStep,
 	isOnboardingComplete,
 	OnboardingSteps,
+	requireActiveOnboardingClaim,
 	setOnboardingStep
 } from '$lib/server/onboarding';
 import type { Actions, PageServerLoad } from './$types';
@@ -105,9 +106,16 @@ export const load: PageServerLoad = async ({ request, parent }) => {
 };
 
 export const actions: Actions = {
-	testOrigin: async ({ request }) => {
+	testOrigin: async ({ request, cookies }) => {
 		if (!(await isOnboardingCsrfStep())) {
 			return fail(403, { testError: 'Not allowed at this onboarding stage' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, {
+				testError: err instanceof Error ? err.message : 'Setup claim required'
+			});
 		}
 
 		const formData = await request.formData();
@@ -135,9 +143,18 @@ export const actions: Actions = {
 		return { testSuccess: true, testedOrigin: result.data.csrfOrigin };
 	},
 
-	saveOrigin: async ({ request }) => {
+	saveOrigin: async ({ request, cookies, url }) => {
 		if (!(await isOnboardingCsrfStep())) {
 			return fail(403, { error: 'Not allowed at this onboarding stage' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+		}
+
+		if (!isSameOriginOnboardingAction(request, url)) {
+			return fail(403, { error: 'CSRF origin must be submitted from this Obzorarr origin' });
 		}
 
 		const csrfConfig = await getCsrfConfigWithSource();
@@ -176,9 +193,14 @@ export const actions: Actions = {
 		redirect(303, '/onboarding/plex');
 	},
 
-	skipCsrf: async ({ request, url }) => {
+	skipCsrf: async ({ request, cookies, url }) => {
 		if (!(await isOnboardingCsrfStep())) {
 			return fail(403, { error: 'Not allowed at this onboarding stage' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
 		}
 
 		if (!isSameOriginOnboardingAction(request, url)) {

--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -107,12 +107,12 @@ export const load: PageServerLoad = async ({ request, parent }) => {
 };
 
 export const actions: Actions = {
-	testOrigin: async ({ request, cookies }) => {
+	testOrigin: async ({ request, cookies, url }) => {
 		if (!(await isOnboardingCsrfStep())) {
 			return fail(403, { testError: 'Not allowed at this onboarding stage' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { testError: err.message });
@@ -150,7 +150,7 @@ export const actions: Actions = {
 			return fail(403, { error: 'Not allowed at this onboarding stage' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { error: err.message });
@@ -203,7 +203,7 @@ export const actions: Actions = {
 			return fail(403, { error: 'Not allowed at this onboarding stage' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { error: err.message });

--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -10,6 +10,7 @@ import { logger } from '$lib/server/logging';
 import {
 	getOnboardingStep,
 	isOnboardingComplete,
+	OnboardingClaimRequiredError,
 	OnboardingSteps,
 	requireActiveOnboardingClaim,
 	setOnboardingStep
@@ -113,9 +114,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, {
-				testError: err instanceof Error ? err.message : 'Setup claim required'
-			});
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { testError: err.message });
+			}
+			throw err;
 		}
 
 		const formData = await request.formData();
@@ -150,7 +152,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
 		}
 
 		if (!isSameOriginOnboardingAction(request, url)) {
@@ -200,7 +205,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
 		}
 
 		if (!isSameOriginOnboardingAction(request, url)) {

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -50,12 +50,12 @@ export const load: PageServerLoad = async ({ parent }) => {
 };
 
 export const actions: Actions = {
-	verifyAdmin: async ({ locals, cookies }) => {
+	verifyAdmin: async ({ locals, cookies, url }) => {
 		if (!locals.user) {
 			return fail(401, { error: 'Please sign in with Plex first' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { error: err.message });
@@ -126,12 +126,12 @@ export const actions: Actions = {
 		}
 	},
 
-	continueAfterServerSelection: async ({ locals, cookies }) => {
+	continueAfterServerSelection: async ({ locals, cookies, url }) => {
 		if (!locals.user) {
 			return fail(401, { error: 'Please sign in with Plex first' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { error: err.message });
@@ -151,12 +151,12 @@ export const actions: Actions = {
 		redirect(303, '/onboarding/sync');
 	},
 
-	forceManualSelection: async ({ locals, cookies }) => {
+	forceManualSelection: async ({ locals, cookies, url }) => {
 		if (!locals.user) {
 			return fail(401, { error: 'Please sign in with Plex first' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { error: err.message });
@@ -192,12 +192,12 @@ export const actions: Actions = {
 		});
 	},
 
-	confirmOwnershipOverride: async ({ locals, cookies }) => {
+	confirmOwnershipOverride: async ({ locals, cookies, url }) => {
 		if (!locals.user) {
 			return fail(401, { error: 'Please sign in with Plex first' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { error: err.message });

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -7,7 +7,12 @@ import type { MembershipResult } from '$lib/server/auth/types';
 import { db } from '$lib/server/db/client';
 import { sessions, users } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logging';
-import { isOnboardingComplete, OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
+import {
+	isOnboardingComplete,
+	OnboardingSteps,
+	requireActiveOnboardingClaim,
+	setOnboardingStep
+} from '$lib/server/onboarding';
 import {
 	fetchServerIdentity,
 	refreshConfiguredServerMachineId
@@ -47,6 +52,11 @@ export const actions: Actions = {
 	verifyAdmin: async ({ locals, cookies }) => {
 		if (!locals.user) {
 			return fail(401, { error: 'Please sign in with Plex first' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
 		}
 
 		const sessionId = cookies.get('session');
@@ -112,9 +122,14 @@ export const actions: Actions = {
 		}
 	},
 
-	continueAfterServerSelection: async ({ locals }) => {
+	continueAfterServerSelection: async ({ locals, cookies }) => {
 		if (!locals.user) {
 			return fail(401, { error: 'Please sign in with Plex first' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
 		}
 
 		if (!locals.user.isAdmin) {
@@ -129,9 +144,14 @@ export const actions: Actions = {
 		redirect(303, '/onboarding/sync');
 	},
 
-	forceManualSelection: async ({ locals }) => {
+	forceManualSelection: async ({ locals, cookies }) => {
 		if (!locals.user) {
 			return fail(401, { error: 'Please sign in with Plex first' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
 		}
 
 		if (!locals.user.isAdmin) {
@@ -165,6 +185,11 @@ export const actions: Actions = {
 	confirmOwnershipOverride: async ({ locals, cookies }) => {
 		if (!locals.user) {
 			return fail(401, { error: 'Please sign in with Plex first' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
 		}
 
 		if (await isOnboardingComplete()) {

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -9,6 +9,7 @@ import { sessions, users } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logging';
 import {
 	isOnboardingComplete,
+	OnboardingClaimRequiredError,
 	OnboardingSteps,
 	requireActiveOnboardingClaim,
 	setOnboardingStep
@@ -56,7 +57,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
 		}
 
 		const sessionId = cookies.get('session');
@@ -129,7 +133,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
 		}
 
 		if (!locals.user.isAdmin) {
@@ -151,7 +158,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
 		}
 
 		if (!locals.user.isAdmin) {
@@ -189,7 +199,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
 		}
 
 		if (await isOnboardingComplete()) {

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -55,6 +55,7 @@ let serverSaved = $state(false);
 
 let showCustomUrl = $state(false);
 let customUrl = $state('');
+let plexAllowInsecureLocalHttp = $state(false);
 let isTestingCustomUrl = $state(false);
 let customUrlTestResult = $state<{
 	success: boolean;
@@ -274,6 +275,7 @@ async function handleConnectionSelect(
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({
 				serverUrl: connection.uri,
+				allowInsecureLocalHttp: plexAllowInsecureLocalHttp,
 				clientIdentifier: server.clientIdentifier,
 				serverName: server.name
 			})
@@ -385,6 +387,7 @@ async function testCustomConnection(server: (typeof servers)[0]) {
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({
 				url: customUrl,
+				allowInsecureLocalHttp: plexAllowInsecureLocalHttp,
 				clientIdentifier: server.clientIdentifier
 			})
 		});
@@ -420,8 +423,13 @@ function toggleCustomUrl() {
 	showCustomUrl = !showCustomUrl;
 	if (!showCustomUrl) {
 		customUrl = '';
+		plexAllowInsecureLocalHttp = false;
 		customUrlTestResult = null;
 	}
+}
+
+function isHttpUrl(url: string): boolean {
+	return url.trim().toLowerCase().startsWith('http://');
 }
 
 function isValidUrl(url: string): boolean {
@@ -762,6 +770,16 @@ function formatServerUrl(url: string | null): string {
 									{#if isExpanded && connections.length > 0}
 										<div class="connections-panel">
 											<p class="connections-label">Select a connection</p>
+											{#if connections.some((connection) => isHttpUrl(connection.uri))}
+												<label class="insecure-http-toggle">
+													<input
+														type="checkbox"
+														bind:checked={plexAllowInsecureLocalHttp}
+														disabled={isSavingServer}
+													/>
+													<span>Allow insecure local HTTP Plex connection</span>
+												</label>
+											{/if}
 											<Tooltip.Provider>
 												<div class="connections-list">
 													{#each connections as connection (connection.uri)}
@@ -962,6 +980,17 @@ function formatServerUrl(url: string | null): string {
 															{/if}
 														</button>
 													</div>
+
+													{#if isHttpUrl(customUrl)}
+														<label class="insecure-http-toggle custom">
+															<input
+																type="checkbox"
+																bind:checked={plexAllowInsecureLocalHttp}
+																disabled={isTestingCustomUrl || isSavingServer}
+															/>
+															<span>Allow insecure local HTTP Plex connection</span>
+														</label>
+													{/if}
 
 													<!-- Status Display -->
 													{#if customUrlTestResult}
@@ -1651,6 +1680,25 @@ function formatServerUrl(url: string | null): string {
 			color: rgba(255, 255, 255, 0.5);
 			text-transform: uppercase;
 			letter-spacing: 0.05em;
+		}
+
+		.insecure-http-toggle {
+			display: flex;
+			align-items: center;
+			gap: 0.625rem;
+			margin: 0 0 0.875rem;
+			font-size: 0.8125rem;
+			color: rgba(255, 255, 255, 0.78);
+		}
+
+		.insecure-http-toggle.custom {
+			margin: 0.75rem 0 0;
+		}
+
+		.insecure-http-toggle input {
+			width: 1rem;
+			height: 1rem;
+			accent-color: hsl(var(--primary));
 		}
 
 		.connections-list {

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -36,7 +36,15 @@ import {
 import { testOpenAIConnection } from '$lib/server/funfacts/test-connection';
 import { AIPersonaSchema } from '$lib/server/funfacts/types';
 import { logger } from '$lib/server/logging';
-import { OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
+import {
+	OnboardingSteps,
+	requireActiveOnboardingClaim,
+	setOnboardingStep
+} from '$lib/server/onboarding';
+import {
+	CredentialedUrlError,
+	normalizeOpenAIBaseUrl
+} from '$lib/server/security/credentialed-url';
 import {
 	getGlobalAllowUserControl,
 	getGlobalDefaultShareMode,
@@ -281,9 +289,14 @@ export const actions: Actions = {
 	/**
 	 * Save all settings and continue to completion
 	 */
-	saveSettings: async ({ request, locals }) => {
+	saveSettings: async ({ request, locals, cookies }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
 		}
 
 		try {
@@ -321,14 +334,19 @@ export const actions: Actions = {
 
 			const data = parseResult.data;
 			const openaiApiKey = data.openaiApiKey?.trim();
-			const openaiBaseUrl = data.openaiBaseUrl?.trim().replace(/\/+$/, '');
+			let openaiBaseUrl = data.openaiBaseUrl?.trim().replace(/\/+$/, '');
 			const openaiModel = data.openaiModel?.trim();
 
 			if (data.enableFunFacts && openaiApiKey && openaiBaseUrl) {
 				try {
-					new URL(openaiBaseUrl);
-				} catch {
-					return fail(400, { error: 'Invalid OpenAI base URL' });
+					openaiBaseUrl = normalizeOpenAIBaseUrl(openaiBaseUrl);
+				} catch (err) {
+					return fail(400, {
+						error:
+							err instanceof CredentialedUrlError && err.message !== 'Invalid URL format'
+								? err.message
+								: 'Invalid OpenAI base URL'
+					});
 				}
 			}
 
@@ -420,9 +438,14 @@ export const actions: Actions = {
 	/**
 	 * Skip settings (use defaults) and continue
 	 */
-	skipSettings: async ({ locals }) => {
+	skipSettings: async ({ locals, cookies }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
 		}
 
 		logger.info(
@@ -439,9 +462,14 @@ export const actions: Actions = {
 	 * Test OpenAI connection using values submitted from the form.
 	 * Does not fall back to stored values — onboarding submits fresh input.
 	 */
-	testAIConnection: async ({ request, locals }) => {
+	testAIConnection: async ({ request, locals, cookies }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
 		}
 
 		const formData = await request.formData();

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -37,6 +37,7 @@ import { testOpenAIConnection } from '$lib/server/funfacts/test-connection';
 import { AIPersonaSchema } from '$lib/server/funfacts/types';
 import { logger } from '$lib/server/logging';
 import {
+	OnboardingClaimRequiredError,
 	OnboardingSteps,
 	requireActiveOnboardingClaim,
 	setOnboardingStep
@@ -296,7 +297,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
 		}
 
 		try {
@@ -445,7 +449,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
 		}
 
 		logger.info(
@@ -469,7 +476,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
 		}
 
 		const formData = await request.formData();

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -290,12 +290,12 @@ export const actions: Actions = {
 	/**
 	 * Save all settings and continue to completion
 	 */
-	saveSettings: async ({ request, locals, cookies }) => {
+	saveSettings: async ({ request, locals, cookies, url }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { error: err.message });
@@ -442,12 +442,12 @@ export const actions: Actions = {
 	/**
 	 * Skip settings (use defaults) and continue
 	 */
-	skipSettings: async ({ locals, cookies }) => {
+	skipSettings: async ({ locals, cookies, url }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { error: err.message });
@@ -469,12 +469,12 @@ export const actions: Actions = {
 	 * Test OpenAI connection using values submitted from the form.
 	 * Does not fall back to stored values — onboarding submits fresh input.
 	 */
-	testAIConnection: async ({ request, locals, cookies }) => {
+	testAIConnection: async ({ request, locals, cookies, url }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { error: err.message });

--- a/src/routes/onboarding/sync/+page.server.ts
+++ b/src/routes/onboarding/sync/+page.server.ts
@@ -1,6 +1,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { logger } from '$lib/server/logging';
 import {
+	OnboardingClaimRequiredError,
 	OnboardingSteps,
 	requireActiveOnboardingClaim,
 	setOnboardingStep
@@ -39,7 +40,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
 		}
 
 		try {
@@ -74,7 +78,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
 		}
 
 		const cancelled = cancelSync();
@@ -93,7 +100,10 @@ export const actions: Actions = {
 		try {
 			await requireActiveOnboardingClaim(cookies);
 		} catch (err) {
-			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
 		}
 
 		logger.info('Onboarding: Proceeding to settings (sync may still be running)', 'Onboarding');

--- a/src/routes/onboarding/sync/+page.server.ts
+++ b/src/routes/onboarding/sync/+page.server.ts
@@ -33,12 +33,12 @@ export const load: PageServerLoad = async ({ parent }) => {
 };
 
 export const actions: Actions = {
-	startSync: async ({ locals, cookies }) => {
+	startSync: async ({ locals, cookies, url }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { error: err.message });
@@ -71,12 +71,12 @@ export const actions: Actions = {
 		}
 	},
 
-	cancelSync: async ({ locals, cookies }) => {
+	cancelSync: async ({ locals, cookies, url }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { error: err.message });
@@ -93,12 +93,12 @@ export const actions: Actions = {
 		return { success: true, message: 'Sync cancelled' };
 	},
 
-	continue: async ({ locals, cookies }) => {
+	continue: async ({ locals, cookies, url }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
 		}
 		try {
-			await requireActiveOnboardingClaim(cookies);
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
 		} catch (err) {
 			if (err instanceof OnboardingClaimRequiredError) {
 				return fail(403, { error: err.message });

--- a/src/routes/onboarding/sync/+page.server.ts
+++ b/src/routes/onboarding/sync/+page.server.ts
@@ -1,6 +1,10 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { logger } from '$lib/server/logging';
-import { OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
+import {
+	OnboardingSteps,
+	requireActiveOnboardingClaim,
+	setOnboardingStep
+} from '$lib/server/onboarding';
 import {
 	getPlayHistoryCount,
 	getSyncProgress,
@@ -28,9 +32,14 @@ export const load: PageServerLoad = async ({ parent }) => {
 };
 
 export const actions: Actions = {
-	startSync: async ({ locals }) => {
+	startSync: async ({ locals, cookies }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
 		}
 
 		try {
@@ -58,9 +67,14 @@ export const actions: Actions = {
 		}
 	},
 
-	cancelSync: async ({ locals }) => {
+	cancelSync: async ({ locals, cookies }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
 		}
 
 		const cancelled = cancelSync();
@@ -72,9 +86,14 @@ export const actions: Actions = {
 		return { success: true, message: 'Sync cancelled' };
 	},
 
-	continue: async ({ locals }) => {
+	continue: async ({ locals, cookies }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
+		}
+		try {
+			await requireActiveOnboardingClaim(cookies);
+		} catch (err) {
+			return fail(403, { error: err instanceof Error ? err.message : 'Setup claim required' });
 		}
 
 		logger.info('Onboarding: Proceeding to settings (sync may still be running)', 'Onboarding');

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -16,7 +16,7 @@ process.env.DATABASE_PATH = ':memory:';
 // Mock SvelteKit's $env/dynamic/private module for tests
 mock.module('$env/dynamic/private', () => ({
 	env: {
-		PLEX_SERVER_URL: 'http://test-plex-server:32400',
+		PLEX_SERVER_URL: 'https://test-plex-server:32400',
 		PLEX_TOKEN: 'test-plex-token',
 		ENABLE_LIVE_SYNC: 'false',
 		OPENAI_API_KEY: '',
@@ -27,7 +27,7 @@ mock.module('$env/dynamic/private', () => ({
 
 // Mock SvelteKit's $env/static/private module for tests
 mock.module('$env/static/private', () => ({
-	PLEX_SERVER_URL: 'http://test-plex-server:32400',
+	PLEX_SERVER_URL: 'https://test-plex-server:32400',
 	PLEX_TOKEN: 'test-plex-token'
 }));
 

--- a/tests/unit/admin/settings-actions.test.ts
+++ b/tests/unit/admin/settings-actions.test.ts
@@ -171,6 +171,37 @@ describe('admin updateApiConfig schema hardening', () => {
 			data: { conflict: true }
 		});
 	});
+
+	it('rejects unchecked local HTTP Plex URL instead of relying on stored opt-in', async () => {
+		const dynamicEnv = env as Record<string, string | undefined>;
+		const previousPlexServerUrl = dynamicEnv.PLEX_SERVER_URL;
+		const previousAllowInsecure = dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP;
+		dynamicEnv.PLEX_SERVER_URL = '';
+		dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP = undefined;
+
+		try {
+			await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://192.168.1.10:32400');
+			await setAppSetting(AppSettingsKey.PLEX_ALLOW_INSECURE_LOCAL_HTTP, 'true');
+
+			const result = await runUpdateApiConfig(
+				createApiConfigRequest({
+					plexServerUrl: 'http://192.168.1.10:32400',
+					apiConfigVersion: new Date(Date.now() + 60_000).toISOString()
+				})
+			);
+
+			expect(result).toMatchObject({
+				status: 400,
+				data: {
+					error: 'HTTP Plex URLs require a local/private host and explicit local HTTP opt-in.'
+				}
+			});
+			expect(await getAppSetting(AppSettingsKey.PLEX_ALLOW_INSECURE_LOCAL_HTTP)).toBe('true');
+		} finally {
+			dynamicEnv.PLEX_SERVER_URL = previousPlexServerUrl;
+			dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP = previousAllowInsecure;
+		}
+	});
 });
 
 describe('admin clearOpenaiModel action', () => {

--- a/tests/unit/admin/settings.service.test.ts
+++ b/tests/unit/admin/settings.service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
+import { env } from '$env/dynamic/private';
 import {
 	AnonymizationMode,
 	AppSettingsKey,
@@ -22,6 +23,7 @@ import {
 	getCurrentTheme,
 	getDefaultYear,
 	getFunFactFrequency,
+	getPlexConfig,
 	getUITheme,
 	getWrappedLogoMode,
 	getWrappedTheme,
@@ -771,6 +773,49 @@ describe('Admin Settings Service', () => {
 			});
 		});
 
+		describe('getPlexConfig', () => {
+			it('treats local HTTP Plex URL without opt-in as not configured', async () => {
+				const dynamicEnv = env as Record<string, string | undefined>;
+				const previousPlexServerUrl = dynamicEnv.PLEX_SERVER_URL;
+				const previousAllowInsecure = dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP;
+				dynamicEnv.PLEX_SERVER_URL = '';
+				dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP = undefined;
+
+				try {
+					await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://192.168.1.10:32400');
+
+					const config = await getPlexConfig();
+
+					expect(config.serverUrl).toBe('');
+					expect(config.token).toBe('test-plex-token');
+				} finally {
+					dynamicEnv.PLEX_SERVER_URL = previousPlexServerUrl;
+					dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP = previousAllowInsecure;
+				}
+			});
+
+			it('treats public HTTP Plex URL as not configured even with opt-in', async () => {
+				const dynamicEnv = env as Record<string, string | undefined>;
+				const previousPlexServerUrl = dynamicEnv.PLEX_SERVER_URL;
+				const previousAllowInsecure = dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP;
+				dynamicEnv.PLEX_SERVER_URL = '';
+				dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP = undefined;
+
+				try {
+					await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://plex.example.com:32400');
+					await setAppSetting(AppSettingsKey.PLEX_ALLOW_INSECURE_LOCAL_HTTP, 'true');
+
+					const config = await getPlexConfig();
+
+					expect(config.serverUrl).toBe('');
+					expect(config.token).toBe('test-plex-token');
+				} finally {
+					dynamicEnv.PLEX_SERVER_URL = previousPlexServerUrl;
+					dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP = previousAllowInsecure;
+				}
+			});
+		});
+
 		describe('clearConflictingDbSettings', () => {
 			it('clears DB settings when ENV values exist', async () => {
 				// Plex env vars ARE set in test setup, so these DB values should be cleared
@@ -828,6 +873,25 @@ describe('Admin Settings Service', () => {
 				// Test setup mocks PLEX_SERVER_URL and PLEX_TOKEN via env
 				const configured = await isPlexConfigured();
 				expect(configured).toBe(true);
+			});
+
+			it('returns false when stored Plex URL fails policy validation', async () => {
+				const dynamicEnv = env as Record<string, string | undefined>;
+				const previousPlexServerUrl = dynamicEnv.PLEX_SERVER_URL;
+				const previousAllowInsecure = dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP;
+				dynamicEnv.PLEX_SERVER_URL = '';
+				dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP = undefined;
+
+				try {
+					await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://192.168.1.10:32400');
+
+					const configured = await isPlexConfigured();
+
+					expect(configured).toBe(false);
+				} finally {
+					dynamicEnv.PLEX_SERVER_URL = previousPlexServerUrl;
+					dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP = previousAllowInsecure;
+				}
 			});
 		});
 	});

--- a/tests/unit/admin/settings.service.test.ts
+++ b/tests/unit/admin/settings.service.test.ts
@@ -706,7 +706,7 @@ describe('Admin Settings Service', () => {
 				const config = await getApiConfigWithSources();
 
 				// Plex values come from env (test setup mocks PLEX_SERVER_URL and PLEX_TOKEN)
-				expect(config.plex.serverUrl.value).toBe('http://test-plex-server:32400');
+				expect(config.plex.serverUrl.value).toBe('https://test-plex-server:32400');
 				expect(config.plex.serverUrl.source).toBe('env');
 				expect(config.plex.serverUrl.isLocked).toBe(true);
 				expect(config.plex.token.value).toBe('test-plex-token');
@@ -746,7 +746,7 @@ describe('Admin Settings Service', () => {
 				const config = await getApiConfigWithSources();
 
 				// Plex settings should come from ENV (test setup mocks these)
-				expect(config.plex.serverUrl.value).toBe('http://test-plex-server:32400');
+				expect(config.plex.serverUrl.value).toBe('https://test-plex-server:32400');
 				expect(config.plex.serverUrl.source).toBe('env');
 				expect(config.plex.serverUrl.isLocked).toBe(true);
 				expect(config.plex.token.value).toBe('test-plex-token');

--- a/tests/unit/auth/login-completion.test.ts
+++ b/tests/unit/auth/login-completion.test.ts
@@ -6,6 +6,12 @@ import * as plexOauth from '$lib/server/auth/plex-oauth';
 import { db } from '$lib/server/db/client';
 import { sessions, users } from '$lib/server/db/schema';
 import * as onboarding from '$lib/server/onboarding';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken,
+	OnboardingClaimRequiredError
+} from '$lib/server/onboarding/bootstrap';
 
 interface CookieCall {
 	name: string;
@@ -40,6 +46,7 @@ describe('createSessionFromPlexToken', () => {
 	beforeEach(async () => {
 		await db.delete(sessions);
 		await db.delete(users);
+		clearBootstrapToken();
 
 		spies = [
 			spyOn(settingsService, 'getApiConfigWithSources').mockResolvedValue({
@@ -128,5 +135,60 @@ describe('createSessionFromPlexToken', () => {
 		}
 		expect(responseText).not.toContain('secret-auth-token');
 		expect(responseText).not.toContain('plex-user-token-from-profile');
+	});
+
+	it('rejects first-admin creation during fresh onboarding without an active setup claim', async () => {
+		spies.push(
+			spyOn(onboarding, 'requiresOnboarding').mockResolvedValue(true),
+			spyOn(settingsService, 'getApiConfigWithSources').mockResolvedValue({
+				plex: {
+					serverUrl: { value: '', source: 'default', isLocked: false },
+					token: { value: '', source: 'default', isLocked: false }
+				},
+				openai: {
+					apiKey: { value: '', source: 'default', isLocked: false },
+					baseUrl: { value: 'https://api.openai.com/v1', source: 'default', isLocked: false },
+					model: { value: 'gpt-5-mini', source: 'default', isLocked: false }
+				}
+			})
+		);
+
+		const { createSessionFromPlexToken } = await import('$lib/server/auth/login-completion');
+		await expect(
+			createSessionFromPlexToken('secret-auth-token', createCookies())
+		).rejects.toBeInstanceOf(OnboardingClaimRequiredError);
+	});
+
+	it('allows first-admin creation during fresh onboarding with an active setup claim', async () => {
+		spies.push(
+			spyOn(onboarding, 'requiresOnboarding').mockResolvedValue(true),
+			spyOn(settingsService, 'getApiConfigWithSources').mockResolvedValue({
+				plex: {
+					serverUrl: { value: '', source: 'default', isLocked: false },
+					token: { value: '', source: 'default', isLocked: false }
+				},
+				openai: {
+					apiKey: { value: '', source: 'default', isLocked: false },
+					baseUrl: { value: 'https://api.openai.com/v1', source: 'default', isLocked: false },
+					model: { value: 'gpt-5-mini', source: 'default', isLocked: false }
+				}
+			}),
+			spyOn(membership, 'verifyServerOwnership').mockResolvedValue({
+				isOwner: true,
+				serverName: 'Owned Plex'
+			})
+		);
+
+		const cookies = createCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies, token)).toBe('claimed');
+
+		const { createSessionFromPlexToken } = await import('$lib/server/auth/login-completion');
+		const result = await createSessionFromPlexToken('secret-auth-token', cookies);
+
+		expect(result).toEqual({
+			user: { username: 'alice', isAdmin: true },
+			redirectTo: '/admin'
+		});
 	});
 });

--- a/tests/unit/auth/login-completion.test.ts
+++ b/tests/unit/auth/login-completion.test.ts
@@ -159,6 +159,35 @@ describe('createSessionFromPlexToken', () => {
 		).rejects.toBeInstanceOf(OnboardingClaimRequiredError);
 	});
 
+	it('propagates unexpected setup claim renewal errors during fresh onboarding', async () => {
+		const unexpectedError = new Error('claim storage failed');
+
+		spies.push(
+			spyOn(onboarding, 'requiresOnboarding').mockResolvedValue(true),
+			spyOn(settingsService, 'getApiConfigWithSources').mockResolvedValue({
+				plex: {
+					serverUrl: { value: '', source: 'default', isLocked: false },
+					token: { value: '', source: 'default', isLocked: false }
+				},
+				openai: {
+					apiKey: { value: '', source: 'default', isLocked: false },
+					baseUrl: { value: 'https://api.openai.com/v1', source: 'default', isLocked: false },
+					model: { value: 'gpt-5-mini', source: 'default', isLocked: false }
+				}
+			}),
+			spyOn(onboarding, 'requireActiveOnboardingClaim').mockRejectedValue(unexpectedError)
+		);
+
+		const { createSessionFromPlexToken } = await import('$lib/server/auth/login-completion');
+		try {
+			await createSessionFromPlexToken('secret-auth-token', createCookies());
+			throw new Error('Expected setup claim renewal to fail');
+		} catch (err) {
+			expect(err).toBe(unexpectedError);
+			expect(err).not.toBeInstanceOf(OnboardingClaimRequiredError);
+		}
+	});
+
 	it('allows first-admin creation during fresh onboarding with an active setup claim', async () => {
 		spies.push(
 			spyOn(onboarding, 'requiresOnboarding').mockResolvedValue(true),

--- a/tests/unit/funfacts/service.test.ts
+++ b/tests/unit/funfacts/service.test.ts
@@ -612,6 +612,19 @@ describe('getFunFactsConfig', () => {
 		expect(config.aiTimeoutMs).toBe(10000);
 	});
 
+	it('uses defaults when an invalid base URL is configured without an API key', async () => {
+		await db.insert(appSettings).values({
+			key: AppSettingsKey.OPENAI_BASE_URL,
+			value: 'http://localhost:11434/v1'
+		});
+
+		const config = await getFunFactsConfig();
+
+		expect(config.aiEnabled).toBe(false);
+		expect(config.openaiApiKey).toBeUndefined();
+		expect(config.openaiBaseUrl).toBe('https://api.openai.com/v1');
+	});
+
 	it('returns aiEnabled true when API key is set', async () => {
 		await db.insert(appSettings).values({
 			key: AppSettingsKey.OPENAI_API_KEY,
@@ -873,6 +886,30 @@ describe('generateFunFacts', () => {
 		const facts = await generateFunFacts(stats, { count: 3, preferAI: false });
 
 		expect(facts).toHaveLength(3);
+	});
+
+	it('uses templates when the OpenAI base URL is invalid regardless of AI preference', async () => {
+		const warnMock = spyOn(console, 'warn').mockImplementation(() => {});
+		fetchMock = spyOn(globalThis, 'fetch').mockImplementation((() => {
+			throw new Error('AI generation should not be called');
+		}) as unknown as typeof fetch);
+
+		try {
+			await db.insert(appSettings).values([
+				{ key: AppSettingsKey.OPENAI_API_KEY, value: 'sk-test' },
+				{ key: AppSettingsKey.OPENAI_BASE_URL, value: 'https://user:pass@example.com/v1' }
+			]);
+
+			const stats = createMockUserStats();
+			const aiPreferredFacts = await generateFunFacts(stats, { count: 3 });
+			const templatesOnlyFacts = await generateFunFacts(stats, { count: 3, preferAI: false });
+
+			expect(aiPreferredFacts).toHaveLength(3);
+			expect(templatesOnlyFacts).toHaveLength(3);
+			expect(fetchMock).not.toHaveBeenCalled();
+		} finally {
+			warnMock.mockRestore();
+		}
 	});
 
 	it('falls back to templates when AI fails', async () => {

--- a/tests/unit/hooks/onboarding-bootstrap-origin.test.ts
+++ b/tests/unit/hooks/onboarding-bootstrap-origin.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'bun:test';
+
+describe('hooks onboarding bootstrap banner origin', () => {
+	it('does not pass request-derived origin to the bootstrap banner', async () => {
+		const source = await Bun.file('src/hooks.server.ts').text();
+
+		expect(source).toContain('await printOnboardingBootstrapBanner();');
+		expect(source).not.toContain('printOnboardingBootstrapBanner(event.url.origin');
+	});
+});

--- a/tests/unit/lib/server/funfacts/test-connection.test.ts
+++ b/tests/unit/lib/server/funfacts/test-connection.test.ts
@@ -86,6 +86,19 @@ describe('testOpenAIConnection', () => {
 		expect(JSON.parse(captured.body ?? '{}').model).toBe('gpt-4o-mini');
 	});
 
+	it('rejects HTTP baseUrl without calling fetch', async () => {
+		let fetchCalled = false;
+		globalThis.fetch = mock(async () => {
+			fetchCalled = true;
+			return new Response(null, { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test', 'http://custom.example.com/v1');
+
+		expect(result).toEqual({ success: false, error: 'OpenAI base URL must use HTTPS.' });
+		expect(fetchCalled).toBe(false);
+	});
+
 	it('maps 401 to authentication error', async () => {
 		globalThis.fetch = mock(async () => {
 			return new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' });

--- a/tests/unit/onboarding/bootstrap.test.ts
+++ b/tests/unit/onboarding/bootstrap.test.ts
@@ -18,11 +18,19 @@ import {
 
 function createCookies() {
 	const values = new Map<string, string>();
+	const options = new Map<string, { secure?: boolean }>();
 	return {
 		get: (name: string) => values.get(name),
-		set: (name: string, value: string) => values.set(name, value),
-		delete: (name: string) => values.delete(name),
-		values
+		set: (name: string, value: string, nextOptions: { secure?: boolean } = {}) => {
+			values.set(name, value);
+			options.set(name, nextOptions);
+		},
+		delete: (name: string) => {
+			values.delete(name);
+			options.delete(name);
+		},
+		values,
+		options
 	};
 }
 
@@ -82,6 +90,14 @@ describe('onboarding bootstrap token and claim', () => {
 		expect(printedSetupUrls(consoleInfoSpy)).toEqual(['/onboarding/claim']);
 	});
 
+	it('prints only one valid bootstrap token when banner calls race', async () => {
+		await Promise.all(Array.from({ length: 5 }, () => printOnboardingBootstrapBanner()));
+
+		const tokens = printedBootstrapTokens(consoleInfoSpy);
+		expect(tokens).toHaveLength(1);
+		expect(validateBootstrapToken(tokens[0] ?? '')).toBe(true);
+	});
+
 	it('prints a replacement token after the current banner token expires', async () => {
 		await printOnboardingBootstrapBanner();
 		const firstToken = printedBootstrapTokens(consoleInfoSpy)[0] ?? '';
@@ -110,6 +126,32 @@ describe('onboarding bootstrap token and claim', () => {
 		expect(rawProof).toBeTruthy();
 		expect(storedHash).toBeTruthy();
 		expect(storedHash).not.toBe(rawProof);
+	});
+
+	it('sets a non-secure claim cookie for HTTP request URLs', async () => {
+		const cookies = createCookies();
+		const token = createBootstrapToken();
+
+		expect(
+			await claimOnboardingInstance(cookies as unknown as Cookies, token, {
+				requestUrl: new URL('http://example.com/onboarding/claim')
+			})
+		).toBe('claimed');
+
+		expect(cookies.options.get(ONBOARDING_CLAIM_COOKIE)?.secure).toBe(false);
+	});
+
+	it('sets a secure claim cookie for HTTPS request URLs', async () => {
+		const cookies = createCookies();
+		const token = createBootstrapToken();
+
+		expect(
+			await claimOnboardingInstance(cookies as unknown as Cookies, token, {
+				requestUrl: new URL('https://example.com/onboarding/claim')
+			})
+		).toBe('claimed');
+
+		expect(cookies.options.get(ONBOARDING_CLAIM_COOKIE)?.secure).toBe(true);
 	});
 
 	it('rejects a competing claimant while the claim is active', async () => {

--- a/tests/unit/onboarding/bootstrap.test.ts
+++ b/tests/unit/onboarding/bootstrap.test.ts
@@ -113,6 +113,19 @@ describe('onboarding bootstrap token and claim', () => {
 		expect(validateBootstrapToken(replacementToken)).toBe(true);
 	});
 
+	it('caches completed onboarding after claim cleanup resets banner state', async () => {
+		await printOnboardingBootstrapBanner();
+		expect(printedBootstrapTokens(consoleInfoSpy)).toHaveLength(1);
+		await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+		await clearOnboardingClaim();
+
+		await printOnboardingBootstrapBanner();
+		await db.delete(appSettings);
+		await printOnboardingBootstrapBanner();
+
+		expect(printedBootstrapTokens(consoleInfoSpy)).toHaveLength(1);
+	});
+
 	it('stores only the claim proof hash and renews the same claimant', async () => {
 		const cookies = createCookies();
 		const token = createBootstrapToken();

--- a/tests/unit/onboarding/bootstrap.test.ts
+++ b/tests/unit/onboarding/bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import type { Cookies } from '@sveltejs/kit';
 import { AppSettingsKey, getAppSetting } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
@@ -12,6 +12,7 @@ import {
 	hasActiveOnboardingClaim,
 	isBootstrapTokenExpired,
 	ONBOARDING_CLAIM_COOKIE,
+	printOnboardingBootstrapBanner,
 	validateBootstrapToken
 } from '$lib/server/onboarding/bootstrap';
 
@@ -25,10 +26,24 @@ function createCookies() {
 	};
 }
 
+function printedBootstrapTokens(consoleInfoSpy: ReturnType<typeof spyOn>): string[] {
+	return (consoleInfoSpy.mock.calls as Array<[unknown]>)
+		.map(([message]) => String(message))
+		.filter((message) => message.startsWith('Bootstrap token: '))
+		.map((message) => message.replace('Bootstrap token: ', ''));
+}
+
 describe('onboarding bootstrap token and claim', () => {
+	let consoleInfoSpy: ReturnType<typeof spyOn>;
+
 	beforeEach(async () => {
 		await db.delete(appSettings);
 		clearBootstrapToken();
+		consoleInfoSpy = spyOn(console, 'info').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		consoleInfoSpy.mockRestore();
 	});
 
 	it('generates lowercase fixed-format bootstrap tokens', () => {
@@ -42,6 +57,21 @@ describe('onboarding bootstrap token and claim', () => {
 		clearBootstrapToken();
 		expect(isBootstrapTokenExpired()).toBe(true);
 		expect(validateBootstrapToken(token)).toBe(false);
+	});
+
+	it('prints a replacement token after the current banner token expires', async () => {
+		await printOnboardingBootstrapBanner('http://localhost');
+		const firstToken = printedBootstrapTokens(consoleInfoSpy)[0] ?? '';
+		expect(validateBootstrapToken(firstToken)).toBe(true);
+
+		createBootstrapToken(0);
+		await printOnboardingBootstrapBanner('http://localhost');
+
+		const tokens = printedBootstrapTokens(consoleInfoSpy);
+		const replacementToken = tokens[1] ?? '';
+		expect(tokens).toHaveLength(2);
+		expect(replacementToken).not.toBe(firstToken);
+		expect(validateBootstrapToken(replacementToken)).toBe(true);
 	});
 
 	it('stores only the claim proof hash and renews the same claimant', async () => {

--- a/tests/unit/onboarding/bootstrap.test.ts
+++ b/tests/unit/onboarding/bootstrap.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import type { Cookies } from '@sveltejs/kit';
+import { AppSettingsKey, getAppSetting } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	clearOnboardingClaim,
+	createBootstrapToken,
+	generateBootstrapToken,
+	hasActiveOnboardingClaim,
+	isBootstrapTokenExpired,
+	ONBOARDING_CLAIM_COOKIE,
+	validateBootstrapToken
+} from '$lib/server/onboarding/bootstrap';
+
+function createCookies() {
+	const values = new Map<string, string>();
+	return {
+		get: (name: string) => values.get(name),
+		set: (name: string, value: string) => values.set(name, value),
+		delete: (name: string) => values.delete(name),
+		values
+	};
+}
+
+describe('onboarding bootstrap token and claim', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		clearBootstrapToken();
+	});
+
+	it('generates lowercase fixed-format bootstrap tokens', () => {
+		expect(generateBootstrapToken()).toMatch(/^[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$/);
+	});
+
+	it('validates active tokens, expires them, and clears them', () => {
+		const token = createBootstrapToken(20);
+		expect(validateBootstrapToken(token)).toBe(true);
+		expect(validateBootstrapToken(`${token}x`)).toBe(false);
+		clearBootstrapToken();
+		expect(isBootstrapTokenExpired()).toBe(true);
+		expect(validateBootstrapToken(token)).toBe(false);
+	});
+
+	it('stores only the claim proof hash and renews the same claimant', async () => {
+		const cookies = createCookies();
+		const token = createBootstrapToken();
+
+		expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
+		expect(await hasActiveOnboardingClaim(cookies as unknown as Cookies)).toBe(true);
+		expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('renewed');
+
+		const rawProof = cookies.values.get(ONBOARDING_CLAIM_COOKIE);
+		const storedHash = await getAppSetting(AppSettingsKey.ONBOARDING_CLAIM_PROOF_HASH);
+		expect(rawProof).toBeTruthy();
+		expect(storedHash).toBeTruthy();
+		expect(storedHash).not.toBe(rawProof);
+	});
+
+	it('rejects a competing claimant while the claim is active', async () => {
+		const token = createBootstrapToken();
+		const first = createCookies();
+		const second = createCookies();
+
+		expect(await claimOnboardingInstance(first as unknown as Cookies, token)).toBe('claimed');
+		expect(await claimOnboardingInstance(second as unknown as Cookies, token)).toBe(
+			'already-claimed'
+		);
+	});
+
+	it('clears claim state', async () => {
+		const cookies = createCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
+
+		await clearOnboardingClaim();
+
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED)).toBeNull();
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIM_PROOF_HASH)).toBeNull();
+		expect(await hasActiveOnboardingClaim(cookies as unknown as Cookies)).toBe(false);
+	});
+});

--- a/tests/unit/onboarding/bootstrap.test.ts
+++ b/tests/unit/onboarding/bootstrap.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import type { Cookies } from '@sveltejs/kit';
-import { AppSettingsKey, getAppSetting } from '$lib/server/admin/settings.service';
+import { AppSettingsKey, getAppSetting, setAppSetting } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
 import {
@@ -33,6 +33,13 @@ function printedBootstrapTokens(consoleInfoSpy: ReturnType<typeof spyOn>): strin
 		.map((message) => message.replace('Bootstrap token: ', ''));
 }
 
+function printedSetupUrls(consoleInfoSpy: ReturnType<typeof spyOn>): string[] {
+	return (consoleInfoSpy.mock.calls as Array<[unknown]>)
+		.map(([message]) => String(message))
+		.filter((message) => message.startsWith('Setup URL: '))
+		.map((message) => message.replace('Setup URL: ', ''));
+}
+
 describe('onboarding bootstrap token and claim', () => {
 	let consoleInfoSpy: ReturnType<typeof spyOn>;
 
@@ -59,13 +66,29 @@ describe('onboarding bootstrap token and claim', () => {
 		expect(validateBootstrapToken(token)).toBe(false);
 	});
 
+	it('prints the configured CSRF origin for the setup URL', async () => {
+		await setAppSetting(AppSettingsKey.CSRF_ORIGIN, 'https://trusted.example.com');
+
+		await printOnboardingBootstrapBanner();
+
+		expect(printedSetupUrls(consoleInfoSpy)).toEqual([
+			'https://trusted.example.com/onboarding/claim'
+		]);
+	});
+
+	it('prints a relative setup URL when no trusted origin is configured', async () => {
+		await printOnboardingBootstrapBanner();
+
+		expect(printedSetupUrls(consoleInfoSpy)).toEqual(['/onboarding/claim']);
+	});
+
 	it('prints a replacement token after the current banner token expires', async () => {
-		await printOnboardingBootstrapBanner('http://localhost');
+		await printOnboardingBootstrapBanner();
 		const firstToken = printedBootstrapTokens(consoleInfoSpy)[0] ?? '';
 		expect(validateBootstrapToken(firstToken)).toBe(true);
 
 		createBootstrapToken(0);
-		await printOnboardingBootstrapBanner('http://localhost');
+		await printOnboardingBootstrapBanner();
 
 		const tokens = printedBootstrapTokens(consoleInfoSpy);
 		const replacementToken = tokens[1] ?? '';

--- a/tests/unit/onboarding/complete-summary.test.ts
+++ b/tests/unit/onboarding/complete-summary.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import type { Cookies } from '@sveltejs/kit';
+import { type Cookies, isRedirect } from '@sveltejs/kit';
 import {
 	AnonymizationMode,
 	AppSettingsKey,
@@ -28,10 +28,13 @@ const adminLocals = {
 	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
 } as unknown as App.Locals;
 
-function createCookies(): Cookies {
+function createCookies(errorToThrow?: Error): Cookies {
 	const values = new Map<string, string>();
 	return {
-		get: (name: string) => values.get(name),
+		get: (name: string) => {
+			if (errorToThrow) throw errorToThrow;
+			return values.get(name);
+		},
 		set: (name: string, value: string) => values.set(name, value),
 		delete: (name: string) => values.delete(name)
 	} as unknown as Cookies;
@@ -50,6 +53,39 @@ describe('onboarding completion summary', () => {
 		await db.delete(appSettings);
 		await db.delete(playHistory);
 		await db.delete(syncStatus);
+	});
+
+	it('redirects to claim when the active onboarding claim is missing', async () => {
+		try {
+			await load({
+				parent: async () => ({}),
+				locals: adminLocals,
+				url: new URL('http://localhost/onboarding/complete'),
+				cookies: createCookies()
+			} as Parameters<typeof load>[0]);
+			expect.unreachable('Expected missing onboarding claim to redirect');
+		} catch (err) {
+			expect(isRedirect(err)).toBe(true);
+			if (!isRedirect(err)) throw err;
+			expect(err.status).toBe(303);
+			expect(err.location).toBe('/onboarding/claim');
+		}
+	});
+
+	it('propagates unexpected onboarding claim failures', async () => {
+		const unexpected = new Error('unexpected claim cookie failure');
+
+		try {
+			await load({
+				parent: async () => ({}),
+				locals: adminLocals,
+				url: new URL('http://localhost/onboarding/complete'),
+				cookies: createCookies(unexpected)
+			} as Parameters<typeof load>[0]);
+			expect.unreachable('Expected unexpected claim error to be thrown');
+		} catch (err) {
+			expect(err).toBe(unexpected);
+		}
 	});
 
 	it('reflects the persisted onboarding configuration', async () => {

--- a/tests/unit/onboarding/complete-summary.test.ts
+++ b/tests/unit/onboarding/complete-summary.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
+import type { Cookies } from '@sveltejs/kit';
 import {
 	AnonymizationMode,
 	AppSettingsKey,
@@ -15,12 +16,34 @@ import {
 } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings, playHistory, syncStatus } from '$lib/server/db/schema';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken
+} from '$lib/server/onboarding/bootstrap';
 import { setGlobalShareDefaults } from '$lib/server/sharing/service';
 import { load } from '../../../src/routes/onboarding/complete/+page.server';
 
 const adminLocals = {
 	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
 } as unknown as App.Locals;
+
+function createCookies(): Cookies {
+	const values = new Map<string, string>();
+	return {
+		get: (name: string) => values.get(name),
+		set: (name: string, value: string) => values.set(name, value),
+		delete: (name: string) => values.delete(name)
+	} as unknown as Cookies;
+}
+
+async function createClaimedCookies(): Promise<Cookies> {
+	clearBootstrapToken();
+	const cookies = createCookies();
+	const token = createBootstrapToken();
+	expect(await claimOnboardingInstance(cookies, token)).toBe('claimed');
+	return cookies;
+}
 
 describe('onboarding completion summary', () => {
 	beforeEach(async () => {
@@ -42,7 +65,8 @@ describe('onboarding completion summary', () => {
 		const result = (await load({
 			parent: async () => ({}),
 			locals: adminLocals,
-			url: new URL('http://localhost/onboarding/complete')
+			url: new URL('http://localhost/onboarding/complete'),
+			cookies: await createClaimedCookies()
 		} as Parameters<typeof load>[0])) as {
 			configSummary: Record<string, string>;
 		};
@@ -63,7 +87,8 @@ describe('onboarding completion summary', () => {
 		const result = (await load({
 			parent: async () => ({}),
 			locals: adminLocals,
-			url: new URL('http://localhost/onboarding/complete?notice=ai-key-missing')
+			url: new URL('http://localhost/onboarding/complete?notice=ai-key-missing'),
+			cookies: await createClaimedCookies()
 		} as Parameters<typeof load>[0])) as { notice: string | null };
 
 		expect(result.notice).toBe('ai-key-missing');
@@ -73,7 +98,8 @@ describe('onboarding completion summary', () => {
 		const result = (await load({
 			parent: async () => ({}),
 			locals: adminLocals,
-			url: new URL('http://localhost/onboarding/complete?notice=evil')
+			url: new URL('http://localhost/onboarding/complete?notice=evil'),
+			cookies: await createClaimedCookies()
 		} as Parameters<typeof load>[0])) as { notice: string | null };
 
 		expect(result.notice).toBeNull();
@@ -86,7 +112,8 @@ describe('onboarding completion summary', () => {
 		const result = (await load({
 			parent: async () => ({}),
 			locals: adminLocals,
-			url: new URL('http://localhost/onboarding/complete')
+			url: new URL('http://localhost/onboarding/complete'),
+			cookies: await createClaimedCookies()
 		} as Parameters<typeof load>[0])) as {
 			configSummary: Record<string, string>;
 		};

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
+import type { Cookies } from '@sveltejs/kit';
 import { isRedirect } from '@sveltejs/kit';
 import {
 	AppSettingsKey,
@@ -9,6 +10,11 @@ import {
 import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
 import { getOnboardingStep, OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken
+} from '$lib/server/onboarding/bootstrap';
 import { actions } from '../../../src/routes/onboarding/csrf/+page.server';
 
 const ORIGIN = 'http://localhost:5173';
@@ -16,11 +22,22 @@ type SaveOriginAction = NonNullable<typeof actions.saveOrigin>;
 type SkipCsrfAction = NonNullable<typeof actions.skipCsrf>;
 type TestOriginAction = NonNullable<typeof actions.testOrigin>;
 
-function createFormRequest(csrfOrigin: string, origin = ORIGIN): Request {
+function createCookies() {
+	const values = new Map<string, string>();
+	return {
+		get: (name: string) => values.get(name),
+		set: (name: string, value: string) => values.set(name, value),
+		delete: (name: string) => values.delete(name)
+	};
+}
+
+let cookies: ReturnType<typeof createCookies>;
+
+function createFormRequest(csrfOrigin: string, origin = ORIGIN, requestBase = ORIGIN): Request {
 	const formData = new FormData();
 	formData.set('csrfOrigin', csrfOrigin);
 
-	return new Request(`${ORIGIN}/onboarding/csrf`, {
+	return new Request(`${requestBase}/onboarding/csrf`, {
 		method: 'POST',
 		headers: { origin },
 		body: formData
@@ -43,17 +60,25 @@ function createFormRequestWithRefererOnly(
 
 async function runSaveOrigin(request: Request) {
 	const saveOrigin = actions.saveOrigin as SaveOriginAction;
-	return saveOrigin({ request } as Parameters<SaveOriginAction>[0]);
+	return saveOrigin({
+		request,
+		cookies,
+		url: new URL(request.url)
+	} as unknown as Parameters<SaveOriginAction>[0]);
 }
 
 async function runTestOrigin(request: Request) {
 	const testOrigin = actions.testOrigin as TestOriginAction;
-	return testOrigin({ request } as Parameters<TestOriginAction>[0]);
+	return testOrigin({ request, cookies } as unknown as Parameters<TestOriginAction>[0]);
 }
 
 async function runSkipCsrf(request: Request) {
 	const skipCsrf = actions.skipCsrf as SkipCsrfAction;
-	return skipCsrf({ request, url: new URL(request.url) } as Parameters<SkipCsrfAction>[0]);
+	return skipCsrf({
+		request,
+		cookies,
+		url: new URL(request.url)
+	} as unknown as Parameters<SkipCsrfAction>[0]);
 }
 
 async function expectRedirect(run: () => Promise<unknown>, location: string) {
@@ -71,6 +96,11 @@ async function expectRedirect(run: () => Promise<unknown>, location: string) {
 describe('onboarding CSRF actions', () => {
 	beforeEach(async () => {
 		await db.delete(appSettings);
+		clearBootstrapToken();
+		cookies = createCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
+		await setOnboardingStep(OnboardingSteps.CSRF);
 	});
 
 	it('test origin succeeds when the submitted origin matches the browser origin', async () => {
@@ -148,7 +178,10 @@ describe('onboarding CSRF actions', () => {
 
 	it('saves a matching CSRF origin when the browser origin has an explicit default port', async () => {
 		await expectRedirect(
-			() => runSaveOrigin(createFormRequest('https://example.com', 'https://example.com:443')),
+			() =>
+				runSaveOrigin(
+					createFormRequest('https://example.com', 'https://example.com:443', 'https://example.com')
+				),
 			'/onboarding/plex'
 		);
 
@@ -186,6 +219,19 @@ describe('onboarding CSRF actions', () => {
 				error:
 					'Origin mismatch: browser sends "http://localhost:5173" but you configured "https://example.com"'
 			}
+		});
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
+	it('saveOrigin rejects cross-origin submissions without persisting the submitted origin', async () => {
+		const result = await runSaveOrigin(
+			createFormRequest('https://evil.example', 'https://evil.example')
+		);
+
+		expect(result).toEqual({
+			status: 403,
+			data: { error: 'CSRF origin must be submitted from this Obzorarr origin' }
 		});
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -33,6 +33,16 @@ function createCookies() {
 
 let cookies: ReturnType<typeof createCookies>;
 
+function createThrowingClaimCookies(errorToThrow: Error): ReturnType<typeof createCookies> {
+	return {
+		get: () => {
+			throw errorToThrow;
+		},
+		set: () => undefined,
+		delete: () => undefined
+	} as unknown as ReturnType<typeof createCookies>;
+}
+
 function createFormRequest(csrfOrigin: string, origin = ORIGIN, requestBase = ORIGIN): Request {
 	const formData = new FormData();
 	formData.set('csrfOrigin', csrfOrigin);
@@ -285,6 +295,24 @@ describe('onboarding CSRF actions', () => {
 
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)).toBeNull();
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
+	});
+
+	it('propagates unexpected claim errors for centralized sanitization', async () => {
+		const unexpected = new Error('raw database path should stay server-side');
+		cookies = createThrowingClaimCookies(unexpected);
+
+		for (const run of [
+			() => runTestOrigin(createFormRequest(ORIGIN)),
+			() => runSaveOrigin(createFormRequest(ORIGIN)),
+			() => runSkipCsrf(createFormRequest('not-a-url'))
+		]) {
+			try {
+				await run();
+				expect.unreachable('Expected unexpected claim error to be thrown');
+			} catch (err) {
+				expect(err).toBe(unexpected);
+			}
+		}
 	});
 
 	describe('onboarding-step guard', () => {

--- a/tests/unit/onboarding/page-action-claim-errors.test.ts
+++ b/tests/unit/onboarding/page-action-claim-errors.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'bun:test';
+import type { Cookies } from '@sveltejs/kit';
+import { ONBOARDING_CLAIM_REQUIRED_MESSAGE } from '$lib/server/onboarding/bootstrap';
+import { actions as plexActions } from '../../../src/routes/onboarding/plex/+page.server';
+import { actions as settingsActions } from '../../../src/routes/onboarding/settings/+page.server';
+import { actions as syncActions } from '../../../src/routes/onboarding/sync/+page.server';
+
+type Action = (event: unknown) => Promise<unknown>;
+
+const adminLocals = {
+	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
+} as unknown as App.Locals;
+
+const claimCheckedActions = [
+	['plex.verifyAdmin', plexActions.verifyAdmin],
+	['plex.continueAfterServerSelection', plexActions.continueAfterServerSelection],
+	['plex.forceManualSelection', plexActions.forceManualSelection],
+	['plex.confirmOwnershipOverride', plexActions.confirmOwnershipOverride],
+	['settings.saveSettings', settingsActions.saveSettings],
+	['settings.skipSettings', settingsActions.skipSettings],
+	['settings.testAIConnection', settingsActions.testAIConnection],
+	['sync.startSync', syncActions.startSync],
+	['sync.cancelSync', syncActions.cancelSync],
+	['sync.continue', syncActions.continue]
+] as const;
+
+function makeCookies(errorToThrow?: Error): Cookies {
+	return {
+		get: () => {
+			if (errorToThrow) throw errorToThrow;
+			return undefined;
+		},
+		getAll: () => [],
+		set: () => {},
+		delete: () => {},
+		serialize: () => ''
+	} as unknown as Cookies;
+}
+
+async function runAction(action: unknown, cookies: Cookies): Promise<unknown> {
+	const request = new Request('http://localhost/onboarding', {
+		method: 'POST',
+		body: new FormData()
+	});
+
+	return (action as Action)({
+		request,
+		locals: adminLocals,
+		cookies,
+		url: new URL(request.url)
+	});
+}
+
+describe('onboarding page action claim checks', () => {
+	for (const [name, action] of claimCheckedActions) {
+		it(`${name} returns the expected claim-required failure`, async () => {
+			const result = await runAction(action, makeCookies());
+
+			expect(result).toMatchObject({
+				status: 403,
+				data: { error: ONBOARDING_CLAIM_REQUIRED_MESSAGE }
+			});
+		});
+
+		it(`${name} propagates unexpected claim errors`, async () => {
+			const unexpected = new Error(`unexpected claim renewal failure in ${name}`);
+
+			try {
+				await runAction(action, makeCookies(unexpected));
+				expect.unreachable('Expected unexpected claim error to be thrown');
+			} catch (err) {
+				expect(err).toBe(unexpected);
+			}
+		});
+	}
+});

--- a/tests/unit/onboarding/select-server-endpoint.test.ts
+++ b/tests/unit/onboarding/select-server-endpoint.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import type { Cookies } from '@sveltejs/kit';
 import { isHttpError } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
 import {
 	AppSettingsKey,
 	getAppSetting,
-	getCachedServerName
+	getCachedServerName,
+	setAppSetting
 } from '$lib/server/admin/settings.service';
 import * as sessionModule from '$lib/server/auth/session';
 import { db } from '$lib/server/db/client';
@@ -169,6 +171,34 @@ describe('POST /api/onboarding/select-server', () => {
 		const body = (await response.json()) as { success: boolean };
 		expect(body.success).toBe(true);
 		expect(await getAppSetting(AppSettingsKey.PLEX_TOKEN)).toBe('legacy-token');
+	});
+
+	it('rejects unchecked local HTTP URLs instead of relying on stored opt-in', async () => {
+		const dynamicEnv = env as Record<string, string | undefined>;
+		const previousAllowInsecure = dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP;
+		dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP = undefined;
+
+		try {
+			await setAppSetting(AppSettingsKey.PLEX_ALLOW_INSECURE_LOCAL_HTTP, 'true');
+			fetchSpy = spyOn(global, 'fetch').mockResolvedValue(makeIdentityResponse());
+
+			const response = await runPost({
+				serverUrl: 'http://plex.local:32400',
+				allowInsecureLocalHttp: false,
+				accessToken: 'legacy-token',
+				serverName: 'Legacy Server'
+			});
+
+			expect(response.status).toBe(400);
+			const body = (await response.json()) as { success: boolean; error?: string };
+			expect(body).toEqual({
+				success: false,
+				error: 'HTTP Plex URLs require a local/private host and explicit local HTTP opt-in.'
+			});
+			expect(await getAppSetting(AppSettingsKey.PLEX_ALLOW_INSECURE_LOCAL_HTTP)).toBe('true');
+		} finally {
+			dynamicEnv.PLEX_ALLOW_INSECURE_LOCAL_HTTP = previousAllowInsecure;
+		}
 	});
 
 	it('returns the expected claim-required error when setup claim is missing', async () => {

--- a/tests/unit/onboarding/select-server-endpoint.test.ts
+++ b/tests/unit/onboarding/select-server-endpoint.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import type { Cookies } from '@sveltejs/kit';
 import {
 	AppSettingsKey,
 	getAppSetting,
@@ -7,6 +8,11 @@ import {
 import * as sessionModule from '$lib/server/auth/session';
 import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken
+} from '$lib/server/onboarding/bootstrap';
 import { POST } from '../../../src/routes/api/onboarding/select-server/+server';
 
 type HandlerArgs = Parameters<typeof POST>[0];
@@ -15,12 +21,14 @@ const adminLocals = {
 	user: { id: 1, plexId: 100, username: 'admin', isAdmin: true }
 } as HandlerArgs['locals'];
 
+let claimValues = new Map<string, string>();
+
 function makeCookies(sessionId?: string): HandlerArgs['cookies'] {
 	return {
-		get: (name: string) => (sessionId && name === 'session' ? sessionId : undefined),
+		get: (name: string) => (sessionId && name === 'session' ? sessionId : claimValues.get(name)),
 		getAll: () => [],
-		set: () => undefined,
-		delete: () => undefined,
+		set: (name: string, value: string) => claimValues.set(name, value),
+		delete: (name: string) => claimValues.delete(name),
 		serialize: () => ''
 	} as unknown as HandlerArgs['cookies'];
 }
@@ -57,6 +65,11 @@ describe('POST /api/onboarding/select-server', () => {
 
 	beforeEach(async () => {
 		await db.delete(appSettings);
+		clearBootstrapToken();
+		claimValues = new Map();
+		const cookies = makeCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
 		fetchSpy?.mockRestore();
 		getSessionPlexTokenSpy?.mockRestore();
 	});
@@ -86,6 +99,7 @@ describe('POST /api/onboarding/select-server', () => {
 		const response = await runPost(
 			{
 				serverUrl: 'http://plex.local:32400',
+				allowInsecureLocalHttp: true,
 				clientIdentifier: 'abc123',
 				serverName: 'Home Server'
 			},
@@ -115,6 +129,7 @@ describe('POST /api/onboarding/select-server', () => {
 
 		const response = await runPost({
 			serverUrl: 'http://plex.local:32400',
+			allowInsecureLocalHttp: true,
 			accessToken: 'legacy-token',
 			serverName: 'Legacy Server'
 		});

--- a/tests/unit/onboarding/select-server-endpoint.test.ts
+++ b/tests/unit/onboarding/select-server-endpoint.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import type { Cookies } from '@sveltejs/kit';
+import { isHttpError } from '@sveltejs/kit';
 import {
 	AppSettingsKey,
 	getAppSetting,
@@ -11,7 +12,8 @@ import { appSettings } from '$lib/server/db/schema';
 import {
 	claimOnboardingInstance,
 	clearBootstrapToken,
-	createBootstrapToken
+	createBootstrapToken,
+	ONBOARDING_CLAIM_REQUIRED_MESSAGE
 } from '$lib/server/onboarding/bootstrap';
 import { POST } from '../../../src/routes/api/onboarding/select-server/+server';
 
@@ -45,6 +47,35 @@ function runPost(body: unknown, sessionId?: string): ReturnType<typeof POST> {
 		locals: adminLocals,
 		cookies: makeCookies(sessionId)
 	} as unknown as HandlerArgs);
+}
+
+function runPostWithCookies(
+	body: unknown,
+	cookies: HandlerArgs['cookies']
+): ReturnType<typeof POST> {
+	const request = new Request('http://localhost/api/onboarding/select-server', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body)
+	});
+
+	return POST({
+		request,
+		locals: adminLocals,
+		cookies
+	} as unknown as HandlerArgs);
+}
+
+function makeThrowingClaimCookies(errorToThrow: Error): HandlerArgs['cookies'] {
+	return {
+		get: () => {
+			throw errorToThrow;
+		},
+		getAll: () => [],
+		set: () => {},
+		delete: () => {},
+		serialize: () => ''
+	} as unknown as HandlerArgs['cookies'];
 }
 
 function makeIdentityResponse(): Response {
@@ -138,5 +169,42 @@ describe('POST /api/onboarding/select-server', () => {
 		const body = (await response.json()) as { success: boolean };
 		expect(body.success).toBe(true);
 		expect(await getAppSetting(AppSettingsKey.PLEX_TOKEN)).toBe('legacy-token');
+	});
+
+	it('returns the expected claim-required error when setup claim is missing', async () => {
+		claimValues = new Map();
+
+		try {
+			await runPost({
+				serverUrl: 'https://plex.example.com:32400',
+				accessToken: 'legacy-token',
+				serverName: 'Legacy Server'
+			});
+			expect.unreachable('Expected error to be thrown');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			expect(err.status).toBe(403);
+			expect(err.body.message).toBe(ONBOARDING_CLAIM_REQUIRED_MESSAGE);
+		}
+	});
+
+	it('propagates unexpected claim errors for centralized sanitization', async () => {
+		const unexpected = new Error('raw database path should stay server-side');
+
+		try {
+			await runPostWithCookies(
+				{
+					serverUrl: 'https://plex.example.com:32400',
+					accessToken: 'legacy-token',
+					serverName: 'Legacy Server'
+				},
+				makeThrowingClaimCookies(unexpected)
+			);
+			expect.unreachable('Expected unexpected claim error to be thrown');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(false);
+			expect(err).toBe(unexpected);
+		}
 	});
 });

--- a/tests/unit/onboarding/servers-endpoint.test.ts
+++ b/tests/unit/onboarding/servers-endpoint.test.ts
@@ -1,16 +1,26 @@
 import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import type { Cookies } from '@sveltejs/kit';
 import { isHttpError } from '@sveltejs/kit';
 import * as sessionModule from '$lib/server/auth/session';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken
+} from '$lib/server/onboarding/bootstrap';
 import { GET } from '../../../src/routes/api/onboarding/servers/+server';
 
 type HandlerArgs = Parameters<typeof GET>[0];
 
+let claimValues = new Map<string, string>();
+
 function makeCookies(sessionId?: string): HandlerArgs['cookies'] {
 	return {
-		get: (name: string) => (sessionId && name === 'session' ? sessionId : undefined),
+		get: (name: string) => (sessionId && name === 'session' ? sessionId : claimValues.get(name)),
 		getAll: () => [],
-		set: () => undefined,
-		delete: () => undefined,
+		set: (name: string, value: string) => claimValues.set(name, value),
+		delete: (name: string) => claimValues.delete(name),
 		serialize: () => ''
 	} as unknown as HandlerArgs['cookies'];
 }
@@ -30,6 +40,15 @@ function createPlexResourcesResponse(resources: unknown[]): Response {
 }
 
 describe('GET /api/onboarding/servers', () => {
+	async function createClaim(): Promise<void> {
+		await db.delete(appSettings);
+		clearBootstrapToken();
+		claimValues = new Map();
+		const cookies = makeCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
+	}
+
 	afterEach(() => {
 		// bun:test's spyOn returns a spy that we reset by restoring the original
 		// module bindings; recreating spies per-test keeps state isolated.
@@ -64,6 +83,7 @@ describe('GET /api/onboarding/servers', () => {
 
 	describe('happy path — authenticated admin', () => {
 		it('returns servers list built from Plex resources', async () => {
+			await createClaim();
 			const publicUri = 'https://plex.example.plex.direct:32400';
 			const resources = [
 				{

--- a/tests/unit/onboarding/servers-endpoint.test.ts
+++ b/tests/unit/onboarding/servers-endpoint.test.ts
@@ -7,7 +7,8 @@ import { appSettings } from '$lib/server/db/schema';
 import {
 	claimOnboardingInstance,
 	clearBootstrapToken,
-	createBootstrapToken
+	createBootstrapToken,
+	ONBOARDING_CLAIM_REQUIRED_MESSAGE
 } from '$lib/server/onboarding/bootstrap';
 import { GET } from '../../../src/routes/api/onboarding/servers/+server';
 
@@ -25,11 +26,27 @@ function makeCookies(sessionId?: string): HandlerArgs['cookies'] {
 	} as unknown as HandlerArgs['cookies'];
 }
 
-function runGet(locals: HandlerArgs['locals'], sessionId?: string): ReturnType<typeof GET> {
+function runGet(
+	locals: HandlerArgs['locals'],
+	sessionId?: string,
+	cookies: HandlerArgs['cookies'] = makeCookies(sessionId)
+): ReturnType<typeof GET> {
 	return GET({
-		cookies: makeCookies(sessionId),
+		cookies,
 		locals
 	} as unknown as HandlerArgs);
+}
+
+function makeThrowingClaimCookies(errorToThrow: Error): HandlerArgs['cookies'] {
+	return {
+		get: () => {
+			throw errorToThrow;
+		},
+		getAll: () => [],
+		set: () => {},
+		delete: () => {},
+		serialize: () => ''
+	} as unknown as HandlerArgs['cookies'];
 }
 
 function createPlexResourcesResponse(resources: unknown[]): Response {
@@ -78,6 +95,37 @@ describe('GET /api/onboarding/servers', () => {
 			if (!isHttpError(err)) throw err;
 			expect(err.status).toBe(403);
 			expect(err.body.message).toBe('Only server owners can configure Obzorarr');
+		}
+	});
+
+	it('returns the expected claim-required error when setup claim is missing', async () => {
+		const locals = {
+			user: { id: 1, plexId: 100, username: 'admin', isAdmin: true }
+		} as HandlerArgs['locals'];
+
+		try {
+			await runGet(locals, 'test-session-id');
+			expect.unreachable('Expected error to be thrown');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			expect(err.status).toBe(403);
+			expect(err.body.message).toBe(ONBOARDING_CLAIM_REQUIRED_MESSAGE);
+		}
+	});
+
+	it('propagates unexpected claim errors for centralized sanitization', async () => {
+		const locals = {
+			user: { id: 1, plexId: 100, username: 'admin', isAdmin: true }
+		} as HandlerArgs['locals'];
+		const unexpected = new Error('raw database path should stay server-side');
+
+		try {
+			await runGet(locals, 'test-session-id', makeThrowingClaimCookies(unexpected));
+			expect.unreachable('Expected unexpected claim error to be thrown');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(false);
+			expect(err).toBe(unexpected);
 		}
 	});
 

--- a/tests/unit/onboarding/settings-actions.test.ts
+++ b/tests/unit/onboarding/settings-actions.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
+import type { Cookies } from '@sveltejs/kit';
 import { isRedirect } from '@sveltejs/kit';
 import {
 	AnonymizationMode,
@@ -16,6 +17,11 @@ import {
 import { db } from '$lib/server/db/client';
 import { appSettings, slideConfig } from '$lib/server/db/schema';
 import { getOnboardingStep, OnboardingSteps } from '$lib/server/onboarding';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken
+} from '$lib/server/onboarding/bootstrap';
 import { getGlobalAllowUserControl, getGlobalDefaultShareMode } from '$lib/server/sharing/service';
 import { initializeDefaultSlideConfig } from '$lib/server/slides/config.service';
 import { actions } from '../../../src/routes/onboarding/settings/+page.server';
@@ -26,6 +32,17 @@ type SaveSettingsAction = NonNullable<typeof actions.saveSettings>;
 const adminLocals = {
 	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
 } as unknown as App.Locals;
+
+let cookies: Cookies;
+
+function createCookies(): Cookies {
+	const values = new Map<string, string>();
+	return {
+		get: (name: string) => values.get(name),
+		set: (name: string, value: string) => values.set(name, value),
+		delete: (name: string) => values.delete(name)
+	} as unknown as Cookies;
+}
 
 function createSettingsRequest(overrides: Record<string, string> = {}): Request {
 	const formData = new FormData();
@@ -55,6 +72,7 @@ async function runSaveSettings(request: Request) {
 	return saveSettings({
 		request,
 		locals: adminLocals,
+		cookies,
 		url: new URL(request.url)
 	} as Parameters<SaveSettingsAction>[0]);
 }
@@ -75,6 +93,10 @@ describe('onboarding settings actions', () => {
 	beforeEach(async () => {
 		await db.delete(appSettings);
 		await db.delete(slideConfig);
+		clearBootstrapToken();
+		cookies = createCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies, token)).toBe('claimed');
 		await initializeDefaultSlideConfig();
 	});
 

--- a/tests/unit/onboarding/test-connection-endpoint.test.ts
+++ b/tests/unit/onboarding/test-connection-endpoint.test.ts
@@ -1,15 +1,25 @@
-import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import type { Cookies } from '@sveltejs/kit';
 import * as sessionModule from '$lib/server/auth/session';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken
+} from '$lib/server/onboarding/bootstrap';
 import { POST } from '../../../src/routes/api/onboarding/test-connection/+server';
 
 type HandlerArgs = Parameters<typeof POST>[0];
 
+let claimValues = new Map<string, string>();
+
 function makeCookies(sessionId?: string): HandlerArgs['cookies'] {
 	return {
-		get: (name: string) => (sessionId && name === 'session' ? sessionId : undefined),
+		get: (name: string) => (sessionId && name === 'session' ? sessionId : claimValues.get(name)),
 		getAll: () => [],
-		set: () => undefined,
-		delete: () => undefined,
+		set: (name: string, value: string) => claimValues.set(name, value),
+		delete: (name: string) => claimValues.delete(name),
 		serialize: () => ''
 	} as unknown as HandlerArgs['cookies'];
 }
@@ -66,6 +76,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 
 		const response = await runPost(adminLocals, {
 			url: 'http://plex.local:32400',
+			allowInsecureLocalHttp: true,
 			accessToken: 'plex-token-abc'
 		});
 
@@ -81,6 +92,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 
 		const response = await runPost(adminLocals, {
 			url: 'http://plex.local:32400',
+			allowInsecureLocalHttp: true,
 			token: 'plex-token-xyz'
 		});
 
@@ -116,6 +128,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 			adminLocals,
 			{
 				url: 'http://plex.local:32400',
+				allowInsecureLocalHttp: true,
 				clientIdentifier: 'abc123'
 			},
 			'test-session-id'
@@ -158,6 +171,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 
 		const response = await runPost(adminLocals, {
 			url: 'http://plex.local:32400',
+			allowInsecureLocalHttp: true,
 			accessToken: 'bad'
 		});
 
@@ -172,6 +186,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 
 		const response = await runPost(adminLocals, {
 			url: 'http://plex.local:32400',
+			allowInsecureLocalHttp: true,
 			accessToken: 'abc'
 		});
 
@@ -190,6 +205,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 
 		const response = await runPost(adminLocals, {
 			url: 'http://plex.local:32400',
+			allowInsecureLocalHttp: true,
 			accessToken: 'abc'
 		});
 
@@ -206,6 +222,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 
 		const response = await runPost(adminLocals, {
 			url: 'http://plex.local:32400',
+			allowInsecureLocalHttp: true,
 			accessToken: 'abc'
 		});
 
@@ -220,6 +237,7 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 
 		const response = await runPost(adminLocals, {
 			url: 'http://plex.local:32400',
+			allowInsecureLocalHttp: true,
 			accessToken: 'abc'
 		});
 
@@ -227,4 +245,12 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 		const body = (await response.json()) as { success: boolean };
 		expect(body.success).toBe(false);
 	});
+});
+beforeEach(async () => {
+	await db.delete(appSettings);
+	clearBootstrapToken();
+	claimValues = new Map();
+	const cookies = makeCookies();
+	const token = createBootstrapToken();
+	expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
 });

--- a/tests/unit/onboarding/test-connection-endpoint.test.ts
+++ b/tests/unit/onboarding/test-connection-endpoint.test.ts
@@ -93,6 +93,15 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 	let fetchSpy: ReturnType<typeof spyOn>;
 	let getSessionPlexTokenSpy: ReturnType<typeof spyOn>;
 
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		clearBootstrapToken();
+		claimValues = new Map();
+		const cookies = makeCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
+	});
+
 	afterEach(() => {
 		fetchSpy?.mockRestore();
 		getSessionPlexTokenSpy?.mockRestore();
@@ -308,12 +317,4 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 		const body = (await response.json()) as { success: boolean };
 		expect(body.success).toBe(false);
 	});
-});
-beforeEach(async () => {
-	await db.delete(appSettings);
-	clearBootstrapToken();
-	claimValues = new Map();
-	const cookies = makeCookies();
-	const token = createBootstrapToken();
-	expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
 });

--- a/tests/unit/onboarding/test-connection-endpoint.test.ts
+++ b/tests/unit/onboarding/test-connection-endpoint.test.ts
@@ -1,12 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
-import type { Cookies } from '@sveltejs/kit';
+import { type Cookies, isHttpError } from '@sveltejs/kit';
 import * as sessionModule from '$lib/server/auth/session';
 import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
 import {
 	claimOnboardingInstance,
 	clearBootstrapToken,
-	createBootstrapToken
+	createBootstrapToken,
+	ONBOARDING_CLAIM_REQUIRED_MESSAGE
 } from '$lib/server/onboarding/bootstrap';
 import { POST } from '../../../src/routes/api/onboarding/test-connection/+server';
 
@@ -36,6 +37,32 @@ function runPost(
 	});
 
 	return POST({ request, locals, cookies: makeCookies(sessionId) } as unknown as HandlerArgs);
+}
+
+function runPostWithCookies(
+	locals: HandlerArgs['locals'],
+	body: unknown,
+	cookies: HandlerArgs['cookies']
+): ReturnType<typeof POST> {
+	const request = new Request('http://localhost/api/onboarding/test-connection', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body)
+	});
+
+	return POST({ request, locals, cookies } as unknown as HandlerArgs);
+}
+
+function makeThrowingClaimCookies(errorToThrow: Error): HandlerArgs['cookies'] {
+	return {
+		get: () => {
+			throw errorToThrow;
+		},
+		getAll: () => [],
+		set: () => {},
+		delete: () => {},
+		serialize: () => ''
+	} as unknown as HandlerArgs['cookies'];
 }
 
 function makeIdentityResponse(): Response {
@@ -69,6 +96,42 @@ describe('POST /api/onboarding/test-connection token alias', () => {
 	afterEach(() => {
 		fetchSpy?.mockRestore();
 		getSessionPlexTokenSpy?.mockRestore();
+	});
+
+	it('returns the expected claim-required error when setup claim is missing', async () => {
+		claimValues = new Map();
+
+		try {
+			await runPost(adminLocals, {
+				url: 'https://plex.example.com:32400',
+				accessToken: 'abc'
+			});
+			expect.unreachable('Expected error to be thrown');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			expect(err.status).toBe(403);
+			expect(err.body.message).toBe(ONBOARDING_CLAIM_REQUIRED_MESSAGE);
+		}
+	});
+
+	it('propagates unexpected claim errors for centralized sanitization', async () => {
+		const unexpected = new Error('raw database path should stay server-side');
+
+		try {
+			await runPostWithCookies(
+				adminLocals,
+				{
+					url: 'https://plex.example.com:32400',
+					accessToken: 'abc'
+				},
+				makeThrowingClaimCookies(unexpected)
+			);
+			expect.unreachable('Expected unexpected claim error to be thrown');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(false);
+			expect(err).toBe(unexpected);
+		}
 	});
 
 	it('accepts the canonical accessToken field', async () => {

--- a/tests/unit/plex/server-identity.service.test.ts
+++ b/tests/unit/plex/server-identity.service.test.ts
@@ -7,7 +7,7 @@ import {
 } from '$lib/server/plex/server-identity.service';
 
 const MOCK_MACHINE_ID = 'a'.repeat(32);
-const MOCK_URL = 'http://plex.example.com:32400';
+const MOCK_URL = 'https://plex.example.com:32400';
 const MOCK_TOKEN = 'plex-token';
 
 function createMockResponse(data: unknown, ok = true, status = 200): Response {

--- a/tests/unit/security/credentialed-url.test.ts
+++ b/tests/unit/security/credentialed-url.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import {
 	CredentialedUrlError,
+	isLocalOrPrivateHost,
 	normalizeOpenAIBaseUrl,
 	normalizePlexServerUrl
 } from '$lib/server/security/credentialed-url';
@@ -31,6 +32,22 @@ describe('credentialed URL policy', () => {
 		).toThrow(CredentialedUrlError);
 	});
 
+	it('does not treat public DNS names beginning with fc or fd as local/private', () => {
+		expect(isLocalOrPrivateHost('fc-public.example.com')).toBe(false);
+		expect(isLocalOrPrivateHost('fdplex.example.com')).toBe(false);
+
+		expect(() =>
+			normalizePlexServerUrl('http://fc-public.example.com:32400', {
+				allowInsecureLocalHttp: true
+			})
+		).toThrow(CredentialedUrlError);
+		expect(() =>
+			normalizePlexServerUrl('http://fdplex.example.com:32400', {
+				allowInsecureLocalHttp: true
+			})
+		).toThrow(CredentialedUrlError);
+	});
+
 	it('requires opt-in for local/private HTTP Plex URLs', () => {
 		expect(() =>
 			normalizePlexServerUrl('http://192.168.1.10:32400', {
@@ -43,6 +60,17 @@ describe('credentialed URL policy', () => {
 				allowInsecureLocalHttp: true
 			})
 		).toBe('http://192.168.1.10:32400');
+	});
+
+	it('allows HTTP Plex URLs for IPv6 ULA literals when opted in', () => {
+		expect(isLocalOrPrivateHost('fc00::1')).toBe(true);
+		expect(isLocalOrPrivateHost('fd12:3456::1')).toBe(true);
+
+		expect(
+			normalizePlexServerUrl('http://[fd00::1]:32400/', {
+				allowInsecureLocalHttp: true
+			})
+		).toBe('http://[fd00::1]:32400');
 	});
 
 	it('rejects credentials, query strings, and fragments in base URLs', () => {

--- a/tests/unit/security/credentialed-url.test.ts
+++ b/tests/unit/security/credentialed-url.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	CredentialedUrlError,
+	normalizeOpenAIBaseUrl,
+	normalizePlexServerUrl
+} from '$lib/server/security/credentialed-url';
+
+describe('credentialed URL policy', () => {
+	it('accepts HTTPS Plex and OpenAI URLs', () => {
+		expect(
+			normalizePlexServerUrl(' https://plex.example.com:32400/ ', {
+				allowInsecureLocalHttp: false
+			})
+		).toBe('https://plex.example.com:32400');
+		expect(normalizeOpenAIBaseUrl('https://api.example.com/v1/')).toBe(
+			'https://api.example.com/v1'
+		);
+	});
+
+	it('rejects OpenAI HTTP URLs', () => {
+		expect(() => normalizeOpenAIBaseUrl('http://api.example.com/v1')).toThrow(
+			'OpenAI base URL must use HTTPS.'
+		);
+	});
+
+	it('rejects public HTTP Plex URLs even with opt-in', () => {
+		expect(() =>
+			normalizePlexServerUrl('http://plex.example.com:32400', {
+				allowInsecureLocalHttp: true
+			})
+		).toThrow(CredentialedUrlError);
+	});
+
+	it('requires opt-in for local/private HTTP Plex URLs', () => {
+		expect(() =>
+			normalizePlexServerUrl('http://192.168.1.10:32400', {
+				allowInsecureLocalHttp: false
+			})
+		).toThrow('HTTP Plex URLs require a local/private host and explicit local HTTP opt-in.');
+
+		expect(
+			normalizePlexServerUrl('http://192.168.1.10:32400/', {
+				allowInsecureLocalHttp: true
+			})
+		).toBe('http://192.168.1.10:32400');
+	});
+
+	it('rejects credentials, query strings, and fragments in base URLs', () => {
+		expect(() => normalizeOpenAIBaseUrl('https://user:pass@example.com/v1')).toThrow();
+		expect(() => normalizeOpenAIBaseUrl('https://example.com/v1?x=1')).toThrow();
+		expect(() => normalizeOpenAIBaseUrl('https://example.com/v1#frag')).toThrow();
+	});
+});


### PR DESCRIPTION
## Summary

- Add a bootstrap token and setup claim gate before first-run onboarding or Plex OAuth admin creation can proceed.
- Enforce same-origin, claim-gated first-run CSRF origin setup.
- Add a credentialed URL policy for Plex and OpenAI requests, including an explicit local HTTP Plex opt-in.

## Details

- Introduces `/onboarding/claim` as the default first onboarding step for fresh installs.
- Generates a short-lived server-only bootstrap token and prints it to stdout only while onboarding is required.
- Stores only a SHA-256 hash of the onboarding claim proof in app settings while keeping the raw proof in an HTTP-only, SameSite Strict cookie.
- Gates onboarding pages, onboarding API endpoints, and first-admin Plex OAuth completion on an active onboarding claim.
- Clears bootstrap token and claim state when onboarding completes or is reset.
- Requires first-run CSRF origin persistence to be both claim-gated and same-origin with the submitted browser request.
- Rejects token-bearing OpenAI base URLs unless they use HTTPS.
- Rejects Plex HTTP URLs unless the host is local or private and the explicit local HTTP opt-in is enabled.
- Adds onboarding and admin settings controls for allowing insecure local HTTP Plex connections, and persists that opt-in only when saving an eligible HTTP Plex URL.

## Verification

- `bun run check`
- `bun run check:biome`
- `bun run test`