### PR TITLE
fix: add safe plex diagnostics and sharing state fixes

### DIFF
--- a/src/lib/components/slides/CustomSlide.svelte
+++ b/src/lib/components/slides/CustomSlide.svelte
@@ -131,6 +131,8 @@ $effect(() => {
 			color: hsl(var(--foreground));
 			text-align: left;
 			width: 100%;
+			overflow-wrap: anywhere;
+			word-break: break-word;
 		}
 
 		/* Markdown styling */

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { untrack } from 'svelte';
 import { enhance } from '$app/forms';
 import { goto } from '$app/navigation';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
@@ -44,13 +45,11 @@ function isBelowFloor(mode: ShareModeType): boolean {
 let copied = $state(false);
 let copyTimeout: ReturnType<typeof setTimeout> | undefined;
 let isUpdating = $state(false);
-let optimisticMode = $state<ShareModeType | null>(null);
-let optimisticShareToken = $state<string | null | undefined>(undefined);
+let localMode = $state<ShareModeType>(untrack(() => shareSettings?.mode ?? 'public'));
+let localShareToken = $state<string | null | undefined>(untrack(() => shareSettings?.shareToken));
 
-const displayMode = $derived(optimisticMode ?? shareSettings?.mode);
-const displayShareToken = $derived(
-	optimisticShareToken === undefined ? shareSettings?.shareToken : optimisticShareToken
-);
+const displayMode = $derived(localMode);
+const displayShareToken = $derived(localShareToken);
 
 // Computed URL based on mode
 const shareUrl = $derived.by(() => {
@@ -136,16 +135,21 @@ function applyShareActionData(data: unknown): void {
 		| undefined;
 
 	if (actionData?.shareSettings?.mode) {
-		optimisticMode = actionData.shareSettings.mode;
+		localMode = actionData.shareSettings.mode;
 	}
 
 	if (actionData?.shareSettings && 'shareToken' in actionData.shareSettings) {
-		optimisticShareToken = actionData.shareSettings.shareToken;
+		localShareToken = actionData.shareSettings.shareToken;
 	}
 
 	if (actionData && 'shareToken' in actionData) {
-		optimisticShareToken = actionData.shareToken;
+		localShareToken = actionData.shareToken;
 	}
+}
+
+function restoreLocalShareState(): void {
+	localMode = shareSettings?.mode ?? 'public';
+	localShareToken = shareSettings?.shareToken;
 }
 
 function currentRouteIdentifier(): string | null {
@@ -216,15 +220,21 @@ $effect(() => {
 });
 
 // Reset optimistic state when the modal transitions from closed to open
-// so a freshly-loaded shareSettings prop (e.g., token rotated elsewhere) is
-// not shadowed by stale optimistic values from a prior session.
+// so a freshly-loaded shareSettings prop (e.g., token rotated elsewhere) is used.
 let prevOpen = false;
 $effect(() => {
 	if (open && !prevOpen) {
-		optimisticMode = null;
-		optimisticShareToken = undefined;
+		restoreLocalShareState();
 	}
 	prevOpen = open;
+});
+
+let lastShareSettings = untrack(() => shareSettings);
+$effect(() => {
+	if (!isUpdating && shareSettings !== lastShareSettings) {
+		lastShareSettings = shareSettings;
+		restoreLocalShareState();
+	}
 });
 </script>
 
@@ -314,17 +324,11 @@ $effect(() => {
 									applyShareActionData(result.data);
 									if (await navigateAfterTokenRouteUpdate(result.data)) return;
 								} else {
-									optimisticMode = null;
-									optimisticShareToken = undefined;
+									restoreLocalShareState();
 								}
 								await update();
 							} finally {
 								isUpdating = false;
-								// Intentionally do NOT reset optimisticMode/optimisticShareToken here.
-								// On success: applyShareActionData() set them to the server's value, so
-								// clearing them between this finally and the next $derived re-evaluation
-								// causes a brief all-unchecked render frame for the radio group.
-								// On failure: the else branch above already cleared them inline.
 							}
 						};
 					}}
@@ -341,10 +345,10 @@ $effect(() => {
 									type="radio"
 									name="mode"
 									value={mode}
-									checked={isUpdating ? optimisticMode === mode : displayMode === mode}
+									checked={displayMode === mode}
 									disabled={isUpdating || isBelowFloor(mode as ShareModeType)}
 									onchange={(e) => {
-										optimisticMode = mode as ShareModeType;
+										localMode = mode as ShareModeType;
 										e.currentTarget.form?.requestSubmit();
 									}}
 								/>
@@ -386,16 +390,13 @@ $effect(() => {
 						action="?/regenerateToken"
 						use:enhance={() => {
 							isUpdating = true;
-							// Seed optimisticMode with the current mode so the radio group's
-							// `checked={isUpdating ? optimisticMode === mode : ...}` expression
-							// keeps the correct option selected for the round-trip duration.
-							// The regenerate action does not change the mode, so we mirror it.
-							optimisticMode = shareSettings?.mode ?? null;
 							return async ({ result, update }) => {
 								try {
 									if (result.type === 'success') {
 										applyShareActionData(result.data);
 										if (await navigateAfterTokenRouteUpdate(result.data)) return;
+									} else {
+										restoreLocalShareState();
 									}
 									await update();
 								} finally {

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -1,5 +1,11 @@
 import { getApiConfigWithSources } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
+import {
+	fingerprintPlexIdentifier,
+	formatPlexConnectionDiagnostic,
+	formatPlexResourceDiagnostic,
+	formatPlexUrlDiagnostic
+} from '$lib/server/plex/diagnostics';
 import { refreshConfiguredServerMachineId } from '$lib/server/plex/server-identity.service';
 import {
 	type MembershipResult,
@@ -307,7 +313,9 @@ function findConfiguredServer(
 		);
 		if (serverByConfiguredId) {
 			logger.debug(
-				`Matched server by /identity machineIdentifier: ${configuredMachineIdFromIdentity} -> ${serverByConfiguredId.name}`,
+				`Matched server by /identity machineIdentifier hash=${fingerprintPlexIdentifier(
+					configuredMachineIdFromIdentity
+				)} serverHash=${fingerprintPlexIdentifier(serverByConfiguredId.clientIdentifier)}`,
 				'Membership'
 			);
 			return serverByConfiguredId;
@@ -323,7 +331,9 @@ function findConfiguredServer(
 		);
 		if (serverByMachineId) {
 			logger.debug(
-				`Matched server by machineId: ${configuredMachineId} -> ${serverByMachineId.name}`,
+				`Matched server by plex.direct machine hash=${fingerprintPlexIdentifier(
+					configuredMachineId
+				)} serverHash=${fingerprintPlexIdentifier(serverByMachineId.clientIdentifier)}`,
 				'Membership'
 			);
 			return serverByMachineId;
@@ -333,9 +343,11 @@ function findConfiguredServer(
 		// This handles cases where the machineId in the URL differs from clientIdentifier
 		const serverByIp = servers.find((s) => matchesByIpAndPort(configuredUrl, s.connections));
 		if (serverByIp) {
-			const extracted = extractPlexDirectIpAndPort(configuredUrl);
 			logger.debug(
-				`Matched server by IP address from .plex.direct URL: ${extracted?.ip} -> ${serverByIp.name}`,
+				`Matched server by IP/port from plex.direct diagnostic=${formatPlexUrlDiagnostic(
+					configuredUrl,
+					'default'
+				)} serverHash=${fingerprintPlexIdentifier(serverByIp.clientIdentifier)}`,
 				'Membership'
 			);
 			return serverByIp;
@@ -346,7 +358,10 @@ function findConfiguredServer(
 		const serverByPlainHost = servers.find((s) => matchesPlainHost(configuredUrl, s));
 		if (serverByPlainHost) {
 			logger.debug(
-				`Matched server by plain host/port: ${configuredUrl} -> ${serverByPlainHost.name}`,
+				`Matched server by plain host/port diagnostic=${formatPlexUrlDiagnostic(
+					configuredUrl,
+					'default'
+				)} serverHash=${fingerprintPlexIdentifier(serverByPlainHost.clientIdentifier)}`,
 				'Membership'
 			);
 			return serverByPlainHost;
@@ -375,20 +390,20 @@ export async function verifyServerMembership(userToken: string): Promise<Members
 
 	// Debug logging to help diagnose membership issues
 	logger.debug(
-		`Configured PLEX_SERVER_URL: ${configuredUrl} (source: ${apiConfig.plex.serverUrl.source})`,
+		`Configured PLEX_SERVER_URL diagnostic=${formatPlexUrlDiagnostic(
+			configuredUrl,
+			apiConfig.plex.serverUrl.source
+		)}`,
 		'Membership'
 	);
 	logger.debug(`Found ${servers.length} server(s) accessible to user`, 'Membership');
 
-	for (const server of servers) {
-		logger.debug(
-			`Server: ${server.name} | clientIdentifier: ${server.clientIdentifier} | owned: ${server.owned}`,
-			'Membership'
-		);
+	for (const [index, server] of servers.entries()) {
+		logger.debug(`Server resource: ${formatPlexResourceDiagnostic(server, index)}`, 'Membership');
 		if (server.connections) {
 			for (const conn of server.connections) {
 				logger.debug(
-					`  - Connection URI: ${conn.uri} | local: ${conn.local} | relay: ${conn.relay}`,
+					`  - Connection: ${formatPlexConnectionDiagnostic(conn, 'default')}`,
 					'Membership'
 				);
 			}
@@ -418,9 +433,11 @@ export async function verifyServerMembership(userToken: string): Promise<Members
 
 	const configuredMachineIdFromIdentity = identityResult.machineId ?? undefined;
 	logger.debug(
-		`Configured server machineIdentifier: ${identityResult.machineId ?? 'null'} (source: ${
-			identityResult.source
-		}${identityResult.errorReason ? `, reason: ${identityResult.errorReason}` : ''})`,
+		`Configured server machineIdentifier hash=${fingerprintPlexIdentifier(
+			identityResult.machineId
+		)} source=${identityResult.source}${
+			identityResult.errorReason ? ` reason=${identityResult.errorReason}` : ''
+		}`,
 		'Membership'
 	);
 
@@ -458,7 +475,9 @@ export async function verifyServerMembership(userToken: string): Promise<Members
 	}
 
 	logger.debug(
-		`Matched server: ${configuredServer.name} | isOwner: ${configuredServer.owned}`,
+		`Matched server hash=${fingerprintPlexIdentifier(configuredServer.clientIdentifier)} isOwner=${
+			configuredServer.owned
+		}`,
 		'Membership'
 	);
 
@@ -586,7 +605,10 @@ export function selectBestConnection(server: PlexResource): string | undefined {
 		(c) => c.uri.includes('.plex.direct') && !c.local && !c.relay
 	);
 	if (publicPlexDirect) {
-		logger.debug(`Selected public .plex.direct connection: ${publicPlexDirect.uri}`, 'Membership');
+		logger.debug(
+			`Selected public plex.direct connection: ${formatPlexConnectionDiagnostic(publicPlexDirect)}`,
+			'Membership'
+		);
 		return publicPlexDirect.uri;
 	}
 
@@ -595,28 +617,40 @@ export function selectBestConnection(server: PlexResource): string | undefined {
 		(c) => c.uri.includes('.plex.direct') && c.local && !c.relay
 	);
 	if (localPlexDirect) {
-		logger.debug(`Selected local .plex.direct connection: ${localPlexDirect.uri}`, 'Membership');
+		logger.debug(
+			`Selected local plex.direct connection: ${formatPlexConnectionDiagnostic(localPlexDirect)}`,
+			'Membership'
+		);
 		return localPlexDirect.uri;
 	}
 
 	// Priority 3: Find public (non-local, non-relay) connection
 	const publicConnection = connections.find((c) => !c.local && !c.relay);
 	if (publicConnection) {
-		logger.debug(`Selected public connection: ${publicConnection.uri}`, 'Membership');
+		logger.debug(
+			`Selected public connection: ${formatPlexConnectionDiagnostic(publicConnection)}`,
+			'Membership'
+		);
 		return publicConnection.uri;
 	}
 
 	// Priority 4: Find local (non-relay) connection as fallback
 	const localConnection = connections.find((c) => c.local && !c.relay);
 	if (localConnection) {
-		logger.debug(`Selected local connection: ${localConnection.uri}`, 'Membership');
+		logger.debug(
+			`Selected local connection: ${formatPlexConnectionDiagnostic(localConnection)}`,
+			'Membership'
+		);
 		return localConnection.uri;
 	}
 
 	// Last resort: use any available connection
 	const anyConnection = connections[0];
 	if (anyConnection) {
-		logger.debug(`Selected fallback connection: ${anyConnection.uri}`, 'Membership');
+		logger.debug(
+			`Selected fallback connection: ${formatPlexConnectionDiagnostic(anyConnection)}`,
+			'Membership'
+		);
 		return anyConnection.uri;
 	}
 
@@ -658,7 +692,10 @@ export function generatePlexDirectUrl(
 	}
 
 	const url = `https://${ipWithDashes}.${machineId}.plex.direct:${port}`;
-	logger.debug(`Generated .plex.direct URL: ${url}`, 'Membership');
+	logger.debug(
+		`Generated plex.direct URL diagnostic=${formatPlexUrlDiagnostic(url, 'default')}`,
+		'Membership'
+	);
 
 	return url;
 }
@@ -673,11 +710,8 @@ export async function verifyServerOwnership(userToken: string): Promise<Ownershi
 	// Debug logging
 	logger.debug(`Found ${servers.length} server(s) accessible to user`, 'Membership');
 
-	for (const server of servers) {
-		logger.debug(
-			`Server: ${server.name} | clientIdentifier: ${server.clientIdentifier} | owned: ${server.owned}`,
-			'Membership'
-		);
+	for (const [index, server] of servers.entries()) {
+		logger.debug(`Server resource: ${formatPlexResourceDiagnostic(server, index)}`, 'Membership');
 	}
 
 	// Find the first server that the user owns
@@ -703,7 +737,9 @@ export async function verifyServerOwnership(userToken: string): Promise<Ownershi
 	}
 
 	logger.debug(
-		`Found owned server: ${ownedServer.name} | bestConnection: ${bestConnectionUrl}`,
+		`Found owned server hash=${fingerprintPlexIdentifier(
+			ownedServer.clientIdentifier
+		)} bestConnection=${bestConnectionUrl ? formatPlexUrlDiagnostic(bestConnectionUrl, 'default') : 'none'}`,
 		'Membership'
 	);
 

--- a/src/lib/server/logging/logger.ts
+++ b/src/lib/server/logging/logger.ts
@@ -1,3 +1,4 @@
+import { redactLogMessage, redactLogMetadata } from './redactor';
 import { insertLogsBatch, isDebugEnabled } from './service';
 import { LogLevel, type NewLogEntry } from './types';
 
@@ -16,28 +17,38 @@ class Logger {
 		// Check if debug is enabled (with caching)
 		const debugEnabled = await this.isDebugEnabled();
 		if (!debugEnabled) {
-			// Still output to console for development
-			console.debug(`[${source ?? 'App'}] ${message}`);
 			return;
 		}
 
-		this.addToBuffer({ level: LogLevel.DEBUG, message, source, metadata });
-		console.debug(`[${source ?? 'App'}] ${message}`);
+		const entry = this.sanitizeEntry({ level: LogLevel.DEBUG, message, source, metadata });
+		this.addToBuffer(entry);
+		console.debug(`[${source ?? 'App'}] ${entry.message}`);
 	}
 
 	info(message: string, source?: string, metadata?: Record<string, unknown>): void {
-		this.addToBuffer({ level: LogLevel.INFO, message, source, metadata });
-		console.log(`[${source ?? 'App'}] ${message}`);
+		const entry = this.sanitizeEntry({ level: LogLevel.INFO, message, source, metadata });
+		this.addToBuffer(entry);
+		console.log(`[${source ?? 'App'}] ${entry.message}`);
 	}
 
 	warn(message: string, source?: string, metadata?: Record<string, unknown>): void {
-		this.addToBuffer({ level: LogLevel.WARN, message, source, metadata });
-		console.warn(`[${source ?? 'App'}] ${message}`);
+		const entry = this.sanitizeEntry({ level: LogLevel.WARN, message, source, metadata });
+		this.addToBuffer(entry);
+		console.warn(`[${source ?? 'App'}] ${entry.message}`);
 	}
 
 	error(message: string, source?: string, metadata?: Record<string, unknown>): void {
-		this.addToBuffer({ level: LogLevel.ERROR, message, source, metadata });
-		console.error(`[${source ?? 'App'}] ${message}`);
+		const entry = this.sanitizeEntry({ level: LogLevel.ERROR, message, source, metadata });
+		this.addToBuffer(entry);
+		console.error(`[${source ?? 'App'}] ${entry.message}`);
+	}
+
+	private sanitizeEntry(entry: NewLogEntry): NewLogEntry {
+		return {
+			...entry,
+			message: redactLogMessage(entry.message),
+			metadata: entry.metadata ? redactLogMetadata(entry.metadata) : undefined
+		};
 	}
 
 	private addToBuffer(entry: NewLogEntry): void {

--- a/src/lib/server/logging/redactor.ts
+++ b/src/lib/server/logging/redactor.ts
@@ -1,0 +1,36 @@
+const REDACTED = '<redacted>';
+
+const SENSITIVE_QUERY_PARAM =
+	/([?&](?:token|access_token|auth_token|api_key|apikey|key|x-plex-token)=)[^&#\s"'`]+/gi;
+const URL_USERINFO = /\b(https?:\/\/)[^\s/@:]+(?::[^\s/@]*)?@/gi;
+const HEADER_OR_FIELD_SECRET =
+	/\b((?:X-Plex-Token|plexToken|apiKey|accessToken|authToken)\s*[:=]\s*)[^\s,;}"'`]+/gi;
+const AUTHORIZATION_HEADER = /\b(Authorization\s*[:=]\s*)(?:Bearer|Basic)?\s*[^\s,;}"'`]+/gi;
+const COOKIE_HEADER = /\b((?:Cookie|Set-Cookie)\s*[:=]\s*)[^\n]+/gi;
+const JSON_SECRET =
+	/(["'](?:X-Plex-Token|Authorization|Cookie|Set-Cookie|plexToken|apiKey|accessToken|authToken)["']\s*:\s*["'])[^"']+(["'])/gi;
+
+export function redactLogMessage(message: string): string {
+	return message
+		.replace(URL_USERINFO, `$1${REDACTED}@`)
+		.replace(SENSITIVE_QUERY_PARAM, `$1${REDACTED}`)
+		.replace(JSON_SECRET, `$1${REDACTED}$2`)
+		.replace(AUTHORIZATION_HEADER, `$1${REDACTED}`)
+		.replace(COOKIE_HEADER, `$1${REDACTED}`)
+		.replace(HEADER_OR_FIELD_SECRET, `$1${REDACTED}`);
+}
+
+export function redactLogMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(metadata).map(([key, value]) => [key, redactMetadataValue(value)])
+	);
+}
+
+function redactMetadataValue(value: unknown): unknown {
+	if (typeof value === 'string') return redactLogMessage(value);
+	if (Array.isArray(value)) return value.map(redactMetadataValue);
+	if (value && typeof value === 'object') {
+		return redactLogMetadata(value as Record<string, unknown>);
+	}
+	return value;
+}

--- a/src/lib/server/plex/diagnostics.ts
+++ b/src/lib/server/plex/diagnostics.ts
@@ -1,0 +1,184 @@
+import { createHash } from 'node:crypto';
+import type { ConfigSource } from '$lib/server/admin/settings.service';
+
+export type PlexUrlCategory =
+	| 'https'
+	| 'http'
+	| 'plex.direct'
+	| 'localhost'
+	| 'private-ip'
+	| 'docker/private-range'
+	| 'public-domain'
+	| 'public-ip'
+	| 'invalid';
+
+export interface PlexUrlDiagnostic {
+	source: ConfigSource;
+	scheme: 'https' | 'http' | 'other' | 'invalid';
+	category: PlexUrlCategory;
+	port: string;
+	hostHash?: string;
+	machineHash?: string;
+	hasCredentials: boolean;
+	hasPath: boolean;
+	hasQuery: boolean;
+	hasFragment: boolean;
+}
+
+interface PlexConnectionDiagnosticInput {
+	uri: string;
+	local?: boolean;
+	relay?: boolean;
+}
+
+interface PlexResourceDiagnosticInput {
+	clientIdentifier: string;
+	owned: boolean;
+	connections?: PlexConnectionDiagnosticInput[];
+}
+
+function shortFingerprint(value: string | null | undefined): string | undefined {
+	if (!value) return undefined;
+	return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}
+
+function parseIpv4(hostname: string): number[] | null {
+	const parts = hostname.split('.');
+	if (parts.length !== 4) return null;
+
+	const octets: number[] = [];
+	for (const part of parts) {
+		if (!/^\d{1,3}$/.test(part)) return null;
+		const value = Number(part);
+		if (!Number.isInteger(value) || value < 0 || value > 255) return null;
+		octets.push(value);
+	}
+	return octets;
+}
+
+function isIpv6Literal(hostname: string): boolean {
+	return hostname.includes(':');
+}
+
+function isPlexDirect(hostname: string): boolean {
+	return hostname.toLowerCase().endsWith('.plex.direct');
+}
+
+function extractPlexDirectMachineId(hostname: string): string | undefined {
+	const parts = hostname.toLowerCase().split('.');
+	const machineId = parts.length >= 4 ? parts[parts.length - 3] : undefined;
+	return machineId && /^[a-f0-9]{32}$/i.test(machineId) ? machineId : undefined;
+}
+
+function categoryForHost(hostname: string): PlexUrlCategory {
+	const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+
+	if (isPlexDirect(host)) return 'plex.direct';
+	if (host === 'localhost' || host === '::1') return 'localhost';
+
+	const ipv4 = parseIpv4(host);
+	if (ipv4) {
+		const [a, b] = ipv4;
+		if (a === 127) return 'localhost';
+		if (a === 172 && b !== undefined && b >= 16 && b <= 31) return 'docker/private-range';
+		if (a === 10 || (a === 192 && b === 168) || (a === 169 && b === 254)) return 'private-ip';
+		return 'public-ip';
+	}
+
+	if (isIpv6Literal(host)) {
+		if (host.startsWith('fc') || host.startsWith('fd') || /^fe[89ab]/i.test(host)) {
+			return 'private-ip';
+		}
+		return 'public-ip';
+	}
+
+	if (host.endsWith('.local') || host.endsWith('.lan') || !host.includes('.')) {
+		return 'docker/private-range';
+	}
+
+	return 'public-domain';
+}
+
+function defaultPortForProtocol(protocol: string): string {
+	if (protocol === 'https:') return '443';
+	if (protocol === 'http:') return '80';
+	return 'none';
+}
+
+export function describePlexUrl(rawUrl: string, source: ConfigSource): PlexUrlDiagnostic {
+	try {
+		const parsed = new URL(rawUrl);
+		const scheme =
+			parsed.protocol === 'https:' ? 'https' : parsed.protocol === 'http:' ? 'http' : 'other';
+		const category = categoryForHost(parsed.hostname);
+		return {
+			source,
+			scheme,
+			category,
+			port: parsed.port || defaultPortForProtocol(parsed.protocol),
+			hostHash: shortFingerprint(parsed.hostname.toLowerCase()),
+			machineHash: shortFingerprint(extractPlexDirectMachineId(parsed.hostname)),
+			hasCredentials: Boolean(parsed.username || parsed.password),
+			hasPath: parsed.pathname !== '/' && parsed.pathname !== '',
+			hasQuery: Boolean(parsed.search),
+			hasFragment: Boolean(parsed.hash)
+		};
+	} catch {
+		return {
+			source,
+			scheme: 'invalid',
+			category: 'invalid',
+			port: 'none',
+			hasCredentials: false,
+			hasPath: false,
+			hasQuery: false,
+			hasFragment: false
+		};
+	}
+}
+
+export function formatPlexUrlDiagnostic(rawUrl: string, source: ConfigSource): string {
+	const diagnostic = describePlexUrl(rawUrl, source);
+	const parts = [
+		`source=${diagnostic.source}`,
+		`scheme=${diagnostic.scheme}`,
+		`category=${diagnostic.category}`,
+		`port=${diagnostic.port}`,
+		`hostHash=${diagnostic.hostHash ?? 'none'}`
+	];
+
+	if (diagnostic.machineHash) parts.push(`machineHash=${diagnostic.machineHash}`);
+	if (diagnostic.hasCredentials) parts.push('credentials=present');
+	if (diagnostic.hasPath) parts.push('path=present');
+	if (diagnostic.hasQuery) parts.push('query=present');
+	if (diagnostic.hasFragment) parts.push('fragment=present');
+
+	return parts.join(' ');
+}
+
+export function fingerprintPlexIdentifier(value: string | null | undefined): string {
+	return shortFingerprint(value) ?? 'none';
+}
+
+export function formatPlexConnectionDiagnostic(
+	connection: PlexConnectionDiagnosticInput,
+	source: ConfigSource = 'default'
+): string {
+	return [
+		formatPlexUrlDiagnostic(connection.uri, source),
+		`local=${connection.local === true}`,
+		`relay=${connection.relay === true}`
+	].join(' ');
+}
+
+export function formatPlexResourceDiagnostic(
+	server: PlexResourceDiagnosticInput,
+	index: number
+): string {
+	return [
+		`serverIndex=${index}`,
+		`serverHash=${fingerprintPlexIdentifier(server.clientIdentifier)}`,
+		`owned=${server.owned}`,
+		`connections=${server.connections?.length ?? 0}`
+	].join(' ');
+}

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -41,7 +41,7 @@ import X from '@lucide/svelte/icons/x';
 import Zap from '@lucide/svelte/icons/zap';
 import { type Component, untrack } from 'svelte';
 import { deserialize, enhance } from '$app/forms';
-import { goto } from '$app/navigation';
+import { goto, invalidateAll } from '$app/navigation';
 import { page } from '$app/stores';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import * as Tabs from '$lib/components/ui/tabs';
@@ -108,6 +108,10 @@ let logDebugEnabled = $state(false);
 let selectedServerWrappedMode = $state('public');
 let selectedDefaultShareMode = $state('public');
 let allowUserControl = $state(true);
+let syncedAnonymization = $state('');
+let syncedServerWrappedMode = $state('public');
+let syncedDefaultShareMode = $state('public');
+let syncedAllowUserControl = $state(true);
 let isBulkApplyingUserControl = $state(false);
 
 let bulkApplyShareDefaultsDialogOpen = $state(false);
@@ -209,6 +213,10 @@ $effect(() => {
 	selectedServerWrappedMode = data.serverWrappedShareMode;
 	selectedDefaultShareMode = data.globalDefaults.defaultShareMode;
 	allowUserControl = data.globalDefaults.allowUserControl;
+	syncedAnonymization = data.anonymizationMode;
+	syncedServerWrappedMode = data.serverWrappedShareMode;
+	syncedDefaultShareMode = data.globalDefaults.defaultShareMode;
+	syncedAllowUserControl = data.globalDefaults.allowUserControl;
 });
 
 $effect(() => {
@@ -262,6 +270,16 @@ const wrappedLogoIcons: Record<WrappedLogoModeValue, Component> = {
 
 function selectWrappedLogoMode(mode: WrappedLogoModeValue): void {
 	selectedWrappedLogoMode = mode;
+}
+
+function restoreServerWrappedSettings(): void {
+	selectedAnonymization = syncedAnonymization;
+	selectedServerWrappedMode = syncedServerWrappedMode;
+}
+
+function restoreUserDefaults(): void {
+	selectedDefaultShareMode = syncedDefaultShareMode;
+	allowUserControl = syncedAllowUserControl;
 }
 
 // Show toast notifications for form responses
@@ -1146,7 +1164,12 @@ const logFieldErrors = $derived(
 							use:enhance={() => {
 								return async ({ result, update }) => {
 									try {
-										await update();
+										if (result.type === 'success') {
+											syncedWrappedLogoMode = selectedWrappedLogoMode;
+											await update({ invalidateAll: true });
+										} else {
+											await update();
+										}
 									} finally {
 										if (result.type === 'failure' || result.type === 'error') {
 											selectedWrappedLogoMode = syncedWrappedLogoMode;
@@ -1200,7 +1223,22 @@ const logFieldErrors = $derived(
 		{#if activeTab === 'privacy'}
 			<div class="privacy-content">
 				<!-- Form 1: Server-wide Wrapped (anonymization + server-wide share mode) -->
-				<form method="POST" action="?/updateServerWrappedSettings" use:enhance>
+				<form
+					method="POST"
+					action="?/updateServerWrappedSettings"
+					use:enhance={() => {
+						return async ({ result, update }) => {
+							if (result.type === 'success') {
+								await update({ invalidateAll: true });
+								await invalidateAll();
+								return;
+							}
+
+							restoreServerWrappedSettings();
+							await update();
+						};
+					}}
+				>
 					<input
 						type="hidden"
 						name="settingsVersion"
@@ -1352,7 +1390,22 @@ const logFieldErrors = $derived(
 				</form>
 
 				<!-- Form 2: User Sharing Defaults (defaultShareMode + allowUserControl) -->
-				<form method="POST" action="?/updateUserDefaults" use:enhance>
+				<form
+					method="POST"
+					action="?/updateUserDefaults"
+					use:enhance={() => {
+						return async ({ result, update }) => {
+							if (result.type === 'success') {
+								await update({ invalidateAll: true });
+								await invalidateAll();
+								return;
+							}
+
+							restoreUserDefaults();
+							await update();
+						};
+					}}
+				>
 					<input
 						type="hidden"
 						name="settingsVersion"

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -1220,6 +1220,8 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			overflow-y: auto;
 			font-size: 0.875rem;
 			line-height: 1.6;
+			overflow-wrap: anywhere;
+			word-break: break-word;
 		}
 
 		.preview-placeholder {

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -564,6 +564,8 @@ async function goToPage(page: number) {
 							placeholder="0 0 * * *"
 							class="cron-input"
 							class:cron-input-error={cronError}
+							aria-invalid={cronError ? 'true' : 'false'}
+							aria-describedby={cronError ? 'cronExpression-error' : undefined}
 						/>
 						<button type="submit" class="cron-update-btn" disabled={!!cronError} aria-label="Update schedule">
 							<svg
@@ -579,7 +581,7 @@ async function goToPage(page: number) {
 					</div>
 
 					{#if cronError}
-						<span class="cron-error">{cronError}</span>
+						<span id="cronExpression-error" class="cron-error" role="alert">{cronError}</span>
 					{/if}
 
 					<div class="cron-presets">

--- a/src/routes/api/onboarding/select-server/+server.ts
+++ b/src/routes/api/onboarding/select-server/+server.ts
@@ -17,6 +17,7 @@ import {
 import { logger } from '$lib/server/logging';
 import { OnboardingClaimRequiredError, requireActiveOnboardingClaim } from '$lib/server/onboarding';
 import { resolveOwnedServerToken } from '$lib/server/onboarding/plex-server-selection';
+import { fingerprintPlexIdentifier, formatPlexUrlDiagnostic } from '$lib/server/plex/diagnostics';
 import { classifyConnectionError } from '$lib/server/security';
 import {
 	envAllowsInsecureLocalPlexHttp,
@@ -152,11 +153,19 @@ export const POST: RequestHandler = async ({ request, locals, cookies, url }) =>
 				clientIdentifier: clientIdentifier!
 			}));
 
-		logger.debug(`Testing connection to: ${serverUrl}`, 'Onboarding');
+		logger.debug(
+			`Testing connection diagnostic=${formatPlexUrlDiagnostic(serverUrl, 'default')}`,
+			'Onboarding'
+		);
 		const testResult = await testConnection(serverUrl, accessToken);
 
 		if (!testResult.success) {
-			logger.warn(`Connection test failed for ${serverUrl}: ${testResult.error}`, 'Onboarding');
+			logger.warn(
+				`Connection test failed diagnostic=${formatPlexUrlDiagnostic(serverUrl, 'default')} error=${
+					testResult.error
+				}`,
+				'Onboarding'
+			);
 			return json({
 				success: false,
 				error: testResult.error
@@ -182,7 +191,12 @@ export const POST: RequestHandler = async ({ request, locals, cookies, url }) =>
 			await clearCachedServerMachineId();
 		}
 
-		logger.info(`Onboarding: Server configured - ${serverName} (${serverUrl})`, 'Onboarding');
+		logger.info(
+			`Onboarding: Server configured serverNameHash=${fingerprintPlexIdentifier(
+				serverName
+			)} diagnostic=${formatPlexUrlDiagnostic(serverUrl, 'db')}`,
+			'Onboarding'
+		);
 
 		return json({
 			success: true,

--- a/src/routes/api/onboarding/test-connection/+server.ts
+++ b/src/routes/api/onboarding/test-connection/+server.ts
@@ -10,6 +10,7 @@ import {
 import { logger } from '$lib/server/logging';
 import { OnboardingClaimRequiredError, requireActiveOnboardingClaim } from '$lib/server/onboarding';
 import { resolveOwnedServerToken } from '$lib/server/onboarding/plex-server-selection';
+import { fingerprintPlexIdentifier, formatPlexUrlDiagnostic } from '$lib/server/plex/diagnostics';
 import { classifyConnectionError } from '$lib/server/security';
 import { normalizePlexServerUrl } from '$lib/server/security/credentialed-url';
 import type { RequestHandler } from './$types';
@@ -93,7 +94,10 @@ export const POST: RequestHandler = async ({ request, locals, cookies, url }) =>
 		const normalizedUrl = url.replace(/\/+$/, '');
 		const endpoint = `${normalizedUrl}/identity`;
 
-		logger.debug(`Testing connection to: ${endpoint}`, 'Onboarding');
+		logger.debug(
+			`Testing connection diagnostic=${formatPlexUrlDiagnostic(endpoint, 'default')}`,
+			'Onboarding'
+		);
 
 		// Create abort controller for timeout
 		const controller = new AbortController();
@@ -166,7 +170,12 @@ export const POST: RequestHandler = async ({ request, locals, cookies, url }) =>
 			const { machineIdentifier, friendlyName } = identityResult.data.MediaContainer;
 			const serverName = friendlyName || 'Plex Media Server';
 
-			logger.info(`Connection test successful: ${serverName} (${machineIdentifier})`, 'Onboarding');
+			logger.info(
+				`Connection test successful serverNameHash=${fingerprintPlexIdentifier(
+					serverName
+				)} machineHash=${fingerprintPlexIdentifier(machineIdentifier)}`,
+				'Onboarding'
+			);
 
 			return json({
 				success: true,

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -14,6 +14,7 @@ import {
 	requireActiveOnboardingClaim,
 	setOnboardingStep
 } from '$lib/server/onboarding';
+import { fingerprintPlexIdentifier, formatPlexUrlDiagnostic } from '$lib/server/plex/diagnostics';
 import {
 	fetchServerIdentity,
 	refreshConfiguredServerMachineId
@@ -268,7 +269,12 @@ export const actions: Actions = {
 				membership.configuredMachineId.toLowerCase();
 			if (!matches) {
 				logger.warn(
-					`Onboarding: Admin override denied for ${configuredUrl} user=${locals.user.username} reason=${directProbe.errorReason ?? 'machine_id_mismatch'}`,
+					`Onboarding: Admin override denied diagnostic=${formatPlexUrlDiagnostic(
+						configuredUrl,
+						apiConfig.plex.serverUrl.source
+					)} userHash=${fingerprintPlexIdentifier(locals.user.username)} reason=${
+						directProbe.errorReason ?? 'machine_id_mismatch'
+					}`,
 					'Onboarding'
 				);
 				return fail(403, {
@@ -285,7 +291,12 @@ export const actions: Actions = {
 		});
 
 		logger.warn(
-			`Onboarding: Admin override used for ${configuredUrl} machineId=${membership.configuredMachineId ?? 'unknown'} user=${locals.user.username}`,
+			`Onboarding: Admin override used diagnostic=${formatPlexUrlDiagnostic(
+				configuredUrl,
+				apiConfig.plex.serverUrl.source
+			)} machineHash=${fingerprintPlexIdentifier(
+				membership.configuredMachineId
+			)} userHash=${fingerprintPlexIdentifier(locals.user.username)}`,
 			'Onboarding'
 		);
 

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -341,7 +341,7 @@ export const actions: Actions = {
 			let openaiBaseUrl = data.openaiBaseUrl?.trim().replace(/\/+$/, '');
 			const openaiModel = data.openaiModel?.trim();
 
-			if (data.enableFunFacts && openaiApiKey && openaiBaseUrl) {
+			if (data.enableFunFacts && openaiBaseUrl) {
 				try {
 					openaiBaseUrl = normalizeOpenAIBaseUrl(openaiBaseUrl);
 				} catch (err) {
@@ -383,7 +383,7 @@ export const actions: Actions = {
 				data.enableFunFacts && openaiApiKey
 					? setAppSetting(AppSettingsKey.OPENAI_API_KEY, openaiApiKey)
 					: Promise.resolve(),
-				data.enableFunFacts && openaiApiKey && openaiBaseUrl
+				data.enableFunFacts && openaiBaseUrl
 					? setAppSetting(AppSettingsKey.OPENAI_BASE_URL, openaiBaseUrl)
 					: Promise.resolve(),
 				data.enableFunFacts && openaiApiKey && openaiModel

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -425,7 +425,7 @@ function getThemeColors(themeValue: string) {
 										<label class="radio-card" class:selected={wrappedLogoMode === option.value}>
 											<input
 												type="radio"
-												name="wrappedLogoModeRadio"
+												name="logoMode"
 												value={option.value}
 												bind:group={wrappedLogoMode}
 											/>
@@ -451,7 +451,7 @@ function getThemeColors(themeValue: string) {
 										<label class="radio-card" class:selected={defaultShareMode === option.value}>
 											<input
 												type="radio"
-												name="shareModeRadio"
+												name="defaultShareMode"
 												value={option.value}
 												checked={defaultShareMode === option.value}
 												onchange={() => (defaultShareMode = option.value)}
@@ -488,6 +488,15 @@ function getThemeColors(themeValue: string) {
 									>
 										<span class="toggle-knob"></span>
 									</button>
+									<input
+										type="checkbox"
+										name="allowUserControl"
+										value="true"
+										bind:checked={allowUserControl}
+										class="sr-only"
+										tabindex="-1"
+										aria-hidden="true"
+									/>
 								</label>
 							</div>
 						</div>

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -255,7 +255,7 @@ export const actions: Actions = {
 
 		try {
 			await setUserLogoPreference(locals.user.id, year, showLogo);
-			return { success: true };
+			return { success: true, showLogo };
 		} catch (err) {
 			const message = err instanceof Error ? err.message : 'Failed to update preference';
 			return fail(500, { error: message });

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
@@ -191,9 +191,22 @@ function handleLogoToggle(): void {
 				action="?/toggleLogo"
 				use:enhance={() => {
 					handleLogoToggle();
-					return async () => {
-						// Form submitted - reset override so server value takes precedence
-						showLogoOverride = null;
+					return async ({ result, update }) => {
+						let payload: { showLogo?: boolean } | undefined;
+						if (result.type === 'success') {
+							payload = result.data as { showLogo?: boolean } | undefined;
+							if (typeof payload?.showLogo === 'boolean') {
+								showLogoOverride = payload.showLogo;
+							}
+						} else {
+							showLogoOverride = null;
+						}
+						await update();
+						if (result.type === 'success' && typeof payload?.showLogo === 'boolean') {
+							showLogoOverride = payload.showLogo;
+						} else {
+							showLogoOverride = null;
+						}
 					};
 				}}
 			>

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
@@ -202,11 +202,7 @@ function handleLogoToggle(): void {
 							showLogoOverride = null;
 						}
 						await update();
-						if (result.type === 'success' && typeof payload?.showLogo === 'boolean') {
-							showLogoOverride = payload.showLogo;
-						} else {
-							showLogoOverride = null;
-						}
+						showLogoOverride = null;
 					};
 				}}
 			>

--- a/tests/unit/admin/settings-actions.test.ts
+++ b/tests/unit/admin/settings-actions.test.ts
@@ -176,6 +176,30 @@ describe('admin updateApiConfig schema hardening', () => {
 		});
 	});
 
+	it.each([
+		['http://api.openai.example/v1', 'OpenAI base URL must use HTTPS.'],
+		[
+			'https://user:pass@api.openai.example/v1',
+			'Configured base URLs must not include credentials.'
+		],
+		[
+			'https://api.openai.example/v1?token=abc',
+			'Configured base URLs must not include query strings or fragments.'
+		],
+		[
+			'https://api.openai.example/v1#models',
+			'Configured base URLs must not include query strings or fragments.'
+		]
+	])('rejects unsafe OpenAI base URL %s with no API key submitted', async (openaiBaseUrl, error) => {
+		const result = await runUpdateApiConfig(createApiConfigRequest({ openaiBaseUrl }));
+
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error }
+		});
+		expect(await getAppSetting(AppSettingsKey.OPENAI_BASE_URL)).toBeNull();
+	});
+
 	it('rejects unchecked local HTTP Plex URL instead of relying on stored opt-in', async () => {
 		const dynamicEnv = env as Record<string, string | undefined>;
 		const previousPlexServerUrl = dynamicEnv.PLEX_SERVER_URL;

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -160,6 +160,27 @@ describe('admin UI source regressions', () => {
 		expect(source).not.toContain('bind:group={selectedWrappedLogoMode}');
 	});
 
+	it('uses real onboarding privacy field names for submitted controls', async () => {
+		const source = await readSource('src/routes/onboarding/settings/+page.svelte');
+
+		expect(source).toContain('name="logoMode"');
+		expect(source).toContain('name="defaultShareMode"');
+		expect(source).toContain('name="allowUserControl"');
+		expect(source).not.toContain('name="wrappedLogoModeRadio"');
+		expect(source).not.toContain('name="shareModeRadio"');
+	});
+
+	it('keeps share modal radios checked from local state while updating', async () => {
+		const source = await readSource('src/lib/components/wrapped/ShareModal.svelte');
+
+		expect(source).toContain('let localMode = $state<ShareModeType>');
+		expect(source).toContain('let localShareToken = $state<string | null | undefined>');
+		expect(source).toContain('checked={displayMode === mode}');
+		expect(source).toContain('localMode = mode as ShareModeType;');
+		expect(source).not.toContain('checked={isUpdating ?');
+		expect(source).not.toContain('optimisticMode');
+	});
+
 	it('does not log Plex auth payloads from app-owned browser auth code', async () => {
 		const sources = await Promise.all([
 			readSource('src/lib/client/plex-login.ts'),

--- a/tests/unit/logging/logger.test.ts
+++ b/tests/unit/logging/logger.test.ts
@@ -99,6 +99,21 @@ describe('Logger', () => {
 			expect(debugLog).toBeUndefined();
 		});
 
+		it('does not print debug messages when debug is disabled', async () => {
+			const originalDebug = console.debug;
+			const calls: string[] = [];
+			console.debug = mock((message: string) => {
+				calls.push(message);
+			}) as typeof console.debug;
+
+			try {
+				await logger.debug('Debug message when disabled', 'Debug');
+				expect(calls).toEqual([]);
+			} finally {
+				console.debug = originalDebug;
+			}
+		});
+
 		it('persists when debug is enabled', async () => {
 			// Enable debug logging
 			await db.insert(appSettings).values({
@@ -114,6 +129,39 @@ describe('Logger', () => {
 			const debugLog = result.find((l) => l.message === 'Debug message when enabled');
 			expect(debugLog).toBeDefined();
 			expect(debugLog?.level).toBe(LogLevel.DEBUG);
+		});
+
+		it('redacts secrets before printing and persisting debug logs', async () => {
+			await db.insert(appSettings).values({
+				key: LogSettingsKey.DEBUG_ENABLED,
+				value: 'true'
+			});
+			logger.clearDebugCache();
+
+			const originalDebug = console.debug;
+			const calls: string[] = [];
+			console.debug = mock((message: string) => {
+				calls.push(message);
+			}) as typeof console.debug;
+
+			try {
+				await logger.debug(
+					'GET https://user:pass@example.com/?X-Plex-Token=secret Authorization: Bearer secret Cookie: session=secret',
+					'Debug',
+					{ url: 'https://example.com/?token=secret' }
+				);
+				await logger.forceFlush();
+			} finally {
+				console.debug = originalDebug;
+			}
+
+			const result = await db.select().from(logs);
+			const debugLog = result.find((l) => l.level === LogLevel.DEBUG);
+			expect(debugLog?.message).toContain('<redacted>');
+			expect(debugLog?.message).not.toContain('secret');
+			expect(debugLog?.message).not.toContain('user:pass');
+			expect(calls[0]).toBe(`[Debug] ${debugLog?.message}`);
+			expect(debugLog?.metadata).not.toContain('secret');
 		});
 
 		it('caches debug enabled setting', async () => {

--- a/tests/unit/onboarding/settings-actions.test.ts
+++ b/tests/unit/onboarding/settings-actions.test.ts
@@ -121,19 +121,34 @@ describe('onboarding settings actions', () => {
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.COMPLETE);
 	});
 
-	it('still rejects an invalid OpenAI base URL with 400', async () => {
+	it.each([
+		['not a url', 'Invalid OpenAI base URL'],
+		['http://api.openai.example/v1', 'OpenAI base URL must use HTTPS.'],
+		[
+			'https://user:pass@api.openai.example/v1',
+			'Configured base URLs must not include credentials.'
+		],
+		[
+			'https://api.openai.example/v1?token=abc',
+			'Configured base URLs must not include query strings or fragments.'
+		],
+		[
+			'https://api.openai.example/v1#models',
+			'Configured base URLs must not include query strings or fragments.'
+		]
+	])('rejects OpenAI base URL %s even when the API key is blank', async (openaiBaseUrl, error) => {
 		const request = createSettingsRequest({
 			enableFunFacts: 'true',
 			funFactFrequency: 'normal',
-			openaiApiKey: 'test-key',
-			openaiBaseUrl: 'not a url'
+			openaiApiKey: '',
+			openaiBaseUrl
 		});
 
 		const result = await runSaveSettings(request);
 
 		expect(result).toMatchObject({
 			status: 400,
-			data: { error: 'Invalid OpenAI base URL' }
+			data: { error }
 		});
 	});
 

--- a/tests/unit/plex/diagnostics.test.ts
+++ b/tests/unit/plex/diagnostics.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+import { describePlexUrl, formatPlexUrlDiagnostic } from '$lib/server/plex/diagnostics';
+
+describe('Plex diagnostics', () => {
+	it.each([
+		['https://1-2-3-4.0123456789abcdef0123456789abcdef.plex.direct:32400', 'plex.direct'],
+		['https://plex.example.com:443', 'public-domain'],
+		['http://10.0.0.2:32400', 'private-ip'],
+		['http://172.18.0.3:32400', 'docker/private-range'],
+		['http://192.168.1.10:32400', 'private-ip'],
+		['http://localhost:32400', 'localhost'],
+		['https://8.8.8.8:32400', 'public-ip']
+	] as const)('classifies %s as %s', (url, category) => {
+		expect(describePlexUrl(url, 'db').category).toBe(category);
+	});
+
+	it('formats credentialed and query URLs without leaking raw values', () => {
+		const url =
+			'https://user:pass@plex.example.com:32400/library?X-Plex-Token=secret-token#section';
+		const summary = formatPlexUrlDiagnostic(url, 'env');
+
+		expect(summary).toContain('source=env');
+		expect(summary).toContain('scheme=https');
+		expect(summary).toContain('category=public-domain');
+		expect(summary).toContain('port=32400');
+		expect(summary).toContain('credentials=present');
+		expect(summary).toContain('query=present');
+		expect(summary).toContain('fragment=present');
+		expect(summary).not.toContain('plex.example.com');
+		expect(summary).not.toContain('user');
+		expect(summary).not.toContain('pass');
+		expect(summary).not.toContain('secret-token');
+		expect(summary).not.toContain('/library');
+	});
+});

--- a/tests/unit/sharing/server-wrapped-route.test.ts
+++ b/tests/unit/sharing/server-wrapped-route.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { isHttpError } from '@sveltejs/kit';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import { setServerWrappedShareMode } from '$lib/server/sharing/service';
+import { ShareMode } from '$lib/server/sharing/types';
+import { load } from '../../../src/routes/wrapped/[year]/+page.server';
+
+type ServerWrappedLoad = typeof load;
+
+describe('server wrapped route access', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+	});
+
+	it('denies anonymous route loads when server wrapped mode is private-oauth', async () => {
+		await setServerWrappedShareMode(ShareMode.PRIVATE_OAUTH);
+
+		try {
+			await load({
+				params: { year: '2024' },
+				locals: {},
+				url: new URL('http://localhost/wrapped/2024')
+			} as Parameters<ServerWrappedLoad>[0]);
+			expect.unreachable('Expected server wrapped load to throw');
+		} catch (error) {
+			expect(isHttpError(error)).toBe(true);
+			if (!isHttpError(error)) throw error;
+			expect(error.status).toBe(403);
+			expect(error.body.message).toContain('Sign in');
+		}
+	});
+});

--- a/tests/unit/sharing/wrapped-actions.test.ts
+++ b/tests/unit/sharing/wrapped-actions.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { AppSettingsKey, setAppSetting, WrappedLogoMode } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings, shareSettings } from '$lib/server/db/schema';
+import { getUserLogoPreference } from '$lib/server/sharing/service';
+import { actions } from '../../../src/routes/wrapped/[year]/u/[identifier]/+page.server';
+
+type ToggleLogoAction = NonNullable<typeof actions.toggleLogo>;
+
+const locals = {
+	user: { id: 42, plexId: 4200, username: 'owner', isAdmin: false }
+} as unknown as App.Locals;
+
+function createToggleLogoRequest(showLogo: boolean): Request {
+	const formData = new FormData();
+	formData.set('showLogo', showLogo ? 'true' : 'false');
+	return new Request('http://localhost/wrapped/2024/u/42?/toggleLogo', {
+		method: 'POST',
+		body: formData
+	});
+}
+
+describe('wrapped actions', () => {
+	beforeEach(async () => {
+		await db.delete(shareSettings);
+		await db.delete(appSettings);
+	});
+
+	it('toggleLogo returns and persists the saved showLogo value', async () => {
+		await setAppSetting(AppSettingsKey.WRAPPED_LOGO_MODE, WrappedLogoMode.USER_CHOICE);
+
+		const action = actions.toggleLogo as ToggleLogoAction;
+		const result = await action({
+			request: createToggleLogoRequest(false),
+			params: { year: '2024', identifier: '42' },
+			locals
+		} as Parameters<ToggleLogoAction>[0]);
+
+		expect(result).toMatchObject({ success: true, showLogo: false });
+		expect(await getUserLogoPreference(42, 2024)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

This PR addresses the actionable dogfood findings around Plex diagnostics, settings persistence, wrapped sharing state, and small UI/accessibility issues.

The main goal is to preserve useful Plex troubleshooting context without logging identifying or credential-bearing data. Plex URL diagnostics now report classified connection context such as scheme, source, category, port, and stable short fingerprints instead of raw hostnames, IP addresses, machine identifiers, connection URIs, paths, query strings, or tokens.

## Changes

### Safe Plex diagnostics and logging

- Added server-only Plex diagnostic helpers for classifying Plex URLs and resource connections.
- Replaced membership and onboarding debug logs that previously included raw Plex URL, hostname, IP, server name, machine identifier, or connection URI data with safe diagnostic summaries and short hashes.
- Added a defensive logger redactor for credentials, URL userinfo, token-like query parameters, cookies, authorization headers, and Plex token fields.
- Updated `logger.debug` so debug-disabled messages are not printed to stdout, and enabled debug logs use the same sanitized message for console and database output.

### Settings and onboarding fixes

- Validate submitted OpenAI base URLs even when the OpenAI API key is blank.
- Preserve the specific URL-policy error messages for HTTP, credentialed, query-string, and fragment URLs.
- Use real submitted field names for onboarding privacy controls instead of hidden-input-only indirection.
- Reconcile admin logo and privacy settings from server-backed state after enhanced saves, with rollback behavior on failures.

### Wrapped sharing state fixes

- Return `showLogo` from the user wrapped `toggleLogo` action and update client state from the saved server value.
- Simplified `ShareModal` mode/token state so radio checked state always derives from local state, including while form submissions are in flight.
- Preserved existing private-link 404 behavior and global privacy-floor behavior.

### UI polish and access-control coverage

- Added route-level regression coverage for anonymous server-wide wrapped access when the server share mode is `private-oauth`.
- Added persistent cron validation semantics with `aria-invalid` and `aria-describedby`.
- Added long-word wrapping to custom slide preview and rendered custom slide Markdown containers.
- Kept the documented non-admin admin-route redirect behavior unchanged: logged-in non-admin users continue to land on `/dashboard`.

## Validation

- `bun run check`
- `bun run check:biome`
- `bun run test`

All checks pass locally. The full test suite reports 1630 passing tests and 0 failures.

## Notes

`dogfood-output/` is ignored by this repository, so local QA report artifact edits are not included in this branch. The application behavior for ISSUE-008 was left unchanged because it matches the documented authorization flow.
