### PR TITLE
fix: contain oauth payloads and normalize log search

### DIFF
--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -101,6 +101,8 @@ async function fetchPin(redirectUrl?: string): Promise<PinResponse> {
 export function sanitizeCompletedLoginResponse(result: unknown): CompletedLoginResponse | null {
 	if (!result || typeof result !== 'object' || !('user' in result)) return null;
 
+	// Obzorarr cannot redact Plex-hosted auth page console output, so this keeps
+	// every app-owned browser response limited to session-safe fields.
 	const raw = result as {
 		user?: { username?: unknown; isAdmin?: unknown };
 		redirectTo?: unknown;

--- a/src/lib/server/logging/service.ts
+++ b/src/lib/server/logging/service.ts
@@ -32,6 +32,7 @@ export async function insertLogsBatch(entries: NewLogEntry[]): Promise<void> {
 
 export async function queryLogs(options: LogQueryOptions = {}): Promise<LogQueryResult> {
 	const { levels, search, source, fromTimestamp, toTimestamp, cursor, limit = 100 } = options;
+	const normalizedSearch = search?.trim();
 
 	const conditions = [];
 
@@ -54,8 +55,8 @@ export async function queryLogs(options: LogQueryOptions = {}): Promise<LogQuery
 		conditions.push(lt(logs.id, cursor));
 	}
 
-	if (search) {
-		conditions.push(like(logs.message, `%${search}%`));
+	if (normalizedSearch) {
+		conditions.push(like(logs.message, `%${normalizedSearch}%`));
 	}
 
 	const whereClause = conditions.length > 0 ? and(...conditions) : undefined;

--- a/src/routes/admin/logs/+page.server.ts
+++ b/src/routes/admin/logs/+page.server.ts
@@ -55,6 +55,11 @@ const CursorSchema = z
 		return Number.isNaN(parsed) ? undefined : parsed;
 	});
 
+function normalizeSearchParam(search: string | null): string | undefined {
+	const normalized = search?.trim();
+	return normalized ? normalized : undefined;
+}
+
 export const load: PageServerLoad = async ({ url }) => {
 	// Initialize retention scheduler if not already configured
 	if (!isRetentionSchedulerConfigured()) {
@@ -62,7 +67,7 @@ export const load: PageServerLoad = async ({ url }) => {
 	}
 
 	const levelsParam = url.searchParams.get('levels');
-	const search = url.searchParams.get('search') || undefined;
+	const search = normalizeSearchParam(url.searchParams.get('search'));
 	const source = url.searchParams.get('source') || undefined;
 	const fromParam = url.searchParams.get('from');
 	const toParam = url.searchParams.get('to');
@@ -155,7 +160,7 @@ export const actions: Actions = requireAdminActions({
 
 	exportLogs: async ({ url }) => {
 		const levelsParam = url.searchParams.get('levels');
-		const search = url.searchParams.get('search') || undefined;
+		const search = normalizeSearchParam(url.searchParams.get('search'));
 		const source = url.searchParams.get('source') || undefined;
 		const fromParam = url.searchParams.get('from');
 		const toParam = url.searchParams.get('to');

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -34,6 +34,8 @@ let searchText = $state('');
 $effect.pre(() => {
 	searchText = data.filters?.search ?? '';
 });
+let normalizedSearchText = $derived(searchText.trim());
+let normalizedSearchLower = $derived(normalizedSearchText.toLowerCase());
 
 // Date range filter state
 let fromDate = $state('');
@@ -76,7 +78,8 @@ const filteredStreamedLogs = $derived(
 	streamedLogs.filter((log) => {
 		if (selectedLevels.length > 0 && !selectedLevels.includes(log.level)) return false;
 		if (selectedSource && log.source !== selectedSource) return false;
-		if (searchText && !log.message.toLowerCase().includes(searchText.toLowerCase())) return false;
+		if (normalizedSearchLower && !log.message.toLowerCase().includes(normalizedSearchLower))
+			return false;
 		if (data.filters?.fromTimestamp && log.timestamp < data.filters.fromTimestamp) return false;
 		if (data.filters?.toTimestamp && log.timestamp > data.filters.toTimestamp) return false;
 		return true;
@@ -86,7 +89,8 @@ const filteredStreamedLogs = $derived(
 function matchesVisibleFilters(log: LogEntry): boolean {
 	if (selectedLevels.length > 0 && !selectedLevels.includes(log.level)) return false;
 	if (selectedSource && log.source !== selectedSource) return false;
-	if (searchText && !log.message.toLowerCase().includes(searchText.toLowerCase())) return false;
+	if (normalizedSearchLower && !log.message.toLowerCase().includes(normalizedSearchLower))
+		return false;
 	if (data.filters?.fromTimestamp && log.timestamp < data.filters.fromTimestamp) return false;
 	if (data.filters?.toTimestamp && log.timestamp > data.filters.toTimestamp) return false;
 	return true;
@@ -174,7 +178,7 @@ const exportAction = $derived.by(() => {
 function applyFilters(overrides?: { levels?: LogLevelType[]; search?: string; source?: string }) {
 	const params = new URLSearchParams();
 	const levels = overrides?.levels ?? selectedLevels;
-	const search = overrides?.search ?? searchText;
+	const search = (overrides?.search ?? searchText).trim();
 	const source = overrides?.source ?? selectedSource;
 
 	if (levels.length > 0) {

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -28,6 +28,25 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain("toast.error('Failed to export logs');");
 	});
 
+	it('normalizes admin log search before URL and local filtering', async () => {
+		const clientSource = await readSource('src/routes/admin/logs/+page.svelte');
+		const serverSource = await readSource('src/routes/admin/logs/+page.server.ts');
+
+		expect(clientSource).toContain('let normalizedSearchText = $derived(searchText.trim());');
+		expect(clientSource).toContain(
+			'let normalizedSearchLower = $derived(normalizedSearchText.toLowerCase());'
+		);
+		expect(clientSource).toContain('const search = (overrides?.search ?? searchText).trim();');
+		expect(clientSource).toContain(
+			'if (normalizedSearchLower && !log.message.toLowerCase().includes(normalizedSearchLower))'
+		);
+		expect(serverSource).toContain('function normalizeSearchParam(search: string | null)');
+		expect(serverSource).toContain('const normalized = search?.trim();');
+		expect(serverSource).toContain(
+			"const search = normalizeSearchParam(url.searchParams.get('search'));"
+		);
+	});
+
 	it('renders security help as real disclosure buttons', async () => {
 		const source = await readSource('src/routes/admin/settings/+page.svelte');
 

--- a/tests/unit/logging/service.test.ts
+++ b/tests/unit/logging/service.test.ts
@@ -174,6 +174,21 @@ describe('Logging Service', () => {
 				expect(result.logs[0]?.message).toContain('Warning');
 			});
 
+			it('treats whitespace-only search like no search', async () => {
+				const unfiltered = await queryLogs();
+				const result = await queryLogs({ search: '   ' });
+
+				expect(result.totalCount).toBe(unfiltered.totalCount);
+				expect(result.logs.map((log) => log.id)).toEqual(unfiltered.logs.map((log) => log.id));
+			});
+
+			it('trims search text before filtering', async () => {
+				const result = await queryLogs({ search: ' Warning ' });
+
+				expect(result.logs).toHaveLength(1);
+				expect(result.logs[0]?.message).toContain('Warning');
+			});
+
 			it('filters by time range', async () => {
 				const now = Date.now();
 				const before = now - 1000;

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -60,6 +60,7 @@ describe('sanitizeCompletedLoginResponse', () => {
 			authToken: 'plex-auth-token',
 			token: 'provider-token',
 			secret: 'provider-secret',
+			clientIdentifier: 'root-client-id',
 			user: {
 				id: 7,
 				uuid: 'raw-plex-uuid',
@@ -80,6 +81,7 @@ describe('sanitizeCompletedLoginResponse', () => {
 				{
 					name: 'Plex Server',
 					clientIdentifier: 'server-client-id',
+					machineIdentifier: 'server-machine-id',
 					accessToken: 'server-access-token'
 				}
 			],
@@ -106,15 +108,18 @@ describe('sanitizeCompletedLoginResponse', () => {
 			'uuid',
 			'resources',
 			'clientIdentifier',
+			'machineIdentifier',
 			'accessToken',
 			'plex-auth-token',
 			'provider-token',
 			'provider-secret',
 			'nested-auth-token',
+			'root-client-id',
 			'service-token',
 			'service-secret',
 			'server-access-token',
 			'server-client-id',
+			'server-machine-id',
 			'owner@example.com',
 			'123456',
 			'raw-plex-uuid'


### PR DESCRIPTION
## Summary

This PR addresses the dogfood QA findings around Plex OAuth payload containment and admin log search behavior.

### OAuth payload containment

- Keeps `src/lib/client/plex-login.ts` as the browser-side boundary for completed login responses.
- Documents that Obzorarr cannot redact console output produced by Plex-hosted auth pages, while app-owned responses must remain browser-safe.
- Strengthens sanitizer coverage for `AUTH_COMPLETE`-shaped payloads containing provider tokens, secrets, Plex identifiers, email addresses, services, resources, access tokens, and client identifiers.

### Admin log search normalization

- Trims admin log search input before applying URL search params from the Svelte page.
- Uses the normalized search text for streamed-log filtering and visible-log filtering.
- Normalizes `search` in the `/admin/logs` load path and export action so direct whitespace-only URLs behave like an empty search.
- Defensively trims `search` inside `queryLogs()` so service callers cannot accidentally apply whitespace-only filters.

## Verification

- `bun run check`
- `bun run test`
- `bun run check:biome`
- Targeted coverage for Plex login sanitization, logging service search behavior, and admin logs UI source regressions

## Operational note

The QA evidence appears to include Plex-hosted auth-page console output. This PR contains Obzorarr-owned responses and browser handling, but it does not attempt to monkey-patch third-party Plex auth-page logging. Any Plex credentials or tokens captured in QA artifacts should be rotated outside of this code change.
