### PR TITLE
Fix dogfood findings and coverage gaps

### DIFF
--- a/src/lib/components/wrapped/ModeToggle.svelte
+++ b/src/lib/components/wrapped/ModeToggle.svelte
@@ -98,8 +98,12 @@ function handleKeyDown(event: KeyboardEvent): void {
 		}
 
 		.mode-toggle:focus-visible {
-			outline: 2px solid var(--primary, #dc2626);
-			outline-offset: 2px;
+			outline: 3px solid #ffffff;
+			outline-offset: 3px;
+			border-color: #ffffff;
+			box-shadow:
+				0 0 0 6px rgba(0, 0, 0, 0.85),
+				0 0 0 8px var(--primary, #dc2626);
 		}
 
 		.mode-toggle:active {

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -454,6 +454,14 @@ function handleSlideAnimationComplete(): void {}
 			-webkit-user-select: none;
 		}
 
+		.story-mode:focus-visible {
+			outline: none;
+			box-shadow:
+				inset 0 0 0 3px #ffffff,
+				inset 0 0 0 6px var(--primary, #dc2626),
+				inset 0 0 0 9px rgba(0, 0, 0, 0.85);
+		}
+
 		/* Noise texture layer - covers entire viewport */
 		.story-mode::before {
 			content: '';

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -431,6 +431,8 @@ function handleSlideAnimationComplete(): void {}
 			</svg>
 		</button>
 	{/if}
+
+	<div class="focus-ring" aria-hidden="true"></div>
 </div>
 
 <style>
@@ -456,10 +458,22 @@ function handleSlideAnimationComplete(): void {}
 
 		.story-mode:focus-visible {
 			outline: none;
+		}
+
+		.focus-ring {
+			position: absolute;
+			inset: 0;
+			z-index: 100;
+			pointer-events: none;
+			opacity: 0;
 			box-shadow:
 				inset 0 0 0 3px #ffffff,
 				inset 0 0 0 6px var(--primary, #dc2626),
 				inset 0 0 0 9px rgba(0, 0, 0, 0.85);
+		}
+
+		.story-mode:focus-visible .focus-ring {
+			opacity: 1;
 		}
 
 		/* Noise texture layer - covers entire viewport */

--- a/src/routes/onboarding/claim/+page.svelte
+++ b/src/routes/onboarding/claim/+page.svelte
@@ -13,6 +13,13 @@ let token = $state('');
 			<KeyRound size={36} strokeWidth={1.75} />
 		</div>
 
+		<p class="claim-help">
+			Only one browser can claim setup at a time. Active claims expire after 10 minutes,
+			and bootstrap tokens expire after 15 minutes. If another browser already claimed
+			setup, wait for it to expire and use the current console token, or restart the
+			server to print a new banner.
+		</p>
+
 		<div class="field">
 			<label for="bootstrap-token">Bootstrap token</label>
 			<input
@@ -62,6 +69,13 @@ let token = $state('');
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
+	}
+
+	.claim-help {
+		margin: 0;
+		color: hsl(var(--muted-foreground));
+		font-size: 0.875rem;
+		line-height: 1.5;
 	}
 
 	label {

--- a/tests/unit/admin/logs-actions.test.ts
+++ b/tests/unit/admin/logs-actions.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { db } from '$lib/server/db/client';
+import { appSettings, logs } from '$lib/server/db/schema';
+import { LogLevel } from '$lib/server/logging';
+import { actions, load } from '../../../src/routes/admin/logs/+page.server';
+
+type ExportLogsAction = NonNullable<typeof actions.exportLogs>;
+type LoadArgs = Parameters<typeof load>[0];
+type LogsLoadData = Exclude<Awaited<ReturnType<typeof load>>, void>;
+
+const adminLocals = {
+	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
+} as unknown as App.Locals;
+
+async function seedLog(entry: {
+	level: (typeof LogLevel)[keyof typeof LogLevel];
+	message: string;
+	timestamp: number;
+	source?: string;
+}): Promise<void> {
+	await db.insert(logs).values({
+		level: entry.level,
+		message: entry.message,
+		source: entry.source ?? null,
+		metadata: null,
+		timestamp: entry.timestamp
+	});
+}
+
+async function invokeLoad(url: string): Promise<LogsLoadData> {
+	return (await load({ url: new URL(url) } as unknown as LoadArgs)) as LogsLoadData;
+}
+
+async function invokeExport(url: string) {
+	const exportLogs = actions.exportLogs as ExportLogsAction;
+	return exportLogs({
+		locals: adminLocals,
+		url: new URL(url)
+	} as unknown as Parameters<ExportLogsAction>[0]);
+}
+
+function logMessages(data: LogsLoadData): string[] {
+	return (data.logs as Array<{ message: string }>).map((entry) => entry.message);
+}
+
+describe('admin logs page load/actions', () => {
+	beforeEach(async () => {
+		await db.delete(logs);
+		await db.delete(appSettings);
+	});
+
+	it('exportLogs returns valid JSON for the filtered result set', async () => {
+		await seedLog({
+			level: LogLevel.INFO,
+			message: 'kept sync event',
+			source: 'Sync',
+			timestamp: 1000
+		});
+		await seedLog({
+			level: LogLevel.ERROR,
+			message: 'ignored auth event',
+			source: 'Auth',
+			timestamp: 2000
+		});
+
+		const result = await invokeExport(
+			'http://localhost/admin/logs?levels=INFO&search=sync&source=Sync'
+		);
+
+		expect(result).toMatchObject({ success: true });
+		const exportData = (result as { exportData?: string }).exportData;
+		expect(exportData).toBeString();
+		const parsed = JSON.parse(exportData ?? '[]') as Array<{ message: string; level: string }>;
+		expect(parsed.map((entry) => entry.message)).toEqual(['kept sync event']);
+		expect(parsed[0]?.level).toBe(LogLevel.INFO);
+	});
+
+	it('load paginates with cursor and reports hasMore for load-more links', async () => {
+		for (let i = 1; i <= 4; i++) {
+			await seedLog({
+				level: LogLevel.INFO,
+				message: `entry ${i}`,
+				timestamp: 1000 + i
+			});
+		}
+
+		const firstPage = await invokeLoad('http://localhost/admin/logs?limit=2');
+		expect(logMessages(firstPage)).toEqual(['entry 4', 'entry 3']);
+		expect(firstPage.hasMore).toBe(true);
+
+		const cursor = firstPage.logs.at(-1)?.id;
+		expect(cursor).toBeNumber();
+
+		const secondPage = await invokeLoad(`http://localhost/admin/logs?limit=2&cursor=${cursor}`);
+		expect(logMessages(secondPage)).toEqual(['entry 2', 'entry 1']);
+		expect(secondPage.hasMore).toBe(false);
+		expect(secondPage.filters.cursor).toBe(cursor);
+	});
+
+	it('load filters by manual datetime timestamp fields', async () => {
+		await seedLog({
+			level: LogLevel.INFO,
+			message: 'before window',
+			timestamp: 999
+		});
+		await seedLog({
+			level: LogLevel.INFO,
+			message: 'inside window',
+			timestamp: 1500
+		});
+		await seedLog({
+			level: LogLevel.INFO,
+			message: 'after window',
+			timestamp: 2001
+		});
+
+		const data = await invokeLoad('http://localhost/admin/logs?from=1000&to=2000');
+
+		expect(logMessages(data)).toEqual(['inside window']);
+		expect(data.filters.fromTimestamp).toBe(1000);
+		expect(data.filters.toTimestamp).toBe(2000);
+	});
+});

--- a/tests/unit/admin/logs-actions.test.ts
+++ b/tests/unit/admin/logs-actions.test.ts
@@ -1,7 +1,7 @@
-import { beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { db } from '$lib/server/db/client';
 import { appSettings, logs } from '$lib/server/db/schema';
-import { LogLevel } from '$lib/server/logging';
+import { LogLevel, stopLogRetentionScheduler } from '$lib/server/logging';
 import { actions, load } from '../../../src/routes/admin/logs/+page.server';
 
 type ExportLogsAction = NonNullable<typeof actions.exportLogs>;
@@ -47,6 +47,10 @@ describe('admin logs page load/actions', () => {
 	beforeEach(async () => {
 		await db.delete(logs);
 		await db.delete(appSettings);
+	});
+
+	afterEach(() => {
+		stopLogRetentionScheduler();
 	});
 
 	it('exportLogs returns valid JSON for the filtered result set', async () => {

--- a/tests/unit/admin/slides-actions.test.ts
+++ b/tests/unit/admin/slides-actions.test.ts
@@ -2,6 +2,10 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import { FunFactFrequency, getFunFactFrequency } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings, customSlides } from '$lib/server/db/schema';
+import {
+	getSlideConfigByType,
+	initializeDefaultSlideConfig
+} from '$lib/server/slides/config.service';
 import { actions } from '../../../src/routes/admin/slides/+page.server';
 
 type SetFunFactFrequencyAction = NonNullable<typeof actions.setFunFactFrequency>;
@@ -9,6 +13,7 @@ type CreateCustomAction = NonNullable<typeof actions.createCustom>;
 type UpdateCustomAction = NonNullable<typeof actions.updateCustom>;
 type DeleteCustomAction = NonNullable<typeof actions.deleteCustom>;
 type ToggleCustomSlideAction = NonNullable<typeof actions.toggleCustomSlide>;
+type ReorderAction = NonNullable<typeof actions.reorder>;
 
 const adminLocals = {
 	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
@@ -66,6 +71,17 @@ function buildIdRequest(action: string, id: string): Request {
 	});
 }
 
+function buildReorderRequest(
+	order: Array<{ type: 'builtin' | 'custom'; id: string | number }>
+): Request {
+	const formData = new FormData();
+	formData.set('order', JSON.stringify(order));
+	return new Request('http://localhost/admin/slides?/reorder', {
+		method: 'POST',
+		body: formData
+	});
+}
+
 async function runCreateCustom(request: Request) {
 	const handler = actions.createCustom as CreateCustomAction;
 	return handler({
@@ -96,6 +112,14 @@ async function runToggleCustomSlide(request: Request) {
 		request,
 		locals: adminLocals
 	} as Parameters<ToggleCustomSlideAction>[0]);
+}
+
+async function runReorder(request: Request) {
+	const handler = actions.reorder as ReorderAction;
+	return handler({
+		request,
+		locals: adminLocals
+	} as Parameters<ReorderAction>[0]);
 }
 
 describe('admin slides actions', () => {
@@ -237,6 +261,40 @@ describe('admin slides actions', () => {
 				status: 404,
 				data: { error: expect.stringContaining('not found') }
 			});
+		});
+	});
+
+	describe('reorder', () => {
+		it('persists unified built-in and custom slide order', async () => {
+			await initializeDefaultSlideConfig();
+			const insertResult = await db
+				.insert(customSlides)
+				.values({
+					title: 'Custom recap',
+					content: 'Custom content',
+					enabled: true,
+					sortOrder: 99,
+					year: null
+				})
+				.returning();
+			const customId = insertResult[0]?.id;
+			expect(customId).toBeDefined();
+
+			const result = await runReorder(
+				buildReorderRequest([
+					{ type: 'custom', id: customId ?? 0 },
+					{ type: 'builtin', id: 'genres' },
+					{ type: 'builtin', id: 'total-time' }
+				])
+			);
+
+			expect(result).toMatchObject({ success: true });
+
+			const customRows = await db.select().from(customSlides);
+			const customRow = customRows.find((row) => row.id === customId);
+			expect(customRow?.sortOrder).toBe(0);
+			expect((await getSlideConfigByType('genres'))?.sortOrder).toBe(1);
+			expect((await getSlideConfigByType('total-time'))?.sortOrder).toBe(2);
 		});
 	});
 });

--- a/tests/unit/admin/slides-actions.test.ts
+++ b/tests/unit/admin/slides-actions.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { FunFactFrequency, getFunFactFrequency } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
-import { appSettings, customSlides } from '$lib/server/db/schema';
+import { appSettings, customSlides, slideConfig } from '$lib/server/db/schema';
 import {
 	getSlideConfigByType,
 	initializeDefaultSlideConfig
@@ -126,6 +126,7 @@ describe('admin slides actions', () => {
 	beforeEach(async () => {
 		await db.delete(appSettings);
 		await db.delete(customSlides);
+		await db.delete(slideConfig);
 	});
 
 	for (const customCount of ['0', '16', '', '1abc', '1.5']) {

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -259,6 +259,21 @@ describe('admin UI source regressions', () => {
 		expect(source).not.toContain('optimisticMode');
 	});
 
+	it('disables share modes that are more permissive than the server privacy floor', async () => {
+		const [shareModalSource, dashboardSource] = await Promise.all([
+			readSource('src/lib/components/wrapped/ShareModal.svelte'),
+			readSource('src/routes/dashboard/settings/+page.svelte')
+		]);
+
+		for (const source of [shareModalSource, dashboardSource]) {
+			expect(source).toContain('class:below-floor={isBelowFloor');
+			expect(source).toContain('aria-disabled={isBelowFloor');
+			expect(source).toContain('disabled={');
+			expect(source).toContain('isBelowFloor');
+			expect(source).toContain('floor-note');
+		}
+	});
+
 	it('does not log Plex auth payloads from app-owned browser auth code', async () => {
 		const sources = await Promise.all([
 			readSource('src/lib/client/plex-login.ts'),
@@ -270,6 +285,61 @@ describe('admin UI source regressions', () => {
 			expect(source).not.toContain('console.debug');
 			expect(source).not.toContain('console.info');
 		}
+	});
+
+	it('explains bootstrap and claim expiry on the onboarding claim page', async () => {
+		const source = await readSource('src/routes/onboarding/claim/+page.svelte');
+
+		expect(source).toContain('Active claims expire after 10 minutes');
+		expect(source).toContain('bootstrap tokens expire after 15 minutes');
+		expect(source).toContain('use the current console token');
+		expect(source).toContain('restart the');
+		expect(source).toContain('server to print a new banner');
+	});
+
+	it('renders invalid cron feedback inline while disabling schedule save', async () => {
+		const source = await readSource('src/routes/admin/sync/+page.svelte');
+
+		expect(source).toContain('const cronError = $derived(validateCron(cronExpression));');
+		expect(source).toContain("aria-invalid={cronError ? 'true' : 'false'}");
+		expect(source).toContain("aria-describedby={cronError ? 'cronExpression-error' : undefined}");
+		expect(source).toContain('disabled={!!cronError}');
+		expect(source).toContain('id="cronExpression-error"');
+		expect(source).toContain('class="cron-error"');
+		expect(source).toContain('role="alert"');
+	});
+
+	it('wires Clear All Logs through a visible confirmation dialog', async () => {
+		const source = await readSource('src/routes/admin/logs/+page.svelte');
+
+		expect(source).toContain('let clearLogsDialogOpen = $state(false);');
+		expect(source).toContain('onclick={() => (clearLogsDialogOpen = true)}');
+		expect(source).toContain('<AlertDialog.Root bind:open={clearLogsDialogOpen}>');
+		expect(source).toContain('<AlertDialog.Title>Clear all logs?</AlertDialog.Title>');
+		expect(source).toContain(
+			'<AlertDialog.Cancel disabled={isClearingLogs}>Cancel</AlertDialog.Cancel>'
+		);
+		expect(source).toContain('action="?/clearLogs"');
+		expect(source).toContain('isClearingLogs = true;');
+		expect(source).toContain('await refreshAfterLogMutation(update);');
+		expect(source).toContain('clearLogsDialogOpen = false;');
+		expect(source).toContain("{isClearingLogs ? 'Clearing");
+	});
+
+	it('keeps wrapped keyboard focus visible on the mode toggle and StoryMode container', async () => {
+		const [modeToggleSource, storyModeSource] = await Promise.all([
+			readSource('src/lib/components/wrapped/ModeToggle.svelte'),
+			readSource('src/lib/components/wrapped/StoryMode.svelte')
+		]);
+
+		expect(modeToggleSource).toContain('.mode-toggle:focus-visible');
+		expect(modeToggleSource).toContain('outline: 3px solid #ffffff;');
+		expect(modeToggleSource).toContain('box-shadow:');
+		expect(modeToggleSource).toContain('0 0 0 8px var(--primary, #dc2626);');
+		expect(storyModeSource).toContain('tabindex="0"');
+		expect(storyModeSource).toContain('.story-mode:focus-visible');
+		expect(storyModeSource).toContain('inset 0 0 0 3px #ffffff');
+		expect(storyModeSource).toContain('inset 0 0 0 6px var(--primary, #dc2626)');
 	});
 
 	it('guards wrapped story transitions against stale rapid navigation', async () => {

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -340,6 +340,9 @@ describe('admin UI source regressions', () => {
 		expect(storyModeSource).toContain('.story-mode:focus-visible');
 		expect(storyModeSource).toContain('inset 0 0 0 3px #ffffff');
 		expect(storyModeSource).toContain('inset 0 0 0 6px var(--primary, #dc2626)');
+		expect(storyModeSource).toContain('class="focus-ring" aria-hidden="true"');
+		expect(storyModeSource).toContain('.story-mode:focus-visible .focus-ring');
+		expect(storyModeSource).toContain('z-index: 100;');
 	});
 
 	it('guards wrapped story transitions against stale rapid navigation', async () => {

--- a/tests/unit/onboarding/plex-owner-actions.test.ts
+++ b/tests/unit/onboarding/plex-owner-actions.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import type { Cookies } from '@sveltejs/kit';
+import { isRedirect } from '@sveltejs/kit';
+import * as membershipModule from '$lib/server/auth/membership';
+import * as sessionModule from '$lib/server/auth/session';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import { getOnboardingStep, OnboardingSteps } from '$lib/server/onboarding';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken
+} from '$lib/server/onboarding/bootstrap';
+import { actions } from '../../../src/routes/onboarding/plex/+page.server';
+
+type VerifyAdminAction = NonNullable<typeof actions.verifyAdmin>;
+
+const ownerLocals = {
+	user: { id: 1, plexId: 100, username: 'owner', isAdmin: true }
+} as unknown as App.Locals;
+
+const verifyAdmin = actions.verifyAdmin as VerifyAdminAction;
+
+let claimValues = new Map<string, string>();
+
+function makeCookies(): Cookies {
+	return {
+		get: (name: string) => (name === 'session' ? 'session-id' : claimValues.get(name)),
+		getAll: () => [],
+		set: (name: string, value: string) => claimValues.set(name, value),
+		delete: (name: string) => claimValues.delete(name),
+		serialize: () => ''
+	} as unknown as Cookies;
+}
+
+async function createClaim(cookies: Cookies): Promise<void> {
+	const token = createBootstrapToken();
+	expect(await claimOnboardingInstance(cookies, token)).toBe('claimed');
+}
+
+function invokeVerifyAdmin(cookies: Cookies) {
+	return verifyAdmin({
+		locals: ownerLocals,
+		cookies,
+		url: new URL('http://localhost/onboarding/plex')
+	} as unknown as Parameters<VerifyAdminAction>[0]);
+}
+
+describe('onboarding Plex owner verification', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		clearBootstrapToken();
+		claimValues = new Map();
+	});
+
+	it('allows the server owner to complete Plex setup verification', async () => {
+		const cookies = makeCookies();
+		await createClaim(cookies);
+		const getTokenSpy = spyOn(sessionModule, 'getSessionPlexToken').mockResolvedValue('plex-token');
+		const membershipSpy = spyOn(membershipModule, 'verifyServerMembership').mockResolvedValue({
+			isMember: true,
+			isOwner: true
+		});
+
+		try {
+			await invokeVerifyAdmin(cookies);
+			expect.unreachable('Expected redirect to sync step');
+		} catch (err) {
+			expect(isRedirect(err)).toBe(true);
+			if (!isRedirect(err)) throw err;
+			expect(err.status).toBe(303);
+			expect(err.location).toBe('/onboarding/sync');
+		} finally {
+			getTokenSpy.mockRestore();
+			membershipSpy.mockRestore();
+		}
+
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.SYNC);
+	});
+
+	it('rejects non-owner Plex members with the owner-only setup message', async () => {
+		const cookies = makeCookies();
+		await createClaim(cookies);
+		const getTokenSpy = spyOn(sessionModule, 'getSessionPlexToken').mockResolvedValue('plex-token');
+		const membershipSpy = spyOn(membershipModule, 'verifyServerMembership').mockResolvedValue({
+			isMember: true,
+			isOwner: false,
+			reason: 'not_owner'
+		});
+
+		try {
+			const result = await invokeVerifyAdmin(cookies);
+
+			expect(result).toMatchObject({
+				status: 403,
+				data: {
+					error:
+						'Only the server owner can configure Obzorarr. Please sign in with the server owner account.'
+				}
+			});
+			expect(await getOnboardingStep()).not.toBe(OnboardingSteps.SYNC);
+		} finally {
+			getTokenSpy.mockRestore();
+			membershipSpy.mockRestore();
+		}
+	});
+});

--- a/tests/unit/sharing/wrapped-identifier-loader.test.ts
+++ b/tests/unit/sharing/wrapped-identifier-loader.test.ts
@@ -11,9 +11,11 @@ import {
 } from '$lib/server/db/schema';
 import { setGlobalShareDefaults } from '$lib/server/sharing/service';
 import { ShareMode, ShareModeSource } from '$lib/server/sharing/types';
+import { load as loadServerWrapped } from '../../../src/routes/wrapped/[year]/+page.server';
 import { actions, load } from '../../../src/routes/wrapped/[year]/u/[identifier]/+page.server';
 
 type LoadArgs = Parameters<typeof load>[0];
+type ServerLoadArgs = Parameters<typeof loadServerWrapped>[0];
 
 /**
  * Regression tests for private-link cross-year token leak.
@@ -86,6 +88,47 @@ async function invokeLoad(params: {
 	} as unknown as LoadArgs);
 	return result as LoadData;
 }
+
+async function expectLoadStatus(
+	params: {
+		year: number;
+		identifier: string;
+		availableYears?: number[];
+		currentUser?: TestUser;
+	},
+	expectedStatus: number
+): Promise<void> {
+	try {
+		await invokeLoad({
+			year: params.year,
+			identifier: params.identifier,
+			availableYears: params.availableYears ?? [params.year],
+			currentUser: params.currentUser
+		});
+		expect.unreachable(`Expected status ${expectedStatus} for ${params.year}/${params.identifier}`);
+	} catch (err) {
+		expect((err as { status?: number }).status).toBe(expectedStatus);
+	}
+}
+
+async function expectServerWrappedStatus(year: string, expectedStatus: number): Promise<void> {
+	try {
+		await loadServerWrapped({
+			params: { year },
+			locals: {}
+		} as unknown as ServerLoadArgs);
+		expect.unreachable(`Expected server wrapped status ${expectedStatus} for ${year}`);
+	} catch (err) {
+		expect((err as { status?: number }).status).toBe(expectedStatus);
+	}
+}
+
+describe('wrapped/[year] loader: year bounds', () => {
+	it('returns 404 for years outside the supported range', async () => {
+		await expectServerWrappedStatus('1999', 404);
+		await expectServerWrappedStatus('2101', 404);
+	});
+});
 
 describe('wrapped/[year]/u/[identifier] loader: cross-year token isolation', () => {
 	const USER_ID = 42;
@@ -217,6 +260,30 @@ describe('wrapped/[year]/u/[identifier] loader: identifier validation (F-303)', 
 
 	it('returns 404 for a negative numeric identifier', async () => {
 		await expectStatus('-5', 404);
+	});
+
+	it('returns 404 for a private-link numeric URL without a token', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		await seedShareSettings({
+			userId: USER_ID,
+			year: ORIGIN_YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: '550e8400-e29b-41d4-a716-446655441111'
+		});
+
+		await expectStatus(String(USER_ID), 404);
+	});
+
+	it('returns 404 for a well-formed but unknown private-link token', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+
+		await expectStatus('550e8400-e29b-41d4-a716-446655449999', 404);
 	});
 
 	it('resolves a valid numeric identifier to the matching user', async () => {
@@ -544,5 +611,70 @@ describe('wrapped/[year]/u/[identifier] actions: token URL + floor-elevated mode
 		// Without the fix this would be: { status: 400, data: { error: 'Invalid user identifier' } }
 		const status = (result as { status?: number }).status;
 		expect(status).not.toBe(400);
+	});
+});
+
+describe('wrapped/[year]/u/[identifier] actions: token regeneration', () => {
+	const USER_ID = 77;
+	const YEAR = 2024;
+	const OLD_TOKEN = '990e8400-e29b-41d4-a716-446655440444';
+	type RegenerateTokenAction = NonNullable<typeof actions.regenerateToken>;
+
+	beforeEach(async () => {
+		await db.delete(shareSettings);
+		await db.delete(appSettings);
+		await db.delete(users);
+		await db.delete(cachedStats);
+		await db.delete(playHistory);
+		await db.delete(slideConfig);
+
+		await seedUser(USER_ID, 100077, 200077);
+		await seedShareSettings({
+			userId: USER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: OLD_TOKEN
+		});
+		await db
+			.update(shareSettings)
+			.set({ canUserControl: true })
+			.where(and(eq(shareSettings.userId, USER_ID), eq(shareSettings.year, YEAR)));
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: true
+		});
+	});
+
+	async function invokeRegenerate() {
+		const regenerateToken = actions.regenerateToken as RegenerateTokenAction;
+		return regenerateToken({
+			params: { year: String(YEAR), identifier: String(USER_ID) },
+			locals: {
+				user: {
+					id: USER_ID,
+					plexId: 100077,
+					username: `user-${USER_ID}`,
+					isAdmin: false
+				}
+			}
+		} as unknown as Parameters<RegenerateTokenAction>[0]);
+	}
+
+	it('invalidates old private-link tokens after regeneration', async () => {
+		const result = await invokeRegenerate();
+		const newToken = (result as { shareToken?: string }).shareToken;
+
+		expect(result).toMatchObject({ success: true });
+		expect(newToken).toBeDefined();
+		expect(newToken).not.toBe(OLD_TOKEN);
+
+		await expectLoadStatus({ year: YEAR, identifier: OLD_TOKEN }, 404);
+
+		const data = await invokeLoad({
+			year: YEAR,
+			identifier: newToken ?? '',
+			availableYears: [YEAR]
+		});
+		expect(data.userId).toBe(USER_ID);
 	});
 });


### PR DESCRIPTION
## Summary

Addresses the dogfood follow-up findings and related coverage gaps with surgical UI/accessibility fixes and regression tests.

## Changes

- Clarifies onboarding claim contention copy, including the 10-minute active-claim expiry, 15-minute bootstrap-token expiry, and recovery path.
- Improves visible keyboard focus treatment for the wrapped mode toggle and full-viewport StoryMode container.
- Adds source regression coverage for app-owned Plex auth console logging, cron inline validation, Clear All Logs confirmation behavior, share floor UI disabling, and wrapped focus styling.
- Adds action/load tests for admin log export JSON, pagination, and manual timestamp filtering.
- Adds onboarding owner-verification tests for server owner success and non-owner rejection.
- Adds wrapped edge coverage for out-of-range years, invalid/missing private-link tokens, token regeneration invalidating old tokens, and slide reorder persistence.

## Verification

- `bun run check`
- `bun run test` (1684 passing, coverage above threshold)
- `bun run lint`
- Browser smoke check of `/onboarding/claim` with `agent-browser`, verifying the new copy renders and the console has no app errors.