### PR TITLE
fix: resolve dogfood qa findings

### DIFF
--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -11,7 +11,7 @@ import Settings from '@lucide/svelte/icons/settings';
 import User from '@lucide/svelte/icons/user';
 import Users from '@lucide/svelte/icons/users';
 import X from '@lucide/svelte/icons/x';
-import type { Component, Snippet } from 'svelte';
+import { type Component, type Snippet, tick } from 'svelte';
 import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
@@ -62,6 +62,7 @@ let sidebarOpen = $state(false);
 let isMobileSidebar = $state(false);
 let sidebarHiddenFromMobile = $derived(isMobileSidebar && !sidebarOpen);
 let adminAvatarError = $state(false);
+let sidebarCloseButton: HTMLButtonElement | undefined;
 
 $effect(() => {
 	if (!browser) return;
@@ -94,8 +95,13 @@ $effect(() => {
 	}
 });
 
-function toggleSidebar() {
+async function toggleSidebar() {
 	sidebarOpen = !sidebarOpen;
+
+	if (sidebarOpen && isMobileSidebar) {
+		await tick();
+		sidebarCloseButton?.focus();
+	}
 }
 
 function closeSidebar() {
@@ -159,6 +165,7 @@ function handleCsrfWarningDismissed() {
 				<button
 					type="button"
 					class="sidebar-close-button"
+					bind:this={sidebarCloseButton}
 					onclick={closeSidebar}
 					aria-label="Close navigation"
 				>

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -62,6 +62,7 @@ let sidebarOpen = $state(false);
 let isMobileSidebar = $state(false);
 let sidebarHiddenFromMobile = $derived(isMobileSidebar && !sidebarOpen);
 let adminAvatarError = $state(false);
+let mobileMenuButton: HTMLButtonElement | undefined;
 let sidebarCloseButton: HTMLButtonElement | undefined;
 
 $effect(() => {
@@ -104,8 +105,13 @@ async function toggleSidebar() {
 	}
 }
 
-function closeSidebar() {
+async function closeSidebar() {
 	sidebarOpen = false;
+
+	if (isMobileSidebar) {
+		await tick();
+		mobileMenuButton?.focus();
+	}
 }
 
 function handleCsrfWarningDismissed() {
@@ -120,6 +126,7 @@ function handleCsrfWarningDismissed() {
 		<button
 			type="button"
 			class="menu-button"
+			bind:this={mobileMenuButton}
 			onclick={toggleSidebar}
 			aria-label="Toggle navigation"
 		>

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -110,7 +110,7 @@ function handleCsrfWarningDismissed() {
 
 <div class="admin-layout">
 	<!-- Mobile header -->
-	<header class="mobile-header">
+		<header class="mobile-header" class:sidebar-open={sidebarOpen}>
 		<button
 			type="button"
 			class="menu-button"
@@ -148,15 +148,23 @@ function handleCsrfWarningDismissed() {
 		inert={sidebarHiddenFromMobile}
 		aria-hidden={sidebarHiddenFromMobile ? 'true' : undefined}
 	>
-		<div class="sidebar-header">
-			<div class="sidebar-branding">
-				<Logo size="md" />
-				<div class="sidebar-text">
-					<h2 class="sidebar-title">Obzorarr</h2>
-					<span class="sidebar-subtitle">Admin Panel</span>
+			<div class="sidebar-header">
+				<div class="sidebar-branding">
+					<Logo size="md" />
+					<div class="sidebar-text">
+						<h2 class="sidebar-title">Obzorarr</h2>
+						<span class="sidebar-subtitle">Admin Panel</span>
+					</div>
 				</div>
+				<button
+					type="button"
+					class="sidebar-close-button"
+					onclick={closeSidebar}
+					aria-label="Close navigation"
+				>
+					<X class="sidebar-close-icon" />
+				</button>
 			</div>
-		</div>
 
 		<nav class="sidebar-nav" aria-label="Admin navigation">
 			<ul class="nav-list">
@@ -312,38 +320,76 @@ function handleCsrfWarningDismissed() {
 			z-index: 50;
 		}
 
-		.sidebar-header {
-			padding: 1.25rem 1.5rem;
-			border-bottom: 1px solid hsl(var(--border) / 0.5);
-		}
+			.sidebar-header {
+				padding: 1.25rem 1.5rem;
+				border-bottom: 1px solid hsl(var(--border) / 0.5);
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				gap: 0.75rem;
+				min-width: 0;
+			}
 
-		.sidebar-branding {
-			display: flex;
-			align-items: center;
-			gap: 0.75rem;
-		}
+			.sidebar-branding {
+				display: flex;
+				align-items: center;
+				gap: 0.75rem;
+				flex: 1;
+				min-width: 0;
+			}
 
-		.sidebar-text {
-			display: flex;
-			flex-direction: column;
-		}
+			.sidebar-text {
+				display: flex;
+				flex-direction: column;
+				min-width: 0;
+			}
 
-		.sidebar-title {
-			font-size: 1.25rem;
-			font-weight: 700;
+			.sidebar-title {
+				font-size: 1.25rem;
+				font-weight: 700;
 			color: hsl(var(--primary));
-			margin: 0;
-			line-height: 1.2;
-			letter-spacing: -0.01em;
-		}
+				margin: 0;
+				line-height: 1.2;
+				letter-spacing: 0;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
 
-		.sidebar-subtitle {
-			font-size: 0.6875rem;
-			color: hsl(var(--muted-foreground));
-			text-transform: uppercase;
-			letter-spacing: 0.08em;
-			margin-top: 0.125rem;
-		}
+			.sidebar-subtitle {
+				font-size: 0.6875rem;
+				color: hsl(var(--muted-foreground));
+				text-transform: uppercase;
+				letter-spacing: 0.08em;
+				margin-top: 0.125rem;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
+
+			.sidebar-close-button {
+				display: none;
+				align-items: center;
+				justify-content: center;
+				width: 2.25rem;
+				height: 2.25rem;
+				flex: 0 0 2.25rem;
+				background: transparent;
+				border: 1px solid hsl(var(--border) / 0.6);
+				color: hsl(var(--foreground));
+				cursor: pointer;
+				border-radius: 0.5rem;
+				transition: all 0.2s ease;
+			}
+
+			.sidebar-close-button:hover {
+				background: hsl(var(--muted));
+			}
+
+			.sidebar-close-button :global(.sidebar-close-icon) {
+				width: 1rem;
+				height: 1rem;
+			}
 
 		.sidebar-nav {
 			flex: 1;
@@ -537,13 +583,18 @@ function handleCsrfWarningDismissed() {
 		   main-content left margin, so content fills the viewport without horizontal
 		   scroll at smaller widths. */
 		@media (max-width: 768px) {
-			.mobile-header {
-				display: flex;
-			}
+				.mobile-header {
+					display: flex;
+				}
 
-			.sidebar-overlay {
-				display: block;
-			}
+				.mobile-header.sidebar-open {
+					visibility: hidden;
+					pointer-events: none;
+				}
+
+				.sidebar-overlay {
+					display: block;
+				}
 
 			.sidebar {
 				transform: translateX(-100%);
@@ -554,12 +605,16 @@ function handleCsrfWarningDismissed() {
 					visibility 0s linear 0.3s;
 			}
 
-			.sidebar.open {
-				transform: translateX(0);
-				visibility: visible;
-				pointer-events: auto;
-				transition-delay: 0s;
-			}
+				.sidebar.open {
+					transform: translateX(0);
+					visibility: visible;
+					pointer-events: auto;
+					transition-delay: 0s;
+				}
+
+				.sidebar-close-button {
+					display: flex;
+				}
 
 			.main-content {
 				margin-left: 0;

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -1145,9 +1145,12 @@ const logFieldErrors = $derived(
 							action="?/updateWrappedLogoMode"
 							use:enhance={() => {
 								return async ({ result, update }) => {
-									await update();
-									if (result.type === 'failure' || result.type === 'error') {
-										selectedWrappedLogoMode = syncedWrappedLogoMode;
+									try {
+										await update();
+									} finally {
+										if (result.type === 'failure' || result.type === 'error') {
+											selectedWrappedLogoMode = syncedWrappedLogoMode;
+										}
 									}
 								};
 							}}

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -39,6 +39,7 @@ import Users from '@lucide/svelte/icons/users';
 import VenetianMask from '@lucide/svelte/icons/venetian-mask';
 import X from '@lucide/svelte/icons/x';
 import Zap from '@lucide/svelte/icons/zap';
+import { type Component, untrack } from 'svelte';
 import { deserialize, enhance } from '$app/forms';
 import { goto } from '$app/navigation';
 import { page } from '$app/stores';
@@ -77,6 +78,7 @@ function selectTab(value: TabValue) {
  */
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
+type WrappedLogoModeValue = PageData['wrappedLogoOptions'][number]['value'];
 
 // Local form state (initialized and synced via $effect)
 let plexServerUrl = $state('');
@@ -90,7 +92,8 @@ let showOpenaiKey = $state(false);
 let selectedUITheme = $state('');
 let selectedWrappedTheme = $state('');
 let selectedAnonymization = $state('');
-let selectedWrappedLogoMode = $state('');
+let selectedWrappedLogoMode = $state<WrappedLogoModeValue>(untrack(() => data.wrappedLogoMode));
+let syncedWrappedLogoMode = $state<WrappedLogoModeValue>(untrack(() => data.wrappedLogoMode));
 let isTesting = $state(false);
 let testConnectionResult = $state<{ type: 'success' | 'error'; message: string } | null>(null);
 let isTestingAI = $state(false);
@@ -200,13 +203,20 @@ $effect(() => {
 	selectedUITheme = data.uiTheme;
 	selectedWrappedTheme = data.wrappedTheme;
 	selectedAnonymization = data.anonymizationMode;
-	selectedWrappedLogoMode = data.wrappedLogoMode;
 	logRetentionDays = data.logSettings.retentionDays;
 	logMaxCount = data.logSettings.maxCount;
 	logDebugEnabled = data.logSettings.debugEnabled;
 	selectedServerWrappedMode = data.serverWrappedShareMode;
 	selectedDefaultShareMode = data.globalDefaults.defaultShareMode;
 	allowUserControl = data.globalDefaults.allowUserControl;
+});
+
+$effect(() => {
+	const serverWrappedLogoMode = data.wrappedLogoMode;
+	if (serverWrappedLogoMode === syncedWrappedLogoMode) return;
+
+	selectedWrappedLogoMode = serverWrappedLogoMode;
+	syncedWrappedLogoMode = serverWrappedLogoMode;
 });
 
 // Source label helper
@@ -238,11 +248,21 @@ const anonymizationDescriptions: Record<string, string> = {
 };
 
 // Wrapped logo mode descriptions
-const wrappedLogoDescriptions: Record<string, string> = {
+const wrappedLogoDescriptions: Record<WrappedLogoModeValue, string> = {
 	always_show: 'Logo always visible on wrapped pages',
 	always_hide: 'Logo hidden on all wrapped pages',
 	user_choice: 'Users can toggle logo visibility'
 };
+
+const wrappedLogoIcons: Record<WrappedLogoModeValue, Component> = {
+	always_show: Image,
+	always_hide: ImageOff,
+	user_choice: ToggleRight
+};
+
+function selectWrappedLogoMode(mode: WrappedLogoModeValue): void {
+	selectedWrappedLogoMode = mode;
+}
 
 // Show toast notifications for form responses
 $effect(() => {
@@ -1120,74 +1140,37 @@ const logFieldErrors = $derived(
 						Control logo visibility on Year in Review slideshow pages.
 					</p>
 
-					<form method="POST" action="?/updateWrappedLogoMode" use:enhance>
-						<div class="option-cards">
-							<label
-								class="option-card"
-								class:selected={selectedWrappedLogoMode === 'always_show'}
-							>
-								<input
-									type="radio"
-									name="logoMode"
-									value="always_show"
-									bind:group={selectedWrappedLogoMode}
-								/>
-								<div class="option-icon">
-									<Image />
-								</div>
-								<div class="option-content">
-									<span class="option-title">Always Show</span>
-									<span class="option-desc">{wrappedLogoDescriptions.always_show}</span>
-								</div>
-								{#if selectedWrappedLogoMode === 'always_show'}
-									<div class="option-check"><Check /></div>
-								{/if}
-							</label>
-
-							<label
-								class="option-card"
-								class:selected={selectedWrappedLogoMode === 'always_hide'}
-							>
-								<input
-									type="radio"
-									name="logoMode"
-									value="always_hide"
-									bind:group={selectedWrappedLogoMode}
-								/>
-								<div class="option-icon">
-									<ImageOff />
-								</div>
-								<div class="option-content">
-									<span class="option-title">Always Hide</span>
-									<span class="option-desc">{wrappedLogoDescriptions.always_hide}</span>
-								</div>
-								{#if selectedWrappedLogoMode === 'always_hide'}
-									<div class="option-check"><Check /></div>
-								{/if}
-							</label>
-
-							<label
-								class="option-card"
-								class:selected={selectedWrappedLogoMode === 'user_choice'}
-							>
-								<input
-									type="radio"
-									name="logoMode"
-									value="user_choice"
-									bind:group={selectedWrappedLogoMode}
-								/>
-								<div class="option-icon">
-									<ToggleRight />
-								</div>
-								<div class="option-content">
-									<span class="option-title">User Choice</span>
-									<span class="option-desc">{wrappedLogoDescriptions.user_choice}</span>
-								</div>
-								{#if selectedWrappedLogoMode === 'user_choice'}
-									<div class="option-check"><Check /></div>
-								{/if}
-							</label>
-						</div>
+						<form method="POST" action="?/updateWrappedLogoMode" use:enhance>
+							<div class="option-cards">
+								{#each data.wrappedLogoOptions as option}
+									{@const optionId = `wrapped-logo-mode-${option.value}`}
+									{@const LogoModeIcon = wrappedLogoIcons[option.value] ?? ToggleRight}
+									<label
+										for={optionId}
+										class="option-card"
+										class:selected={selectedWrappedLogoMode === option.value}
+									>
+										<input
+											id={optionId}
+											type="radio"
+											name="logoMode"
+											value={option.value}
+											checked={selectedWrappedLogoMode === option.value}
+											onchange={() => selectWrappedLogoMode(option.value)}
+										/>
+										<div class="option-icon">
+											<LogoModeIcon />
+										</div>
+										<div class="option-content">
+											<span class="option-title">{option.label}</span>
+											<span class="option-desc">{wrappedLogoDescriptions[option.value]}</span>
+										</div>
+										{#if selectedWrappedLogoMode === option.value}
+											<div class="option-check"><Check /></div>
+										{/if}
+									</label>
+								{/each}
+							</div>
 						<div class="panel-actions">
 							<button type="submit" class="btn-primary">
 								<Image class="btn-icon" />

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -1140,7 +1140,18 @@ const logFieldErrors = $derived(
 						Control logo visibility on Year in Review slideshow pages.
 					</p>
 
-						<form method="POST" action="?/updateWrappedLogoMode" use:enhance>
+						<form
+							method="POST"
+							action="?/updateWrappedLogoMode"
+							use:enhance={() => {
+								return async ({ result, update }) => {
+									await update();
+									if (result.type === 'failure') {
+										selectedWrappedLogoMode = syncedWrappedLogoMode;
+									}
+								};
+							}}
+						>
 							<div class="option-cards">
 								{#each data.wrappedLogoOptions as option}
 									{@const optionId = `wrapped-logo-mode-${option.value}`}

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -1146,7 +1146,7 @@ const logFieldErrors = $derived(
 							use:enhance={() => {
 								return async ({ result, update }) => {
 									await update();
-									if (result.type === 'failure') {
+									if (result.type === 'failure' || result.type === 'error') {
 										selectedWrappedLogoMode = syncedWrappedLogoMode;
 									}
 								};

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -100,16 +100,16 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 						{#each data.users as user (user.id)}
 							<tr>
 								<td>
-									<div class="user-cell">
-										<a href={user.wrappedHref} class="user-avatar-link">
-											{#if user.thumb}
-												<img src={user.thumb} alt="" class="user-avatar" />
-											{:else}
-												<span class="user-avatar placeholder">&#9787;</span>
-											{/if}
-										</a>
-										<div class="user-info">
-											<a href={user.wrappedHref} class="user-name">
+										<div class="user-cell">
+											<span class="user-avatar-link" aria-hidden="true">
+												{#if user.thumb}
+													<img src={user.thumb} alt="" class="user-avatar" />
+												{:else}
+													<span class="user-avatar placeholder">&#9787;</span>
+												{/if}
+											</span>
+											<div class="user-info">
+												<a href={user.wrappedHref} class="user-name">
 												{user.username}
 												{#if user.isAdmin}
 													<span class="admin-badge">Admin</span>
@@ -179,17 +179,17 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 			</div>
 			<div class="mobile-users-list">
 				{#each data.users as user (user.id)}
-					<div class="mobile-user-row">
-						<div class="mobile-user-main">
-							<a href={user.wrappedHref} class="user-avatar-link">
-								{#if user.thumb}
-									<img src={user.thumb} alt="" class="user-avatar" />
-								{:else}
-									<span class="user-avatar placeholder">&#9787;</span>
-								{/if}
-							</a>
-							<div class="user-info">
-								<a href={user.wrappedHref} class="user-name">
+							<div class="mobile-user-row">
+							<div class="mobile-user-main">
+								<span class="user-avatar-link" aria-hidden="true">
+									{#if user.thumb}
+										<img src={user.thumb} alt="" class="user-avatar" />
+									{:else}
+										<span class="user-avatar placeholder">&#9787;</span>
+									{/if}
+								</span>
+								<div class="user-info">
+									<a href={user.wrappedHref} class="user-name">
 									{user.username}
 									{#if user.isAdmin}
 										<span class="admin-badge">Admin</span>
@@ -423,10 +423,15 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 			gap: 0.75rem;
 		}
 
-		.user-avatar-link,
-		.user-name {
-			text-decoration: none;
-		}
+			.user-avatar-link,
+			.user-name {
+				text-decoration: none;
+			}
+
+			.user-avatar-link {
+				display: inline-flex;
+				flex: 0 0 auto;
+			}
 
 		.user-avatar {
 			width: 36px;

--- a/tests/unit/admin/settings-actions.test.ts
+++ b/tests/unit/admin/settings-actions.test.ts
@@ -367,9 +367,9 @@ describe('admin updateWrappedLogoMode action', () => {
 		await db.delete(appSettings);
 	});
 
-	function createWrappedLogoModeRequest(logoMode: string): Request {
+	function createWrappedLogoModeRequest(logoMode?: string): Request {
 		const formData = new FormData();
-		formData.set('logoMode', logoMode);
+		if (logoMode !== undefined) formData.set('logoMode', logoMode);
 
 		return new Request('http://localhost/admin/settings?/updateWrappedLogoMode', {
 			method: 'POST',
@@ -398,4 +398,32 @@ describe('admin updateWrappedLogoMode action', () => {
 			expect(await getWrappedLogoMode()).toBe(logoMode);
 		});
 	}
+
+	it('rejects invalid logo mode without persisting a change', async () => {
+		await setAppSetting(AppSettingsKey.WRAPPED_LOGO_MODE, WrappedLogoMode.ALWAYS_HIDE);
+
+		const result = await runUpdateWrappedLogoMode(createWrappedLogoModeRequest('invalid'));
+
+		expect(result).toMatchObject({
+			status: 400,
+			data: {
+				error: 'Invalid logo mode'
+			}
+		});
+		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.ALWAYS_HIDE);
+	});
+
+	it('rejects missing logo mode without persisting a change', async () => {
+		await setAppSetting(AppSettingsKey.WRAPPED_LOGO_MODE, WrappedLogoMode.ALWAYS_HIDE);
+
+		const result = await runUpdateWrappedLogoMode(createWrappedLogoModeRequest());
+
+		expect(result).toMatchObject({
+			status: 400,
+			data: {
+				error: 'Invalid logo mode'
+			}
+		});
+		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.ALWAYS_HIDE);
+	});
 });

--- a/tests/unit/admin/settings-actions.test.ts
+++ b/tests/unit/admin/settings-actions.test.ts
@@ -4,8 +4,10 @@ import {
 	AppSettingsKey,
 	getAppSetting,
 	getAppSettingsUpdatedAt,
+	getWrappedLogoMode,
 	setAppSetting,
-	USER_DEFAULTS_SETTINGS_KEYS
+	USER_DEFAULTS_SETTINGS_KEYS,
+	WrappedLogoMode
 } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
@@ -16,6 +18,7 @@ type UpdateUserDefaultsAction = NonNullable<typeof actions.updateUserDefaults>;
 type UpdateApiConfigAction = NonNullable<typeof actions.updateApiConfig>;
 type ClearOpenaiModelAction = NonNullable<typeof actions.clearOpenaiModel>;
 type UpdateTrustProxyAction = NonNullable<typeof actions.updateTrustProxy>;
+type UpdateWrappedLogoModeAction = NonNullable<typeof actions.updateWrappedLogoMode>;
 
 const adminLocals = {
 	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
@@ -357,4 +360,42 @@ describe('admin updateTrustProxy action', () => {
 			restoreTrustProxyEnv();
 		}
 	});
+});
+
+describe('admin updateWrappedLogoMode action', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+	});
+
+	function createWrappedLogoModeRequest(logoMode: string): Request {
+		const formData = new FormData();
+		formData.set('logoMode', logoMode);
+
+		return new Request('http://localhost/admin/settings?/updateWrappedLogoMode', {
+			method: 'POST',
+			body: formData
+		});
+	}
+
+	async function runUpdateWrappedLogoMode(request: Request) {
+		const handler = actions.updateWrappedLogoMode as UpdateWrappedLogoModeAction;
+		return handler({ request, locals: adminLocals } as Parameters<UpdateWrappedLogoModeAction>[0]);
+	}
+
+	for (const logoMode of [
+		WrappedLogoMode.ALWAYS_SHOW,
+		WrappedLogoMode.ALWAYS_HIDE,
+		WrappedLogoMode.USER_CHOICE
+	]) {
+		it(`persists logo mode ${logoMode}`, async () => {
+			await expect(
+				runUpdateWrappedLogoMode(createWrappedLogoModeRequest(logoMode))
+			).resolves.toMatchObject({
+				success: true,
+				message: 'Logo visibility mode updated'
+			});
+
+			expect(await getWrappedLogoMode()).toBe(logoMode);
+		});
+	}
 });

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -126,7 +126,7 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('pointer-events: none;');
 		expect(source).toContain('min-width: 0;');
 		expect(source).toContain('text-overflow: ellipsis;');
-		expect(source).not.toContain('</a>\n\t\t\t\t\t\t\t</a>');
+		expect(source).not.toMatch(/<a\b[^>]*>(?:(?!<\/a>).)*<a\b/s);
 	});
 
 	it('renders user avatars as decorative non-link artwork', async () => {

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -115,6 +115,62 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('pointer-events: auto;');
 	});
 
+	it('keeps the open mobile admin drawer header self-contained', async () => {
+		const source = await readSource('src/routes/admin/+layout.svelte');
+
+		expect(source).toContain('class="mobile-header" class:sidebar-open={sidebarOpen}');
+		expect(source).toContain('aria-label="Close navigation"');
+		expect(source).toContain('class="sidebar-close-button"');
+		expect(source).toContain('.mobile-header.sidebar-open');
+		expect(source).toContain('visibility: hidden;');
+		expect(source).toContain('pointer-events: none;');
+		expect(source).toContain('min-width: 0;');
+		expect(source).toContain('text-overflow: ellipsis;');
+		expect(source).not.toContain('</a>\n\t\t\t\t\t\t\t</a>');
+	});
+
+	it('renders user avatars as decorative non-link artwork', async () => {
+		const source = await readSource('src/routes/admin/users/+page.svelte');
+
+		expect(source).toContain('<span class="user-avatar-link" aria-hidden="true">');
+		expect(source).not.toContain('<a href={user.wrappedHref} class="user-avatar-link">');
+		expect(source).toContain('<img src={user.thumb} alt="" class="user-avatar" />');
+		expect(source).toContain('<a href={user.wrappedHref} class="user-name">');
+		expect(source).toContain('class="preview-link"');
+	});
+
+	it('updates wrapped logo mode selection explicitly without resetting local clicks', async () => {
+		const source = await readSource('src/routes/admin/settings/+page.svelte');
+
+		expect(source).toContain(
+			'let selectedWrappedLogoMode = $state<WrappedLogoModeValue>(untrack(() => data.wrappedLogoMode));'
+		);
+		expect(source).toContain(
+			'let syncedWrappedLogoMode = $state<WrappedLogoModeValue>(untrack(() => data.wrappedLogoMode));'
+		);
+		expect(source).toContain('if (serverWrappedLogoMode === syncedWrappedLogoMode) return;');
+		expect(source).toContain('function selectWrappedLogoMode(mode: WrappedLogoModeValue): void');
+		expect(source).toContain('{#each data.wrappedLogoOptions as option}');
+		expect(source).toContain('for={optionId}');
+		expect(source).toContain('name="logoMode"');
+		expect(source).toContain('checked={selectedWrappedLogoMode === option.value}');
+		expect(source).toContain('onchange={() => selectWrappedLogoMode(option.value)}');
+		expect(source).not.toContain('bind:group={selectedWrappedLogoMode}');
+	});
+
+	it('does not log Plex auth payloads from app-owned browser auth code', async () => {
+		const sources = await Promise.all([
+			readSource('src/lib/client/plex-login.ts'),
+			readSource('src/routes/auth/plex/redirect/+page.svelte')
+		]);
+
+		for (const source of sources) {
+			expect(source).not.toContain('console.log');
+			expect(source).not.toContain('console.debug');
+			expect(source).not.toContain('console.info');
+		}
+	});
+
 	it('guards wrapped story transitions against stale rapid navigation', async () => {
 		const source = await readSource('src/lib/components/wrapped/StoryMode.svelte');
 

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -118,7 +118,9 @@ describe('admin UI source regressions', () => {
 	it('keeps the open mobile admin drawer header self-contained', async () => {
 		const source = await readSource('src/routes/admin/+layout.svelte');
 
-		expect(source).toContain('class="mobile-header" class:sidebar-open={sidebarOpen}');
+		expect(source).toMatch(
+			/<header\b(?=[^>]*\bclass="[^"]*\bmobile-header\b[^"]*")(?=[^>]*\bclass:sidebar-open=\{sidebarOpen\})[^>]*>/
+		);
 		expect(source).toContain('aria-label="Close navigation"');
 		expect(source).toContain('class="sidebar-close-button"');
 		expect(source).toContain('.mobile-header.sidebar-open');

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -104,7 +104,6 @@ describe('sanitizeCompletedLoginResponse', () => {
 			'services',
 			'plexId',
 			'uuid',
-			'id',
 			'resources',
 			'clientIdentifier',
 			'accessToken',

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -53,6 +53,76 @@ describe('sanitizeCompletedLoginResponse', () => {
 			expect(responseText).not.toContain(forbidden);
 		}
 	});
+
+	it('strips provider auth payload fields from AUTH_COMPLETE-shaped responses', () => {
+		const sanitized = sanitizeCompletedLoginResponse({
+			type: 'AUTH_COMPLETE',
+			authToken: 'plex-auth-token',
+			token: 'provider-token',
+			secret: 'provider-secret',
+			user: {
+				id: 7,
+				uuid: 'raw-plex-uuid',
+				plexId: '123456',
+				username: 'owner',
+				email: 'owner@example.com',
+				isAdmin: false,
+				authToken: 'nested-auth-token',
+				services: [
+					{
+						identifier: 'server-resource',
+						token: 'service-token',
+						secret: 'service-secret'
+					}
+				]
+			},
+			resources: [
+				{
+					name: 'Plex Server',
+					clientIdentifier: 'server-client-id',
+					accessToken: 'server-access-token'
+				}
+			],
+			redirectTo: '/dashboard'
+		});
+
+		expect(sanitized).toEqual({
+			user: {
+				username: 'owner',
+				isAdmin: false
+			},
+			redirectTo: '/dashboard'
+		});
+
+		const responseText = JSON.stringify(sanitized);
+		for (const forbidden of [
+			'AUTH_COMPLETE',
+			'authToken',
+			'token',
+			'secret',
+			'email',
+			'services',
+			'plexId',
+			'uuid',
+			'id',
+			'resources',
+			'clientIdentifier',
+			'accessToken',
+			'plex-auth-token',
+			'provider-token',
+			'provider-secret',
+			'nested-auth-token',
+			'service-token',
+			'service-secret',
+			'server-access-token',
+			'server-client-id',
+			'owner@example.com',
+			'123456',
+			'raw-plex-uuid'
+		]) {
+			expect(responseText).not.toContain(forbidden);
+		}
+	});
 });
 
 interface MemoryStorage {


### PR DESCRIPTION
## Summary

This pull request resolves the four findings from the Obzorarr dogfood QA report.

## Changes

- Treats the Plex-hosted `AUTH_COMPLETE` console payload as an external provider limitation while adding app-owned regression coverage to ensure Obzorarr sanitizes completed login responses and does not log auth payloads from browser auth code.
- Fixes the mobile admin sidebar at narrow widths by adding a drawer-local close button, hiding the fixed mobile header while the drawer is open, and constraining the sidebar brand/header layout so text and controls cannot overlap.
- Improves the Users admin page accessibility by making avatar artwork decorative and non-focusable while preserving the adjacent username and Preview Wrapped links as the accessible navigation controls.
- Fixes Wrapped Page Logo mode selection by rendering options from server-provided data, using explicit radio checked/change handling, and guarding local state sync so a local selection is not immediately overwritten by unchanged server data.

## Tests

- `bun test tests/unit/plex-login.test.ts tests/unit/admin/settings-actions.test.ts tests/unit/admin/ui-source-regressions.test.ts --env-file=.env.test`
- `bun run check`
- `bun run test`
- `bun run check:biome`

## Notes

The Plex OAuth console payload captured in QA originates from the hosted Plex auth page, not Obzorarr-owned code. This PR therefore focuses on app-side safeguards: sanitized client responses and source regressions that prevent Obzorarr browser auth code from logging token-bearing payloads.