### PR TITLE
fix: remediate dogfood QA findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ bundle-stats.html
 
 # Test artifacts
 screenshots/
+dogfood-output/

--- a/scripts/scrub-dogfood-output.ts
+++ b/scripts/scrub-dogfood-output.ts
@@ -23,8 +23,8 @@ const TEXT_EXTENSIONS = new Set([
 	'.yml'
 ]);
 
-const envPath = path.resolve(process.cwd(), '.env');
-const outputRoot = path.resolve(process.cwd(), 'dogfood-output');
+const envPath = path.resolve(process.cwd(), process.env.DOGFOOD_ENV_PATH ?? '.env');
+const outputRoot = path.resolve(process.cwd(), process.env.DOGFOOD_OUTPUT_ROOT ?? 'dogfood-output');
 const writeChanges = Bun.argv.includes('--write');
 
 type Secret = {
@@ -33,6 +33,8 @@ type Secret = {
 	placeholder: string;
 	pathPlaceholder: string;
 };
+
+type RedactionResult = { text: string; keys: string[] };
 
 function parseEnv(content: string): Map<string, string> {
 	const values = new Map<string, string>();
@@ -56,7 +58,30 @@ function parseEnv(content: string): Map<string, string> {
 	return values;
 }
 
-function redactText(text: string, secrets: Secret[]): { text: string; keys: string[] } {
+function redactDynamicDogfoodSecrets(text: string): RedactionResult {
+	let redacted = text;
+	const found = new Set<string>();
+
+	const bootstrapTokenPattern = /Bootstrap token:\s+[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}/gi;
+	if (bootstrapTokenPattern.test(redacted)) {
+		redacted = redacted.replace(bootstrapTokenPattern, 'Bootstrap token: <BOOTSTRAP_TOKEN>');
+		found.add('BOOTSTRAP_TOKEN');
+	}
+
+	const claimCookiePatterns: Array<[RegExp, string]> = [
+		[/(\bobzorarr_onboarding_claim=)[^;\s"'`]+/g, '$1<ONBOARDING_CLAIM_COOKIE>'],
+		[/(["']obzorarr_onboarding_claim["']\s*:\s*["'])[^"']+(["'])/g, '$1<ONBOARDING_CLAIM_COOKIE>$2']
+	];
+	for (const [pattern, replacement] of claimCookiePatterns) {
+		if (!pattern.test(redacted)) continue;
+		redacted = redacted.replace(pattern, replacement);
+		found.add('ONBOARDING_CLAIM_COOKIE');
+	}
+
+	return { text: redacted, keys: [...found] };
+}
+
+function redactText(text: string, secrets: Secret[]): RedactionResult {
 	let redacted = text;
 	const found = new Set<string>();
 
@@ -65,6 +90,10 @@ function redactText(text: string, secrets: Secret[]): { text: string; keys: stri
 		redacted = redacted.split(secret.value).join(secret.placeholder);
 		found.add(secret.key);
 	}
+
+	const dynamicResult = redactDynamicDogfoodSecrets(redacted);
+	redacted = dynamicResult.text;
+	for (const key of dynamicResult.keys) found.add(key);
 
 	return { text: redacted, keys: [...found] };
 }
@@ -108,64 +137,70 @@ function redactedPath(filePath: string, secrets: Secret[]): { filePath: string; 
 	return { filePath: path.join(outputRoot, nextPath), keys: [...found] };
 }
 
-const envFile = Bun.file(envPath);
-if (!(await envFile.exists())) {
-	console.error('No .env file found; cannot compare dogfood artifacts against runtime secrets.');
-	process.exit(1);
-}
+async function main(): Promise<void> {
+	const envFile = Bun.file(envPath);
+	if (!(await envFile.exists())) {
+		console.error('No .env file found; cannot compare dogfood artifacts against runtime secrets.');
+		process.exit(1);
+	}
 
-const envValues = parseEnv(await envFile.text());
-const secrets = SECRET_KEYS.map((key) => {
-	const value = envValues.get(key)?.trim() ?? '';
-	return value ? { key, value, placeholder: `<${key}>`, pathPlaceholder: `__${key}__` } : null;
-})
-	.filter((secret): secret is Secret => secret !== null)
-	.sort((a, b) => b.value.length - a.value.length);
+	const envValues = parseEnv(await envFile.text());
+	const secrets = SECRET_KEYS.map((key) => {
+		const value = envValues.get(key)?.trim() ?? '';
+		return value ? { key, value, placeholder: `<${key}>`, pathPlaceholder: `__${key}__` } : null;
+	})
+		.filter((secret): secret is Secret => secret !== null)
+		.sort((a, b) => b.value.length - a.value.length);
 
-if (secrets.length === 0) {
-	console.error('No configured secret values found in .env.');
-	process.exit(1);
-}
+	if (secrets.length === 0) {
+		console.error('No configured secret values found in .env.');
+		process.exit(1);
+	}
 
-const files = await listFiles(outputRoot);
-const findings: Array<{ file: string; keys: string[]; type: 'content' | 'filename' }> = [];
+	const files = await listFiles(outputRoot);
+	const findings: Array<{ file: string; keys: string[]; type: 'content' | 'filename' }> = [];
 
-for (const filePath of files) {
-	let currentPath = filePath;
-	const pathResult = redactedPath(filePath, secrets);
-	if (pathResult.keys.length > 0) {
-		if (writeChanges) {
-			await mkdir(path.dirname(pathResult.filePath), { recursive: true });
-			await rename(filePath, pathResult.filePath);
-			currentPath = pathResult.filePath;
+	for (const filePath of files) {
+		let currentPath = filePath;
+		const pathResult = redactedPath(filePath, secrets);
+		if (pathResult.keys.length > 0) {
+			if (writeChanges) {
+				await mkdir(path.dirname(pathResult.filePath), { recursive: true });
+				await rename(filePath, pathResult.filePath);
+				currentPath = pathResult.filePath;
+			}
+			findings.push({ file: currentPath, keys: pathResult.keys, type: 'filename' });
 		}
-		findings.push({ file: currentPath, keys: pathResult.keys, type: 'filename' });
+
+		if (!(await isLikelyTextFile(currentPath))) continue;
+
+		const original = await Bun.file(currentPath).text();
+		const result = redactText(original, secrets);
+		if (result.keys.length === 0) continue;
+
+		findings.push({ file: currentPath, keys: result.keys, type: 'content' });
+		if (writeChanges) {
+			await writeFile(currentPath, result.text);
+		}
 	}
 
-	if (!(await isLikelyTextFile(currentPath))) continue;
+	if (findings.length === 0) {
+		console.log('No configured .env secrets found in dogfood-output text artifacts or filenames.');
+		process.exit(0);
+	}
 
-	const original = await Bun.file(currentPath).text();
-	const result = redactText(original, secrets);
-	if (result.keys.length === 0) continue;
+	for (const finding of findings) {
+		console.log(
+			`${writeChanges ? 'Redacted' : 'Found'} ${finding.type} secret(s) ${finding.keys.join(', ')} in ${path.relative(process.cwd(), finding.file)}`
+		);
+	}
 
-	findings.push({ file: currentPath, keys: result.keys, type: 'content' });
-	if (writeChanges) {
-		await writeFile(currentPath, result.text);
+	if (!writeChanges) {
+		console.error('Run `bun run dogfood:scrub -- --write` to redact text artifacts.');
+		process.exit(1);
 	}
 }
 
-if (findings.length === 0) {
-	console.log('No configured .env secrets found in dogfood-output text artifacts or filenames.');
-	process.exit(0);
-}
-
-for (const finding of findings) {
-	console.log(
-		`${writeChanges ? 'Redacted' : 'Found'} ${finding.type} secret(s) ${finding.keys.join(', ')} in ${path.relative(process.cwd(), finding.file)}`
-	);
-}
-
-if (!writeChanges) {
-	console.error('Run `bun run dogfood:scrub -- --write` to redact text artifacts.');
-	process.exit(1);
+if (import.meta.main) {
+	await main();
 }

--- a/scripts/scrub-dogfood-output.ts
+++ b/scripts/scrub-dogfood-output.ts
@@ -23,8 +23,16 @@ const TEXT_EXTENSIONS = new Set([
 	'.yml'
 ]);
 
-const envPath = path.resolve(process.cwd(), process.env.DOGFOOD_ENV_PATH ?? '.env');
-const outputRoot = path.resolve(process.cwd(), process.env.DOGFOOD_OUTPUT_ROOT ?? 'dogfood-output');
+function resolveConfiguredPath(envKey: string, fallback: string): string {
+	const configuredPath = process.env[envKey];
+	return path.resolve(
+		process.cwd(),
+		configuredPath === '' || configuredPath === undefined ? fallback : configuredPath
+	);
+}
+
+const envPath = resolveConfiguredPath('DOGFOOD_ENV_PATH', '.env');
+const outputRoot = resolveConfiguredPath('DOGFOOD_OUTPUT_ROOT', 'dogfood-output');
 const writeChanges = Bun.argv.includes('--write');
 
 type Secret = {
@@ -139,12 +147,13 @@ function redactedPath(filePath: string, secrets: Secret[]): { filePath: string; 
 
 async function main(): Promise<void> {
 	const envFile = Bun.file(envPath);
-	if (!(await envFile.exists())) {
-		console.error('No .env file found; cannot compare dogfood artifacts against runtime secrets.');
-		process.exit(1);
+	const hasEnvFile = await envFile.exists();
+	const envValues = hasEnvFile ? parseEnv(await envFile.text()) : new Map<string, string>();
+
+	if (!hasEnvFile) {
+		console.warn('No .env file found; continuing with dynamic redactions only.');
 	}
 
-	const envValues = parseEnv(await envFile.text());
 	const secrets = SECRET_KEYS.map((key) => {
 		const value = envValues.get(key)?.trim() ?? '';
 		return value ? { key, value, placeholder: `<${key}>`, pathPlaceholder: `__${key}__` } : null;
@@ -152,7 +161,7 @@ async function main(): Promise<void> {
 		.filter((secret): secret is Secret => secret !== null)
 		.sort((a, b) => b.value.length - a.value.length);
 
-	if (secrets.length === 0) {
+	if (hasEnvFile && secrets.length === 0) {
 		console.warn('No configured secret values found in .env; continuing with dynamic redactions.');
 	}
 

--- a/scripts/scrub-dogfood-output.ts
+++ b/scripts/scrub-dogfood-output.ts
@@ -169,7 +169,7 @@ async function main(): Promise<void> {
 				await rename(filePath, pathResult.filePath);
 				currentPath = pathResult.filePath;
 			}
-			findings.push({ file: currentPath, keys: pathResult.keys, type: 'filename' });
+			findings.push({ file: pathResult.filePath, keys: pathResult.keys, type: 'filename' });
 		}
 
 		if (!(await isLikelyTextFile(currentPath))) continue;

--- a/scripts/scrub-dogfood-output.ts
+++ b/scripts/scrub-dogfood-output.ts
@@ -153,8 +153,7 @@ async function main(): Promise<void> {
 		.sort((a, b) => b.value.length - a.value.length);
 
 	if (secrets.length === 0) {
-		console.error('No configured secret values found in .env.');
-		process.exit(1);
+		console.warn('No configured secret values found in .env; continuing with dynamic redactions.');
 	}
 
 	const files = await listFiles(outputRoot);

--- a/scripts/scrub-dogfood-output.ts
+++ b/scripts/scrub-dogfood-output.ts
@@ -178,7 +178,7 @@ async function main(): Promise<void> {
 		const result = redactText(original, secrets);
 		if (result.keys.length === 0) continue;
 
-		findings.push({ file: currentPath, keys: result.keys, type: 'content' });
+		findings.push({ file: pathResult.filePath, keys: result.keys, type: 'content' });
 		if (writeChanges) {
 			await writeFile(currentPath, result.text);
 		}

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -185,7 +185,8 @@ const CsrfOriginSchema = z.object({
 });
 
 const TrustProxySchema = z.object({
-	enabled: z.enum(['true', 'false']).transform((v) => v === 'true')
+	enabled: z.enum(['true', 'false']).transform((v) => v === 'true'),
+	confirmRisk: z.enum(['true']).optional()
 });
 
 interface SettingValue {
@@ -1111,11 +1112,19 @@ export const actions: Actions = requireAdminActions({
 		}
 
 		const formData = await request.formData();
-		const parsed = TrustProxySchema.safeParse({ enabled: formData.get('enabled') });
+		const parsed = TrustProxySchema.safeParse({
+			enabled: formData.get('enabled'),
+			confirmRisk: formData.get('confirmRisk') ?? undefined
+		});
 		if (!parsed.success) {
 			return fail(400, { error: 'Invalid input: enabled must be "true" or "false"' });
 		}
 		const enabled = parsed.data.enabled;
+		if (enabled && parsed.data.confirmRisk !== 'true') {
+			return fail(400, {
+				error: 'Confirm the reverse-proxy header trust risk before enabling TRUST_PROXY.'
+			});
+		}
 
 		try {
 			await setAppSetting(AppSettingsKey.TRUST_PROXY, enabled ? 'true' : 'false');

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -1117,7 +1117,10 @@ export const actions: Actions = requireAdminActions({
 			confirmRisk: formData.get('confirmRisk') ?? undefined
 		});
 		if (!parsed.success) {
-			return fail(400, { error: 'Invalid input: enabled must be "true" or "false"' });
+			return fail(400, {
+				error:
+					'Invalid input: enabled must be "true" or "false"; confirmRisk must be "true" when provided'
+			});
 		}
 		const enabled = parsed.data.enabled;
 		if (enabled && parsed.data.confirmRisk !== 'true') {

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -468,6 +468,8 @@ let trustProxyValue = $state(false);
 let trustProxySource = $state<'env' | 'db' | 'default'>('default');
 let trustProxyLocked = $state(false);
 let isSavingTrustProxy = $state(false);
+let trustProxyConfirmDialogOpen = $state(false);
+let isConfirmingTrustProxy = $state(false);
 
 // CSRF mismatch confirmation dialog state. Server returns fail(409,
 // { requireConfirmation: true, attemptedOrigin, ... }) when the submitted
@@ -524,6 +526,9 @@ const logFieldErrors = $derived(
 				type="button"
 				class="tab-button"
 				class:active={activeTab === tab.value}
+				aria-label={`Open ${tab.label} settings`}
+				aria-pressed={activeTab === tab.value}
+				aria-current={activeTab === tab.value ? 'page' : undefined}
 				onclick={() => selectTab(tab.value)}
 			>
 				<tab.icon class="tab-icon" />
@@ -1785,48 +1790,49 @@ const logFieldErrors = $derived(
 
 							{#if !trustProxyLocked}
 								<div class="csrf-actions">
-									<form
-										method="POST"
-										action="?/updateTrustProxy"
-										use:enhance={() => {
-											isSavingTrustProxy = true;
-											return async ({ result, update }) => {
-												isSavingTrustProxy = false;
-												if (result.type === 'success' || result.type === 'failure') {
-													handleFormToast(
-														result.data as {
-															success?: boolean;
-															message?: string;
-															error?: string;
-														}
-													);
-												}
-												await update({ reset: false });
-											};
-										}}
-									>
-										<input
-											type="hidden"
-											name="enabled"
-											value={trustProxyValue ? 'false' : 'true'}
-										/>
-										<button
-											type="submit"
-											class={trustProxyValue ? 'btn-destructive' : 'btn-primary'}
-											disabled={isSavingTrustProxy}
+									{#if trustProxyValue}
+										<form
+											method="POST"
+											action="?/updateTrustProxy"
+											use:enhance={() => {
+												isSavingTrustProxy = true;
+												return async ({ result, update }) => {
+													isSavingTrustProxy = false;
+													if (result.type === 'success' || result.type === 'failure') {
+														handleFormToast(
+															result.data as {
+																success?: boolean;
+																message?: string;
+																error?: string;
+															}
+														);
+													}
+													await update({ reset: false });
+												};
+											}}
 										>
-											{#if isSavingTrustProxy}
-												<Loader2 class="btn-icon spinning" />
-												Saving...
-											{:else if trustProxyValue}
-												<ShieldAlert class="btn-icon" />
-												Disable Header Trust
-											{:else}
-												<ShieldCheck class="btn-icon" />
-												Enable Header Trust
-											{/if}
+											<input type="hidden" name="enabled" value="false" />
+											<button type="submit" class="btn-destructive" disabled={isSavingTrustProxy}>
+												{#if isSavingTrustProxy}
+													<Loader2 class="btn-icon spinning" />
+													Saving...
+												{:else}
+													<ShieldAlert class="btn-icon" />
+													Disable Header Trust
+												{/if}
+											</button>
+										</form>
+									{:else}
+										<button
+											type="button"
+											class="btn-primary"
+											disabled={isConfirmingTrustProxy}
+											onclick={() => (trustProxyConfirmDialogOpen = true)}
+										>
+											<ShieldCheck class="btn-icon" />
+											Enable Header Trust
 										</button>
-									</form>
+									{/if}
 								</div>
 							{/if}
 						</div>
@@ -2347,6 +2353,55 @@ const logFieldErrors = $derived(
 				<input type="hidden" name="confirmMismatch" value="true" />
 				<AlertDialog.Action type="submit" disabled={isConfirmingCsrfMismatch}>
 					{isConfirmingCsrfMismatch ? 'Saving…' : 'Save anyway'}
+				</AlertDialog.Action>
+			</form>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
+
+<!-- Reverse Proxy Header Trust Confirmation Dialog -->
+<AlertDialog.Root bind:open={trustProxyConfirmDialogOpen}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Enable reverse-proxy header trust?</AlertDialog.Title>
+			<AlertDialog.Description>
+				Only enable this when your upstream proxy strips client-supplied
+				<code>X-Forwarded-*</code> headers before forwarding requests to Obzorarr. If those
+				headers can reach Obzorarr from clients, attackers can spoof the host or protocol used for
+				security decisions and generated URLs.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel disabled={isConfirmingTrustProxy}>Cancel</AlertDialog.Cancel>
+			<form
+				method="POST"
+				action="?/updateTrustProxy"
+				use:enhance={() => {
+					isConfirmingTrustProxy = true;
+					return async ({ result, update }) => {
+						try {
+							if (result.type === 'success' || result.type === 'failure') {
+								handleFormToast(
+									result.data as {
+										success?: boolean;
+										message?: string;
+										error?: string;
+									}
+								);
+							}
+							await update({ reset: false });
+						} finally {
+							isConfirmingTrustProxy = false;
+							trustProxyConfirmDialogOpen = false;
+						}
+					};
+				}}
+				style="display: contents;"
+			>
+				<input type="hidden" name="enabled" value="true" />
+				<input type="hidden" name="confirmRisk" value="true" />
+				<AlertDialog.Action type="submit" disabled={isConfirmingTrustProxy}>
+					{isConfirmingTrustProxy ? 'Enabling...' : 'Enable header trust'}
 				</AlertDialog.Action>
 			</form>
 		</AlertDialog.Footer>

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -72,6 +72,46 @@ let previewError = $state('');
 let previewRendered = $state(false);
 let editorTriggerRef: HTMLElement | null = null;
 let editorTitleInputRef: HTMLInputElement | null = $state(null);
+let editorModalRef: HTMLElement | null = $state(null);
+
+const FOCUSABLE_SELECTOR = [
+	'a[href]',
+	'button:not([disabled])',
+	'input:not([disabled])',
+	'select:not([disabled])',
+	'textarea:not([disabled])',
+	'[tabindex]:not([tabindex="-1"])'
+].join(',');
+
+function getEditorFocusableElements(): HTMLElement[] {
+	if (!editorModalRef) return [];
+	return Array.from(editorModalRef.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+		(element) => element.tabIndex >= 0 && element.getClientRects().length > 0
+	);
+}
+
+function trapEditorFocus(event: KeyboardEvent) {
+	if (event.key !== 'Tab') return;
+
+	const focusableElements = getEditorFocusableElements();
+	if (focusableElements.length === 0) {
+		event.preventDefault();
+		editorModalRef?.focus();
+		return;
+	}
+
+	const first = focusableElements[0];
+	const last = focusableElements.at(-1);
+	const activeElement = document.activeElement;
+
+	if (event.shiftKey && (activeElement === first || !editorModalRef?.contains(activeElement))) {
+		event.preventDefault();
+		last?.focus();
+	} else if (!event.shiftKey && activeElement === last) {
+		event.preventDefault();
+		first?.focus();
+	}
+}
 
 $effect(() => {
 	if (!showEditor) return;
@@ -79,7 +119,9 @@ $effect(() => {
 		if (e.key === 'Escape') {
 			e.preventDefault();
 			closeEditor();
+			return;
 		}
+		trapEditorFocus(e);
 	};
 	document.addEventListener('keydown', handler);
 	queueMicrotask(() => editorTitleInputRef?.focus());
@@ -232,6 +274,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 </script>
 
 <div class="admin-container">
+	<div class="admin-page-content" inert={showEditor} aria-hidden={showEditor ? 'true' : undefined}>
 	<header class="admin-header">
 		<h1>Slide Configuration</h1>
 		<p class="subtitle">Manage slides for Year in Review presentations</p>
@@ -496,10 +539,11 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 				class="save-frequency-button"
 				disabled={selectedFrequencyMode === 'custom' && (customCount < 1 || customCount > 15)}
 			>
-				Save Frequency Settings
-			</button>
-		</form>
+			Save Frequency Settings
+		</button>
+	</form>
 	</section>
+	</div>
 
 	<!-- Custom Slide Editor Modal -->
 	{#if showEditor}
@@ -512,6 +556,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 				aria-modal="true"
 				aria-labelledby="editor-title"
 				tabindex="-1"
+				bind:this={editorModalRef}
 			>
 				<header class="modal-header">
 					<h2 id="editor-title">

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -107,7 +107,10 @@ function trapEditorFocus(event: KeyboardEvent) {
 	if (event.shiftKey && (activeElement === first || !editorModalRef?.contains(activeElement))) {
 		event.preventDefault();
 		last?.focus();
-	} else if (!event.shiftKey && activeElement === last) {
+	} else if (
+		!event.shiftKey &&
+		(activeElement === last || !editorModalRef?.contains(activeElement))
+	) {
 		event.preventDefault();
 		first?.focus();
 	}

--- a/src/routes/onboarding/+layout.server.ts
+++ b/src/routes/onboarding/+layout.server.ts
@@ -7,6 +7,7 @@ import {
 import {
 	getOnboardingStep,
 	getStepNumber,
+	hasActiveOnboardingClaim,
 	isOnboardingComplete,
 	type OnboardingStep,
 	OnboardingSteps
@@ -14,7 +15,7 @@ import {
 import { getServerName } from '$lib/server/plex/server-name.service';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async ({ locals, url }) => {
+export const load: LayoutServerLoad = async ({ cookies, locals, url }) => {
 	const isComplete = await isOnboardingComplete();
 	if (isComplete) {
 		redirect(303, locals.user?.isAdmin ? '/admin' : '/');
@@ -22,17 +23,26 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 
 	const currentStep = await getOnboardingStep();
 	const requestedPath = url.pathname;
+	const isClaimPath = requestedPath === '/onboarding/claim';
+	const hasActiveClaim = await hasActiveOnboardingClaim(cookies);
+
+	if (!hasActiveClaim && !isClaimPath) {
+		redirect(303, '/onboarding/claim');
+	}
 
 	const isOnCompleteWithoutAdmin =
 		currentStep === OnboardingSteps.COMPLETE && !locals.user?.isAdmin;
 
 	if (
+		hasActiveClaim &&
 		!isOnCompleteWithoutAdmin &&
 		requestedPath !== '/onboarding' &&
 		!requestedPath.startsWith(`/onboarding/${currentStep}`)
 	) {
 		redirect(303, `/onboarding/${currentStep}`);
 	}
+
+	const displayedStep = !hasActiveClaim && isClaimPath ? OnboardingSteps.CLAIM : currentStep;
 
 	const [apiConfig, uiTheme] = await Promise.all([getApiConfigWithSources(), getUITheme()]);
 	const hasEnvConfigValue = hasPlexEnvConfig();
@@ -49,8 +59,8 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 
 	return {
 		steps,
-		currentStep,
-		currentStepIndex: getStepNumber(currentStep) - 1,
+		currentStep: displayedStep,
+		currentStepIndex: getStepNumber(displayedStep) - 1,
 		totalSteps: steps.length,
 		isAuthenticated: !!locals.user,
 		isAdmin: locals.user?.isAdmin ?? false,

--- a/tests/unit/admin/settings-actions.test.ts
+++ b/tests/unit/admin/settings-actions.test.ts
@@ -302,6 +302,32 @@ describe('admin updateTrustProxy action', () => {
 		}
 	});
 
+	it('rejects malformed risk confirmation with a specific validation message', async () => {
+		try {
+			const formData = new FormData();
+			formData.set('enabled', 'true');
+			formData.set('confirmRisk', 'false');
+
+			const result = await runUpdateTrustProxy(
+				new Request('http://localhost/admin/settings?/updateTrustProxy', {
+					method: 'POST',
+					body: formData
+				})
+			);
+
+			expect(result).toMatchObject({
+				status: 400,
+				data: {
+					error:
+						'Invalid input: enabled must be "true" or "false"; confirmRisk must be "true" when provided'
+				}
+			});
+			expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+		} finally {
+			restoreTrustProxyEnv();
+		}
+	});
+
 	it('persists trust_proxy=true when enabling with risk confirmation', async () => {
 		try {
 			const result = await runUpdateTrustProxy(createTrustProxyRequest(true, true));

--- a/tests/unit/admin/settings-actions.test.ts
+++ b/tests/unit/admin/settings-actions.test.ts
@@ -15,6 +15,7 @@ import { actions } from '../../../src/routes/admin/settings/+page.server';
 type UpdateUserDefaultsAction = NonNullable<typeof actions.updateUserDefaults>;
 type UpdateApiConfigAction = NonNullable<typeof actions.updateApiConfig>;
 type ClearOpenaiModelAction = NonNullable<typeof actions.clearOpenaiModel>;
+type UpdateTrustProxyAction = NonNullable<typeof actions.updateTrustProxy>;
 
 const adminLocals = {
 	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
@@ -249,6 +250,85 @@ describe('admin clearOpenaiModel action', () => {
 		} finally {
 			if (previous === undefined) delete dynamicEnv.OPENAI_MODEL;
 			else dynamicEnv.OPENAI_MODEL = previous;
+		}
+	});
+});
+
+describe('admin updateTrustProxy action', () => {
+	let previousTrustProxyEnv: string | undefined;
+
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		const dynamicEnv = env as Record<string, string | undefined>;
+		previousTrustProxyEnv = dynamicEnv.TRUST_PROXY;
+		delete dynamicEnv.TRUST_PROXY;
+	});
+
+	function restoreTrustProxyEnv() {
+		const dynamicEnv = env as Record<string, string | undefined>;
+		if (previousTrustProxyEnv === undefined) delete dynamicEnv.TRUST_PROXY;
+		else dynamicEnv.TRUST_PROXY = previousTrustProxyEnv;
+	}
+
+	function createTrustProxyRequest(enabled: boolean, confirmRisk?: boolean): Request {
+		const formData = new FormData();
+		formData.set('enabled', enabled ? 'true' : 'false');
+		if (confirmRisk) formData.set('confirmRisk', 'true');
+
+		return new Request('http://localhost/admin/settings?/updateTrustProxy', {
+			method: 'POST',
+			body: formData
+		});
+	}
+
+	async function runUpdateTrustProxy(request: Request) {
+		const handler = actions.updateTrustProxy as UpdateTrustProxyAction;
+		return handler({ request, locals: adminLocals } as Parameters<UpdateTrustProxyAction>[0]);
+	}
+
+	it('rejects enabling TRUST_PROXY without explicit risk confirmation', async () => {
+		try {
+			const result = await runUpdateTrustProxy(createTrustProxyRequest(true));
+
+			expect(result).toMatchObject({
+				status: 400,
+				data: {
+					error: 'Confirm the reverse-proxy header trust risk before enabling TRUST_PROXY.'
+				}
+			});
+			expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+		} finally {
+			restoreTrustProxyEnv();
+		}
+	});
+
+	it('persists trust_proxy=true when enabling with risk confirmation', async () => {
+		try {
+			const result = await runUpdateTrustProxy(createTrustProxyRequest(true, true));
+
+			expect(result).toMatchObject({
+				success: true,
+				message: 'Reverse-proxy header trust enabled.'
+			});
+			expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBe('true');
+		} finally {
+			restoreTrustProxyEnv();
+		}
+	});
+
+	it('allows disabling TRUST_PROXY without risk confirmation', async () => {
+		try {
+			await setAppSetting(AppSettingsKey.TRUST_PROXY, 'true');
+
+			const result = await runUpdateTrustProxy(createTrustProxyRequest(false));
+
+			expect(result).toMatchObject({
+				success: true,
+				message: 'Reverse-proxy header trust disabled.'
+			});
+			expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBe('false');
+		} finally {
+			restoreTrustProxyEnv();
 		}
 	});
 });

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -38,6 +38,22 @@ describe('admin UI source regressions', () => {
 		expect(source).not.toContain('role="button"');
 	});
 
+	it('labels mobile settings tab buttons and exposes their active state', async () => {
+		const source = await readSource('src/routes/admin/settings/+page.svelte');
+
+		expect(source).toContain('aria-label={`Open $' + '{tab.label} settings`}');
+		expect(source).toContain('aria-pressed={activeTab === tab.value}');
+		expect(source).toContain("aria-current={activeTab === tab.value ? 'page' : undefined}");
+	});
+
+	it('requires confirmation before enabling reverse-proxy header trust', async () => {
+		const source = await readSource('src/routes/admin/settings/+page.svelte');
+
+		expect(source).toContain('bind:open={trustProxyConfirmDialogOpen}');
+		expect(source).toContain('name="confirmRisk" value="true"');
+		expect(source).toContain('Enable reverse-proxy header trust?');
+	});
+
 	it('keeps the users table desktop-only and renders a mobile list', async () => {
 		const source = await readSource('src/routes/admin/users/+page.svelte');
 
@@ -59,6 +75,18 @@ describe('admin UI source regressions', () => {
 			'syncedFrequencyKey = `$' + '{frequency.mode}:$' + '{frequency.count}`;'
 		);
 		expect(source).not.toContain('class="frequency-options" onclick');
+	});
+
+	it('traps focus in the custom slide modal and marks page content inert', async () => {
+		const source = await readSource('src/routes/admin/slides/+page.svelte');
+
+		expect(source).toContain('function trapEditorFocus(event: KeyboardEvent)');
+		expect(source).toContain("if (event.key !== 'Tab') return;");
+		expect(source).toContain('bind:this={editorTitleInputRef}');
+		expect(source).toContain('queueMicrotask(() => editorTitleInputRef?.focus());');
+		expect(source).toContain('queueMicrotask(() => trigger?.focus());');
+		expect(source).toContain('inert={showEditor}');
+		expect(source).toContain("aria-hidden={showEditor ? 'true' : undefined}");
 	});
 
 	it('marks onboarding theme swatches as pressed when selected', async () => {

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -82,6 +82,10 @@ describe('admin UI source regressions', () => {
 
 		expect(source).toContain('function trapEditorFocus(event: KeyboardEvent)');
 		expect(source).toContain("if (event.key !== 'Tab') return;");
+		expect(source).toContain('!event.shiftKey &&');
+		expect(source).toContain(
+			'(activeElement === last || !editorModalRef?.contains(activeElement))'
+		);
 		expect(source).toContain('bind:this={editorTitleInputRef}');
 		expect(source).toContain('queueMicrotask(() => editorTitleInputRef?.focus());');
 		expect(source).toContain('queueMicrotask(() => trigger?.focus());');

--- a/tests/unit/auth/login-completion.test.ts
+++ b/tests/unit/auth/login-completion.test.ts
@@ -93,7 +93,7 @@ describe('createSessionFromPlexToken', () => {
 				email: 'alice@example.com',
 				thumb: 'https://plex.example/avatar.png',
 				authToken: 'plex-user-token-from-profile',
-				services: [{ identifier: 'metadata-provider' }]
+				services: [{ identifier: 'metadata-provider', secret: 'service-secret' }]
 			})
 		];
 	});
@@ -122,6 +122,8 @@ describe('createSessionFromPlexToken', () => {
 		const responseText = JSON.stringify(result);
 		for (const forbidden of [
 			'authToken',
+			'token',
+			'secret',
 			'plexToken',
 			'plexId',
 			'email',
@@ -135,6 +137,7 @@ describe('createSessionFromPlexToken', () => {
 		}
 		expect(responseText).not.toContain('secret-auth-token');
 		expect(responseText).not.toContain('plex-user-token-from-profile');
+		expect(responseText).not.toContain('service-secret');
 	});
 
 	it('rejects first-admin creation during fresh onboarding without an active setup claim', async () => {

--- a/tests/unit/onboarding/layout-routing.test.ts
+++ b/tests/unit/onboarding/layout-routing.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { type Cookies, isRedirect } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken
+} from '$lib/server/onboarding/bootstrap';
+import { OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding/status';
+import { load } from '../../../src/routes/onboarding/+layout.server';
+
+const adminLocals = {
+	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
+} as unknown as App.Locals;
+
+function createCookies(): Cookies {
+	const values = new Map<string, string>();
+	return {
+		get: (name: string) => values.get(name),
+		set: (name: string, value: string) => values.set(name, value),
+		delete: (name: string) => values.delete(name)
+	} as unknown as Cookies;
+}
+
+async function createClaimedCookies(): Promise<Cookies> {
+	const cookies = createCookies();
+	const token = createBootstrapToken();
+	expect(await claimOnboardingInstance(cookies, token)).toBe('claimed');
+	return cookies;
+}
+
+async function runLayout(pathname: string, cookies: Cookies = createCookies()) {
+	return load({
+		cookies,
+		locals: adminLocals,
+		url: new URL(`http://localhost${pathname}`)
+	} as Parameters<typeof load>[0]);
+}
+
+async function expectRedirect(run: () => Promise<unknown>, location: string) {
+	try {
+		await run();
+		expect.unreachable('Expected onboarding layout to redirect');
+	} catch (error) {
+		expect(isRedirect(error)).toBe(true);
+		if (!isRedirect(error)) throw error;
+		expect(error.status).toBe(303);
+		expect(error.location).toBe(location);
+	}
+}
+
+describe('onboarding layout claim routing', () => {
+	let previousPlexServerUrl: string | undefined;
+	let previousPlexToken: string | undefined;
+
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		clearBootstrapToken();
+		await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'false');
+		const dynamicEnv = env as Record<string, string | undefined>;
+		previousPlexServerUrl = dynamicEnv.PLEX_SERVER_URL;
+		previousPlexToken = dynamicEnv.PLEX_TOKEN;
+		dynamicEnv.PLEX_SERVER_URL = '';
+		dynamicEnv.PLEX_TOKEN = '';
+	});
+
+	afterEach(() => {
+		const dynamicEnv = env as Record<string, string | undefined>;
+		if (previousPlexServerUrl === undefined) delete dynamicEnv.PLEX_SERVER_URL;
+		else dynamicEnv.PLEX_SERVER_URL = previousPlexServerUrl;
+		if (previousPlexToken === undefined) delete dynamicEnv.PLEX_TOKEN;
+		else dynamicEnv.PLEX_TOKEN = previousPlexToken;
+	});
+
+	it('lets a no-claim browser render the claim page after setup has advanced', async () => {
+		await setOnboardingStep(OnboardingSteps.CSRF);
+
+		const result = await runLayout('/onboarding/claim');
+		if (!result) expect.unreachable('Expected onboarding layout data');
+
+		expect(result.currentStep).toBe(OnboardingSteps.CLAIM);
+		expect(result.currentStepIndex).toBe(0);
+	});
+
+	it('redirects no-claim browsers from guarded onboarding steps back to claim', async () => {
+		await setOnboardingStep(OnboardingSteps.CSRF);
+
+		await expectRedirect(() => runLayout('/onboarding/csrf'), '/onboarding/claim');
+	});
+
+	it('keeps active-claim browsers pinned to the current onboarding step', async () => {
+		const cookies = await createClaimedCookies();
+		await setOnboardingStep(OnboardingSteps.CSRF);
+
+		await expectRedirect(() => runLayout('/onboarding/claim', cookies), '/onboarding/csrf');
+	});
+});

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -18,7 +18,7 @@ describe('sanitizeCompletedLoginResponse', () => {
 				email: 'alice@example.com',
 				isAdmin: true,
 				authToken: 'plex-user-token',
-				services: [{ accessToken: 'service-token' }]
+				services: [{ accessToken: 'service-token', secret: 'service-secret' }]
 			},
 			redirectTo: '/admin',
 			authToken: 'raw-auth-token',
@@ -37,6 +37,8 @@ describe('sanitizeCompletedLoginResponse', () => {
 		const responseText = JSON.stringify(sanitized);
 		for (const forbidden of [
 			'authToken',
+			'token',
+			'secret',
 			'plexToken',
 			'plexId',
 			'email',
@@ -45,7 +47,8 @@ describe('sanitizeCompletedLoginResponse', () => {
 			'clientIdentifier',
 			'resources',
 			'raw-auth-token',
-			'service-token'
+			'service-token',
+			'service-secret'
 		]) {
 			expect(responseText).not.toContain(forbidden);
 		}

--- a/tests/unit/scripts/scrub-dogfood-output.test.ts
+++ b/tests/unit/scripts/scrub-dogfood-output.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 const PROJECT_ROOT = join(import.meta.dir, '..', '..', '..');
+const SCRIPT_PATH = join(PROJECT_ROOT, 'scripts', 'scrub-dogfood-output.ts');
 
 describe('scrub dogfood output script', () => {
 	let tempDir: string;
@@ -45,20 +46,21 @@ describe('scrub dogfood output script', () => {
 		await rm(tempDir, { recursive: true, force: true });
 	});
 
-	async function runScrub(write = false) {
-		const result = Bun.spawn(
-			['bun', 'run', 'scripts/scrub-dogfood-output.ts', ...(write ? ['--write'] : [])],
-			{
-				cwd: PROJECT_ROOT,
-				env: {
-					...process.env,
-					DOGFOOD_ENV_PATH: envPath,
-					DOGFOOD_OUTPUT_ROOT: outputRoot
-				},
-				stdout: 'pipe',
-				stderr: 'pipe'
-			}
-		);
+	async function runScrub(
+		write = false,
+		options: { cwd?: string; env?: Record<string, string> } = {}
+	) {
+		const result = Bun.spawn(['bun', 'run', SCRIPT_PATH, ...(write ? ['--write'] : [])], {
+			cwd: options.cwd ?? PROJECT_ROOT,
+			env: {
+				...process.env,
+				DOGFOOD_ENV_PATH: envPath,
+				DOGFOOD_OUTPUT_ROOT: outputRoot,
+				...options.env
+			},
+			stdout: 'pipe',
+			stderr: 'pipe'
+		});
 
 		const [exitCode, stdout, stderr] = await Promise.all([
 			result.exited,
@@ -92,6 +94,33 @@ describe('scrub dogfood output script', () => {
 		expect(result.stdout).not.toContain('env-plex-token');
 	});
 
+	it('treats an empty env path override as the default .env path', async () => {
+		await writeFile(reportPath, 'Configured token: env-plex-token');
+
+		const result = await runScrub(false, {
+			cwd: tempDir,
+			env: { DOGFOOD_ENV_PATH: '', DOGFOOD_OUTPUT_ROOT: outputRoot }
+		});
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stdout).toContain('Found content secret(s) PLEX_TOKEN');
+		expect(result.stderr).toContain('Run `bun run dogfood:scrub -- --write`');
+	});
+
+	it('treats an empty output root override as the default dogfood-output path', async () => {
+		await writeFile(reportPath, 'No secrets here');
+		await writeFile(join(tempDir, 'outside.md'), 'Configured token: env-plex-token');
+
+		const result = await runScrub(false, {
+			cwd: tempDir,
+			env: { DOGFOOD_ENV_PATH: envPath, DOGFOOD_OUTPUT_ROOT: '' }
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('No configured .env secrets found');
+		expect(result.stdout).not.toContain('outside.md');
+	});
+
 	it('redacts bootstrap tokens and onboarding claim cookie values with --write', async () => {
 		const result = await runScrub(true);
 
@@ -121,6 +150,32 @@ describe('scrub dogfood output script', () => {
 
 		expect(result.exitCode).toBe(0);
 		expect(result.stdout).toContain('Redacted content secret(s)');
+
+		const redacted = await readFile(reportPath, 'utf8');
+		expect(redacted).toContain('Bootstrap token: <BOOTSTRAP_TOKEN>');
+		expect(redacted).toContain('obzorarr_onboarding_claim=<ONBOARDING_CLAIM_COOKIE>');
+		expect(redacted).toContain('"obzorarr_onboarding_claim":"<ONBOARDING_CLAIM_COOKIE>"');
+		expect(redacted).not.toContain('claim-cookie-secret');
+		expect(redacted).not.toContain('json-claim-secret');
+	});
+
+	it('redacts dynamic secrets when .env is missing', async () => {
+		await rm(envPath, { force: true });
+		await writeFile(
+			reportPath,
+			[
+				'Bootstrap token: abcd-ef12-3456',
+				'Cookie: obzorarr_onboarding_claim=claim-cookie-secret; Path=/',
+				'JSON cookie: "obzorarr_onboarding_claim":"json-claim-secret"'
+			].join('\n')
+		);
+
+		const result = await runScrub(true, {
+			env: { DOGFOOD_ENV_PATH: join(tempDir, 'missing.env') }
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toContain('No .env file found; continuing with dynamic redactions only.');
 
 		const redacted = await readFile(reportPath, 'utf8');
 		expect(redacted).toContain('Bootstrap token: <BOOTSTRAP_TOKEN>');

--- a/tests/unit/scripts/scrub-dogfood-output.test.ts
+++ b/tests/unit/scripts/scrub-dogfood-output.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const PROJECT_ROOT = join(import.meta.dir, '..', '..', '..');
+
+describe('scrub dogfood output script', () => {
+	let tempDir: string;
+	let envPath: string;
+	let outputRoot: string;
+	let reportPath: string;
+
+	beforeEach(async () => {
+		tempDir = await mkdtemp(join(tmpdir(), 'obzorarr-dogfood-scrub-'));
+		envPath = join(tempDir, '.env');
+		outputRoot = join(tempDir, 'dogfood-output');
+		reportPath = join(outputRoot, 'report.md');
+
+		await mkdir(outputRoot, { recursive: true });
+		await writeFile(
+			envPath,
+			[
+				'PLEX_SERVER_URL=http://plex-secret.local:32400',
+				'PLEX_TOKEN=env-plex-token',
+				'PLEX_ADMIN_USER_EMAIL=admin@example.com',
+				'PLEX_ADMIN_USER_PASSWORD=admin-password',
+				'PLEX_TEST_USER_EMAIL=user@example.com',
+				'PLEX_TEST_USER_PASSWORD=user-password'
+			].join('\n')
+		);
+		await writeFile(
+			reportPath,
+			[
+				'Bootstrap token: abcd-ef12-3456',
+				'Cookie: obzorarr_onboarding_claim=claim-cookie-secret; Path=/',
+				'JSON cookie: "obzorarr_onboarding_claim":"json-claim-secret"',
+				'Configured token: env-plex-token',
+				'Admin password: admin-password'
+			].join('\n')
+		);
+	});
+
+	afterEach(async () => {
+		await rm(tempDir, { recursive: true, force: true });
+	});
+
+	async function runScrub(write = false) {
+		const result = Bun.spawn(
+			['bun', 'run', 'scripts/scrub-dogfood-output.ts', ...(write ? ['--write'] : [])],
+			{
+				cwd: PROJECT_ROOT,
+				env: {
+					...process.env,
+					DOGFOOD_ENV_PATH: envPath,
+					DOGFOOD_OUTPUT_ROOT: outputRoot
+				},
+				stdout: 'pipe',
+				stderr: 'pipe'
+			}
+		);
+
+		const [exitCode, stdout, stderr] = await Promise.all([
+			result.exited,
+			new Response(result.stdout).text(),
+			new Response(result.stderr).text()
+		]);
+		return { exitCode, stdout, stderr };
+	}
+
+	it('detects bootstrap tokens during dry run', async () => {
+		const result = await runScrub();
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stdout).toContain('BOOTSTRAP_TOKEN');
+		expect(result.stderr).toContain('Run `bun run dogfood:scrub -- --write`');
+	});
+
+	it('redacts bootstrap tokens and onboarding claim cookie values with --write', async () => {
+		const result = await runScrub(true);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('Redacted content secret(s)');
+
+		const redacted = await readFile(reportPath, 'utf8');
+		expect(redacted).toContain('Bootstrap token: <BOOTSTRAP_TOKEN>');
+		expect(redacted).toContain('obzorarr_onboarding_claim=<ONBOARDING_CLAIM_COOKIE>');
+		expect(redacted).toContain('"obzorarr_onboarding_claim":"<ONBOARDING_CLAIM_COOKIE>"');
+		expect(redacted).not.toContain('claim-cookie-secret');
+		expect(redacted).not.toContain('json-claim-secret');
+	});
+
+	it('leaves no configured .env secret values in text artifacts after --write', async () => {
+		await runScrub(true);
+
+		const redacted = await readFile(reportPath, 'utf8');
+		for (const secret of ['env-plex-token', 'admin-password']) {
+			expect(redacted).not.toContain(secret);
+		}
+		expect(redacted).toContain('<PLEX_TOKEN>');
+		expect(redacted).toContain('<PLEX_ADMIN_USER_PASSWORD>');
+	});
+});

--- a/tests/unit/scripts/scrub-dogfood-output.test.ts
+++ b/tests/unit/scripts/scrub-dogfood-output.test.ts
@@ -77,12 +77,16 @@ describe('scrub dogfood output script', () => {
 	});
 
 	it('reports redacted filenames during dry run', async () => {
-		await writeFile(join(outputRoot, 'report-env-plex-token.md'), 'No configured secrets here');
+		await writeFile(
+			join(outputRoot, 'report-env-plex-token.md'),
+			'Configured token: env-plex-token'
+		);
 
 		const result = await runScrub();
 
 		expect(result.exitCode).toBe(1);
 		expect(result.stdout).toContain('Found filename secret(s) PLEX_TOKEN');
+		expect(result.stdout).toContain('Found content secret(s) PLEX_TOKEN');
 		expect(result.stdout).toContain('report-__PLEX_TOKEN__.md');
 		expect(result.stdout).not.toContain('report-env-plex-token.md');
 		expect(result.stdout).not.toContain('env-plex-token');

--- a/tests/unit/scripts/scrub-dogfood-output.test.ts
+++ b/tests/unit/scripts/scrub-dogfood-output.test.ts
@@ -106,6 +106,30 @@ describe('scrub dogfood output script', () => {
 		expect(redacted).not.toContain('json-claim-secret');
 	});
 
+	it('redacts dynamic secrets when no configured .env secret values exist', async () => {
+		await writeFile(envPath, 'OTHER=value');
+		await writeFile(
+			reportPath,
+			[
+				'Bootstrap token: abcd-ef12-3456',
+				'Cookie: obzorarr_onboarding_claim=claim-cookie-secret; Path=/',
+				'JSON cookie: "obzorarr_onboarding_claim":"json-claim-secret"'
+			].join('\n')
+		);
+
+		const result = await runScrub(true);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toContain('Redacted content secret(s)');
+
+		const redacted = await readFile(reportPath, 'utf8');
+		expect(redacted).toContain('Bootstrap token: <BOOTSTRAP_TOKEN>');
+		expect(redacted).toContain('obzorarr_onboarding_claim=<ONBOARDING_CLAIM_COOKIE>');
+		expect(redacted).toContain('"obzorarr_onboarding_claim":"<ONBOARDING_CLAIM_COOKIE>"');
+		expect(redacted).not.toContain('claim-cookie-secret');
+		expect(redacted).not.toContain('json-claim-secret');
+	});
+
 	it('leaves no configured .env secret values in text artifacts after --write', async () => {
 		await runScrub(true);
 

--- a/tests/unit/scripts/scrub-dogfood-output.test.ts
+++ b/tests/unit/scripts/scrub-dogfood-output.test.ts
@@ -76,6 +76,18 @@ describe('scrub dogfood output script', () => {
 		expect(result.stderr).toContain('Run `bun run dogfood:scrub -- --write`');
 	});
 
+	it('reports redacted filenames during dry run', async () => {
+		await writeFile(join(outputRoot, 'report-env-plex-token.md'), 'No configured secrets here');
+
+		const result = await runScrub();
+
+		expect(result.exitCode).toBe(1);
+		expect(result.stdout).toContain('Found filename secret(s) PLEX_TOKEN');
+		expect(result.stdout).toContain('report-__PLEX_TOKEN__.md');
+		expect(result.stdout).not.toContain('report-env-plex-token.md');
+		expect(result.stdout).not.toContain('env-plex-token');
+	});
+
 	it('redacts bootstrap tokens and onboarding claim cookie values with --write', async () => {
 		const result = await runScrub(true);
 


### PR DESCRIPTION
## Summary

This PR remediates the dogfood QA findings around onboarding claim routing, reverse-proxy trust configuration, admin UI accessibility, custom slide modal focus behavior, and dogfood artifact secret hygiene.

## Changes

- Updates onboarding layout routing so browsers without a valid setup claim can still reach `/onboarding/claim` after another browser has advanced setup, while redirecting no-claim access to guarded onboarding steps back to the claim page.
- Adds a required confirmation flow before enabling reverse-proxy header trust, including a server-side `confirmRisk=true` gate in the `updateTrustProxy` action. Disabling remains a direct action.
- Adds accessible names and active-state semantics to icon-only admin settings tabs for mobile and assistive technology users.
- Adds focus trapping, initial title-field focus, trigger focus restoration, and inert background behavior for the custom slide editor modal.
- Extends dogfood output scrubbing to redact dynamic bootstrap banner tokens and onboarding claim cookie values, and ignores `dogfood-output/` in git.
- Strengthens auth/login sanitization regression coverage for token-shaped fields, `services`, and nested `secret` values.

## Issue Handling

- ISSUE-001: Fixed onboarding claim routing for no-claim browsers after setup has advanced.
- ISSUE-002: Fixed reverse-proxy trust enablement by requiring explicit risk confirmation in both the UI and server action.
- ISSUE-003: Closed through sanitizer regression coverage. The app-facing completion response continues to expose only browser-safe login fields.
- ISSUE-004: Left unchanged by design. Non-admin admin deep links continue redirecting authenticated non-admin users to `/dashboard`, matching the existing authorization architecture.
- ISSUE-005: Fixed mobile settings tab accessibility labels and state semantics.
- ISSUE-006: Fixed custom slide modal keyboard focus containment and background inert behavior.
- ISSUE-007: Fixed dogfood secret hygiene for dynamic bootstrap and onboarding claim values.

## Testing

Added regression coverage for:

- Onboarding claim routing with no-claim and active-claim browsers.
- `TRUST_PROXY` action confirmation requirements.
- Settings tab accessibility source guards.
- Custom slide modal focus trap and inert source guards.
- Auth/login response sanitization for token-shaped and nested secret fields.
- Dogfood scrubber redaction of bootstrap tokens, onboarding claim cookies, and configured `.env` secrets.

## Verification

- `bun run check`
- `bun run lint`
- `bun run test` (`1592 pass`)

## Notes

No database migration or public API change is included.