### PR TITLE
fix: resolve admin dogfood regressions

### DIFF
--- a/src/lib/server/admin/users.service.ts
+++ b/src/lib/server/admin/users.service.ts
@@ -18,6 +18,8 @@ export interface UserWithStats {
 	isAdmin: boolean;
 	createdAt: Date | null;
 	totalWatchTimeMinutes: number;
+	totalPlays: number;
+	hasWatchHistory: boolean;
 	shareMode: ShareModeType | null;
 	shareModeSource: ShareModeSourceType | null;
 	canUserControl: boolean;
@@ -54,7 +56,8 @@ export async function getAllUsersWithStats(year: number): Promise<UserWithStats[
 	const watchTimeByUser = await db
 		.select({
 			accountId: playHistory.accountId,
-			totalDuration: sql<number>`coalesce(sum(${playHistory.duration}), 0)`
+			totalDuration: sql<number>`coalesce(sum(${playHistory.duration}), 0)`,
+			totalPlays: sql<number>`count(*)`
 		})
 		.from(playHistory)
 		.where(between(playHistory.viewedAt, yearStart, yearEnd))
@@ -65,9 +68,12 @@ export async function getAllUsersWithStats(year: number): Promise<UserWithStats[
 		.from(shareSettings)
 		.where(eq(shareSettings.year, year));
 
-	const watchTimeMap = new Map<number, number>();
+	const watchTimeMap = new Map<number, { totalDuration: number; totalPlays: number }>();
 	for (const wt of watchTimeByUser) {
-		watchTimeMap.set(wt.accountId, wt.totalDuration);
+		watchTimeMap.set(wt.accountId, {
+			totalDuration: wt.totalDuration,
+			totalPlays: wt.totalPlays
+		});
 	}
 
 	const shareSettingsMap = new Map<
@@ -85,10 +91,8 @@ export async function getAllUsersWithStats(year: number): Promise<UserWithStats[
 	return allUsers.map((user) => {
 		// Try accountId first (matches playHistory.accountId), then fall back to plexId
 		// This handles the accountId/plexId mismatch for server owners
-		const watchTimeSeconds =
-			(user.accountId !== null ? watchTimeMap.get(user.accountId) : undefined) ??
-			watchTimeMap.get(user.plexId) ??
-			0;
+		const stats = (user.accountId !== null ? watchTimeMap.get(user.accountId) : undefined) ??
+			watchTimeMap.get(user.plexId) ?? { totalDuration: 0, totalPlays: 0 };
 		const settings = shareSettingsMap.get(user.id);
 
 		return {
@@ -99,7 +103,9 @@ export async function getAllUsersWithStats(year: number): Promise<UserWithStats[
 			thumb: user.thumb,
 			isAdmin: user.isAdmin ?? false,
 			createdAt: user.createdAt,
-			totalWatchTimeMinutes: Math.round(watchTimeSeconds / 60),
+			totalWatchTimeMinutes: Math.round(stats.totalDuration / 60),
+			totalPlays: stats.totalPlays,
+			hasWatchHistory: stats.totalPlays > 0,
 			shareMode: settings?.mode ?? null,
 			shareModeSource: settings?.modeSource ?? null,
 			canUserControl: settings?.canUserControl ?? false

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -240,6 +240,7 @@ function handleCsrfWarningDismissed() {
 		inert={sidebarHiddenFromMobile}
 		aria-hidden={sidebarHiddenFromMobile ? 'true' : undefined}
 		onkeydown={trapSidebarFocus}
+		tabindex="-1"
 		bind:this={sidebarElement}
 	>
 			<div class="sidebar-header">

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -147,6 +147,7 @@ function handleAdminNavigation(event: MouseEvent) {
 	event.preventDefault();
 	if (isMobileSidebar) {
 		sidebarOpen = false;
+		focusAfterRender('.menu-button');
 	}
 	void goto(href);
 }

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -11,10 +11,10 @@ import Settings from '@lucide/svelte/icons/settings';
 import User from '@lucide/svelte/icons/user';
 import Users from '@lucide/svelte/icons/users';
 import X from '@lucide/svelte/icons/x';
-import { type Component, type Snippet, tick } from 'svelte';
+import { type Component, type Snippet } from 'svelte';
 import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
-import { invalidateAll } from '$app/navigation';
+import { goto, invalidateAll } from '$app/navigation';
 import { page } from '$app/stores';
 import Logo from '$lib/components/Logo.svelte';
 import CsrfWarningBanner from '$lib/components/security/CsrfWarningBanner.svelte';
@@ -61,9 +61,18 @@ const isActive = $derived((href: string) => {
 let sidebarOpen = $state(false);
 let isMobileSidebar = $state(false);
 let sidebarHiddenFromMobile = $derived(isMobileSidebar && !sidebarOpen);
+let mainContentHiddenFromMobile = $derived(isMobileSidebar && sidebarOpen);
 let adminAvatarError = $state(false);
-let mobileMenuButton: HTMLButtonElement | undefined;
-let sidebarCloseButton: HTMLButtonElement | undefined;
+let sidebarElement = $state<HTMLElement | undefined>();
+
+const FOCUSABLE_SELECTOR = [
+	'a[href]',
+	'button:not([disabled])',
+	'input:not([disabled])',
+	'select:not([disabled])',
+	'textarea:not([disabled])',
+	'[tabindex]:not([tabindex="-1"])'
+].join(',');
 
 $effect(() => {
 	if (!browser) return;
@@ -78,6 +87,12 @@ $effect(() => {
 
 	return () => query.removeEventListener('change', syncMobileState);
 });
+
+function focusAfterRender(selector: string) {
+	requestAnimationFrame(() => {
+		setTimeout(() => document.querySelector<HTMLElement>(selector)?.focus(), 0);
+	});
+}
 
 // Reset avatar error when thumb URL changes so a new URL gets a fresh load attempt
 $effect(() => {
@@ -96,21 +111,83 @@ $effect(() => {
 	}
 });
 
-async function toggleSidebar() {
+function toggleSidebar() {
 	sidebarOpen = !sidebarOpen;
 
-	if (sidebarOpen && isMobileSidebar) {
-		await tick();
-		sidebarCloseButton?.focus();
+	if (sidebarOpen) {
+		focusAfterRender('.sidebar-close-button');
 	}
 }
 
-async function closeSidebar() {
+function closeSidebar() {
 	sidebarOpen = false;
+	focusAfterRender('.menu-button');
+}
 
+function shouldUseClientNavigation(event: MouseEvent, anchor: HTMLAnchorElement): boolean {
+	return (
+		event.button === 0 &&
+		!event.metaKey &&
+		!event.ctrlKey &&
+		!event.shiftKey &&
+		!event.altKey &&
+		(!anchor.target || anchor.target === '_self')
+	);
+}
+
+function handleAdminNavigation(event: MouseEvent) {
+	const anchor = event.currentTarget;
+	if (!(anchor instanceof HTMLAnchorElement) || !shouldUseClientNavigation(event, anchor)) {
+		return;
+	}
+
+	const href = anchor.getAttribute('href');
+	if (!href) return;
+
+	event.preventDefault();
 	if (isMobileSidebar) {
-		await tick();
-		mobileMenuButton?.focus();
+		sidebarOpen = false;
+	}
+	void goto(href);
+}
+
+function getSidebarFocusableElements(): HTMLElement[] {
+	if (!sidebarElement) return [];
+	return Array.from(sidebarElement.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+		(element) => element.tabIndex >= 0 && element.getClientRects().length > 0
+	);
+}
+
+function trapSidebarFocus(event: KeyboardEvent) {
+	if (!isMobileSidebar || !sidebarOpen || event.key !== 'Tab') return;
+
+	const focusableElements = getSidebarFocusableElements();
+	if (focusableElements.length === 0) {
+		event.preventDefault();
+		sidebarElement?.focus();
+		return;
+	}
+
+	const first = focusableElements[0];
+	const last = focusableElements.at(-1);
+	const activeElement = document.activeElement;
+
+	if (event.shiftKey && (activeElement === first || !sidebarElement?.contains(activeElement))) {
+		event.preventDefault();
+		last?.focus();
+	} else if (
+		!event.shiftKey &&
+		(activeElement === last || !sidebarElement?.contains(activeElement))
+	) {
+		event.preventDefault();
+		first?.focus();
+	}
+}
+
+function handleWindowKeydown(event: KeyboardEvent) {
+	if (isMobileSidebar && sidebarOpen && event.key === 'Escape') {
+		event.preventDefault();
+		void closeSidebar();
 	}
 }
 
@@ -120,13 +197,14 @@ function handleCsrfWarningDismissed() {
 }
 </script>
 
+<svelte:window onkeydown={handleWindowKeydown} />
+
 <div class="admin-layout">
 	<!-- Mobile header -->
 		<header class="mobile-header" class:sidebar-open={sidebarOpen}>
 		<button
 			type="button"
 			class="menu-button"
-			bind:this={mobileMenuButton}
 			onclick={toggleSidebar}
 			aria-label="Toggle navigation"
 		>
@@ -160,6 +238,8 @@ function handleCsrfWarningDismissed() {
 		class:open={sidebarOpen}
 		inert={sidebarHiddenFromMobile}
 		aria-hidden={sidebarHiddenFromMobile ? 'true' : undefined}
+		onkeydown={trapSidebarFocus}
+		bind:this={sidebarElement}
 	>
 			<div class="sidebar-header">
 				<div class="sidebar-branding">
@@ -172,7 +252,6 @@ function handleCsrfWarningDismissed() {
 				<button
 					type="button"
 					class="sidebar-close-button"
-					bind:this={sidebarCloseButton}
 					onclick={closeSidebar}
 					aria-label="Close navigation"
 				>
@@ -190,7 +269,7 @@ function handleCsrfWarningDismissed() {
 							class="nav-link"
 							class:active
 							aria-current={active ? 'page' : undefined}
-							onclick={closeSidebar}
+							onclick={handleAdminNavigation}
 						>
 							<span class="nav-icon-wrap" class:active>
 								<item.icon class="nav-icon" />
@@ -242,7 +321,11 @@ function handleCsrfWarningDismissed() {
 	</aside>
 
 	<!-- Main content -->
-	<main class="main-content">
+	<main
+		class="main-content"
+		inert={mainContentHiddenFromMobile}
+		aria-hidden={mainContentHiddenFromMobile ? 'true' : undefined}
+	>
 		{#if showCsrfWarning}
 			<CsrfWarningBanner onDismiss={handleCsrfWarningDismissed} />
 		{/if}

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -11,7 +11,7 @@ import Settings from '@lucide/svelte/icons/settings';
 import User from '@lucide/svelte/icons/user';
 import Users from '@lucide/svelte/icons/users';
 import X from '@lucide/svelte/icons/x';
-import { type Component, type Snippet } from 'svelte';
+import { type Component, type Snippet, tick } from 'svelte';
 import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
@@ -88,10 +88,9 @@ $effect(() => {
 	return () => query.removeEventListener('change', syncMobileState);
 });
 
-function focusAfterRender(selector: string) {
-	requestAnimationFrame(() => {
-		setTimeout(() => document.querySelector<HTMLElement>(selector)?.focus(), 0);
-	});
+async function focusAfterRender(selector: string) {
+	await tick();
+	document.querySelector<HTMLElement>(selector)?.focus();
 }
 
 // Reset avatar error when thumb URL changes so a new URL gets a fresh load attempt
@@ -115,13 +114,13 @@ function toggleSidebar() {
 	sidebarOpen = !sidebarOpen;
 
 	if (sidebarOpen) {
-		focusAfterRender('.sidebar-close-button');
+		void focusAfterRender('.sidebar-close-button');
 	}
 }
 
 function closeSidebar() {
 	sidebarOpen = false;
-	focusAfterRender('.menu-button');
+	void focusAfterRender('.menu-button');
 }
 
 function shouldUseClientNavigation(event: MouseEvent, anchor: HTMLAnchorElement): boolean {
@@ -135,7 +134,7 @@ function shouldUseClientNavigation(event: MouseEvent, anchor: HTMLAnchorElement)
 	);
 }
 
-function handleAdminNavigation(event: MouseEvent) {
+async function handleAdminNavigation(event: MouseEvent) {
 	const anchor = event.currentTarget;
 	if (!(anchor instanceof HTMLAnchorElement) || !shouldUseClientNavigation(event, anchor)) {
 		return;
@@ -145,11 +144,12 @@ function handleAdminNavigation(event: MouseEvent) {
 	if (!href) return;
 
 	event.preventDefault();
-	if (isMobileSidebar) {
+	const shouldRestoreFocus = isMobileSidebar;
+	if (shouldRestoreFocus) {
 		sidebarOpen = false;
-		focusAfterRender('.menu-button');
+		await focusAfterRender('.menu-button');
 	}
-	void goto(href);
+	void goto(href, { keepFocus: shouldRestoreFocus });
 }
 
 function getSidebarFocusableElements(): HTMLElement[] {

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -15,6 +15,7 @@ import Settings from '@lucide/svelte/icons/settings';
 import SlidersHorizontal from '@lucide/svelte/icons/sliders-horizontal';
 import Star from '@lucide/svelte/icons/star';
 import Users from '@lucide/svelte/icons/users';
+import { goto } from '$app/navigation';
 import { formatDuration } from '$lib/utils/format';
 import type { PageData } from './$types';
 
@@ -60,6 +61,30 @@ function formatRelativeTime(isoDate: string | null): string {
 function formatDate(isoDate: string | null): string {
 	if (!isoDate) return 'N/A';
 	return new Date(isoDate).toLocaleString();
+}
+
+function shouldUseClientNavigation(event: MouseEvent, anchor: HTMLAnchorElement): boolean {
+	return (
+		event.button === 0 &&
+		!event.metaKey &&
+		!event.ctrlKey &&
+		!event.shiftKey &&
+		!event.altKey &&
+		(!anchor.target || anchor.target === '_self')
+	);
+}
+
+function handleAdminNavigation(event: MouseEvent) {
+	const anchor = event.currentTarget;
+	if (!(anchor instanceof HTMLAnchorElement) || !shouldUseClientNavigation(event, anchor)) {
+		return;
+	}
+
+	const href = anchor.getAttribute('href');
+	if (!href) return;
+
+	event.preventDefault();
+	void goto(href);
 }
 
 // Stats configuration with icons and colors
@@ -155,7 +180,7 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 					<RefreshCw class="section-icon" />
 					<h2>Sync Status</h2>
 				</div>
-				<a href="/admin/sync" class="section-link">
+				<a href="/admin/sync" class="section-link" onclick={handleAdminNavigation}>
 					<span>Manage</span>
 					<ArrowRight class="h-4 w-4" />
 				</a>
@@ -252,14 +277,14 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 					<Star class="section-icon text-amber-400" />
 					<h2>Wrapped</h2>
 				</div>
-				<a href="/admin/wrapped" class="section-link">
+				<a href="/admin/wrapped" class="section-link" onclick={handleAdminNavigation}>
 					<span>View All</span>
 					<ArrowRight class="h-4 w-4" />
 				</a>
 			</div>
 
 			<div class="wrapped-grid">
-				<a href={data.wrappedHref} class="wrapped-card personal">
+				<a href={data.wrappedHref} class="wrapped-card personal" onclick={handleAdminNavigation}>
 					<div class="wrapped-card-glow"></div>
 					<div class="wrapped-icon-wrap">
 						<Star class="wrapped-icon" />
@@ -268,7 +293,7 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 					<ArrowRight class="wrapped-arrow" />
 				</a>
 
-				<a href="/wrapped/{data.year}" class="wrapped-card server">
+				<a href="/wrapped/{data.year}" class="wrapped-card server" onclick={handleAdminNavigation}>
 					<div class="wrapped-card-glow"></div>
 					<div class="wrapped-icon-wrap">
 						<Server class="wrapped-icon" />
@@ -277,7 +302,7 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 					<ArrowRight class="wrapped-arrow" />
 				</a>
 
-				<a href="/admin/slides" class="wrapped-card config">
+				<a href="/admin/slides" class="wrapped-card config" onclick={handleAdminNavigation}>
 					<div class="wrapped-card-glow"></div>
 					<div class="wrapped-icon-wrap">
 						<SlidersHorizontal class="wrapped-icon" />
@@ -294,7 +319,7 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 		<h2 class="actions-title">Quick Actions</h2>
 
 		<div class="actions-grid">
-			<a href="/admin/sync" class="action-card">
+			<a href="/admin/sync" class="action-card" onclick={handleAdminNavigation}>
 				<div class="action-icon-wrap">
 					<RefreshCw class="action-icon" />
 				</div>
@@ -305,7 +330,7 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 				<ArrowRight class="action-arrow" />
 			</a>
 
-			<a href="/admin/users" class="action-card">
+			<a href="/admin/users" class="action-card" onclick={handleAdminNavigation}>
 				<div class="action-icon-wrap">
 					<Users class="action-icon" />
 				</div>
@@ -316,7 +341,7 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 				<ArrowRight class="action-arrow" />
 			</a>
 
-			<a href="/admin/settings" class="action-card">
+			<a href="/admin/settings" class="action-card" onclick={handleAdminNavigation}>
 				<div class="action-icon-wrap">
 					<Settings class="action-icon" />
 				</div>

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import Plus from '@lucide/svelte/icons/plus';
 import { untrack } from 'svelte';
 import { deserialize, enhance } from '$app/forms';
 import type { SlideType } from '$lib/components/slides/types';
@@ -286,26 +287,14 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 	<!-- Slide Order Section -->
 	<section class="section">
 		<div class="section-header">
-			<div>
+			<div class="section-title-content">
 				<h2>Slide Order</h2>
 				<p class="section-description">
 					Drag and drop to reorder. Toggle to enable or disable slides.
 				</p>
 			</div>
 			<button type="button" class="add-button" onclick={openNewEditor}>
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					width="16"
-					height="16"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-				>
-					<path d="M12 5v14M5 12h14" />
-				</svg>
+				<Plus class="add-button-icon" />
 				Add Custom Slide
 			</button>
 		</div>
@@ -757,6 +746,10 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			margin-bottom: 1rem;
 		}
 
+		.section-title-content {
+			min-width: 0;
+		}
+
 		.section-header h2 {
 			margin: 0 0 0.25rem;
 		}
@@ -1001,7 +994,9 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			transform: translateY(-1px);
 		}
 
-		.add-button svg {
+		.add-button :global(.add-button-icon) {
+			width: 1rem;
+			height: 1rem;
 			flex-shrink: 0;
 		}
 
@@ -1432,5 +1427,17 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 
 		.save-frequency-button:hover {
 			opacity: 0.9;
+		}
+
+		@media (max-width: 430px) {
+			.section-header {
+				flex-direction: column;
+				align-items: stretch;
+			}
+
+			.add-button {
+				width: 100%;
+				justify-content: center;
+			}
 		}
 </style>

--- a/src/routes/admin/users/+page.server.ts
+++ b/src/routes/admin/users/+page.server.ts
@@ -37,6 +37,8 @@ export const load: PageServerLoad = async ({ url }) => {
 			thumb: u.thumb,
 			isAdmin: u.isAdmin,
 			totalWatchTimeMinutes: u.totalWatchTimeMinutes,
+			totalPlays: u.totalPlays,
+			hasWatchHistory: u.hasWatchHistory,
 			shareMode: u.shareMode,
 			shareModeSource: u.shareModeSource,
 			canUserControl: u.canUserControl,

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -21,8 +21,10 @@ $effect(() => {
 
 // Format watch time as hours
 function formatWatchTime(minutes: number): string {
+	if (minutes === 0) return '0h';
+	if (minutes > 0 && minutes < 60) return '<1h';
+
 	const hours = Math.round(minutes / 60);
-	if (hours < 1) return '<1h';
 	if (hours >= 24) {
 		const days = (hours / 24).toFixed(1);
 		return `${days}d`;
@@ -109,12 +111,21 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 												{/if}
 											</span>
 											<div class="user-info">
-												<a href={user.wrappedHref} class="user-name">
+												{#if user.hasWatchHistory}
+													<a href={user.wrappedHref} class="user-name">
+														{user.username}
+														{#if user.isAdmin}
+															<span class="admin-badge">Admin</span>
+														{/if}
+													</a>
+												{:else}
+													<span class="user-name">
 												{user.username}
 												{#if user.isAdmin}
 													<span class="admin-badge">Admin</span>
 												{/if}
-											</a>
+											</span>
+												{/if}
 											{#if user.email}
 												<span class="user-email">{user.email}</span>
 											{/if}
@@ -163,14 +174,18 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 									</form>
 								</td>
 								<td>
-									<a
-										href={user.wrappedHref}
-										target="_blank"
-										rel="noopener noreferrer"
-										class="preview-link"
-									>
-										Preview Wrapped
-									</a>
+									{#if user.hasWatchHistory}
+										<a
+											href={user.wrappedHref}
+											target="_blank"
+											rel="noopener noreferrer"
+											class="preview-link"
+										>
+											Preview Wrapped
+										</a>
+									{:else}
+										<span class="preview-link unavailable">No Wrapped yet</span>
+									{/if}
 								</td>
 							</tr>
 						{/each}
@@ -189,12 +204,21 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 									{/if}
 								</span>
 								<div class="user-info">
-									<a href={user.wrappedHref} class="user-name">
+									{#if user.hasWatchHistory}
+										<a href={user.wrappedHref} class="user-name">
+											{user.username}
+											{#if user.isAdmin}
+												<span class="admin-badge">Admin</span>
+											{/if}
+										</a>
+									{:else}
+										<span class="user-name">
 									{user.username}
 									{#if user.isAdmin}
 										<span class="admin-badge">Admin</span>
 									{/if}
-								</a>
+								</span>
+									{/if}
 								{#if user.email}
 									<span class="user-email">{user.email}</span>
 								{/if}
@@ -244,14 +268,18 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 								</form>
 							</div>
 						</div>
-						<a
-							href={user.wrappedHref}
-							target="_blank"
-							rel="noopener noreferrer"
-							class="preview-link mobile-preview-link"
-						>
-							Preview Wrapped
-						</a>
+						{#if user.hasWatchHistory}
+							<a
+								href={user.wrappedHref}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="preview-link mobile-preview-link"
+							>
+								Preview Wrapped
+							</a>
+						{:else}
+							<span class="preview-link unavailable mobile-preview-link">No Wrapped yet</span>
+						{/if}
 					</div>
 				{/each}
 			</div>
@@ -463,7 +491,7 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 			gap: 0.5rem;
 		}
 
-		.user-name:hover {
+		.user-name[href]:hover {
 			color: hsl(var(--primary));
 		}
 
@@ -548,6 +576,15 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 
 		.preview-link:hover {
 			text-decoration: underline;
+		}
+
+		.preview-link.unavailable {
+			color: hsl(var(--muted-foreground));
+			cursor: default;
+		}
+
+		.preview-link.unavailable:hover {
+			text-decoration: none;
 		}
 
 		.mobile-users-list {

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -206,6 +206,9 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain(
 			'(activeElement === last || !sidebarElement?.contains(activeElement))'
 		);
+		expect(source).toContain('if (focusableElements.length === 0) {');
+		expect(source).toContain('sidebarElement?.focus();');
+		expect(source).toMatch(/<aside[\s\S]*tabindex="-1"[\s\S]*bind:this=\{sidebarElement\}/);
 		expect(source).toContain('onkeydown={trapSidebarFocus}');
 		expect(source).toContain('bind:this={sidebarElement}');
 		expect(source).toContain('function handleWindowKeydown(event: KeyboardEvent)');
@@ -273,9 +276,10 @@ describe('admin UI source regressions', () => {
 			expect(source).toContain('!event.ctrlKey');
 			expect(source).toContain('!event.shiftKey');
 			expect(source).toContain('!event.altKey');
-			expect(source).toContain('void goto(href);');
 		}
 
+		expect(layoutSource).toContain('void goto(href, { keepFocus: shouldRestoreFocus });');
+		expect(dashboardSource).toContain('void goto(href);');
 		expect(layoutSource).toContain('href={item.href}');
 		expect(layoutSource).toContain('onclick={handleAdminNavigation}');
 		expect(dashboardSource).toContain('href="/admin/settings" class="action-card"');

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -193,6 +193,27 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('pointer-events: auto;');
 	});
 
+	it('traps focus in the open mobile admin drawer and marks page content inert', async () => {
+		const source = await readSource('src/routes/admin/+layout.svelte');
+
+		expect(source).toContain(
+			'let mainContentHiddenFromMobile = $derived(isMobileSidebar && sidebarOpen);'
+		);
+		expect(source).toContain('function trapSidebarFocus(event: KeyboardEvent)');
+		expect(source).toContain(
+			"if (!isMobileSidebar || !sidebarOpen || event.key !== 'Tab') return;"
+		);
+		expect(source).toContain(
+			'(activeElement === last || !sidebarElement?.contains(activeElement))'
+		);
+		expect(source).toContain('onkeydown={trapSidebarFocus}');
+		expect(source).toContain('bind:this={sidebarElement}');
+		expect(source).toContain('function handleWindowKeydown(event: KeyboardEvent)');
+		expect(source).toContain('void closeSidebar();');
+		expect(source).toContain('inert={mainContentHiddenFromMobile}');
+		expect(source).toContain("aria-hidden={mainContentHiddenFromMobile ? 'true' : undefined}");
+	});
+
 	it('keeps the open mobile admin drawer header self-contained', async () => {
 		const source = await readSource('src/routes/admin/+layout.svelte');
 
@@ -215,8 +236,63 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('<span class="user-avatar-link" aria-hidden="true">');
 		expect(source).not.toContain('<a href={user.wrappedHref} class="user-avatar-link">');
 		expect(source).toContain('<img src={user.thumb} alt="" class="user-avatar" />');
+		expect(source).toContain('{#if user.hasWatchHistory}');
 		expect(source).toContain('<a href={user.wrappedHref} class="user-name">');
 		expect(source).toContain('class="preview-link"');
+	});
+
+	it('does not render wrapped links for admin users without watch history', async () => {
+		const [clientSource, serverSource] = await Promise.all([
+			readSource('src/routes/admin/users/+page.svelte'),
+			readSource('src/routes/admin/users/+page.server.ts')
+		]);
+
+		expect(serverSource).toContain('totalPlays: u.totalPlays');
+		expect(serverSource).toContain('hasWatchHistory: u.hasWatchHistory');
+		expect(clientSource).toContain("if (minutes === 0) return '0h';");
+		expect(clientSource).toContain("if (minutes > 0 && minutes < 60) return '<1h';");
+		expect(clientSource).toContain('{#if user.hasWatchHistory}');
+		expect(clientSource).toContain('<span class="preview-link unavailable">No Wrapped yet</span>');
+		expect(clientSource).toContain(
+			'<span class="preview-link unavailable mobile-preview-link">No Wrapped yet</span>'
+		);
+		expect(clientSource).toContain('.preview-link.unavailable');
+	});
+
+	it('uses client navigation for unmodified admin links while preserving real hrefs', async () => {
+		const [layoutSource, dashboardSource] = await Promise.all([
+			readSource('src/routes/admin/+layout.svelte'),
+			readSource('src/routes/admin/+page.svelte')
+		]);
+
+		for (const source of [layoutSource, dashboardSource]) {
+			expect(source).toContain('import { goto');
+			expect(source).toContain('function shouldUseClientNavigation');
+			expect(source).toContain('event.button === 0');
+			expect(source).toContain('!event.metaKey');
+			expect(source).toContain('!event.ctrlKey');
+			expect(source).toContain('!event.shiftKey');
+			expect(source).toContain('!event.altKey');
+			expect(source).toContain('void goto(href);');
+		}
+
+		expect(layoutSource).toContain('href={item.href}');
+		expect(layoutSource).toContain('onclick={handleAdminNavigation}');
+		expect(dashboardSource).toContain('href="/admin/settings" class="action-card"');
+		expect(dashboardSource).toContain('onclick={handleAdminNavigation}');
+	});
+
+	it('stacks the slide order header controls on narrow screens', async () => {
+		const source = await readSource('src/routes/admin/slides/+page.svelte');
+
+		expect(source).toContain('class="section-title-content"');
+		expect(source).toContain('.section-title-content');
+		expect(source).toContain('min-width: 0;');
+		expect(source).toContain('@media (max-width: 430px)');
+		expect(source).toContain('flex-direction: column;');
+		expect(source).toContain('align-items: stretch;');
+		expect(source).toContain('width: 100%;');
+		expect(source).toContain('justify-content: center;');
 	});
 
 	it('updates wrapped logo mode selection explicitly without resetting local clicks', async () => {

--- a/tests/unit/admin/users.service.test.ts
+++ b/tests/unit/admin/users.service.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { getAllUsersWithStats } from '$lib/server/admin/users.service';
+import { db } from '$lib/server/db/client';
+import { playHistory, shareSettings, users } from '$lib/server/db/schema';
+import { createTimestamp } from '../../helpers/factories';
+
+describe('admin users service', () => {
+	beforeEach(async () => {
+		await db.delete(shareSettings);
+		await db.delete(playHistory);
+		await db.delete(users);
+	});
+
+	it('returns play counts and watch-history state for the selected year', async () => {
+		await db.insert(users).values([
+			{
+				id: 1,
+				plexId: 1001,
+				accountId: 2001,
+				username: 'viewer'
+			},
+			{
+				id: 2,
+				plexId: 1002,
+				accountId: 2002,
+				username: 'no-history'
+			}
+		]);
+
+		await db.insert(playHistory).values([
+			{
+				historyKey: 'history-1',
+				ratingKey: 'rating-1',
+				title: 'Movie 1',
+				type: 'movie',
+				viewedAt: createTimestamp(2025, 1, 15),
+				accountId: 2001,
+				librarySectionId: 1,
+				duration: 1800
+			},
+			{
+				historyKey: 'history-2',
+				ratingKey: 'rating-2',
+				title: 'Movie 2',
+				type: 'movie',
+				viewedAt: createTimestamp(2025, 2, 15),
+				accountId: 2001,
+				librarySectionId: 1,
+				duration: 3600
+			},
+			{
+				historyKey: 'history-outside-year',
+				ratingKey: 'rating-outside-year',
+				title: 'Old Movie',
+				type: 'movie',
+				viewedAt: createTimestamp(2024, 12, 31),
+				accountId: 2001,
+				librarySectionId: 1,
+				duration: 7200
+			}
+		]);
+
+		const results = (await getAllUsersWithStats(2025)).sort((a, b) => a.id - b.id);
+
+		expect(results[0]).toMatchObject({
+			id: 1,
+			totalWatchTimeMinutes: 90,
+			totalPlays: 2,
+			hasWatchHistory: true
+		});
+		expect(results[1]).toMatchObject({
+			id: 2,
+			totalWatchTimeMinutes: 0,
+			totalPlays: 0,
+			hasWatchHistory: false
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This PR resolves the actionable Obzorarr dogfood findings for the admin experience while leaving the two policy-confirmed non-product findings unchanged.

### Changes

- Adds guarded client-side navigation for admin sidebar links and admin dashboard cards while preserving real `href` attributes for no-JS, new-tab, and modified-click behavior.
- Extends admin user stats with `totalPlays` and `hasWatchHistory` so the users page can distinguish no-history users from users with very short watch time.
- Updates the admin users page to render `0h` for zero watch time, `<1h` only for positive sub-hour watch time, and non-link `No Wrapped yet` labels for users without watch history.
- Improves the mobile admin drawer by marking the background content inert while open and trapping Tab focus within the drawer.
- Fixes the mobile Slide Order header layout by stacking the title/description and Add Custom Slide action on narrow screens.

### Verification

- `bun test tests/unit/plex-login.test.ts`
- `bun test tests/unit/security/admin-guards.test.ts`
- `bun test tests/unit/admin/ui-source-regressions.test.ts`
- `bun test tests/unit/admin/users.service.test.ts`
- `bun run check`
- `bun run check:biome`
- `bun run test`

Manual browser verification covered:

- Admin dashboard Settings quick action navigates to `/admin/settings`.
- Admin users with no watch history show `0h` and no active Preview Wrapped link.
- Mobile admin drawer at `390x844` traps focus and hides background content from the accessibility tree.
- `/admin/slides` at `390x844` stacks the Slide Order header cleanly.
- Logged-in non-admin `/admin/settings` redirects to `/dashboard`.