### PR TITLE
feat: add reverse proxy diagnostics

### DIFF
--- a/src/lib/server/security/forwarded-headers.ts
+++ b/src/lib/server/security/forwarded-headers.ts
@@ -1,0 +1,112 @@
+export type ForwardedHeaderName =
+	| 'Forwarded'
+	| 'X-Forwarded-For'
+	| 'X-Forwarded-Host'
+	| 'X-Forwarded-Proto'
+	| 'X-Real-IP';
+
+export type ForwardedProto = 'http' | 'https';
+
+export type ForwardedProtoHostStatus =
+	| 'usable'
+	| 'missing'
+	| 'partial'
+	| 'invalid-proto'
+	| 'unsafe-host'
+	| 'invalid-host';
+
+export interface ForwardedProtoHostResult {
+	status: ForwardedProtoHostStatus;
+	isUsable: boolean;
+	protoPresent: boolean;
+	hostPresent: boolean;
+	url: URL | null;
+}
+
+type HeaderReader = Pick<Headers, 'get'>;
+
+const FORWARDED_HEADER_LOOKUP: Array<[ForwardedHeaderName, string]> = [
+	['Forwarded', 'forwarded'],
+	['X-Forwarded-For', 'x-forwarded-for'],
+	['X-Forwarded-Host', 'x-forwarded-host'],
+	['X-Forwarded-Proto', 'x-forwarded-proto'],
+	['X-Real-IP', 'x-real-ip']
+];
+
+// Take the rightmost (last-hop) value from a comma-separated forwarded header.
+// Returns null if no usable value is present.
+function lastHopValue(headerValue: string | null): string | null {
+	if (!headerValue) return null;
+	const parts = headerValue.split(',');
+	const last = parts[parts.length - 1]?.trim();
+	return last && last.length > 0 ? last : null;
+}
+
+function isValidForwardedProto(value: string): value is ForwardedProto {
+	return value === 'http' || value === 'https';
+}
+
+// Reject CR/LF (response-splitting / header-injection defense), whitespace,
+// and URL delimiter characters that would confuse new URL() into parsing a
+// different host than intended. Specifically:
+//   @  - userinfo delimiter: "trusted@evil.com" -> hostname is evil.com
+//   /  - path delimiter: "evil.com/path" passes through to pathname
+//   ?  - query delimiter: "evil.com?x=1" passes through to search
+//   #  - fragment delimiter: "evil.com#foo" passes through to hash
+// IPv6 literals like "[::1]:8443" are NOT rejected because they contain no
+// delimiter characters from the banned set.
+function isSafeForwardedHost(value: string): boolean {
+	return value.length > 0 && !/[\r\n\s@/?#]/.test(value);
+}
+
+export function getForwardedHeaderNamesPresent(headers: HeaderReader): ForwardedHeaderName[] {
+	return FORWARDED_HEADER_LOOKUP.flatMap(([name, header]) =>
+		headers.get(header) === null ? [] : [name]
+	);
+}
+
+export function parseForwardedProtoHost(headers: HeaderReader): ForwardedProtoHostResult {
+	const protoCandidate = lastHopValue(headers.get('x-forwarded-proto'));
+	const hostCandidate = lastHopValue(headers.get('x-forwarded-host'));
+	const protoPresent = protoCandidate !== null;
+	const hostPresent = hostCandidate !== null;
+
+	if (!protoPresent && !hostPresent) {
+		return { status: 'missing', isUsable: false, protoPresent, hostPresent, url: null };
+	}
+
+	if (!protoPresent || !hostPresent) {
+		return { status: 'partial', isUsable: false, protoPresent, hostPresent, url: null };
+	}
+
+	const safeProto = isValidForwardedProto(protoCandidate.toLowerCase())
+		? protoCandidate.toLowerCase()
+		: null;
+	if (!safeProto) {
+		return { status: 'invalid-proto', isUsable: false, protoPresent, hostPresent, url: null };
+	}
+
+	if (!isSafeForwardedHost(hostCandidate)) {
+		return { status: 'unsafe-host', isUsable: false, protoPresent, hostPresent, url: null };
+	}
+
+	try {
+		const url = new URL(`${safeProto}://${hostCandidate}/`);
+		return { status: 'usable', isUsable: true, protoPresent, hostPresent, url };
+	} catch {
+		return { status: 'invalid-host', isUsable: false, protoPresent, hostPresent, url: null };
+	}
+}
+
+export function buildForwardedUrl(
+	currentUrl: URL,
+	forwarded: ForwardedProtoHostResult
+): URL | null {
+	if (!forwarded.url) return null;
+
+	const forwardedUrl = new URL(currentUrl);
+	forwardedUrl.protocol = forwarded.url.protocol;
+	forwardedUrl.hostname = forwarded.url.hostname;
+	forwardedUrl.port = forwarded.url.port;
+	return forwardedUrl;
+}

--- a/src/lib/server/security/forwarded-headers.ts
+++ b/src/lib/server/security/forwarded-headers.ts
@@ -51,12 +51,13 @@ function isValidForwardedProto(value: string): value is ForwardedProto {
 // different host than intended. Specifically:
 //   @  - userinfo delimiter: "trusted@evil.com" -> hostname is evil.com
 //   /  - path delimiter: "evil.com/path" passes through to pathname
+//   \  - backslash path delimiter: "evil.com\path" passes through to pathname
 //   ?  - query delimiter: "evil.com?x=1" passes through to search
 //   #  - fragment delimiter: "evil.com#foo" passes through to hash
 // IPv6 literals like "[::1]:8443" are NOT rejected because they contain no
 // delimiter characters from the banned set.
 function isSafeForwardedHost(value: string): boolean {
-	return value.length > 0 && !/[\r\n\s@/?#]/.test(value);
+	return value.length > 0 && !/[\r\n\s@/\\?#]/.test(value);
 }
 
 export function getForwardedHeaderNamesPresent(headers: HeaderReader): ForwardedHeaderName[] {

--- a/src/lib/server/security/proxy-handle.ts
+++ b/src/lib/server/security/proxy-handle.ts
@@ -1,34 +1,9 @@
 import type { Handle } from '@sveltejs/kit';
 import { getTrustProxyConfigWithSource } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
+import { buildForwardedUrl, parseForwardedProtoHost } from './forwarded-headers';
 
 let proxyStartupLogged = false;
-
-// Take the rightmost (last-hop) value from a comma-separated forwarded header.
-// Returns null if no usable value is present.
-function lastHopValue(headerValue: string | null): string | null {
-	if (!headerValue) return null;
-	const parts = headerValue.split(',');
-	const last = parts[parts.length - 1]?.trim();
-	return last && last.length > 0 ? last : null;
-}
-
-function isValidForwardedProto(value: string): value is 'http' | 'https' {
-	return value === 'http' || value === 'https';
-}
-
-// Reject CR/LF (response-splitting / header-injection defense), whitespace,
-// and URL delimiter characters that would confuse new URL() into parsing a
-// different host than intended.  Specifically:
-//   @  — userinfo delimiter: "trusted@evil.com" → hostname is evil.com
-//   /  — path delimiter: "evil.com/path" passes through to pathname
-//   ?  — query delimiter: "evil.com?x=1" passes through to search
-//   #  — fragment delimiter: "evil.com#foo" passes through to hash
-// IPv6 literals like "[::1]:8443" are NOT rejected because they contain no
-// delimiter characters from the banned set.
-function isSafeForwardedHost(value: string): boolean {
-	return value.length > 0 && !/[\r\n\s@/?#]/.test(value);
-}
 
 // NOTE: this handler does NOT touch event.getClientAddress(); the production
 // adapter (svelte-adapter-bun) resolves the client IP independently. Operators
@@ -52,33 +27,8 @@ export const proxyHandle: Handle = async ({ event, resolve }) => {
 		return resolve(event);
 	}
 
-	const protoCandidate = lastHopValue(event.request.headers.get('x-forwarded-proto'));
-	const hostCandidate = lastHopValue(event.request.headers.get('x-forwarded-host'));
-
-	const safeProto =
-		protoCandidate && isValidForwardedProto(protoCandidate.toLowerCase())
-			? (protoCandidate.toLowerCase() as 'http' | 'https')
-			: null;
-	const safeHost = hostCandidate && isSafeForwardedHost(hostCandidate) ? hostCandidate : null;
-
-	if (!safeProto || !safeHost) {
-		return resolve(event);
-	}
-
-	// Parse the forwarded host through URL to validate syntax and split
-	// hostname/port cleanly. Setting URL.host directly preserves the existing
-	// port when the new value omits one — not what we want for a public URL.
-	let parsedHost: URL;
-	try {
-		parsedHost = new URL(`${safeProto}://${safeHost}/`);
-	} catch {
-		return resolve(event);
-	}
-
-	const forwardedUrl = new URL(event.url);
-	forwardedUrl.protocol = parsedHost.protocol;
-	forwardedUrl.hostname = parsedHost.hostname;
-	forwardedUrl.port = parsedHost.port;
+	const forwardedUrl = buildForwardedUrl(event.url, parseForwardedProtoHost(event.request.headers));
+	if (!forwardedUrl) return resolve(event);
 
 	Object.defineProperty(event, 'url', {
 		value: forwardedUrl,

--- a/src/lib/server/security/reverse-proxy-diagnostic.ts
+++ b/src/lib/server/security/reverse-proxy-diagnostic.ts
@@ -1,0 +1,385 @@
+import { isIP } from 'node:net';
+import {
+	type ConfigSource,
+	type ConfigValue,
+	getCsrfConfigWithSource,
+	getTrustProxyConfigWithSource
+} from '$lib/server/admin/settings.service';
+import {
+	type ForwardedHeaderName,
+	type ForwardedProtoHostStatus,
+	getForwardedHeaderNamesPresent,
+	parseForwardedProtoHost
+} from './forwarded-headers';
+
+export type SourceAddressCategory =
+	| 'loopback'
+	| 'private-lan'
+	| 'docker/private-range'
+	| 'tailscale/cgnat'
+	| 'link-local'
+	| 'public'
+	| 'unknown';
+
+export type ReverseProxyRecommendationAction =
+	| 'enable'
+	| 'leave-disabled'
+	| 'review-proxy'
+	| 'appears-working'
+	| 'unable-to-determine'
+	| 'env-controlled';
+
+export interface ReverseProxyDiagnosticInput {
+	request: Request;
+	rawAppUrl: string | URL;
+	effectiveAppUrl: string | URL;
+	browserOrigin?: string | null;
+	sourceAddress?: string | null;
+}
+
+export interface ReverseProxyDiagnosticBuildInput extends ReverseProxyDiagnosticInput {
+	trustProxy: ConfigValue<string>;
+	csrfOrigin: ConfigValue<string>;
+}
+
+export interface OriginDiagnostic {
+	origin: string | null;
+	isValid: boolean;
+}
+
+export interface ConfiguredOriginDiagnostic extends OriginDiagnostic {
+	source: ConfigSource;
+	isConfigured: boolean;
+	isLocked: boolean;
+}
+
+export interface ForwardedPairDiagnostic {
+	status: ForwardedProtoHostStatus;
+	isUsable: boolean;
+	protoPresent: boolean;
+	hostPresent: boolean;
+}
+
+export interface ReverseProxyDiagnostic {
+	trustProxy: {
+		enabled: boolean;
+		source: ConfigSource;
+		isLocked: boolean;
+	};
+	origins: {
+		rawApp: string | null;
+		effectiveApp: string | null;
+		browser: OriginDiagnostic;
+		configuredPublic: ConfiguredOriginDiagnostic;
+	};
+	forwardedHeaders: {
+		present: ForwardedHeaderName[];
+		pair: ForwardedPairDiagnostic;
+	};
+	sourceAddress: {
+		category: SourceAddressCategory;
+	};
+	originComparison: {
+		browserMatchesRawApp: boolean | null;
+		browserMatchesEffectiveApp: boolean | null;
+		forwardedPairMatchesBrowser: boolean | null;
+	};
+	recommendation: {
+		action: ReverseProxyRecommendationAction;
+		summary: string;
+	};
+	reasons: string[];
+	safetyNotice: string;
+}
+
+const SAFETY_NOTICE =
+	'Only enable reverse proxy header trust when your upstream proxy strips visitor-supplied forwarding headers before requests reach Obzorarr.';
+
+function originFromUrl(value: string | URL): string | null {
+	try {
+		return value instanceof URL ? value.origin : new URL(value).origin;
+	} catch {
+		return null;
+	}
+}
+
+function normalizeOrigin(value: string | null | undefined): OriginDiagnostic {
+	if (!value) return { origin: null, isValid: false };
+
+	try {
+		const parsed = new URL(value);
+		const isHttpOrigin =
+			(parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+			!parsed.username &&
+			!parsed.password;
+		return {
+			origin: isHttpOrigin ? parsed.origin : null,
+			isValid: isHttpOrigin
+		};
+	} catch {
+		return { origin: null, isValid: false };
+	}
+}
+
+function originsEqual(a: string | null, b: string | null): boolean | null {
+	if (!a || !b) return null;
+	return a.toLowerCase() === b.toLowerCase();
+}
+
+function stripIpv6Zone(address: string): string {
+	const zoneIndex = address.indexOf('%');
+	return zoneIndex === -1 ? address : address.slice(0, zoneIndex);
+}
+
+function normalizeSourceAddress(address: string): string | null {
+	const trimmed = address.trim();
+	if (!trimmed) return null;
+
+	const withoutBrackets =
+		trimmed.startsWith('[') && trimmed.includes(']')
+			? trimmed.slice(1, trimmed.indexOf(']'))
+			: trimmed;
+
+	const addressWithoutZone = stripIpv6Zone(withoutBrackets.toLowerCase());
+	if (isIP(addressWithoutZone)) return addressWithoutZone;
+
+	const maybeIpv4WithPort = trimmed.match(/^(\d{1,3}(?:\.\d{1,3}){3}):\d+$/);
+	if (maybeIpv4WithPort?.[1] && isIP(maybeIpv4WithPort[1])) return maybeIpv4WithPort[1];
+
+	return null;
+}
+
+function ipv4Octets(address: string): [number, number, number, number] | null {
+	const parts = address.split('.');
+	if (parts.length !== 4) return null;
+	const octets = parts.map((part) => Number(part)) as [number, number, number, number];
+	if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+		return null;
+	}
+	return octets;
+}
+
+export function classifySourceAddress(address: string | null | undefined): SourceAddressCategory {
+	const normalized = normalizeSourceAddress(address ?? '');
+	if (!normalized) return 'unknown';
+
+	if (normalized.startsWith('::ffff:')) {
+		return classifySourceAddress(normalized.slice('::ffff:'.length));
+	}
+
+	const ipv4 = ipv4Octets(normalized);
+	if (ipv4) {
+		const [a, b] = ipv4;
+		if (a === 127) return 'loopback';
+		if (a === 172 && b >= 16 && b <= 31) return 'docker/private-range';
+		if (a === 10 || (a === 192 && b === 168)) return 'private-lan';
+		if (a === 169 && b === 254) return 'link-local';
+		if (a === 100 && b >= 64 && b <= 127) return 'tailscale/cgnat';
+		return 'public';
+	}
+
+	if (normalized === '::1') return 'loopback';
+	if (normalized.startsWith('fc') || normalized.startsWith('fd')) return 'private-lan';
+	if (/^fe[89ab]/.test(normalized)) return 'link-local';
+	return 'public';
+}
+
+function recommendationFor(input: {
+	trustEnabled: boolean;
+	trustSource: ConfigSource;
+	browserOrigin: OriginDiagnostic;
+	rawAppOrigin: string | null;
+	effectiveAppOrigin: string | null;
+	forwardedPair: ReturnType<typeof parseForwardedProtoHost>;
+}): Pick<ReverseProxyDiagnostic, 'recommendation' | 'reasons'> {
+	const browserMatchesRawApp = originsEqual(input.browserOrigin.origin, input.rawAppOrigin);
+	const browserMatchesEffectiveApp = originsEqual(
+		input.browserOrigin.origin,
+		input.effectiveAppOrigin
+	);
+	const forwardedPairMatchesBrowser = originsEqual(
+		input.browserOrigin.origin,
+		input.forwardedPair.url?.origin ?? null
+	);
+	const reasons: string[] = [];
+
+	if (input.trustSource === 'env') {
+		reasons.push(
+			`TRUST_PROXY is controlled by the environment and is currently ${input.trustEnabled ? 'enabled' : 'disabled'}.`
+		);
+		reasons.push('Obzorarr will not change this setting from the UI while it is locked.');
+		return {
+			recommendation: {
+				action: 'env-controlled',
+				summary: 'TRUST_PROXY is controlled by the environment.'
+			},
+			reasons
+		};
+	}
+
+	if (!input.browserOrigin.isValid) {
+		reasons.push(
+			'The browser origin was missing or invalid, so the server cannot compare it safely.'
+		);
+		if (input.forwardedPair.isUsable) {
+			reasons.push(
+				'A usable forwarded proto and host pair is present, but it was not trusted alone.'
+			);
+		}
+		return {
+			recommendation: {
+				action: 'unable-to-determine',
+				summary: 'Unable to determine safely without a valid browser origin.'
+			},
+			reasons
+		};
+	}
+
+	if (!input.trustEnabled) {
+		if (
+			browserMatchesRawApp === false &&
+			input.forwardedPair.isUsable &&
+			forwardedPairMatchesBrowser === true
+		) {
+			reasons.push('The browser origin differs from the raw app origin seen by Obzorarr.');
+			reasons.push('The forwarded proto and host pair is usable and matches the browser origin.');
+			reasons.push(
+				'Enabling trust may fix public URL detection after you verify proxy header stripping.'
+			);
+			return {
+				recommendation: {
+					action: 'enable',
+					summary: 'Enable reverse proxy header trust after confirming your proxy strips headers.'
+				},
+				reasons
+			};
+		}
+
+		if (browserMatchesRawApp === true && input.forwardedPair.status === 'missing') {
+			reasons.push('The browser origin already matches the raw app origin.');
+			reasons.push('No usable forwarded proto and host pair is present.');
+			return {
+				recommendation: {
+					action: 'leave-disabled',
+					summary: 'Leave reverse proxy header trust disabled.'
+				},
+				reasons
+			};
+		}
+
+		reasons.push(
+			'Forwarded headers are partial, invalid, missing for this proxy shape, or do not match the browser origin.'
+		);
+		reasons.push('Review your reverse proxy configuration before enabling header trust.');
+		return {
+			recommendation: {
+				action: 'review-proxy',
+				summary: 'Review proxy configuration before changing reverse proxy header trust.'
+			},
+			reasons
+		};
+	}
+
+	if (input.forwardedPair.isUsable && browserMatchesEffectiveApp === true) {
+		reasons.push('Reverse proxy header trust is enabled.');
+		reasons.push('The effective app origin matches the browser origin.');
+		reasons.push(
+			'This appears to be working only if the upstream proxy strips visitor-supplied forwarding headers.'
+		);
+		return {
+			recommendation: {
+				action: 'appears-working',
+				summary: 'Reverse proxy header trust appears to be working.'
+			},
+			reasons
+		};
+	}
+
+	reasons.push(
+		'Reverse proxy header trust is enabled, but the forwarded pair is missing, invalid, or not producing the browser origin.'
+	);
+	reasons.push('Review the proxy setup and disable trust if no trusted reverse proxy needs it.');
+	return {
+		recommendation: {
+			action: 'review-proxy',
+			summary: 'Review proxy configuration for the current TRUST_PROXY setting.'
+		},
+		reasons
+	};
+}
+
+export function buildReverseProxyDiagnostic(
+	input: ReverseProxyDiagnosticBuildInput
+): ReverseProxyDiagnostic {
+	const forwardedPair = parseForwardedProtoHost(input.request.headers);
+	const rawAppOrigin = originFromUrl(input.rawAppUrl);
+	const effectiveAppOrigin = originFromUrl(input.effectiveAppUrl);
+	const browserOrigin = normalizeOrigin(input.browserOrigin);
+	const configuredPublicOrigin = normalizeOrigin(input.csrfOrigin.value || null);
+	const trustEnabled = input.trustProxy.value === 'true';
+	const { recommendation, reasons } = recommendationFor({
+		trustEnabled,
+		trustSource: input.trustProxy.source,
+		browserOrigin,
+		rawAppOrigin,
+		effectiveAppOrigin,
+		forwardedPair
+	});
+
+	return {
+		trustProxy: {
+			enabled: trustEnabled,
+			source: input.trustProxy.source,
+			isLocked: input.trustProxy.isLocked
+		},
+		origins: {
+			rawApp: rawAppOrigin,
+			effectiveApp: effectiveAppOrigin,
+			browser: browserOrigin,
+			configuredPublic: {
+				...configuredPublicOrigin,
+				source: input.csrfOrigin.source,
+				isConfigured: Boolean(input.csrfOrigin.value),
+				isLocked: input.csrfOrigin.isLocked
+			}
+		},
+		forwardedHeaders: {
+			present: getForwardedHeaderNamesPresent(input.request.headers),
+			pair: {
+				status: forwardedPair.status,
+				isUsable: forwardedPair.isUsable,
+				protoPresent: forwardedPair.protoPresent,
+				hostPresent: forwardedPair.hostPresent
+			}
+		},
+		sourceAddress: {
+			category: classifySourceAddress(input.sourceAddress)
+		},
+		originComparison: {
+			browserMatchesRawApp: originsEqual(browserOrigin.origin, rawAppOrigin),
+			browserMatchesEffectiveApp: originsEqual(browserOrigin.origin, effectiveAppOrigin),
+			forwardedPairMatchesBrowser: originsEqual(
+				browserOrigin.origin,
+				forwardedPair.url?.origin ?? null
+			)
+		},
+		recommendation,
+		reasons,
+		safetyNotice: SAFETY_NOTICE
+	};
+}
+
+export async function createReverseProxyDiagnostic(
+	input: ReverseProxyDiagnosticInput
+): Promise<ReverseProxyDiagnostic> {
+	const [trustProxy, csrfOrigin] = await Promise.all([
+		getTrustProxyConfigWithSource(),
+		getCsrfConfigWithSource()
+	]);
+
+	return buildReverseProxyDiagnostic({
+		...input,
+		trustProxy: trustProxy.trustProxy,
+		csrfOrigin: csrfOrigin.origin
+	});
+}

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -52,6 +52,77 @@ import type { ActionData, PageData } from './$types';
 const validTabs = ['connections', 'appearance', 'privacy', 'security', 'data', 'system'] as const;
 type TabValue = (typeof validTabs)[number];
 
+type ConfigSource = 'env' | 'db' | 'default';
+type ForwardedHeaderName =
+	| 'forwarded'
+	| 'x-forwarded-for'
+	| 'x-forwarded-host'
+	| 'x-forwarded-proto'
+	| 'x-real-ip';
+type ForwardedPairStatus = 'missing' | 'partial' | 'invalid' | 'usable';
+type RecommendationAction =
+	| 'enable'
+	| 'leave-disabled'
+	| 'review-proxy'
+	| 'appears-working'
+	| 'unable-to-determine'
+	| 'env-controlled';
+
+interface OriginDiagnostic {
+	origin: string | null;
+	isValid: boolean;
+}
+
+interface ConfiguredOriginDiagnostic extends OriginDiagnostic {
+	source: ConfigSource;
+	isConfigured: boolean;
+	isLocked: boolean;
+}
+
+interface ReverseProxyDiagnostic {
+	trustProxy: {
+		enabled: boolean;
+		source: ConfigSource;
+		isLocked: boolean;
+	};
+	origins: {
+		rawApp: string | null;
+		effectiveApp: string | null;
+		browser: OriginDiagnostic;
+		configuredPublic: ConfiguredOriginDiagnostic;
+	};
+	forwardedHeaders: {
+		present: ForwardedHeaderName[];
+		pair: {
+			status: ForwardedPairStatus;
+			isUsable: boolean;
+			protoPresent: boolean;
+			hostPresent: boolean;
+		};
+	};
+	sourceAddress: {
+		category:
+			| 'loopback'
+			| 'private-lan'
+			| 'docker/private-range'
+			| 'tailscale/cgnat'
+			| 'link-local'
+			| 'public'
+			| 'unknown';
+	};
+	originComparison: {
+		browserMatchesRawApp: boolean | null;
+		browserMatchesEffectiveApp: boolean | null;
+		forwardedPairMatchesBrowser: boolean | null;
+	};
+	recommendation: {
+		action: RecommendationAction;
+		summary: string;
+	};
+	reasons: string[];
+	safetyNotice: string;
+}
+
 // Active tab state - initialized from URL params if available
 let activeTab = $state<TabValue>('connections');
 
@@ -305,6 +376,13 @@ $effect(() => {
 	}
 });
 
+$effect(() => {
+	if (activeTab !== 'security' || trustProxyDiagnosticAutoRunStarted) return;
+
+	trustProxyDiagnosticAutoRunStarted = true;
+	void runTrustProxyDiagnostic();
+});
+
 // Cache clearing dialog state
 let cacheDialogOpen = $state(false);
 let pendingCacheYear = $state<number | undefined>(undefined);
@@ -515,6 +593,10 @@ let trustProxyLocked = $state(false);
 let isSavingTrustProxy = $state(false);
 let trustProxyConfirmDialogOpen = $state(false);
 let isConfirmingTrustProxy = $state(false);
+let isCheckingTrustProxyDiagnostic = $state(false);
+let trustProxyDiagnosticAutoRunStarted = $state(false);
+let trustProxyDiagnostic = $state<ReverseProxyDiagnostic | null>(null);
+let trustProxyDiagnosticError = $state<string | null>(null);
 
 // CSRF mismatch confirmation dialog state. Server returns fail(409,
 // { requireConfirmation: true, attemptedOrigin, ... }) when the submitted
@@ -544,6 +626,87 @@ $effect(() => {
 function detectCurrentUrl() {
 	if (typeof window !== 'undefined') {
 		csrfOriginValue = window.location.origin;
+	}
+}
+
+function formatOrigin(origin: string | null): string {
+	return origin ?? 'Not available';
+}
+
+function formatComparison(value: boolean | null): string {
+	if (value === true) return 'Matches';
+	if (value === false) return 'Does not match';
+	return 'Unknown';
+}
+
+function getForwardedPairLabel(status: ForwardedPairStatus): string {
+	switch (status) {
+		case 'usable':
+			return 'Usable proto and host pair';
+		case 'partial':
+			return 'Partial proto/host pair';
+		case 'invalid':
+			return 'Invalid proto/host pair';
+		default:
+			return 'No proto/host pair';
+	}
+}
+
+function getRecommendationLabel(action: RecommendationAction): string {
+	switch (action) {
+		case 'enable':
+			return 'Enable';
+		case 'leave-disabled':
+			return 'Leave disabled';
+		case 'review-proxy':
+			return 'Review proxy setup';
+		case 'appears-working':
+			return 'Already enabled';
+		case 'env-controlled':
+			return 'Already controlled by environment';
+		default:
+			return 'Unable to determine safely';
+	}
+}
+
+function getTrustProxySourceLabel(source: ConfigSource): string {
+	return source === 'env' ? 'environment' : source === 'db' ? 'database' : 'default';
+}
+
+async function runTrustProxyDiagnostic() {
+	if (isCheckingTrustProxyDiagnostic) return;
+
+	isCheckingTrustProxyDiagnostic = true;
+	trustProxyDiagnosticError = null;
+
+	try {
+		const browserOrigin = typeof window === 'undefined' ? '' : window.location.origin;
+		const params = new URLSearchParams();
+		if (browserOrigin) params.set('browserOrigin', browserOrigin);
+
+		const query = params.toString();
+		const response = await fetch(
+			`/api/security/reverse-proxy-diagnostic${query ? `?${query}` : ''}`,
+			{
+				headers: { Accept: 'application/json' }
+			}
+		);
+		const payload = await response.json();
+
+		if (!response.ok) {
+			trustProxyDiagnostic = null;
+			trustProxyDiagnosticError =
+				(payload as { error?: string }).error ?? 'Unable to run the diagnostic.';
+			return;
+		}
+
+		trustProxyDiagnostic = payload as ReverseProxyDiagnostic;
+	} catch (error) {
+		trustProxyDiagnostic = null;
+		trustProxyDiagnosticError =
+			error instanceof Error ? error.message : 'Unable to run the diagnostic.';
+	} finally {
+		isCheckingTrustProxyDiagnostic = false;
 	}
 }
 
@@ -1918,8 +2081,9 @@ const logFieldErrors = $derived(
 						</div>
 
 						<p class="panel-description">
-							Trust <code>X-Forwarded-Proto</code> and <code>X-Forwarded-Host</code> from the
-							upstream reverse proxy. Default: off.
+							Use this when Obzorarr is behind a trusted proxy and the app needs to understand
+							the public protocol and host your browser used. The diagnostic is read-only and
+							never changes <code>TRUST_PROXY</code> by itself.
 						</p>
 						{#if trustProxyHelpOpen}
 							<div id="trust-proxy-help-panel" class="security-help-panel">
@@ -1930,6 +2094,11 @@ const logFieldErrors = $derived(
 									absolute URLs. Enable only if your reverse proxy strips inbound forwarded
 									headers from clients; otherwise an attacker can poison the app's view of its own
 									host and protocol.
+								</p>
+								<p>
+									This commonly matters for Nginx Proxy Manager, Nginx, Caddy, Traefik, Pangolin,
+									Tailscale/headscale, Docker bridge or host networking, LAN/private IP access,
+									and localhost setups where the browser URL differs from Obzorarr's internal URL.
 								</p>
 							</div>
 						{/if}
@@ -1951,14 +2120,164 @@ const logFieldErrors = $derived(
 								</div>
 								{#if trustProxyLocked}
 									<span class="field-hint env-hint">
-										This value is set via TRUST_PROXY environment variable and cannot be changed
-										here.
+										This value is set by the <code>TRUST_PROXY</code> environment variable. Change
+										it in your environment, container, or compose configuration; the UI cannot
+										override it.
 									</span>
 								{:else}
 									<span class="field-hint">
-										Enable only if your reverse proxy strips inbound <code>X-Forwarded-*</code>
-										headers from clients. Environment variable takes priority over database.
+										Leave this disabled for direct localhost or LAN access unless a trusted proxy
+										sits in front of Obzorarr. Enable only if that proxy strips visitor-supplied
+										<code>X-Forwarded-*</code> headers before forwarding requests.
 									</span>
+								{/if}
+							</div>
+
+							<div class="trust-proxy-diagnostic">
+								<div class="diagnostic-header">
+									<div>
+										<h3>Connection Diagnostic</h3>
+										<p>
+											Compare the browser URL with what Obzorarr sees and with sanitized forwarded
+											header signals.
+										</p>
+									</div>
+									<button
+										type="button"
+										class="btn-secondary"
+										onclick={runTrustProxyDiagnostic}
+										disabled={isCheckingTrustProxyDiagnostic}
+									>
+										{#if isCheckingTrustProxyDiagnostic}
+											<Loader2 class="btn-icon spinning" />
+											Checking...
+										{:else}
+											<RefreshCw class="btn-icon" />
+											Check again
+										{/if}
+									</button>
+								</div>
+
+								{#if trustProxyLocked}
+									<div class="diagnostic-env-lock">
+										<Lock class="diagnostic-inline-icon" />
+										<span>
+											<code>TRUST_PROXY</code> is locked by the environment and is currently
+											{trustProxyValue ? 'enabled' : 'disabled'}. Update your environment or
+											container configuration to change it.
+										</span>
+									</div>
+								{/if}
+
+								{#if isCheckingTrustProxyDiagnostic && !trustProxyDiagnostic}
+									<div class="diagnostic-empty">
+										<Loader2 class="btn-icon spinning" />
+										Checking the current request path...
+									</div>
+								{:else if trustProxyDiagnosticError}
+									<div class="diagnostic-error">
+										<AlertTriangle class="diagnostic-inline-icon" />
+										<span>{trustProxyDiagnosticError}</span>
+									</div>
+								{:else if trustProxyDiagnostic}
+									<div class="diagnostic-result-grid">
+										<section class="diagnostic-group">
+											<h4>What your browser used</h4>
+											<dl>
+												<div>
+													<dt>Browser origin</dt>
+													<dd>{formatOrigin(trustProxyDiagnostic.origins.browser.origin)}</dd>
+												</div>
+												<div>
+													<dt>Configured public origin</dt>
+													<dd>
+														{formatOrigin(trustProxyDiagnostic.origins.configuredPublic.origin)}
+														<span class="diagnostic-muted">
+															({getTrustProxySourceLabel(
+																trustProxyDiagnostic.origins.configuredPublic.source
+															)})
+														</span>
+													</dd>
+												</div>
+											</dl>
+										</section>
+
+										<section class="diagnostic-group">
+											<h4>What Obzorarr sees</h4>
+											<dl>
+												<div>
+													<dt>Raw app origin</dt>
+													<dd>{formatOrigin(trustProxyDiagnostic.origins.rawApp)}</dd>
+												</div>
+												<div>
+													<dt>Effective app origin</dt>
+													<dd>{formatOrigin(trustProxyDiagnostic.origins.effectiveApp)}</dd>
+												</div>
+												<div>
+													<dt>Source category</dt>
+													<dd>{trustProxyDiagnostic.sourceAddress.category}</dd>
+												</div>
+												<div>
+													<dt>Browser vs effective</dt>
+													<dd>
+														{formatComparison(
+															trustProxyDiagnostic.originComparison.browserMatchesEffectiveApp
+														)}
+													</dd>
+												</div>
+											</dl>
+										</section>
+
+										<section class="diagnostic-group">
+											<h4>Forwarded headers detected</h4>
+											<dl>
+												<div>
+													<dt>Header names</dt>
+													<dd>
+														{trustProxyDiagnostic.forwardedHeaders.present.length > 0
+															? trustProxyDiagnostic.forwardedHeaders.present.join(', ')
+															: 'None detected'}
+													</dd>
+												</div>
+												<div>
+													<dt>Proto and host pair</dt>
+													<dd>
+														{getForwardedPairLabel(
+															trustProxyDiagnostic.forwardedHeaders.pair.status
+														)}
+													</dd>
+												</div>
+												<div>
+													<dt>Pair matches browser</dt>
+													<dd>
+														{formatComparison(
+															trustProxyDiagnostic.originComparison.forwardedPairMatchesBrowser
+														)}
+													</dd>
+												</div>
+											</dl>
+										</section>
+
+										<section class="diagnostic-group diagnostic-recommendation">
+											<h4>Recommendation</h4>
+											<div class="recommendation-label">
+												{getRecommendationLabel(trustProxyDiagnostic.recommendation.action)}
+											</div>
+											<p>{trustProxyDiagnostic.recommendation.summary}</p>
+											{#if trustProxyDiagnostic.reasons.length > 0}
+												<ul>
+													{#each trustProxyDiagnostic.reasons as reason}
+														<li>{reason}</li>
+													{/each}
+												</ul>
+											{/if}
+											<p class="safety-notice">{trustProxyDiagnostic.safetyNotice}</p>
+										</section>
+									</div>
+								{:else}
+									<div class="diagnostic-empty">
+										Open the Security tab to run a diagnostic, or use Check again.
+									</div>
 								{/if}
 							</div>
 
@@ -3895,7 +4214,161 @@ const logFieldErrors = $derived(
 		}
 
 		.security-help-panel p {
+			margin: 0 0 0.625rem;
+		}
+
+		.security-help-panel p:last-child {
+			margin-bottom: 0;
+		}
+
+		.trust-proxy-diagnostic {
+			margin-top: 1.25rem;
+			padding: 1rem;
+			border: 1px solid hsl(var(--border) / 0.7);
+			border-radius: 8px;
+			background: hsl(var(--muted) / 0.16);
+		}
+
+		.diagnostic-header {
+			display: flex;
+			align-items: flex-start;
+			justify-content: space-between;
+			gap: 1rem;
+			margin-bottom: 1rem;
+		}
+
+		.diagnostic-header h3 {
 			margin: 0;
+			color: hsl(var(--foreground));
+			font-size: 0.9375rem;
+			font-weight: 600;
+		}
+
+		.diagnostic-header p {
+			margin: 0.25rem 0 0;
+			color: hsl(var(--muted-foreground));
+			font-size: 0.8125rem;
+			line-height: 1.45;
+		}
+
+		.diagnostic-env-lock,
+		.diagnostic-error,
+		.diagnostic-empty {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			margin-bottom: 1rem;
+			padding: 0.75rem 0.875rem;
+			border-radius: 8px;
+			font-size: 0.8125rem;
+			line-height: 1.45;
+		}
+
+		.diagnostic-env-lock {
+			border: 1px solid hsl(210 60% 35% / 0.45);
+			background: hsl(210 60% 50% / 0.08);
+			color: hsl(210 60% 70%);
+		}
+
+		.diagnostic-error {
+			border: 1px solid hsl(0 70% 40% / 0.45);
+			background: hsl(0 70% 45% / 0.12);
+			color: hsl(0 70% 72%);
+		}
+
+		.diagnostic-empty {
+			margin-bottom: 0;
+			border: 1px dashed hsl(var(--border) / 0.7);
+			background: hsl(var(--background) / 0.35);
+			color: hsl(var(--muted-foreground));
+		}
+
+		.diagnostic-inline-icon {
+			width: 15px;
+			height: 15px;
+			flex: 0 0 auto;
+		}
+
+		.diagnostic-result-grid {
+			display: grid;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			gap: 0.875rem;
+		}
+
+		.diagnostic-group {
+			padding: 0.875rem;
+			border: 1px solid hsl(var(--border) / 0.55);
+			border-radius: 8px;
+			background: hsl(var(--background) / 0.4);
+		}
+
+		.diagnostic-group h4 {
+			margin: 0 0 0.75rem;
+			color: hsl(var(--foreground));
+			font-size: 0.8125rem;
+			font-weight: 600;
+		}
+
+		.diagnostic-group dl {
+			display: grid;
+			gap: 0.625rem;
+			margin: 0;
+		}
+
+		.diagnostic-group dt {
+			color: hsl(var(--muted-foreground));
+			font-size: 0.6875rem;
+			font-weight: 600;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+		}
+
+		.diagnostic-group dd {
+			margin: 0.125rem 0 0;
+			color: hsl(var(--foreground));
+			font-size: 0.8125rem;
+			line-height: 1.45;
+			overflow-wrap: anywhere;
+		}
+
+		.diagnostic-muted {
+			color: hsl(var(--muted-foreground));
+		}
+
+		.diagnostic-recommendation {
+			border-color: hsl(145 70% 45% / 0.35);
+			background: hsl(145 70% 35% / 0.1);
+		}
+
+		.recommendation-label {
+			display: inline-flex;
+			margin-bottom: 0.5rem;
+			padding: 0.25rem 0.625rem;
+			border-radius: 999px;
+			background: hsl(145 60% 24%);
+			color: hsl(145 70% 72%);
+			font-size: 0.75rem;
+			font-weight: 700;
+		}
+
+		.diagnostic-recommendation p {
+			margin: 0 0 0.625rem;
+			color: hsl(var(--foreground));
+			font-size: 0.8125rem;
+			line-height: 1.5;
+		}
+
+		.diagnostic-recommendation ul {
+			margin: 0 0 0.625rem;
+			padding-left: 1.1rem;
+			color: hsl(var(--muted-foreground));
+			font-size: 0.78125rem;
+			line-height: 1.45;
+		}
+
+		.diagnostic-recommendation .safety-notice {
+			margin-bottom: 0;
+			color: hsl(45 90% 72%);
 		}
 
 		/* Documentation - Compact Collapsible */
@@ -4060,6 +4533,14 @@ const logFieldErrors = $derived(
 			.option-cards.three-col {
 				grid-template-columns: repeat(2, 1fr);
 			}
+
+			.diagnostic-header {
+				flex-direction: column;
+			}
+
+			.diagnostic-result-grid {
+				grid-template-columns: 1fr;
+			}
 		}
 
 		@media (max-width: 480px) {
@@ -4102,6 +4583,10 @@ const logFieldErrors = $derived(
 			.openai-maintenance-actions,
 			.openai-maintenance-form,
 			.openai-maintenance-form button {
+				width: 100%;
+			}
+
+			.diagnostic-header button {
 				width: 100%;
 			}
 		}

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -59,7 +59,13 @@ type ForwardedHeaderName =
 	| 'x-forwarded-host'
 	| 'x-forwarded-proto'
 	| 'x-real-ip';
-type ForwardedPairStatus = 'missing' | 'partial' | 'invalid' | 'usable';
+type ForwardedPairStatus =
+	| 'missing'
+	| 'partial'
+	| 'invalid-proto'
+	| 'unsafe-host'
+	| 'invalid-host'
+	| 'usable';
 type RecommendationAction =
 	| 'enable'
 	| 'leave-disabled'
@@ -645,7 +651,9 @@ function getForwardedPairLabel(status: ForwardedPairStatus): string {
 			return 'Usable proto and host pair';
 		case 'partial':
 			return 'Partial proto/host pair';
-		case 'invalid':
+		case 'invalid-proto':
+		case 'unsafe-host':
+		case 'invalid-host':
 			return 'Invalid proto/host pair';
 		default:
 			return 'No proto/host pair';

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -54,11 +54,11 @@ type TabValue = (typeof validTabs)[number];
 
 type ConfigSource = 'env' | 'db' | 'default';
 type ForwardedHeaderName =
-	| 'forwarded'
-	| 'x-forwarded-for'
-	| 'x-forwarded-host'
-	| 'x-forwarded-proto'
-	| 'x-real-ip';
+	| 'Forwarded'
+	| 'X-Forwarded-For'
+	| 'X-Forwarded-Host'
+	| 'X-Forwarded-Proto'
+	| 'X-Real-IP';
 type ForwardedPairStatus =
 	| 'missing'
 	| 'partial'
@@ -73,6 +73,10 @@ type RecommendationAction =
 	| 'appears-working'
 	| 'unable-to-determine'
 	| 'env-controlled';
+type DiagnosticErrorPayload = {
+	error?: string;
+	message?: string;
+};
 
 interface OriginDiagnostic {
 	origin: string | null;
@@ -702,9 +706,10 @@ async function runTrustProxyDiagnostic() {
 		const payload = await response.json();
 
 		if (!response.ok) {
+			const diagnosticError = payload as DiagnosticErrorPayload;
 			trustProxyDiagnostic = null;
 			trustProxyDiagnosticError =
-				(payload as { error?: string }).error ?? 'Unable to run the diagnostic.';
+				diagnosticError.error ?? diagnosticError.message ?? 'Unable to run the diagnostic.';
 			return;
 		}
 

--- a/src/routes/api/security/reverse-proxy-diagnostic/+server.ts
+++ b/src/routes/api/security/reverse-proxy-diagnostic/+server.ts
@@ -1,0 +1,59 @@
+import { error, json } from '@sveltejs/kit';
+import { checkRateLimit } from '$lib/server/ratelimit';
+import { createReverseProxyDiagnostic } from '$lib/server/security/reverse-proxy-diagnostic';
+import type { RequestHandler } from './$types';
+
+const RATE_LIMIT = {
+	name: 'reverseProxyDiagnostic',
+	windowMs: 60_000,
+	maxRequests: 12
+};
+
+const MAX_BROWSER_ORIGIN_LENGTH = 2048;
+
+export const GET: RequestHandler = async ({ getClientAddress, locals, request, url }) => {
+	if (!locals.user) {
+		throw error(401, 'Unauthorized');
+	}
+
+	if (!locals.user.isAdmin) {
+		throw error(403, 'Admin access required');
+	}
+
+	const browserOrigin = url.searchParams.get('browserOrigin');
+	if (browserOrigin && browserOrigin.length > MAX_BROWSER_ORIGIN_LENGTH) {
+		throw error(400, 'browserOrigin is too long');
+	}
+
+	const rateLimit = checkRateLimit(`${locals.user.id}:${getClientAddress()}`, RATE_LIMIT);
+	if (!rateLimit.allowed) {
+		return json(
+			{ error: 'Too many diagnostic requests' },
+			{
+				status: 429,
+				headers: {
+					'Cache-Control': 'no-store',
+					'Retry-After': String(rateLimit.retryAfter ?? 60),
+					'X-RateLimit-Remaining': '0',
+					'X-RateLimit-Reset': String(rateLimit.resetTime)
+				}
+			}
+		);
+	}
+
+	const diagnostic = await createReverseProxyDiagnostic({
+		request,
+		rawAppUrl: request.url,
+		effectiveAppUrl: url,
+		browserOrigin,
+		sourceAddress: getClientAddress()
+	});
+
+	return json(diagnostic, {
+		headers: {
+			'Cache-Control': 'no-store',
+			'X-RateLimit-Remaining': String(rateLimit.remaining),
+			'X-RateLimit-Reset': String(rateLimit.resetTime)
+		}
+	});
+};

--- a/src/routes/api/security/reverse-proxy-diagnostic/+server.ts
+++ b/src/routes/api/security/reverse-proxy-diagnostic/+server.ts
@@ -1,4 +1,4 @@
-import { error, json } from '@sveltejs/kit';
+import { json } from '@sveltejs/kit';
 import { checkRateLimit } from '$lib/server/ratelimit';
 import { createReverseProxyDiagnostic } from '$lib/server/security/reverse-proxy-diagnostic';
 import type { RequestHandler } from './$types';
@@ -10,19 +10,23 @@ const RATE_LIMIT = {
 };
 
 const MAX_BROWSER_ORIGIN_LENGTH = 2048;
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' };
 
 export const GET: RequestHandler = async ({ getClientAddress, locals, request, url }) => {
 	if (!locals.user) {
-		throw error(401, 'Unauthorized');
+		return json({ message: 'Unauthorized' }, { status: 401, headers: NO_STORE_HEADERS });
 	}
 
 	if (!locals.user.isAdmin) {
-		throw error(403, 'Admin access required');
+		return json({ message: 'Admin access required' }, { status: 403, headers: NO_STORE_HEADERS });
 	}
 
 	const browserOrigin = url.searchParams.get('browserOrigin');
 	if (browserOrigin && browserOrigin.length > MAX_BROWSER_ORIGIN_LENGTH) {
-		throw error(400, 'browserOrigin is too long');
+		return json(
+			{ message: 'browserOrigin is too long' },
+			{ status: 400, headers: NO_STORE_HEADERS }
+		);
 	}
 
 	const rateLimit = checkRateLimit(`${locals.user.id}:${getClientAddress()}`, RATE_LIMIT);

--- a/src/routes/api/security/reverse-proxy-diagnostic/+server.ts
+++ b/src/routes/api/security/reverse-proxy-diagnostic/+server.ts
@@ -29,7 +29,8 @@ export const GET: RequestHandler = async ({ getClientAddress, locals, request, u
 		);
 	}
 
-	const rateLimit = checkRateLimit(`${locals.user.id}:${getClientAddress()}`, RATE_LIMIT);
+	const sourceAddress = getClientAddress();
+	const rateLimit = checkRateLimit(`${locals.user.id}:${sourceAddress}`, RATE_LIMIT);
 	if (!rateLimit.allowed) {
 		return json(
 			{ error: 'Too many diagnostic requests' },
@@ -50,7 +51,7 @@ export const GET: RequestHandler = async ({ getClientAddress, locals, request, u
 		rawAppUrl: request.url,
 		effectiveAppUrl: url,
 		browserOrigin,
-		sourceAddress: getClientAddress()
+		sourceAddress
 	});
 
 	return json(diagnostic, {

--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -63,6 +63,8 @@ function isSubmittedBrowserOriginAction(request: Request, browserOrigin: string)
 	return requestOrigin !== null && originsMatch(requestOrigin, browserOrigin);
 }
 
+const MAX_BROWSER_ORIGIN_LENGTH = 2048;
+
 const CsrfOriginSchema = z.object({
 	csrfOrigin: z
 		.string()
@@ -85,6 +87,7 @@ const BrowserOriginSchema = z.object({
 	browserOrigin: z
 		.string()
 		.min(1, 'Browser origin is required')
+		.max(MAX_BROWSER_ORIGIN_LENGTH, 'browserOrigin is too long')
 		.url('Browser origin is invalid')
 		.refine((url) => url.startsWith('http://') || url.startsWith('https://'), {
 			message: 'Browser origin must start with http:// or https://'

--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -4,6 +4,7 @@ import {
 	AppSettingsKey,
 	deleteAppSetting,
 	getCsrfConfigWithSource,
+	getTrustProxyConfigWithSource,
 	setAppSetting
 } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
@@ -15,6 +16,8 @@ import {
 	requireActiveOnboardingClaim,
 	setOnboardingStep
 } from '$lib/server/onboarding';
+import { parseForwardedProtoHost } from '$lib/server/security/forwarded-headers';
+import { createReverseProxyDiagnostic } from '$lib/server/security/reverse-proxy-diagnostic';
 import type { Actions, PageServerLoad } from './$types';
 
 async function isOnboardingCsrfStep(): Promise<boolean> {
@@ -55,6 +58,11 @@ function isSameOriginOnboardingAction(request: Request, url: URL): boolean {
 	return requestOrigin !== null && originsMatch(requestOrigin, url.origin);
 }
 
+function isSubmittedBrowserOriginAction(request: Request, browserOrigin: string): boolean {
+	const requestOrigin = getRequestOrigin(request);
+	return requestOrigin !== null && originsMatch(requestOrigin, browserOrigin);
+}
+
 const CsrfOriginSchema = z.object({
 	csrfOrigin: z
 		.string()
@@ -73,52 +81,64 @@ const CsrfOriginSchema = z.object({
 		})
 });
 
+const BrowserOriginSchema = z.object({
+	browserOrigin: z
+		.string()
+		.min(1, 'Browser origin is required')
+		.url('Browser origin is invalid')
+		.refine((url) => url.startsWith('http://') || url.startsWith('https://'), {
+			message: 'Browser origin must start with http:// or https://'
+		})
+		.transform((url) => new URL(url).origin)
+});
+
+const TrustProxyEnableSchema = BrowserOriginSchema.extend({
+	confirmRisk: z.literal('true')
+});
+
+async function requireOnboardingCsrfAction(
+	cookies: Parameters<NonNullable<Actions['testOrigin']>>[0]['cookies'],
+	url: URL,
+	errorKey: 'error' | 'testError' | 'diagnosticError' | 'trustProxyError'
+) {
+	if (!(await isOnboardingCsrfStep())) {
+		return fail(403, { [errorKey]: 'Not allowed at this onboarding stage' });
+	}
+	try {
+		await requireActiveOnboardingClaim(cookies, { requestUrl: url });
+	} catch (err) {
+		if (err instanceof OnboardingClaimRequiredError) {
+			return fail(403, { [errorKey]: err.message });
+		}
+		throw err;
+	}
+	return null;
+}
+
 export const load: PageServerLoad = async ({ request, parent }) => {
 	const parentData = await parent();
 	const csrfConfig = await getCsrfConfigWithSource();
 
-	const forwardedProtoRaw = request.headers.get('x-forwarded-proto');
-	const forwardedHostRaw = request.headers.get('x-forwarded-host');
-	const forwardedProto = forwardedProtoRaw?.split(',')[0]?.trim();
-	const forwardedHost = forwardedHostRaw?.split(',')[0]?.trim();
-	const isReverseProxy = !!(forwardedProto || forwardedHost);
-
+	const forwardedPair = parseForwardedProtoHost(request.headers);
 	const requestUrl = new URL(request.url);
-	let detectedOrigin: string;
-	if (forwardedHost) {
-		const proto = forwardedProto?.includes('https')
-			? 'https'
-			: forwardedProto || requestUrl.protocol.replace(':', '');
-		detectedOrigin = `${proto}://${forwardedHost}`;
-	} else {
-		detectedOrigin = requestUrl.origin;
-	}
+	const isReverseProxy = forwardedPair.protoPresent || forwardedPair.hostPresent;
+	const detectedOrigin = forwardedPair.url?.origin ?? requestUrl.origin;
 
 	return {
 		...parentData,
 		csrfConfig: csrfConfig.origin,
+		reverseProxyDiagnostic: null,
 		detection: {
 			isReverseProxy,
-			detectedOrigin,
-			forwardedProto,
-			forwardedHost
+			detectedOrigin
 		}
 	};
 };
 
 export const actions: Actions = {
 	testOrigin: async ({ request, cookies, url }) => {
-		if (!(await isOnboardingCsrfStep())) {
-			return fail(403, { testError: 'Not allowed at this onboarding stage' });
-		}
-		try {
-			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
-		} catch (err) {
-			if (err instanceof OnboardingClaimRequiredError) {
-				return fail(403, { testError: err.message });
-			}
-			throw err;
-		}
+		const guardResult = await requireOnboardingCsrfAction(cookies, url, 'testError');
+		if (guardResult) return guardResult;
 
 		const formData = await request.formData();
 		const proposedOrigin = formData.get('csrfOrigin')?.toString();
@@ -146,17 +166,8 @@ export const actions: Actions = {
 	},
 
 	saveOrigin: async ({ request, cookies, url }) => {
-		if (!(await isOnboardingCsrfStep())) {
-			return fail(403, { error: 'Not allowed at this onboarding stage' });
-		}
-		try {
-			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
-		} catch (err) {
-			if (err instanceof OnboardingClaimRequiredError) {
-				return fail(403, { error: err.message });
-			}
-			throw err;
-		}
+		const guardResult = await requireOnboardingCsrfAction(cookies, url, 'error');
+		if (guardResult) return guardResult;
 
 		if (!isSameOriginOnboardingAction(request, url)) {
 			return fail(403, { error: 'CSRF origin must be submitted from this Obzorarr origin' });
@@ -199,17 +210,8 @@ export const actions: Actions = {
 	},
 
 	skipCsrf: async ({ request, cookies, url }) => {
-		if (!(await isOnboardingCsrfStep())) {
-			return fail(403, { error: 'Not allowed at this onboarding stage' });
-		}
-		try {
-			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
-		} catch (err) {
-			if (err instanceof OnboardingClaimRequiredError) {
-				return fail(403, { error: err.message });
-			}
-			throw err;
-		}
+		const guardResult = await requireOnboardingCsrfAction(cookies, url, 'error');
+		if (guardResult) return guardResult;
 
 		if (!isSameOriginOnboardingAction(request, url)) {
 			return fail(403, { error: 'CSRF skip must be submitted from this Obzorarr origin' });
@@ -220,5 +222,86 @@ export const actions: Actions = {
 
 		await setOnboardingStep(OnboardingSteps.PLEX);
 		redirect(303, '/onboarding/plex');
+	},
+
+	diagnoseReverseProxy: async ({ request, cookies, url, getClientAddress }) => {
+		const guardResult = await requireOnboardingCsrfAction(cookies, url, 'diagnosticError');
+		if (guardResult) return guardResult;
+
+		const formData = await request.formData();
+		const parsed = BrowserOriginSchema.safeParse({
+			browserOrigin: formData.get('browserOrigin')
+		});
+		if (!parsed.success) {
+			return fail(400, {
+				diagnosticError: parsed.error.issues[0]?.message ?? 'Could not read browser origin safely'
+			});
+		}
+
+		try {
+			const diagnostic = await createReverseProxyDiagnostic({
+				request,
+				rawAppUrl: request.url,
+				effectiveAppUrl: url,
+				browserOrigin: parsed.data.browserOrigin,
+				sourceAddress: getClientAddress()
+			});
+			return { reverseProxyDiagnostic: diagnostic };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Unknown diagnostic error';
+			logger.error(`Onboarding reverse proxy diagnostic failed: ${message}`, 'Onboarding');
+			return fail(500, { diagnosticError: 'Could not run reverse proxy diagnostic' });
+		}
+	},
+
+	enableTrustProxy: async ({ request, cookies, url, getClientAddress }) => {
+		const guardResult = await requireOnboardingCsrfAction(cookies, url, 'trustProxyError');
+		if (guardResult) return guardResult;
+
+		const trustProxyConfig = await getTrustProxyConfigWithSource();
+		if (trustProxyConfig.trustProxy.isLocked) {
+			return fail(400, {
+				trustProxyError:
+					'TRUST_PROXY is set via environment variable and must be changed in your environment or container configuration.'
+			});
+		}
+
+		const formData = await request.formData();
+		const parsed = TrustProxyEnableSchema.safeParse({
+			browserOrigin: formData.get('browserOrigin'),
+			confirmRisk: formData.get('confirmRisk')
+		});
+		if (!parsed.success) {
+			return fail(400, {
+				trustProxyError: 'Confirm the reverse-proxy header trust risk before enabling TRUST_PROXY.'
+			});
+		}
+
+		if (!isSubmittedBrowserOriginAction(request, parsed.data.browserOrigin)) {
+			return fail(403, {
+				trustProxyError: 'Reverse proxy header trust must be enabled from this browser origin'
+			});
+		}
+
+		const diagnostic = await createReverseProxyDiagnostic({
+			request,
+			rawAppUrl: request.url,
+			effectiveAppUrl: url,
+			browserOrigin: parsed.data.browserOrigin,
+			sourceAddress: getClientAddress()
+		});
+		if (diagnostic.recommendation.action !== 'enable') {
+			return fail(400, {
+				trustProxyError:
+					'The current diagnostic does not recommend enabling reverse proxy header trust.'
+			});
+		}
+
+		await setAppSetting(AppSettingsKey.TRUST_PROXY, 'true');
+		logger.warn(
+			'Reverse-proxy header trust enabled during onboarding. Verify your upstream proxy strips inbound x-forwarded-* headers.',
+			'Onboarding'
+		);
+		return { trustProxySuccess: true, trustProxyMessage: 'Reverse-proxy header trust enabled.' };
 	}
 };

--- a/src/routes/onboarding/csrf/+page.svelte
+++ b/src/routes/onboarding/csrf/+page.svelte
@@ -8,6 +8,43 @@ import type { ActionData, PageData } from './$types';
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
+type ReverseProxyDiagnosticView = {
+	trustProxy: {
+		enabled: boolean;
+		source: 'env' | 'db' | 'default';
+		isLocked: boolean;
+	};
+	forwardedHeaders: {
+		present: string[];
+		pair: {
+			status: string;
+			isUsable: boolean;
+			protoPresent: boolean;
+			hostPresent: boolean;
+		};
+	};
+	sourceAddress: {
+		category: string;
+	};
+	originComparison: {
+		browserMatchesRawApp: boolean | null;
+		browserMatchesEffectiveApp: boolean | null;
+		forwardedPairMatchesBrowser: boolean | null;
+	};
+	recommendation: {
+		action:
+			| 'enable'
+			| 'leave-disabled'
+			| 'review-proxy'
+			| 'appears-working'
+			| 'unable-to-determine'
+			| 'env-controlled';
+		summary: string;
+	};
+	reasons: string[];
+	safetyNotice: string;
+};
+
 function getInitialOrigin(): string {
 	return data.csrfConfig.value || data.detection.detectedOrigin;
 }
@@ -25,6 +62,23 @@ let testResult = $state<'idle' | 'testing' | 'success' | 'failure'>(
 );
 let testError = $state<string | null>(null);
 let testedOrigin = $state<string | null>(initialOriginVerified ? initialOrigin : null);
+let browserOrigin = $state<string>('');
+let reverseProxyDiagnostic = $state<ReverseProxyDiagnosticView | null>(null);
+let diagnosticStatus = $state<'idle' | 'checking' | 'success' | 'failure'>('idle');
+let diagnosticError = $state<string | null>(null);
+let hasRunInitialDiagnostic = $state(false);
+
+function updateDiagnosticFromActionForm() {
+	if (form?.reverseProxyDiagnostic) {
+		reverseProxyDiagnostic = form.reverseProxyDiagnostic as ReverseProxyDiagnosticView;
+		diagnosticStatus = 'success';
+		diagnosticError = null;
+	}
+	if (form?.diagnosticError) {
+		diagnosticStatus = 'failure';
+		diagnosticError = form.diagnosticError;
+	}
+}
 
 let previousInput = $state<string>(initialOrigin);
 $effect(() => {
@@ -40,6 +94,56 @@ $effect(() => {
 			testedOrigin = null;
 		}
 	}
+});
+
+async function runDiagnostic() {
+	if (diagnosticStatus === 'checking') return;
+
+	browserOrigin = window.location.origin;
+	diagnosticStatus = 'checking';
+	diagnosticError = null;
+
+	const formData = new FormData();
+	formData.set('browserOrigin', browserOrigin);
+
+	try {
+		const response = await fetch('?/diagnoseReverseProxy', {
+			method: 'POST',
+			body: formData
+		});
+		const text = await response.text();
+		const result: ActionResult = deserialize(text);
+
+		if (result.type === 'success') {
+			const payload = result.data as
+				| { reverseProxyDiagnostic?: ReverseProxyDiagnosticView }
+				| undefined;
+			if (payload?.reverseProxyDiagnostic) {
+				reverseProxyDiagnostic = payload.reverseProxyDiagnostic;
+				diagnosticStatus = 'success';
+			} else {
+				diagnosticStatus = 'failure';
+				diagnosticError = 'Diagnostic response was incomplete';
+			}
+		} else if (result.type === 'failure') {
+			diagnosticStatus = 'failure';
+			const payload = result.data as { diagnosticError?: string } | undefined;
+			diagnosticError = payload?.diagnosticError ?? 'Diagnostic failed';
+		} else {
+			diagnosticStatus = 'failure';
+			diagnosticError = 'Unexpected diagnostic response';
+		}
+	} catch {
+		diagnosticStatus = 'failure';
+		diagnosticError = 'Network error - could not complete diagnostic';
+	}
+}
+
+$effect(() => {
+	updateDiagnosticFromActionForm();
+	if (hasRunInitialDiagnostic) return;
+	hasRunInitialDiagnostic = true;
+	void runDiagnostic();
 });
 
 async function runTest() {
@@ -120,6 +224,39 @@ $effect(() => {
 function useDetectedOrigin() {
 	csrfOriginInput = data.detection.detectedOrigin;
 }
+
+function getForwardedPairLabel(status: string): string {
+	switch (status) {
+		case 'usable':
+			return 'Forwarded scheme and host look usable';
+		case 'missing':
+			return 'No forwarded scheme/host pair detected';
+		case 'partial':
+			return 'Forwarded scheme/host pair is incomplete';
+		case 'invalid-proto':
+		case 'unsafe-host':
+		case 'invalid-host':
+			return 'Forwarded scheme/host pair is invalid';
+		default:
+			return 'Forwarded scheme/host pair needs review';
+	}
+}
+
+function getRecommendationTone(
+	action: ReverseProxyDiagnosticView['recommendation']['action']
+): string {
+	if (action === 'enable' || action === 'appears-working') return 'success';
+	if (action === 'leave-disabled') return 'neutral';
+	return 'warning';
+}
+
+function canEnableTrustProxy(): boolean {
+	return (
+		diagnosticStatus === 'success' &&
+		reverseProxyDiagnostic?.recommendation.action === 'enable' &&
+		!reverseProxyDiagnostic.trustProxy.isLocked
+	);
+}
 </script>
 
 <OnboardingCard title="Security Settings" subtitle="Configure CSRF protection for your application">
@@ -192,10 +329,131 @@ function useDetectedOrigin() {
 					<span class="detection-value origin">{data.detection.detectedOrigin}</span>
 				</div>
 			</div>
-		</div>
+			</div>
 
-		{#if data.csrfConfig.isLocked}
-			<div class="preconfigured-card animate-item">
+			<div class="diagnostic-card animate-item">
+				<div class="diagnostic-header">
+					<div>
+						<span class="diagnostic-eyebrow">Reverse Proxy Header Trust</span>
+						<h3>Connection safety check</h3>
+					</div>
+					<button
+						type="button"
+						class="diagnostic-check-btn"
+						onclick={runDiagnostic}
+						disabled={diagnosticStatus === 'checking'}
+					>
+						{#if diagnosticStatus === 'checking'}
+							<span class="spinner small"></span>
+							Checking...
+						{:else}
+							Check again
+						{/if}
+					</button>
+				</div>
+
+				{#if diagnosticStatus === 'checking' && !reverseProxyDiagnostic}
+					<div class="diagnostic-loading">
+						<span class="spinner"></span>
+						<span>Checking whether Obzorarr should trust proxy headers...</span>
+					</div>
+				{:else if diagnosticStatus === 'failure'}
+					<div class="test-result error">
+						<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+							<circle cx="12" cy="12" r="10" />
+							<line x1="15" y1="9" x2="9" y2="15" stroke-linecap="round" />
+							<line x1="9" y1="9" x2="15" y2="15" stroke-linecap="round" />
+						</svg>
+						<span>{diagnosticError ?? 'Diagnostic failed'}</span>
+					</div>
+				{/if}
+
+				{#if reverseProxyDiagnostic}
+					<div
+						class="diagnostic-recommendation {getRecommendationTone(
+							reverseProxyDiagnostic.recommendation.action
+						)}"
+					>
+						<span class="recommendation-title">
+							{reverseProxyDiagnostic.recommendation.summary}
+						</span>
+						<ul>
+							{#each reverseProxyDiagnostic.reasons as reason}
+								<li>{reason}</li>
+							{/each}
+						</ul>
+					</div>
+
+					<div class="diagnostic-facts">
+						<div>
+							<span class="fact-label">Forwarded headers</span>
+							<span class="fact-value">
+								{getForwardedPairLabel(reverseProxyDiagnostic.forwardedHeaders.pair.status)}
+							</span>
+						</div>
+						<div>
+							<span class="fact-label">Signals present</span>
+							<span class="fact-value">
+								{reverseProxyDiagnostic.forwardedHeaders.present.length > 0
+									? reverseProxyDiagnostic.forwardedHeaders.present.join(', ')
+									: 'None'}
+							</span>
+						</div>
+						<div>
+							<span class="fact-label">Current setting</span>
+							<span class="fact-value">
+								{reverseProxyDiagnostic.trustProxy.enabled ? 'Enabled' : 'Disabled'}
+								{#if reverseProxyDiagnostic.trustProxy.isLocked}
+									<span class="inline-badge">ENV</span>
+								{/if}
+							</span>
+						</div>
+					</div>
+
+					<p class="diagnostic-safety">{reverseProxyDiagnostic.safetyNotice}</p>
+
+					{#if reverseProxyDiagnostic.recommendation.action === 'env-controlled'}
+						<p class="diagnostic-safety">
+							Change <code>TRUST_PROXY</code> in your environment or container configuration,
+							then restart Obzorarr.
+						</p>
+					{:else if canEnableTrustProxy()}
+						<form method="POST" action="?/enableTrustProxy" class="trust-proxy-enable-form">
+							<input type="hidden" name="browserOrigin" value={browserOrigin} />
+							<label class="risk-confirmation">
+								<input type="checkbox" name="confirmRisk" value="true" required />
+								<span>
+									I confirm my reverse proxy strips visitor-supplied forwarding headers before
+									requests reach Obzorarr.
+								</span>
+							</label>
+							<button type="submit" class="enable-trust-btn">Enable Header Trust</button>
+						</form>
+					{/if}
+
+					{#if form?.trustProxySuccess}
+						<div class="test-result success">
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+								<circle cx="12" cy="12" r="10" />
+								<path d="M9 12l2 2 4-4" stroke-linecap="round" stroke-linejoin="round" />
+							</svg>
+							<span>{form.trustProxyMessage ?? 'Reverse-proxy header trust enabled.'}</span>
+						</div>
+					{:else if form?.trustProxyError}
+						<div class="test-result error">
+							<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+								<circle cx="12" cy="12" r="10" />
+								<line x1="15" y1="9" x2="9" y2="15" stroke-linecap="round" />
+								<line x1="9" y1="9" x2="15" y2="15" stroke-linecap="round" />
+							</svg>
+							<span>{form.trustProxyError}</span>
+						</div>
+					{/if}
+				{/if}
+			</div>
+
+			{#if data.csrfConfig.isLocked}
+				<div class="preconfigured-card animate-item">
 				<div class="preconfigured-icon">
 					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
 						<path
@@ -518,6 +776,219 @@ function useDetectedOrigin() {
 			font-family: 'SF Mono', 'Monaco', 'Inconsolata', monospace;
 			font-size: 0.8rem;
 			color: rgba(255, 255, 255, 0.7);
+		}
+
+		/* Reverse Proxy Diagnostic */
+		.diagnostic-card {
+			display: flex;
+			flex-direction: column;
+			gap: 1rem;
+			padding: 1rem 1.25rem;
+			background: rgba(255, 255, 255, 0.035);
+			border: 1px solid rgba(255, 255, 255, 0.09);
+			border-radius: 12px;
+		}
+
+		.diagnostic-header {
+			display: flex;
+			align-items: flex-start;
+			justify-content: space-between;
+			gap: 1rem;
+		}
+
+		.diagnostic-eyebrow {
+			display: block;
+			margin-bottom: 0.25rem;
+			font-size: 0.65rem;
+			font-weight: 600;
+			text-transform: uppercase;
+			letter-spacing: 0.06em;
+			color: rgba(255, 255, 255, 0.45);
+		}
+
+		.diagnostic-header h3 {
+			margin: 0;
+			font-size: 1rem;
+			line-height: 1.3;
+			color: rgba(255, 255, 255, 0.94);
+		}
+
+		.diagnostic-check-btn,
+		.enable-trust-btn {
+			flex-shrink: 0;
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			gap: 0.375rem;
+			padding: 0.5rem 0.75rem;
+			border-radius: 6px;
+			font-size: 0.75rem;
+			font-weight: 600;
+			cursor: pointer;
+			transition:
+				background 0.2s,
+				border-color 0.2s,
+				opacity 0.2s;
+		}
+
+		.diagnostic-check-btn {
+			background: rgba(59, 130, 246, 0.08);
+			border: 1px solid rgba(59, 130, 246, 0.18);
+			color: hsl(217, 91%, 68%);
+		}
+
+		.diagnostic-check-btn:hover:not(:disabled) {
+			background: rgba(59, 130, 246, 0.14);
+			border-color: rgba(59, 130, 246, 0.28);
+		}
+
+		.diagnostic-check-btn:disabled {
+			opacity: 0.5;
+			cursor: not-allowed;
+		}
+
+		.diagnostic-loading {
+			display: flex;
+			align-items: center;
+			gap: 0.75rem;
+			font-size: 0.85rem;
+			color: rgba(255, 255, 255, 0.55);
+		}
+
+		.diagnostic-recommendation {
+			padding: 0.875rem 1rem;
+			border-radius: 10px;
+			border: 1px solid rgba(255, 255, 255, 0.1);
+		}
+
+		.diagnostic-recommendation.success {
+			background: rgba(34, 197, 94, 0.09);
+			border-color: rgba(34, 197, 94, 0.22);
+		}
+
+		.diagnostic-recommendation.warning {
+			background: rgba(245, 158, 11, 0.09);
+			border-color: rgba(245, 158, 11, 0.22);
+		}
+
+		.diagnostic-recommendation.neutral {
+			background: rgba(255, 255, 255, 0.04);
+		}
+
+		.recommendation-title {
+			display: block;
+			margin-bottom: 0.5rem;
+			font-size: 0.9rem;
+			font-weight: 600;
+			color: rgba(255, 255, 255, 0.92);
+		}
+
+		.diagnostic-recommendation ul {
+			margin: 0;
+			padding-left: 1rem;
+			color: rgba(255, 255, 255, 0.6);
+			font-size: 0.8rem;
+			line-height: 1.45;
+		}
+
+		.diagnostic-facts {
+			display: grid;
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+			gap: 0.75rem;
+		}
+
+		.diagnostic-facts > div {
+			display: flex;
+			flex-direction: column;
+			gap: 0.25rem;
+			min-width: 0;
+			padding: 0.75rem;
+			background: rgba(255, 255, 255, 0.035);
+			border: 1px solid rgba(255, 255, 255, 0.07);
+			border-radius: 8px;
+		}
+
+		.fact-label {
+			font-size: 0.65rem;
+			font-weight: 600;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+			color: rgba(255, 255, 255, 0.38);
+		}
+
+		.fact-value {
+			display: flex;
+			align-items: center;
+			gap: 0.375rem;
+			min-width: 0;
+			font-size: 0.8rem;
+			line-height: 1.35;
+			color: rgba(255, 255, 255, 0.72);
+			overflow-wrap: anywhere;
+		}
+
+		.inline-badge {
+			display: inline-flex;
+			align-items: center;
+			padding: 0.1rem 0.35rem;
+			border-radius: 4px;
+			background: rgba(34, 197, 94, 0.14);
+			border: 1px solid rgba(34, 197, 94, 0.25);
+			color: hsl(142, 71%, 60%);
+			font-size: 0.6rem;
+			font-weight: 700;
+			letter-spacing: 0.05em;
+		}
+
+		.diagnostic-safety {
+			margin: 0;
+			font-size: 0.8rem;
+			line-height: 1.5;
+			color: rgba(255, 255, 255, 0.52);
+		}
+
+		.diagnostic-safety code {
+			font-family: 'SF Mono', 'Monaco', 'Inconsolata', monospace;
+			font-size: 0.76rem;
+			background: rgba(255, 255, 255, 0.08);
+			padding: 0.125rem 0.35rem;
+			border-radius: 4px;
+			color: rgba(255, 255, 255, 0.72);
+		}
+
+		.trust-proxy-enable-form {
+			display: flex;
+			flex-direction: column;
+			gap: 0.75rem;
+			margin: 0;
+			padding-top: 0.125rem;
+		}
+
+		.risk-confirmation {
+			display: flex;
+			align-items: flex-start;
+			gap: 0.625rem;
+			font-size: 0.78rem;
+			line-height: 1.45;
+			color: rgba(255, 255, 255, 0.62);
+		}
+
+		.risk-confirmation input {
+			flex-shrink: 0;
+			margin-top: 0.15rem;
+			accent-color: hsl(217, 91%, 60%);
+		}
+
+		.enable-trust-btn {
+			width: fit-content;
+			background: rgba(34, 197, 94, 0.12);
+			border: 1px solid rgba(34, 197, 94, 0.28);
+			color: hsl(142, 71%, 58%);
+		}
+
+		.enable-trust-btn:hover {
+			background: rgba(34, 197, 94, 0.18);
+			border-color: rgba(34, 197, 94, 0.38);
 		}
 
 		/* Preconfigured Card */
@@ -1119,6 +1590,20 @@ function useDetectedOrigin() {
 				flex-direction: column;
 				align-items: flex-start;
 				gap: 0.25rem;
+			}
+
+			.diagnostic-header {
+				flex-direction: column;
+				align-items: stretch;
+			}
+
+			.diagnostic-check-btn,
+			.enable-trust-btn {
+				width: 100%;
+			}
+
+			.diagnostic-facts {
+				grid-template-columns: 1fr;
 			}
 
 			.preconfigured-card {

--- a/src/routes/onboarding/csrf/+page.svelte
+++ b/src/routes/onboarding/csrf/+page.svelte
@@ -88,6 +88,7 @@ function updateDiagnosticFromActionForm() {
 		diagnosticError = null;
 	}
 	if (form?.diagnosticError) {
+		reverseProxyDiagnostic = null;
 		diagnosticStatus = 'failure';
 		diagnosticError = form.diagnosticError;
 	}
@@ -113,6 +114,7 @@ async function runDiagnostic() {
 	if (diagnosticStatus === 'checking') return;
 
 	browserOrigin = window.location.origin;
+	reverseProxyDiagnostic = null;
 	diagnosticStatus = 'checking';
 	diagnosticError = null;
 

--- a/src/routes/onboarding/csrf/+page.svelte
+++ b/src/routes/onboarding/csrf/+page.svelte
@@ -67,8 +67,21 @@ let reverseProxyDiagnostic = $state<ReverseProxyDiagnosticView | null>(null);
 let diagnosticStatus = $state<'idle' | 'checking' | 'success' | 'failure'>('idle');
 let diagnosticError = $state<string | null>(null);
 let hasRunInitialDiagnostic = $state(false);
+let hasRefreshedAfterTrustProxySuccess = $state(false);
 
 function updateDiagnosticFromActionForm() {
+	if (form?.trustProxySuccess) {
+		diagnosticError = null;
+		if (!hasRefreshedAfterTrustProxySuccess) {
+			hasRefreshedAfterTrustProxySuccess = true;
+			hasRunInitialDiagnostic = true;
+			void runDiagnostic();
+		}
+		return;
+	}
+	if (hasRefreshedAfterTrustProxySuccess) {
+		hasRefreshedAfterTrustProxySuccess = false;
+	}
 	if (form?.reverseProxyDiagnostic) {
 		reverseProxyDiagnostic = form.reverseProxyDiagnostic as ReverseProxyDiagnosticView;
 		diagnosticStatus = 'success';

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -73,6 +73,65 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('Enable reverse-proxy header trust?');
 	});
 
+	it('auto-runs the reverse-proxy diagnostic once on the security tab', async () => {
+		const source = await readSource('src/routes/admin/settings/+page.svelte');
+
+		expect(source).toContain('let isCheckingTrustProxyDiagnostic = $state(false);');
+		expect(source).toContain('let trustProxyDiagnosticAutoRunStarted = $state(false);');
+		expect(source).toContain(
+			"if (activeTab !== 'security' || trustProxyDiagnosticAutoRunStarted) return;"
+		);
+		expect(source).toContain('trustProxyDiagnosticAutoRunStarted = true;');
+		expect(source).toContain('void runTrustProxyDiagnostic();');
+	});
+
+	it('guards duplicate reverse-proxy diagnostic requests and exposes a manual check', async () => {
+		const source = await readSource('src/routes/admin/settings/+page.svelte');
+
+		expect(source).toContain('async function runTrustProxyDiagnostic()');
+		expect(source).toContain('if (isCheckingTrustProxyDiagnostic) return;');
+		expect(source).toContain('/api/security/reverse-proxy-diagnostic');
+		expect(source).toContain("params.set('browserOrigin', browserOrigin);");
+		expect(source).toContain('Check again');
+		expect(source).toContain('disabled={isCheckingTrustProxyDiagnostic}');
+		expect(source).toContain('What your browser used');
+		expect(source).toContain('What Obzorarr sees');
+		expect(source).toContain('Forwarded headers detected');
+		expect(source).toContain('Recommendation');
+	});
+
+	it('keeps the diagnostic read-only while preserving the explicit enable flow', async () => {
+		const source = await readSource('src/routes/admin/settings/+page.svelte');
+		const diagnosticFunction = source.match(
+			/async function runTrustProxyDiagnostic\(\) \{[\s\S]*?\n\}/
+		)?.[0];
+
+		expect(diagnosticFunction).toBeDefined();
+		expect(diagnosticFunction).not.toContain('?/updateTrustProxy');
+		expect(source).toContain('bind:open={trustProxyConfirmDialogOpen}');
+		expect(source).toContain('name="confirmRisk" value="true"');
+	});
+
+	it('explains env-locked reverse-proxy trust and common setup examples', async () => {
+		const source = await readSource('src/routes/admin/settings/+page.svelte');
+
+		expect(source).toContain('Change');
+		expect(source).toContain('it in your environment, container, or compose configuration');
+		expect(source).toContain('Update your environment or');
+		expect(source).toContain('container configuration to change it.');
+		expect(source).toContain('Already controlled by environment');
+		expect(source).toContain('Nginx Proxy Manager');
+		expect(source).toContain('Nginx');
+		expect(source).toContain('Caddy');
+		expect(source).toContain('Traefik');
+		expect(source).toContain('Pangolin');
+		expect(source).toContain('Tailscale/headscale');
+		expect(source).toContain('Docker bridge or host networking');
+		expect(source).toContain('LAN/private IP access');
+		expect(source).toContain('localhost setups');
+		expect(source).toContain('strips visitor-supplied');
+	});
+
 	it('keeps the users table desktop-only and renders a mobile list', async () => {
 		const source = await readSource('src/routes/admin/users/+page.svelte');
 

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -19,6 +19,7 @@ import {
 import { actions } from '../../../src/routes/onboarding/csrf/+page.server';
 
 const ORIGIN = 'http://localhost:5173';
+const OVERSIZED_BROWSER_ORIGIN = `https://wrapped.example.com/${'a'.repeat(2049)}`;
 type SaveOriginAction = NonNullable<typeof actions.saveOrigin>;
 type SkipCsrfAction = NonNullable<typeof actions.skipCsrf>;
 type TestOriginAction = NonNullable<typeof actions.testOrigin>;
@@ -378,6 +379,19 @@ describe('onboarding CSRF actions', () => {
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
 	});
 
+	it('rejects structurally abusive reverse proxy diagnostic browser origins', async () => {
+		const result = await runDiagnoseReverseProxy(
+			createReverseProxyDiagnosticRequest(OVERSIZED_BROWSER_ORIGIN)
+		);
+
+		expect(result).toEqual({
+			status: 400,
+			data: { diagnosticError: 'browserOrigin is too long' }
+		});
+		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
 	it('does not expose raw forwarded header values in the onboarding diagnostic payload', async () => {
 		const result = await runDiagnoseReverseProxy(
 			createReverseProxyDiagnosticRequest('https://wrapped.example.com', 'http://internal.local', {
@@ -401,6 +415,32 @@ describe('onboarding CSRF actions', () => {
 
 	it('rejects enabling TRUST_PROXY without explicit risk confirmation', async () => {
 		const result = await runEnableTrustProxy(createEnableTrustProxyRequest(false));
+
+		expect(result).toEqual({
+			status: 400,
+			data: {
+				trustProxyError: 'Confirm the reverse-proxy header trust risk before enabling TRUST_PROXY.'
+			}
+		});
+		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+	});
+
+	it('rejects enabling TRUST_PROXY with a structurally abusive browser origin', async () => {
+		const formData = new FormData();
+		formData.set('browserOrigin', OVERSIZED_BROWSER_ORIGIN);
+		formData.set('confirmRisk', 'true');
+
+		const result = await runEnableTrustProxy(
+			new Request('http://internal.local/onboarding/csrf', {
+				method: 'POST',
+				headers: {
+					origin: 'https://wrapped.example.com',
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'wrapped.example.com'
+				},
+				body: formData
+			})
+		);
 
 		expect(result).toEqual({
 			status: 400,

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { Cookies } from '@sveltejs/kit';
 import { isRedirect } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
 import {
 	AppSettingsKey,
 	deleteAppSetting,
@@ -21,6 +22,12 @@ const ORIGIN = 'http://localhost:5173';
 type SaveOriginAction = NonNullable<typeof actions.saveOrigin>;
 type SkipCsrfAction = NonNullable<typeof actions.skipCsrf>;
 type TestOriginAction = NonNullable<typeof actions.testOrigin>;
+type DiagnoseReverseProxyAction = NonNullable<typeof actions.diagnoseReverseProxy>;
+type EnableTrustProxyAction = NonNullable<typeof actions.enableTrustProxy>;
+
+function envRecord(): Record<string, string | undefined> {
+	return env as Record<string, string | undefined>;
+}
 
 function createCookies() {
 	const values = new Map<string, string>();
@@ -32,6 +39,7 @@ function createCookies() {
 }
 
 let cookies: ReturnType<typeof createCookies>;
+let previousTrustProxyEnv: string | undefined;
 
 function createThrowingClaimCookies(errorToThrow: Error): ReturnType<typeof createCookies> {
 	return {
@@ -50,6 +58,42 @@ function createFormRequest(csrfOrigin: string, origin = ORIGIN, requestBase = OR
 	return new Request(`${requestBase}/onboarding/csrf`, {
 		method: 'POST',
 		headers: { origin },
+		body: formData
+	});
+}
+
+function createReverseProxyDiagnosticRequest(
+	browserOrigin = 'https://wrapped.example.com',
+	requestBase = 'http://internal.local',
+	headers: Record<string, string> = {}
+): Request {
+	const formData = new FormData();
+	formData.set('browserOrigin', browserOrigin);
+
+	return new Request(`${requestBase}/onboarding/csrf`, {
+		method: 'POST',
+		headers: {
+			origin: browserOrigin,
+			'x-forwarded-proto': 'https',
+			'x-forwarded-host': 'wrapped.example.com',
+			...headers
+		},
+		body: formData
+	});
+}
+
+function createEnableTrustProxyRequest(confirmRisk = true): Request {
+	const formData = new FormData();
+	formData.set('browserOrigin', 'https://wrapped.example.com');
+	if (confirmRisk) formData.set('confirmRisk', 'true');
+
+	return new Request('http://internal.local/onboarding/csrf', {
+		method: 'POST',
+		headers: {
+			origin: 'https://wrapped.example.com',
+			'x-forwarded-proto': 'https',
+			'x-forwarded-host': 'wrapped.example.com'
+		},
 		body: formData
 	});
 }
@@ -91,6 +135,26 @@ async function runSkipCsrf(request: Request) {
 	} as unknown as Parameters<SkipCsrfAction>[0]);
 }
 
+async function runDiagnoseReverseProxy(request: Request) {
+	const diagnoseReverseProxy = actions.diagnoseReverseProxy as DiagnoseReverseProxyAction;
+	return diagnoseReverseProxy({
+		request,
+		cookies,
+		url: new URL(request.url),
+		getClientAddress: () => '172.18.0.2'
+	} as unknown as Parameters<DiagnoseReverseProxyAction>[0]);
+}
+
+async function runEnableTrustProxy(request: Request) {
+	const enableTrustProxy = actions.enableTrustProxy as EnableTrustProxyAction;
+	return enableTrustProxy({
+		request,
+		cookies,
+		url: new URL(request.url),
+		getClientAddress: () => '172.18.0.2'
+	} as unknown as Parameters<EnableTrustProxyAction>[0]);
+}
+
 async function expectRedirect(run: () => Promise<unknown>, location: string) {
 	try {
 		await run();
@@ -105,12 +169,19 @@ async function expectRedirect(run: () => Promise<unknown>, location: string) {
 
 describe('onboarding CSRF actions', () => {
 	beforeEach(async () => {
+		previousTrustProxyEnv = envRecord().TRUST_PROXY;
+		delete envRecord().TRUST_PROXY;
 		await db.delete(appSettings);
 		clearBootstrapToken();
 		cookies = createCookies();
 		const token = createBootstrapToken();
 		expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
 		await setOnboardingStep(OnboardingSteps.CSRF);
+	});
+
+	afterEach(() => {
+		if (previousTrustProxyEnv === undefined) delete envRecord().TRUST_PROXY;
+		else envRecord().TRUST_PROXY = previousTrustProxyEnv;
 	});
 
 	it('test origin succeeds when the submitted origin matches the browser origin', async () => {
@@ -288,6 +359,133 @@ describe('onboarding CSRF actions', () => {
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
 	});
 
+	it('runs a read-only reverse proxy diagnostic without persisting TRUST_PROXY', async () => {
+		const result = await runDiagnoseReverseProxy(createReverseProxyDiagnosticRequest());
+
+		expect(result).toMatchObject({
+			reverseProxyDiagnostic: {
+				trustProxy: {
+					enabled: false,
+					source: 'default',
+					isLocked: false
+				},
+				recommendation: {
+					action: 'enable'
+				}
+			}
+		});
+		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
+	it('does not expose raw forwarded header values in the onboarding diagnostic payload', async () => {
+		const result = await runDiagnoseReverseProxy(
+			createReverseProxyDiagnosticRequest('https://wrapped.example.com', 'http://internal.local', {
+				cookie: 'session=secret-cookie',
+				authorization: 'Bearer secret-authorization',
+				'x-forwarded-host': 'wrapped.example.com',
+				'x-forwarded-for': '203.0.113.77',
+				'x-real-ip': '198.51.100.88',
+				forwarded: 'for=hidden-client;proto=https;host=hidden.example'
+			})
+		);
+
+		const serialized = JSON.stringify(result);
+		expect(serialized).not.toContain('secret-cookie');
+		expect(serialized).not.toContain('secret-authorization');
+		expect(serialized).not.toContain('203.0.113.77');
+		expect(serialized).not.toContain('198.51.100.88');
+		expect(serialized).not.toContain('hidden-client');
+		expect(serialized).not.toContain('hidden.example');
+	});
+
+	it('rejects enabling TRUST_PROXY without explicit risk confirmation', async () => {
+		const result = await runEnableTrustProxy(createEnableTrustProxyRequest(false));
+
+		expect(result).toEqual({
+			status: 400,
+			data: {
+				trustProxyError: 'Confirm the reverse-proxy header trust risk before enabling TRUST_PROXY.'
+			}
+		});
+		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+	});
+
+	it('rejects enabling TRUST_PROXY when environment controlled', async () => {
+		envRecord().TRUST_PROXY = 'true';
+
+		const result = await runEnableTrustProxy(createEnableTrustProxyRequest(true));
+
+		expect(result).toEqual({
+			status: 400,
+			data: {
+				trustProxyError:
+					'TRUST_PROXY is set via environment variable and must be changed in your environment or container configuration.'
+			}
+		});
+		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+	});
+
+	it('rejects enabling TRUST_PROXY when the request origin differs from the submitted browser origin', async () => {
+		const formData = new FormData();
+		formData.set('browserOrigin', 'https://wrapped.example.com');
+		formData.set('confirmRisk', 'true');
+		const mismatchedRequest = new Request('http://internal.local/onboarding/csrf', {
+			method: 'POST',
+			headers: {
+				origin: 'https://other.example.com',
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'wrapped.example.com'
+			},
+			body: formData
+		});
+
+		const mismatchedResult = await runEnableTrustProxy(mismatchedRequest);
+
+		expect(mismatchedResult).toEqual({
+			status: 403,
+			data: {
+				trustProxyError: 'Reverse proxy header trust must be enabled from this browser origin'
+			}
+		});
+		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+	});
+
+	it('persists TRUST_PROXY only after confirmation and a current enable recommendation', async () => {
+		const result = await runEnableTrustProxy(createEnableTrustProxyRequest(true));
+
+		expect(result).toEqual({
+			trustProxySuccess: true,
+			trustProxyMessage: 'Reverse-proxy header trust enabled.'
+		});
+		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBe('true');
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
+	it('rejects enabling TRUST_PROXY when the current diagnostic does not recommend it', async () => {
+		const result = await runEnableTrustProxy(
+			new Request(`${ORIGIN}/onboarding/csrf`, {
+				method: 'POST',
+				headers: { origin: ORIGIN },
+				body: (() => {
+					const formData = new FormData();
+					formData.set('browserOrigin', ORIGIN);
+					formData.set('confirmRisk', 'true');
+					return formData;
+				})()
+			})
+		);
+
+		expect(result).toEqual({
+			status: 400,
+			data: {
+				trustProxyError:
+					'The current diagnostic does not recommend enabling reverse proxy header trust.'
+			}
+		});
+		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+	});
+
 	it('saveOrigin clears CSRF_ORIGIN_SKIPPED on success', async () => {
 		await setAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED, 'true');
 
@@ -304,7 +502,9 @@ describe('onboarding CSRF actions', () => {
 		for (const run of [
 			() => runTestOrigin(createFormRequest(ORIGIN)),
 			() => runSaveOrigin(createFormRequest(ORIGIN)),
-			() => runSkipCsrf(createFormRequest('not-a-url'))
+			() => runSkipCsrf(createFormRequest('not-a-url')),
+			() => runDiagnoseReverseProxy(createReverseProxyDiagnosticRequest()),
+			() => runEnableTrustProxy(createEnableTrustProxyRequest(true))
 		]) {
 			try {
 				await run();
@@ -361,6 +561,30 @@ describe('onboarding CSRF actions', () => {
 				data: { error: 'Not allowed at this onboarding stage' }
 			});
 			expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED)).toBeNull();
+		});
+
+		it('diagnoseReverseProxy returns 403 when current step is past CSRF', async () => {
+			await setOnboardingStep(OnboardingSteps.PLEX);
+
+			const result = await runDiagnoseReverseProxy(createReverseProxyDiagnosticRequest());
+
+			expect(result).toEqual({
+				status: 403,
+				data: { diagnosticError: 'Not allowed at this onboarding stage' }
+			});
+			expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+		});
+
+		it('enableTrustProxy returns 403 when onboarding is complete', async () => {
+			await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+
+			const result = await runEnableTrustProxy(createEnableTrustProxyRequest(true));
+
+			expect(result).toEqual({
+				status: 403,
+				data: { trustProxyError: 'Not allowed at this onboarding stage' }
+			});
+			expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
 		});
 	});
 });

--- a/tests/unit/onboarding/csrf-page-source.test.ts
+++ b/tests/unit/onboarding/csrf-page-source.test.ts
@@ -50,4 +50,24 @@ describe('onboarding CSRF page source', () => {
 		expect(skipForm).toContain('formnovalidate');
 		expect(saveForm).toContain('type="submit"');
 	});
+
+	it('runs onboarding reverse proxy diagnostics through the CSRF page action only', async () => {
+		const source = await readPageSource();
+
+		expect(source).toContain("fetch('?/diagnoseReverseProxy'");
+		expect(source).toContain('action="?/enableTrustProxy"');
+		expect(source).not.toContain('/api/security');
+	});
+
+	it('prevents duplicate in-flight diagnostic checks and keeps enable confirmation explicit', async () => {
+		const source = await readPageSource();
+		const enableForm = findPostForm(source, '?/enableTrustProxy', 'trust-proxy-enable-form');
+
+		expect(source).toContain("if (diagnosticStatus === 'checking') return;");
+		expect(source).toContain('hasRunInitialDiagnostic');
+		expect(enableForm).toContain('name="confirmRisk"');
+		expect(enableForm).toContain('type="checkbox"');
+		expect(enableForm).toContain('required');
+		expect(enableForm).toContain('name="browserOrigin"');
+	});
 });

--- a/tests/unit/security/proxy-handle.test.ts
+++ b/tests/unit/security/proxy-handle.test.ts
@@ -238,6 +238,19 @@ describe('proxyHandle', () => {
 			expect(rewrittenUrl.host).toBe('localhost:5173');
 		});
 
+		it('rejects a forwarded host containing \\ (backslash path delimiter)', async () => {
+			const { rewrittenUrl } = await invokeWithRawHeaders({
+				url: 'http://localhost:5173/p',
+				headerLookup: (name) => {
+					if (name === 'x-forwarded-proto') return 'https';
+					if (name === 'x-forwarded-host') return 'evil.com\\injected';
+					return null;
+				}
+			});
+
+			expect(rewrittenUrl.host).toBe('localhost:5173');
+		});
+
 		it('rejects a forwarded host containing ? (query delimiter)', async () => {
 			const { rewrittenUrl } = await invokeWithRawHeaders({
 				url: 'http://localhost:5173/p',

--- a/tests/unit/security/reverse-proxy-diagnostic-endpoint.test.ts
+++ b/tests/unit/security/reverse-proxy-diagnostic-endpoint.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { isHttpError } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import { clearRateLimitStore } from '$lib/server/ratelimit';
+import { GET } from '../../../src/routes/api/security/reverse-proxy-diagnostic/+server';
+
+type HandlerArgs = Parameters<typeof GET>[0];
+
+const adminLocals = {
+	user: { id: 1, plexId: 100, username: 'admin', isAdmin: true }
+} as HandlerArgs['locals'];
+
+const userLocals = {
+	user: { id: 2, plexId: 200, username: 'viewer', isAdmin: false }
+} as HandlerArgs['locals'];
+
+function envRecord(): Record<string, string | undefined> {
+	return env as Record<string, string | undefined>;
+}
+
+function runGet({
+	locals = adminLocals,
+	requestUrl = 'http://internal.local/api/security/reverse-proxy-diagnostic?browserOrigin=https%3A%2F%2Fwrapped.example.com',
+	effectiveUrl,
+	headers = {},
+	ip = '172.18.0.2'
+}: {
+	locals?: HandlerArgs['locals'];
+	requestUrl?: string;
+	effectiveUrl?: string;
+	headers?: Record<string, string>;
+	ip?: string;
+} = {}): ReturnType<typeof GET> {
+	const request = new Request(requestUrl, { headers });
+	return GET({
+		getClientAddress: () => ip,
+		locals,
+		request,
+		url: new URL(effectiveUrl ?? requestUrl)
+	} as unknown as HandlerArgs);
+}
+
+describe('GET /api/security/reverse-proxy-diagnostic', () => {
+	beforeEach(async () => {
+		clearRateLimitStore();
+		await db.delete(appSettings);
+		delete envRecord().TRUST_PROXY;
+		delete envRecord().ORIGIN;
+	});
+
+	it('rejects anonymous requests with 401', async () => {
+		try {
+			await runGet({ locals: {} as HandlerArgs['locals'] });
+			expect.unreachable('Expected error to be thrown');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			expect(err.status).toBe(401);
+			expect(err.body.message).toBe('Unauthorized');
+		}
+	});
+
+	it('rejects non-admin requests with 403', async () => {
+		try {
+			await runGet({ locals: userLocals });
+			expect.unreachable('Expected error to be thrown');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			expect(err.status).toBe(403);
+			expect(err.body.message).toBe('Admin access required');
+		}
+	});
+
+	it('returns the sanitized diagnostic payload for admins', async () => {
+		const response = await runGet({
+			headers: {
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'wrapped.example.com',
+				'x-forwarded-for': '203.0.113.77',
+				'x-real-ip': '198.51.100.88',
+				forwarded: 'for=secret-client;proto=https;host=hidden.example'
+			}
+		});
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Cache-Control')).toBe('no-store');
+		const body = await response.json();
+		expect(Object.keys(body).sort()).toEqual([
+			'forwardedHeaders',
+			'originComparison',
+			'origins',
+			'reasons',
+			'recommendation',
+			'safetyNotice',
+			'sourceAddress',
+			'trustProxy'
+		]);
+		expect(body.recommendation.action).toBe('enable');
+		expect(body.forwardedHeaders).toEqual({
+			present: [
+				'Forwarded',
+				'X-Forwarded-For',
+				'X-Forwarded-Host',
+				'X-Forwarded-Proto',
+				'X-Real-IP'
+			],
+			pair: {
+				status: 'usable',
+				isUsable: true,
+				protoPresent: true,
+				hostPresent: true
+			}
+		});
+		expect(body.sourceAddress).toEqual({ category: 'docker/private-range' });
+	});
+
+	it('compares the browser, raw app, and effective app origins', async () => {
+		await setAppSetting(AppSettingsKey.TRUST_PROXY, 'true');
+
+		const response = await runGet({
+			requestUrl:
+				'http://internal.local/api/security/reverse-proxy-diagnostic?browserOrigin=https%3A%2F%2Fwrapped.example.com',
+			effectiveUrl:
+				'https://wrapped.example.com/api/security/reverse-proxy-diagnostic?browserOrigin=https%3A%2F%2Fwrapped.example.com',
+			headers: {
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'wrapped.example.com'
+			}
+		});
+
+		const body = await response.json();
+		expect(body.origins.rawApp).toBe('http://internal.local');
+		expect(body.origins.effectiveApp).toBe('https://wrapped.example.com');
+		expect(body.origins.browser).toEqual({
+			origin: 'https://wrapped.example.com',
+			isValid: true
+		});
+		expect(body.originComparison).toEqual({
+			browserMatchesRawApp: false,
+			browserMatchesEffectiveApp: true,
+			forwardedPairMatchesBrowser: true
+		});
+		expect(body.recommendation.action).toBe('appears-working');
+	});
+
+	it('handles missing browserOrigin without failing', async () => {
+		const response = await runGet({
+			requestUrl: 'http://internal.local/api/security/reverse-proxy-diagnostic',
+			headers: {
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'wrapped.example.com'
+			}
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.origins.browser).toEqual({ origin: null, isValid: false });
+		expect(body.recommendation.action).toBe('unable-to-determine');
+		expect(body.reasons.join(' ')).toContain('browser origin was missing or invalid');
+	});
+
+	it('handles invalid browserOrigin without failing', async () => {
+		const response = await runGet({
+			requestUrl:
+				'http://internal.local/api/security/reverse-proxy-diagnostic?browserOrigin=not-a-url',
+			headers: {
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'wrapped.example.com'
+			}
+		});
+
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body.origins.browser).toEqual({ origin: null, isValid: false });
+		expect(body.originComparison.forwardedPairMatchesBrowser).toBeNull();
+		expect(body.recommendation.action).toBe('unable-to-determine');
+	});
+
+	it('rejects structurally abusive browserOrigin values', async () => {
+		try {
+			await runGet({
+				requestUrl: `http://internal.local/api/security/reverse-proxy-diagnostic?browserOrigin=${'a'.repeat(2049)}`
+			});
+			expect.unreachable('Expected error to be thrown');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			expect(err.status).toBe(400);
+			expect(err.body.message).toBe('browserOrigin is too long');
+		}
+	});
+
+	it('does not expose raw secrets, forwarded values, source IPs, or query strings', async () => {
+		const response = await runGet({
+			requestUrl:
+				'http://internal.local/api/security/reverse-proxy-diagnostic?browserOrigin=https%3A%2F%2Fbrowser.example.com&token=secret-query',
+			headers: {
+				cookie: 'session=secret-cookie',
+				authorization: 'Bearer secret-authorization',
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'secret-forwarded.example',
+				'x-forwarded-for': '203.0.113.77',
+				'x-real-ip': '198.51.100.88',
+				forwarded: 'for=secret-client;proto=https;host=hidden.example'
+			},
+			ip: '203.0.113.44'
+		});
+
+		const serialized = JSON.stringify(await response.json());
+		expect(serialized).not.toContain('secret-cookie');
+		expect(serialized).not.toContain('secret-authorization');
+		expect(serialized).not.toContain('secret-forwarded.example');
+		expect(serialized).not.toContain('203.0.113.77');
+		expect(serialized).not.toContain('198.51.100.88');
+		expect(serialized).not.toContain('secret-client');
+		expect(serialized).not.toContain('hidden.example');
+		expect(serialized).not.toContain('203.0.113.44');
+		expect(serialized).not.toContain('secret-query');
+	});
+
+	it('rate limits repeated diagnostic requests per admin and source address', async () => {
+		let response: Response | undefined;
+		for (let i = 0; i < 13; i++) {
+			response = await runGet();
+		}
+
+		expect(response?.status).toBe(429);
+		expect(response?.headers.get('Cache-Control')).toBe('no-store');
+		expect(response?.headers.get('Retry-After')).toBeTruthy();
+		expect(await response?.json()).toEqual({ error: 'Too many diagnostic requests' });
+	});
+});

--- a/tests/unit/security/reverse-proxy-diagnostic-endpoint.test.ts
+++ b/tests/unit/security/reverse-proxy-diagnostic-endpoint.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import { isHttpError } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
@@ -52,27 +51,19 @@ describe('GET /api/security/reverse-proxy-diagnostic', () => {
 	});
 
 	it('rejects anonymous requests with 401', async () => {
-		try {
-			await runGet({ locals: {} as HandlerArgs['locals'] });
-			expect.unreachable('Expected error to be thrown');
-		} catch (err) {
-			expect(isHttpError(err)).toBe(true);
-			if (!isHttpError(err)) throw err;
-			expect(err.status).toBe(401);
-			expect(err.body.message).toBe('Unauthorized');
-		}
+		const response = await runGet({ locals: {} as HandlerArgs['locals'] });
+
+		expect(response.status).toBe(401);
+		expect(response.headers.get('Cache-Control')).toBe('no-store');
+		expect(await response.json()).toEqual({ message: 'Unauthorized' });
 	});
 
 	it('rejects non-admin requests with 403', async () => {
-		try {
-			await runGet({ locals: userLocals });
-			expect.unreachable('Expected error to be thrown');
-		} catch (err) {
-			expect(isHttpError(err)).toBe(true);
-			if (!isHttpError(err)) throw err;
-			expect(err.status).toBe(403);
-			expect(err.body.message).toBe('Admin access required');
-		}
+		const response = await runGet({ locals: userLocals });
+
+		expect(response.status).toBe(403);
+		expect(response.headers.get('Cache-Control')).toBe('no-store');
+		expect(await response.json()).toEqual({ message: 'Admin access required' });
 	});
 
 	it('returns the sanitized diagnostic payload for admins', async () => {
@@ -181,17 +172,13 @@ describe('GET /api/security/reverse-proxy-diagnostic', () => {
 	});
 
 	it('rejects structurally abusive browserOrigin values', async () => {
-		try {
-			await runGet({
-				requestUrl: `http://internal.local/api/security/reverse-proxy-diagnostic?browserOrigin=${'a'.repeat(2049)}`
-			});
-			expect.unreachable('Expected error to be thrown');
-		} catch (err) {
-			expect(isHttpError(err)).toBe(true);
-			if (!isHttpError(err)) throw err;
-			expect(err.status).toBe(400);
-			expect(err.body.message).toBe('browserOrigin is too long');
-		}
+		const response = await runGet({
+			requestUrl: `http://internal.local/api/security/reverse-proxy-diagnostic?browserOrigin=${'a'.repeat(2049)}`
+		});
+
+		expect(response.status).toBe(400);
+		expect(response.headers.get('Cache-Control')).toBe('no-store');
+		expect(await response.json()).toEqual({ message: 'browserOrigin is too long' });
 	});
 
 	it('does not expose raw secrets, forwarded values, source IPs, or query strings', async () => {

--- a/tests/unit/security/reverse-proxy-diagnostic.test.ts
+++ b/tests/unit/security/reverse-proxy-diagnostic.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { env } from '$env/dynamic/private';
+import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import {
+	classifySourceAddress,
+	createReverseProxyDiagnostic
+} from '$lib/server/security/reverse-proxy-diagnostic';
+
+function envRecord(): Record<string, string | undefined> {
+	return env as Record<string, string | undefined>;
+}
+
+function requestWith(headers: Record<string, string> = {}): Request {
+	return new Request('http://internal.local/onboarding/csrf', { headers });
+}
+
+describe('reverse proxy diagnostic', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		delete envRecord().TRUST_PROXY;
+		delete envRecord().ORIGIN;
+	});
+
+	afterEach(() => {
+		delete envRecord().TRUST_PROXY;
+		delete envRecord().ORIGIN;
+	});
+
+	it('recommends enabling when disabled and the usable forwarded pair matches the browser origin', async () => {
+		const diagnostic = await createReverseProxyDiagnostic({
+			request: requestWith({
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'wrapped.example.com'
+			}),
+			rawAppUrl: 'http://internal.local/onboarding/csrf',
+			effectiveAppUrl: 'http://internal.local/onboarding/csrf',
+			browserOrigin: 'https://wrapped.example.com',
+			sourceAddress: '172.18.0.2'
+		});
+
+		expect(diagnostic.trustProxy).toEqual({
+			enabled: false,
+			source: 'default',
+			isLocked: false
+		});
+		expect(diagnostic.origins.rawApp).toBe('http://internal.local');
+		expect(diagnostic.origins.effectiveApp).toBe('http://internal.local');
+		expect(diagnostic.origins.browser).toEqual({
+			origin: 'https://wrapped.example.com',
+			isValid: true
+		});
+		expect(diagnostic.forwardedHeaders.present).toEqual(['X-Forwarded-Host', 'X-Forwarded-Proto']);
+		expect(diagnostic.forwardedHeaders.pair).toEqual({
+			status: 'usable',
+			isUsable: true,
+			protoPresent: true,
+			hostPresent: true
+		});
+		expect(diagnostic.sourceAddress.category).toBe('docker/private-range');
+		expect(diagnostic.originComparison).toEqual({
+			browserMatchesRawApp: false,
+			browserMatchesEffectiveApp: false,
+			forwardedPairMatchesBrowser: true
+		});
+		expect(diagnostic.recommendation.action).toBe('enable');
+		expect(diagnostic.safetyNotice).toContain('strips visitor-supplied forwarding headers');
+	});
+
+	it('recommends leaving trust disabled for direct access without a forwarded pair', async () => {
+		const diagnostic = await createReverseProxyDiagnostic({
+			request: requestWith(),
+			rawAppUrl: 'http://localhost:5173/settings',
+			effectiveAppUrl: 'http://localhost:5173/settings',
+			browserOrigin: 'http://localhost:5173',
+			sourceAddress: '127.0.0.1'
+		});
+
+		expect(diagnostic.forwardedHeaders.present).toEqual([]);
+		expect(diagnostic.forwardedHeaders.pair.status).toBe('missing');
+		expect(diagnostic.sourceAddress.category).toBe('loopback');
+		expect(diagnostic.originComparison.browserMatchesRawApp).toBe(true);
+		expect(diagnostic.recommendation.action).toBe('leave-disabled');
+	});
+
+	it('recommends reviewing proxy config for partial forwarded headers', async () => {
+		const diagnostic = await createReverseProxyDiagnostic({
+			request: requestWith({ 'x-forwarded-proto': 'https' }),
+			rawAppUrl: 'http://internal.local/admin/settings',
+			effectiveAppUrl: 'http://internal.local/admin/settings',
+			browserOrigin: 'https://wrapped.example.com',
+			sourceAddress: '10.0.0.5'
+		});
+
+		expect(diagnostic.forwardedHeaders.pair).toEqual({
+			status: 'partial',
+			isUsable: false,
+			protoPresent: true,
+			hostPresent: false
+		});
+		expect(diagnostic.sourceAddress.category).toBe('private-lan');
+		expect(diagnostic.recommendation.action).toBe('review-proxy');
+	});
+
+	it('reports environment-controlled TRUST_PROXY as locked', async () => {
+		await setAppSetting(AppSettingsKey.TRUST_PROXY, 'false');
+		envRecord().TRUST_PROXY = 'true';
+
+		const diagnostic = await createReverseProxyDiagnostic({
+			request: requestWith({
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'wrapped.example.com'
+			}),
+			rawAppUrl: 'http://internal.local/p',
+			effectiveAppUrl: 'https://wrapped.example.com/p',
+			browserOrigin: 'https://wrapped.example.com',
+			sourceAddress: '100.80.0.12'
+		});
+
+		expect(diagnostic.trustProxy).toEqual({
+			enabled: true,
+			source: 'env',
+			isLocked: true
+		});
+		expect(diagnostic.sourceAddress.category).toBe('tailscale/cgnat');
+		expect(diagnostic.recommendation.action).toBe('env-controlled');
+		expect(diagnostic.reasons.join(' ')).toContain('currently enabled');
+	});
+
+	it('reports enabled trust as working when effective origin matches the browser', async () => {
+		await setAppSetting(AppSettingsKey.TRUST_PROXY, 'true');
+
+		const diagnostic = await createReverseProxyDiagnostic({
+			request: requestWith({
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'wrapped.example.com'
+			}),
+			rawAppUrl: 'http://internal.local/wrapped/2025',
+			effectiveAppUrl: 'https://wrapped.example.com/wrapped/2025',
+			browserOrigin: 'https://wrapped.example.com',
+			sourceAddress: '192.168.1.10'
+		});
+
+		expect(diagnostic.trustProxy.enabled).toBe(true);
+		expect(diagnostic.originComparison.browserMatchesEffectiveApp).toBe(true);
+		expect(diagnostic.recommendation.action).toBe('appears-working');
+	});
+
+	it('does not trust forwarded headers alone when the browser origin is invalid', async () => {
+		const diagnostic = await createReverseProxyDiagnostic({
+			request: requestWith({
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'wrapped.example.com'
+			}),
+			rawAppUrl: 'http://internal.local/onboarding/csrf',
+			effectiveAppUrl: 'http://internal.local/onboarding/csrf',
+			browserOrigin: 'not a url',
+			sourceAddress: '8.8.8.8'
+		});
+
+		expect(diagnostic.origins.browser).toEqual({ origin: null, isValid: false });
+		expect(diagnostic.sourceAddress.category).toBe('public');
+		expect(diagnostic.originComparison.forwardedPairMatchesBrowser).toBeNull();
+		expect(diagnostic.recommendation.action).toBe('unable-to-determine');
+	});
+
+	it('includes configured CSRF/public origin without requiring admin auth context', async () => {
+		await setAppSetting(AppSettingsKey.CSRF_ORIGIN, 'https://configured.example.com');
+
+		const diagnostic = await createReverseProxyDiagnostic({
+			request: requestWith(),
+			rawAppUrl: 'http://internal.local/onboarding/csrf',
+			effectiveAppUrl: 'http://internal.local/onboarding/csrf',
+			browserOrigin: 'http://internal.local',
+			sourceAddress: null
+		});
+
+		expect(diagnostic.origins.configuredPublic).toEqual({
+			origin: 'https://configured.example.com',
+			isValid: true,
+			source: 'db',
+			isConfigured: true,
+			isLocked: false
+		});
+		expect(diagnostic.sourceAddress.category).toBe('unknown');
+	});
+
+	it('reports only safe forwarded-header presence signals and no raw sensitive values', async () => {
+		const diagnostic = await createReverseProxyDiagnostic({
+			request: requestWith({
+				cookie: 'session=secret-cookie',
+				authorization: 'Bearer secret-authorization',
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'secret-forwarded.example',
+				'x-forwarded-for': '203.0.113.77',
+				'x-real-ip': '198.51.100.88',
+				forwarded: 'for=secret-forwarded-client;proto=https;host=hidden.example'
+			}),
+			rawAppUrl: 'http://internal.local/onboarding/csrf?token=secret-query',
+			effectiveAppUrl: 'http://internal.local/onboarding/csrf?token=secret-query',
+			browserOrigin: 'https://browser.example.com',
+			sourceAddress: '203.0.113.44'
+		});
+
+		expect(diagnostic.forwardedHeaders.present).toEqual([
+			'Forwarded',
+			'X-Forwarded-For',
+			'X-Forwarded-Host',
+			'X-Forwarded-Proto',
+			'X-Real-IP'
+		]);
+
+		const serialized = JSON.stringify(diagnostic);
+		expect(serialized).not.toContain('secret-cookie');
+		expect(serialized).not.toContain('secret-authorization');
+		expect(serialized).not.toContain('secret-forwarded.example');
+		expect(serialized).not.toContain('203.0.113.77');
+		expect(serialized).not.toContain('198.51.100.88');
+		expect(serialized).not.toContain('secret-forwarded-client');
+		expect(serialized).not.toContain('hidden.example');
+		expect(serialized).not.toContain('secret-query');
+	});
+
+	it('classifies source addresses without returning the raw address', () => {
+		expect(classifySourceAddress('127.0.0.1')).toBe('loopback');
+		expect(classifySourceAddress('[::1]')).toBe('loopback');
+		expect(classifySourceAddress('10.0.0.4')).toBe('private-lan');
+		expect(classifySourceAddress('172.20.0.4')).toBe('docker/private-range');
+		expect(classifySourceAddress('100.64.0.1')).toBe('tailscale/cgnat');
+		expect(classifySourceAddress('169.254.10.20')).toBe('link-local');
+		expect(classifySourceAddress('8.8.8.8')).toBe('public');
+		expect(classifySourceAddress('not-an-address')).toBe('unknown');
+	});
+});


### PR DESCRIPTION
## Summary

Adds a guided Reverse Proxy Header Trust diagnostic for Obzorarr so admins can understand whether trusting `X-Forwarded-Proto` and `X-Forwarded-Host` is likely needed without enabling it automatically.

## What changed

- Added shared reverse proxy diagnostic logic with sanitized output and recommendation reasoning.
- Extracted forwarded proto/host parsing so `proxyHandle` and diagnostics use the same acceptance rules.
- Added an admin-only diagnostic endpoint with `Cache-Control: no-store`, sanitized JSON, and rate limiting.
- Integrated the diagnostic into the existing onboarding Security/CSRF step without adding a new onboarding step.
- Added a guarded onboarding `TRUST_PROXY` enable flow that requires active setup claim, current CSRF step, and explicit risk confirmation.
- Added Admin Settings UI for automatic first diagnostic, manual “Check again”, env-lock messaging, common setup examples, sanitized result groups, and recommendation reasoning.
- Preserved the existing explicit confirmation flow before enabling Reverse Proxy Header Trust.

## Safety notes

- The diagnostic does not expose raw cookies, authorization headers, forwarded header values, raw client IPs, tokens, or secrets.
- The presence of forwarded headers alone is not treated as proof that trusting them is safe.
- The UI does not automatically write `TRUST_PROXY`; any enable action remains explicit and confirmed.
- No database migration or schema change is included.
- No standalone onboarding step was added.

## Verification

- Focused reverse-proxy diagnostic, proxy-handle, endpoint, onboarding, and admin tests passed: 118 tests.
- `bun run check` passed with 0 errors/warnings.
- Full `bun run test` passed: 1666 tests.
- `bun run check:biome` passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/engels74/codesmith/obzorarr/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->