### PR TITLE
fix: harden onboarding oauth guards

### DIFF
--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -145,18 +145,32 @@ function storePinForRedirect(
 	storage.setItem(PIN_STORAGE_KEY, JSON.stringify({ pinId, createdAt: Date.now(), context }));
 }
 
+function getStoredRedirectPinData(storage: Pick<Storage, 'getItem'>): string | null {
+	try {
+		return storage.getItem(PIN_STORAGE_KEY);
+	} catch {
+		return null;
+	}
+}
+
+function removeStoredRedirectPinData(storage: Pick<Storage, 'removeItem'>): void {
+	try {
+		storage.removeItem(PIN_STORAGE_KEY);
+	} catch {}
+}
+
 export function resolveRedirectPinData(
 	storage: Pick<Storage, 'getItem' | 'removeItem'>,
 	serverPinFallback: ServerPinFallback | null | undefined,
 	now = Date.now()
 ): StoredRedirectPinData {
-	const storedData = storage.getItem(PIN_STORAGE_KEY);
+	const storedData = getStoredRedirectPinData(storage);
 	if (storedData) {
 		let pinData: StoredRedirectPinData;
 		try {
 			pinData = JSON.parse(storedData) as StoredRedirectPinData;
 		} catch {
-			storage.removeItem(PIN_STORAGE_KEY);
+			removeStoredRedirectPinData(storage);
 			throw new Error('Invalid authentication data. Please try again.');
 		}
 
@@ -165,13 +179,13 @@ export function resolveRedirectPinData(
 			typeof pinData.createdAt !== 'number' ||
 			(pinData.context !== 'landing' && pinData.context !== 'onboarding')
 		) {
-			storage.removeItem(PIN_STORAGE_KEY);
+			removeStoredRedirectPinData(storage);
 			throw new Error('Invalid authentication data. Please try again.');
 		}
 
 		const pinAge = now - pinData.createdAt;
 		if (pinAge > PIN_MAX_AGE_MS) {
-			storage.removeItem(PIN_STORAGE_KEY);
+			removeStoredRedirectPinData(storage);
 			throw new Error('Authentication session expired. Please try again.');
 		}
 

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -14,6 +14,7 @@ export const PIN_STORAGE_KEY = 'obzorarr_plex_pin';
 
 export const POLL_INTERVAL_MS = 2000;
 export const LOGIN_TIMEOUT_MS = 5 * 60 * 1000;
+export const PIN_MAX_AGE_MS = 15 * 60 * 1000;
 
 export type PlexLoginContext = 'landing' | 'onboarding';
 
@@ -84,6 +85,18 @@ interface PinResponse {
 	authUrl: string;
 }
 
+export interface StoredRedirectPinData {
+	pinId: number;
+	createdAt: number;
+	context: PlexLoginContext;
+}
+
+export interface ServerPinFallback {
+	pinId: number;
+	expiresAt: string;
+	context: PlexLoginContext;
+}
+
 async function fetchPin(redirectUrl?: string): Promise<PinResponse> {
 	const url = redirectUrl
 		? `/auth/plex?redirectUrl=${encodeURIComponent(redirectUrl)}`
@@ -130,6 +143,55 @@ function storePinForRedirect(
 	storage: RedirectStorage = sessionStorage
 ): void {
 	storage.setItem(PIN_STORAGE_KEY, JSON.stringify({ pinId, createdAt: Date.now(), context }));
+}
+
+export function resolveRedirectPinData(
+	storage: Pick<Storage, 'getItem' | 'removeItem'>,
+	serverPinFallback: ServerPinFallback | null | undefined,
+	now = Date.now()
+): StoredRedirectPinData {
+	const storedData = storage.getItem(PIN_STORAGE_KEY);
+	if (storedData) {
+		let pinData: StoredRedirectPinData;
+		try {
+			pinData = JSON.parse(storedData) as StoredRedirectPinData;
+		} catch {
+			storage.removeItem(PIN_STORAGE_KEY);
+			throw new Error('Invalid authentication data. Please try again.');
+		}
+
+		if (
+			typeof pinData.pinId !== 'number' ||
+			typeof pinData.createdAt !== 'number' ||
+			(pinData.context !== 'landing' && pinData.context !== 'onboarding')
+		) {
+			storage.removeItem(PIN_STORAGE_KEY);
+			throw new Error('Invalid authentication data. Please try again.');
+		}
+
+		const pinAge = now - pinData.createdAt;
+		if (pinAge > PIN_MAX_AGE_MS) {
+			storage.removeItem(PIN_STORAGE_KEY);
+			throw new Error('Authentication session expired. Please try again.');
+		}
+
+		return pinData;
+	}
+
+	if (serverPinFallback) {
+		const expiresAt = Date.parse(serverPinFallback.expiresAt);
+		if (!Number.isFinite(expiresAt) || expiresAt <= now) {
+			throw new Error('Authentication session expired. Please try again.');
+		}
+
+		return {
+			pinId: serverPinFallback.pinId,
+			createdAt: now,
+			context: serverPinFallback.context
+		};
+	}
+
+	throw new Error('No pending authentication found. Please try again.');
 }
 
 export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginController {

--- a/src/lib/server/auth/login-completion.ts
+++ b/src/lib/server/auth/login-completion.ts
@@ -23,6 +23,9 @@ const COOKIE_OPTIONS = {
 	maxAge: Math.floor(SESSION_DURATION_MS / 1000)
 };
 
+const ONBOARDING_OWNER_REQUIRED_MESSAGE =
+	'Only the server owner can configure Obzorarr. Please sign in with the server owner account.';
+
 export interface CompletedLoginUser {
 	username: string;
 	isAdmin: boolean;
@@ -49,17 +52,28 @@ export async function createSessionFromPlexToken(
 	let isAdmin = false;
 	let accountId: number;
 
-	if (isOnboarding && !hasServerConfigured) {
+	if (isOnboarding) {
 		await requireActiveOnboardingClaim(cookies, context);
 
-		const ownership = await verifyServerOwnership(authToken);
+		if (hasServerConfigured) {
+			const membership = await requireServerMembership(authToken);
 
-		if (!ownership.isOwner) {
-			throw new NotServerMemberError('You must own a Plex server to configure Obzorarr.');
+			if (!membership.isOwner) {
+				throw new NotServerMemberError(ONBOARDING_OWNER_REQUIRED_MESSAGE);
+			}
+
+			isAdmin = true;
+			accountId = 1;
+		} else {
+			const ownership = await verifyServerOwnership(authToken);
+
+			if (!ownership.isOwner) {
+				throw new NotServerMemberError('You must own a Plex server to configure Obzorarr.');
+			}
+
+			isAdmin = true;
+			accountId = 1;
 		}
-
-		isAdmin = true;
-		accountId = 1;
 	} else {
 		const membership = await requireServerMembership(authToken);
 

--- a/src/lib/server/auth/pin-transactions.ts
+++ b/src/lib/server/auth/pin-transactions.ts
@@ -15,6 +15,11 @@ interface PinTransaction {
 	callbackVerified: boolean;
 }
 
+export interface VerifiedPinCallback {
+	pinId: number;
+	expiresAt: Date;
+}
+
 const COOKIE_OPTIONS = {
 	path: '/',
 	httpOnly: true,
@@ -76,24 +81,34 @@ export function appendPinStateToForwardUrl(
 	return parsed.toString();
 }
 
-export async function markPinCallbackVerified(
+export async function verifyPinCallback(
 	cookies: Cookies,
 	state: string | null
-): Promise<boolean> {
+): Promise<VerifiedPinCallback | null> {
 	await pruneExpired();
 
 	const cookieState = cookies.get(PIN_STATE_COOKIE);
 	if (!state || !cookieState || state !== cookieState) {
-		return false;
+		return null;
 	}
 
 	const updated = await db
 		.update(pinTransactions)
 		.set({ callbackVerified: true })
 		.where(eq(pinTransactions.state, state))
-		.returning({ state: pinTransactions.state });
+		.returning({
+			pinId: pinTransactions.pinId,
+			expiresAt: pinTransactions.expiresAt
+		});
 
-	return updated.length > 0;
+	return updated[0] ?? null;
+}
+
+export async function markPinCallbackVerified(
+	cookies: Cookies,
+	state: string | null
+): Promise<boolean> {
+	return (await verifyPinCallback(cookies, state)) !== null;
 }
 
 export async function getPinTransactionForRequest(

--- a/src/routes/auth/plex/redirect/+page.server.ts
+++ b/src/routes/auth/plex/redirect/+page.server.ts
@@ -1,5 +1,6 @@
 import { redirect } from '@sveltejs/kit';
-import { markPinCallbackVerified } from '$lib/server/auth/pin-transactions';
+import { verifyPinCallback } from '$lib/server/auth/pin-transactions';
+import { requiresOnboarding } from '$lib/server/onboarding';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ cookies, locals, request, url }) => {
@@ -24,8 +25,17 @@ export const load: PageServerLoad = async ({ cookies, locals, request, url }) =>
 		redirect(303, '/');
 	}
 
+	const verifiedPin = await verifyPinCallback(cookies, url.searchParams.get('state'));
+
 	return {
 		flow: url.searchParams.get('flow') === 'popup' ? 'popup' : 'redirect',
-		stateVerified: await markPinCallbackVerified(cookies, url.searchParams.get('state'))
+		stateVerified: verifiedPin !== null,
+		serverPinFallback: verifiedPin
+			? {
+					pinId: verifiedPin.pinId,
+					expiresAt: verifiedPin.expiresAt.toISOString(),
+					context: (await requiresOnboarding()) ? 'onboarding' : 'landing'
+				}
+			: null
 	};
 };

--- a/src/routes/auth/plex/redirect/+page.server.ts
+++ b/src/routes/auth/plex/redirect/+page.server.ts
@@ -20,7 +20,7 @@ export const load: PageServerLoad = async ({ cookies, locals, request, url }) =>
 	const fromPlex = refererOrigin === 'https://app.plex.tv';
 	const fromSameOrigin = refererOrigin === url.origin.toLowerCase();
 
-	// Allow missing/empty referer; sessionStorage PIN check on the client is the real gate.
+	// Allow missing/empty referer; callback state verification below gates the redirect flow.
 	if (referer && !fromPlex && !fromSameOrigin) {
 		redirect(303, '/');
 	}

--- a/src/routes/auth/plex/redirect/+page.svelte
+++ b/src/routes/auth/plex/redirect/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
 import { onMount } from 'svelte';
 import { browser } from '$app/environment';
+import type { ServerPinFallback } from '$lib/client/plex-login';
 import {
 	LOGIN_TIMEOUT_MS,
 	PIN_STORAGE_KEY,
 	POLL_INTERVAL_MS,
+	resolveRedirectPinData,
 	sanitizeCompletedLoginResponse
 } from '$lib/client/plex-login';
 import type { PageData } from './$types';
@@ -16,13 +18,6 @@ let errorMessage = $state<string | null>(null);
 let { data }: { data: PageData } = $props();
 
 const MAX_POLL_ATTEMPTS = Math.floor(LOGIN_TIMEOUT_MS / POLL_INTERVAL_MS);
-const PIN_MAX_AGE_MS = 15 * 60 * 1000;
-
-interface StoredPinData {
-	pinId: number;
-	createdAt: number;
-	context: 'landing' | 'onboarding';
-}
 
 onMount(async () => {
 	if (!browser) return;
@@ -39,32 +34,11 @@ onMount(async () => {
 		return;
 	}
 
-	const storedData = sessionStorage.getItem(PIN_STORAGE_KEY);
-	if (!storedData) {
-		status = 'error';
-		errorMessage = 'No pending authentication found. Please try again.';
-		return;
-	}
-
-	let pinData: StoredPinData;
 	try {
-		pinData = JSON.parse(storedData);
-	} catch {
-		sessionStorage.removeItem(PIN_STORAGE_KEY);
-		status = 'error';
-		errorMessage = 'Invalid authentication data. Please try again.';
-		return;
-	}
-
-	const pinAge = Date.now() - pinData.createdAt;
-	if (pinAge > PIN_MAX_AGE_MS) {
-		sessionStorage.removeItem(PIN_STORAGE_KEY);
-		status = 'error';
-		errorMessage = 'Authentication session expired. Please try again.';
-		return;
-	}
-
-	try {
+		const pinData = resolveRedirectPinData(
+			sessionStorage,
+			data.serverPinFallback as ServerPinFallback | null
+		);
 		const loginResult = await pollForLogin(pinData.pinId);
 
 		if (!loginResult) {

--- a/src/routes/auth/plex/redirect/+page.svelte
+++ b/src/routes/auth/plex/redirect/+page.svelte
@@ -43,10 +43,10 @@ onMount(async () => {
 
 		if (!loginResult) {
 			status = 'cancelled';
-			sessionStorage.removeItem(PIN_STORAGE_KEY);
+			removeRedirectPinData();
 			return;
 		}
-		sessionStorage.removeItem(PIN_STORAGE_KEY);
+		removeRedirectPinData();
 
 		status = 'success';
 
@@ -57,7 +57,7 @@ onMount(async () => {
 
 		window.location.href = targetUrl;
 	} catch (err) {
-		sessionStorage.removeItem(PIN_STORAGE_KEY);
+		removeRedirectPinData();
 		status = 'error';
 		errorMessage = err instanceof Error ? err.message : 'Authentication failed';
 	}
@@ -94,8 +94,14 @@ async function pollForLogin(
 	return null;
 }
 
+function removeRedirectPinData(): void {
+	try {
+		sessionStorage.removeItem(PIN_STORAGE_KEY);
+	} catch {}
+}
+
 function handleRetry(): void {
-	sessionStorage.removeItem(PIN_STORAGE_KEY);
+	removeRedirectPinData();
 	window.location.href = '/';
 }
 </script>

--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -118,6 +118,54 @@ async function requireOnboardingCsrfAction(
 	return null;
 }
 
+async function saveCsrfOrigin({
+	request,
+	cookies,
+	url
+}: Parameters<NonNullable<Actions['saveOrigin']>>[0]) {
+	const guardResult = await requireOnboardingCsrfAction(cookies, url, 'error');
+	if (guardResult) return guardResult;
+
+	if (!isSameOriginOnboardingAction(request, url)) {
+		return fail(403, { error: 'CSRF origin must be submitted from this Obzorarr origin' });
+	}
+
+	const csrfConfig = await getCsrfConfigWithSource();
+	if (csrfConfig.origin.isLocked) {
+		return fail(400, { error: 'CSRF origin is locked via ORIGIN environment variable' });
+	}
+
+	const formData = await request.formData();
+	const result = CsrfOriginSchema.safeParse({
+		csrfOrigin: formData.get('csrfOrigin')
+	});
+
+	if (!result.success) {
+		const errorMessage = result.error.issues[0]?.message ?? 'Invalid input';
+		return fail(400, { error: errorMessage });
+	}
+
+	const actualOrigin = getRequestOrigin(request);
+	if (!actualOrigin) {
+		return fail(400, {
+			error: 'Could not detect browser origin. Ensure you are accessing via HTTP/HTTPS.'
+		});
+	}
+
+	if (!originsMatch(result.data.csrfOrigin, actualOrigin)) {
+		return fail(400, {
+			error: `Origin mismatch: browser sends "${actualOrigin}" but you configured "${result.data.csrfOrigin}"`
+		});
+	}
+
+	await setAppSetting(AppSettingsKey.CSRF_ORIGIN, result.data.csrfOrigin);
+	await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
+	logger.info(`Onboarding: CSRF origin configured - ${result.data.csrfOrigin}`, 'Onboarding');
+
+	await setOnboardingStep(OnboardingSteps.PLEX);
+	redirect(303, '/onboarding/plex');
+}
+
 export const load: PageServerLoad = async ({ request, parent }) => {
 	const parentData = await parent();
 	const csrfConfig = await getCsrfConfigWithSource();
@@ -139,6 +187,8 @@ export const load: PageServerLoad = async ({ request, parent }) => {
 };
 
 export const actions: Actions = {
+	default: saveCsrfOrigin,
+
 	testOrigin: async ({ request, cookies, url }) => {
 		const guardResult = await requireOnboardingCsrfAction(cookies, url, 'testError');
 		if (guardResult) return guardResult;
@@ -168,49 +218,9 @@ export const actions: Actions = {
 		return { testSuccess: true, testedOrigin: result.data.csrfOrigin };
 	},
 
-	saveOrigin: async ({ request, cookies, url }) => {
-		const guardResult = await requireOnboardingCsrfAction(cookies, url, 'error');
-		if (guardResult) return guardResult;
+	save: saveCsrfOrigin,
 
-		if (!isSameOriginOnboardingAction(request, url)) {
-			return fail(403, { error: 'CSRF origin must be submitted from this Obzorarr origin' });
-		}
-
-		const csrfConfig = await getCsrfConfigWithSource();
-		if (csrfConfig.origin.isLocked) {
-			return fail(400, { error: 'CSRF origin is locked via ORIGIN environment variable' });
-		}
-
-		const formData = await request.formData();
-		const result = CsrfOriginSchema.safeParse({
-			csrfOrigin: formData.get('csrfOrigin')
-		});
-
-		if (!result.success) {
-			const errorMessage = result.error.issues[0]?.message ?? 'Invalid input';
-			return fail(400, { error: errorMessage });
-		}
-
-		const actualOrigin = getRequestOrigin(request);
-		if (!actualOrigin) {
-			return fail(400, {
-				error: 'Could not detect browser origin. Ensure you are accessing via HTTP/HTTPS.'
-			});
-		}
-
-		if (!originsMatch(result.data.csrfOrigin, actualOrigin)) {
-			return fail(400, {
-				error: `Origin mismatch: browser sends "${actualOrigin}" but you configured "${result.data.csrfOrigin}"`
-			});
-		}
-
-		await setAppSetting(AppSettingsKey.CSRF_ORIGIN, result.data.csrfOrigin);
-		await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
-		logger.info(`Onboarding: CSRF origin configured - ${result.data.csrfOrigin}`, 'Onboarding');
-
-		await setOnboardingStep(OnboardingSteps.PLEX);
-		redirect(303, '/onboarding/plex');
-	},
+	saveOrigin: saveCsrfOrigin,
 
 	skipCsrf: async ({ request, cookies, url }) => {
 		const guardResult = await requireOnboardingCsrfAction(cookies, url, 'error');

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -283,6 +283,21 @@ function formatSlideLabel(slideType: string): string {
 	return labels[slideType] || slideType;
 }
 
+async function requireOnboardingSettingsClaim(
+	cookies: Parameters<NonNullable<Actions['saveSettings']>>[0]['cookies'],
+	url: URL
+) {
+	try {
+		await requireActiveOnboardingClaim(cookies, { requestUrl: url });
+	} catch (err) {
+		if (err instanceof OnboardingClaimRequiredError) {
+			return fail(403, { error: err.message });
+		}
+		throw err;
+	}
+	return null;
+}
+
 /**
  * Form actions
  */
@@ -291,16 +306,11 @@ export const actions: Actions = {
 	 * Save all settings and continue to completion
 	 */
 	saveSettings: async ({ request, locals, cookies, url }) => {
+		const guardResult = await requireOnboardingSettingsClaim(cookies, url);
+		if (guardResult) return guardResult;
+
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
-		}
-		try {
-			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
-		} catch (err) {
-			if (err instanceof OnboardingClaimRequiredError) {
-				return fail(403, { error: err.message });
-			}
-			throw err;
 		}
 
 		try {
@@ -443,16 +453,11 @@ export const actions: Actions = {
 	 * Skip settings (use defaults) and continue
 	 */
 	skipSettings: async ({ locals, cookies, url }) => {
+		const guardResult = await requireOnboardingSettingsClaim(cookies, url);
+		if (guardResult) return guardResult;
+
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
-		}
-		try {
-			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
-		} catch (err) {
-			if (err instanceof OnboardingClaimRequiredError) {
-				return fail(403, { error: err.message });
-			}
-			throw err;
 		}
 
 		logger.info(
@@ -470,16 +475,11 @@ export const actions: Actions = {
 	 * Does not fall back to stored values — onboarding submits fresh input.
 	 */
 	testAIConnection: async ({ request, locals, cookies, url }) => {
+		const guardResult = await requireOnboardingSettingsClaim(cookies, url);
+		if (guardResult) return guardResult;
+
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
-		}
-		try {
-			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
-		} catch (err) {
-			if (err instanceof OnboardingClaimRequiredError) {
-				return fail(403, { error: err.message });
-			}
-			throw err;
 		}
 
 		const formData = await request.formData();

--- a/src/routes/onboarding/sync/+page.server.ts
+++ b/src/routes/onboarding/sync/+page.server.ts
@@ -15,6 +15,21 @@ import {
 import { cancelSync } from '$lib/server/sync/progress';
 import type { Actions, PageServerLoad } from './$types';
 
+async function requireOnboardingSyncClaim(
+	cookies: Parameters<NonNullable<Actions['startSync']>>[0]['cookies'],
+	url: URL
+) {
+	try {
+		await requireActiveOnboardingClaim(cookies, { requestUrl: url });
+	} catch (err) {
+		if (err instanceof OnboardingClaimRequiredError) {
+			return fail(403, { error: err.message });
+		}
+		throw err;
+	}
+	return null;
+}
+
 export const load: PageServerLoad = async ({ parent }) => {
 	const parentData = await parent();
 
@@ -34,16 +49,11 @@ export const load: PageServerLoad = async ({ parent }) => {
 
 export const actions: Actions = {
 	startSync: async ({ locals, cookies, url }) => {
+		const guardResult = await requireOnboardingSyncClaim(cookies, url);
+		if (guardResult) return guardResult;
+
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
-		}
-		try {
-			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
-		} catch (err) {
-			if (err instanceof OnboardingClaimRequiredError) {
-				return fail(403, { error: err.message });
-			}
-			throw err;
 		}
 
 		try {
@@ -72,16 +82,11 @@ export const actions: Actions = {
 	},
 
 	cancelSync: async ({ locals, cookies, url }) => {
+		const guardResult = await requireOnboardingSyncClaim(cookies, url);
+		if (guardResult) return guardResult;
+
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
-		}
-		try {
-			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
-		} catch (err) {
-			if (err instanceof OnboardingClaimRequiredError) {
-				return fail(403, { error: err.message });
-			}
-			throw err;
 		}
 
 		const cancelled = cancelSync();
@@ -94,16 +99,11 @@ export const actions: Actions = {
 	},
 
 	continue: async ({ locals, cookies, url }) => {
+		const guardResult = await requireOnboardingSyncClaim(cookies, url);
+		if (guardResult) return guardResult;
+
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
-		}
-		try {
-			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
-		} catch (err) {
-			if (err instanceof OnboardingClaimRequiredError) {
-				return fail(403, { error: err.message });
-			}
-			throw err;
 		}
 
 		logger.info('Onboarding: Proceeding to settings (sync may still be running)', 'Onboarding');

--- a/tests/unit/auth/login-completion.test.ts
+++ b/tests/unit/auth/login-completion.test.ts
@@ -3,8 +3,9 @@ import type { Cookies } from '@sveltejs/kit';
 import * as settingsService from '$lib/server/admin/settings.service';
 import * as membership from '$lib/server/auth/membership';
 import * as plexOauth from '$lib/server/auth/plex-oauth';
+import { NotServerMemberError } from '$lib/server/auth/types';
 import { db } from '$lib/server/db/client';
-import { sessions, users } from '$lib/server/db/schema';
+import { appSettings, sessions, users } from '$lib/server/db/schema';
 import * as onboarding from '$lib/server/onboarding';
 import {
 	claimOnboardingInstance,
@@ -44,6 +45,7 @@ describe('createSessionFromPlexToken', () => {
 	let spies: Array<{ mockRestore(): void }> = [];
 
 	beforeEach(async () => {
+		await db.delete(appSettings);
 		await db.delete(sessions);
 		await db.delete(users);
 		clearBootstrapToken();
@@ -160,6 +162,63 @@ describe('createSessionFromPlexToken', () => {
 		await expect(
 			createSessionFromPlexToken('secret-auth-token', createCookies())
 		).rejects.toBeInstanceOf(OnboardingClaimRequiredError);
+	});
+
+	it('rejects configured-Plex onboarding login without an active setup claim', async () => {
+		spies.push(spyOn(onboarding, 'requiresOnboarding').mockResolvedValue(true));
+
+		const { createSessionFromPlexToken } = await import('$lib/server/auth/login-completion');
+
+		await expect(
+			createSessionFromPlexToken('secret-auth-token', createCookies())
+		).rejects.toBeInstanceOf(OnboardingClaimRequiredError);
+		expect(await db.select().from(sessions)).toHaveLength(0);
+	});
+
+	it('rejects configured-Plex onboarding login for non-owners before creating a session', async () => {
+		spies.push(spyOn(onboarding, 'requiresOnboarding').mockResolvedValue(true));
+
+		const cookies = createCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies, token)).toBe('claimed');
+
+		const { createSessionFromPlexToken } = await import('$lib/server/auth/login-completion');
+
+		try {
+			await createSessionFromPlexToken('secret-auth-token', cookies);
+			expect.unreachable('Expected non-owner onboarding login to be rejected');
+		} catch (err) {
+			expect(err).toBeInstanceOf(NotServerMemberError);
+			expect((err as Error).message).toBe(
+				'Only the server owner can configure Obzorarr. Please sign in with the server owner account.'
+			);
+		}
+		expect(await db.select().from(sessions)).toHaveLength(0);
+		expect(await db.select().from(users)).toHaveLength(0);
+	});
+
+	it('allows configured-Plex onboarding login for the server owner', async () => {
+		spies.push(
+			spyOn(onboarding, 'requiresOnboarding').mockResolvedValue(true),
+			spyOn(membership, 'requireServerMembership').mockResolvedValue({
+				isMember: true,
+				isOwner: true,
+				serverName: 'Test Plex'
+			})
+		);
+
+		const cookies = createCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies, token)).toBe('claimed');
+
+		const { createSessionFromPlexToken } = await import('$lib/server/auth/login-completion');
+		const result = await createSessionFromPlexToken('secret-auth-token', cookies);
+
+		expect(result).toEqual({
+			user: { username: 'alice', isAdmin: true },
+			redirectTo: '/admin'
+		});
+		expect(await db.select().from(sessions)).toHaveLength(1);
 	});
 
 	it('propagates unexpected setup claim renewal errors during fresh onboarding', async () => {

--- a/tests/unit/auth/pin-transactions.test.ts
+++ b/tests/unit/auth/pin-transactions.test.ts
@@ -1,14 +1,19 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import type { Cookies } from '@sveltejs/kit';
+import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
 import { completePlexPinLogin } from '$lib/server/auth/login-completion';
 import {
 	_resetPinTransactionsForTests,
 	clearPinTransaction,
 	createPinTransaction,
 	getPinTransactionForRequest,
-	markPinCallbackVerified
+	markPinCallbackVerified,
+	verifyPinCallback
 } from '$lib/server/auth/pin-transactions';
 import { PinExpiredError } from '$lib/server/auth/types';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import { load as redirectLoad } from '../../../src/routes/auth/plex/redirect/+page.server';
 
 interface CookieCall {
 	name: string;
@@ -44,6 +49,7 @@ function createCookies(): TestCookies {
 describe('Plex PIN transactions', () => {
 	beforeEach(async () => {
 		await _resetPinTransactionsForTests();
+		await db.delete(appSettings);
 	});
 
 	it('binds a PIN transaction to the browser state cookie', async () => {
@@ -83,6 +89,62 @@ describe('Plex PIN transactions', () => {
 
 		expect(await markPinCallbackVerified(cookies, state)).toBe(true);
 		expect((await getPinTransactionForRequest(123, cookies))?.callbackVerified).toBe(true);
+	});
+
+	it('returns a server PIN fallback for a verified callback state', async () => {
+		const cookies = createCookies();
+		const state = await createPinTransaction(123, cookies);
+
+		const verified = await verifyPinCallback(cookies, state);
+
+		expect(verified?.pinId).toBe(123);
+		expect(verified?.expiresAt).toBeInstanceOf(Date);
+		expect(JSON.stringify(verified)).not.toContain('token');
+	});
+
+	it('redirect load exposes the verified server PIN fallback without tokens', async () => {
+		const cookies = createCookies();
+		const state = await createPinTransaction(456, cookies);
+
+		const result = await redirectLoad({
+			cookies,
+			locals: {},
+			request: new Request(`http://localhost/auth/plex/redirect?state=${state}`, {
+				headers: { referer: 'https://app.plex.tv' }
+			}),
+			url: new URL(`http://localhost/auth/plex/redirect?state=${state}`)
+		} as unknown as Parameters<typeof redirectLoad>[0]);
+
+		expect(result).toMatchObject({
+			flow: 'redirect',
+			stateVerified: true,
+			serverPinFallback: {
+				pinId: 456,
+				context: 'onboarding'
+			}
+		});
+		expect(JSON.stringify(result)).not.toContain('token');
+	});
+
+	it('redirect load marks the server PIN fallback as landing after onboarding is complete', async () => {
+		await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+		const cookies = createCookies();
+		const state = await createPinTransaction(789, cookies);
+
+		const result = await redirectLoad({
+			cookies,
+			locals: {},
+			request: new Request(`http://localhost/auth/plex/redirect?state=${state}`),
+			url: new URL(`http://localhost/auth/plex/redirect?state=${state}`)
+		} as unknown as Parameters<typeof redirectLoad>[0]);
+
+		expect(result).toMatchObject({
+			stateVerified: true,
+			serverPinFallback: {
+				pinId: 789,
+				context: 'landing'
+			}
+		});
 	});
 
 	it('does not poll Plex or create a session before callback verification', async () => {

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -10,7 +10,12 @@ import {
 } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
-import { getOnboardingStep, OnboardingSteps, setOnboardingStep } from '$lib/server/onboarding';
+import {
+	getOnboardingStep,
+	ONBOARDING_CLAIM_REQUIRED_MESSAGE,
+	OnboardingSteps,
+	setOnboardingStep
+} from '$lib/server/onboarding';
 import {
 	claimOnboardingInstance,
 	clearBootstrapToken,
@@ -21,6 +26,8 @@ import { actions } from '../../../src/routes/onboarding/csrf/+page.server';
 const ORIGIN = 'http://localhost:5173';
 const OVERSIZED_BROWSER_ORIGIN = `https://wrapped.example.com/${'a'.repeat(2049)}`;
 type SaveOriginAction = NonNullable<typeof actions.saveOrigin>;
+type SaveAction = NonNullable<typeof actions.save>;
+type DefaultAction = NonNullable<typeof actions.default>;
 type SkipCsrfAction = NonNullable<typeof actions.skipCsrf>;
 type TestOriginAction = NonNullable<typeof actions.testOrigin>;
 type DiagnoseReverseProxyAction = NonNullable<typeof actions.diagnoseReverseProxy>;
@@ -120,6 +127,24 @@ async function runSaveOrigin(request: Request) {
 		cookies,
 		url: new URL(request.url)
 	} as unknown as Parameters<SaveOriginAction>[0]);
+}
+
+async function runSave(request: Request) {
+	const save = actions.save as SaveAction;
+	return save({
+		request,
+		cookies,
+		url: new URL(request.url)
+	} as unknown as Parameters<SaveAction>[0]);
+}
+
+async function runDefault(request: Request) {
+	const defaultAction = actions.default as DefaultAction;
+	return defaultAction({
+		request,
+		cookies,
+		url: new URL(request.url)
+	} as unknown as Parameters<DefaultAction>[0]);
 }
 
 async function runTestOrigin(request: Request) {
@@ -256,6 +281,33 @@ describe('onboarding CSRF actions', () => {
 
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.PLEX);
+	});
+
+	it('saves a matching CSRF origin through the save alias', async () => {
+		await expectRedirect(() => runSave(createFormRequest(ORIGIN)), '/onboarding/plex');
+
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.PLEX);
+	});
+
+	it('saves a matching CSRF origin through the default action', async () => {
+		await expectRedirect(() => runDefault(createFormRequest(ORIGIN)), '/onboarding/plex');
+
+		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.PLEX);
+	});
+
+	it('returns setup-claim-required for save aliases without an active claim', async () => {
+		cookies = createCookies();
+
+		expect(await runSave(createFormRequest(ORIGIN))).toEqual({
+			status: 403,
+			data: { error: ONBOARDING_CLAIM_REQUIRED_MESSAGE }
+		});
+		expect(await runDefault(createFormRequest(ORIGIN))).toEqual({
+			status: 403,
+			data: { error: ONBOARDING_CLAIM_REQUIRED_MESSAGE }
+		});
 	});
 
 	it('saves a matching CSRF origin when the browser origin has an explicit default port', async () => {

--- a/tests/unit/onboarding/page-action-claim-errors.test.ts
+++ b/tests/unit/onboarding/page-action-claim-errors.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from 'bun:test';
+import { beforeEach, describe, expect, it } from 'bun:test';
 import type { Cookies } from '@sveltejs/kit';
-import { ONBOARDING_CLAIM_REQUIRED_MESSAGE } from '$lib/server/onboarding/bootstrap';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken,
+	ONBOARDING_CLAIM_REQUIRED_MESSAGE
+} from '$lib/server/onboarding/bootstrap';
 import { actions as plexActions } from '../../../src/routes/onboarding/plex/+page.server';
 import { actions as settingsActions } from '../../../src/routes/onboarding/settings/+page.server';
 import { actions as syncActions } from '../../../src/routes/onboarding/sync/+page.server';
@@ -9,6 +16,12 @@ type Action = (event: unknown) => Promise<unknown>;
 
 const adminLocals = {
 	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
+} as unknown as App.Locals;
+
+const anonymousLocals = {} as App.Locals;
+
+const nonAdminLocals = {
+	user: { id: 2, plexId: 2, username: 'user', isAdmin: false }
 } as unknown as App.Locals;
 
 const claimCheckedActions = [
@@ -24,20 +37,38 @@ const claimCheckedActions = [
 	['sync.continue', syncActions.continue]
 ] as const;
 
+const adminRequiredActions = [
+	['settings.saveSettings', settingsActions.saveSettings],
+	['settings.skipSettings', settingsActions.skipSettings],
+	['settings.testAIConnection', settingsActions.testAIConnection],
+	['sync.startSync', syncActions.startSync],
+	['sync.cancelSync', syncActions.cancelSync],
+	['sync.continue', syncActions.continue]
+] as const;
+
 function makeCookies(errorToThrow?: Error): Cookies {
+	const values = new Map<string, string>();
 	return {
 		get: () => {
 			if (errorToThrow) throw errorToThrow;
-			return undefined;
+			return values.get('obzorarr_onboarding_claim');
 		},
 		getAll: () => [],
-		set: () => {},
-		delete: () => {},
+		set: (name: string, value: string) => {
+			values.set(name, value);
+		},
+		delete: (name: string) => {
+			values.delete(name);
+		},
 		serialize: () => ''
 	} as unknown as Cookies;
 }
 
-async function runAction(action: unknown, cookies: Cookies): Promise<unknown> {
+async function runAction(
+	action: unknown,
+	cookies: Cookies,
+	locals: App.Locals = adminLocals
+): Promise<unknown> {
 	const request = new Request('http://localhost/onboarding', {
 		method: 'POST',
 		body: new FormData()
@@ -45,13 +76,18 @@ async function runAction(action: unknown, cookies: Cookies): Promise<unknown> {
 
 	return (action as Action)({
 		request,
-		locals: adminLocals,
+		locals,
 		cookies,
 		url: new URL(request.url)
 	});
 }
 
 describe('onboarding page action claim checks', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		clearBootstrapToken();
+	});
+
 	for (const [name, action] of claimCheckedActions) {
 		it(`${name} returns the expected claim-required failure`, async () => {
 			const result = await runAction(action, makeCookies());
@@ -71,6 +107,26 @@ describe('onboarding page action claim checks', () => {
 			} catch (err) {
 				expect(err).toBe(unexpected);
 			}
+		});
+	}
+
+	for (const [name, action] of adminRequiredActions) {
+		it(`${name} preserves the admin failure after a valid setup claim`, async () => {
+			const cookies = makeCookies();
+			const token = createBootstrapToken();
+			expect(await claimOnboardingInstance(cookies, token)).toBe('claimed');
+
+			const anonymousResult = await runAction(action, cookies, anonymousLocals);
+			expect(anonymousResult).toMatchObject({
+				status: 403,
+				data: { error: 'Admin access required' }
+			});
+
+			const nonAdminResult = await runAction(action, cookies, nonAdminLocals);
+			expect(nonAdminResult).toMatchObject({
+				status: 403,
+				data: { error: 'Admin access required' }
+			});
 		});
 	}
 });

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import {
 	PIN_STORAGE_KEY,
+	resolveRedirectPinData,
 	sanitizeCompletedLoginResponse,
 	startPlexLoginPopup,
 	startPlexLoginRedirect
@@ -296,6 +297,50 @@ describe('startPlexLoginRedirect', () => {
 		expect(receivedError).toBe('Plex unreachable');
 		expect(location.href).toBe(originalHref);
 		expect(sessionStorage.getItem(PIN_STORAGE_KEY)).toBeNull();
+	});
+});
+
+describe('resolveRedirectPinData', () => {
+	it('prefers sessionStorage PIN data over the server fallback', () => {
+		const storage = createSessionStorage();
+		storage.setItem(
+			PIN_STORAGE_KEY,
+			JSON.stringify({ pinId: 111, createdAt: 1000, context: 'landing' })
+		);
+
+		expect(
+			resolveRedirectPinData(
+				storage,
+				{ pinId: 222, expiresAt: new Date(60_000).toISOString(), context: 'onboarding' },
+				2000
+			)
+		).toEqual({ pinId: 111, createdAt: 1000, context: 'landing' });
+	});
+
+	it('uses the server fallback when sessionStorage is absent', () => {
+		const storage = createSessionStorage();
+
+		expect(
+			resolveRedirectPinData(
+				storage,
+				{ pinId: 222, expiresAt: new Date(60_000).toISOString(), context: 'onboarding' },
+				2000
+			)
+		).toEqual({ pinId: 222, createdAt: 2000, context: 'onboarding' });
+	});
+
+	it('does not use the server fallback when stored PIN data is invalid', () => {
+		const storage = createSessionStorage();
+		storage.setItem(PIN_STORAGE_KEY, '{bad-json');
+
+		expect(() =>
+			resolveRedirectPinData(
+				storage,
+				{ pinId: 222, expiresAt: new Date(60_000).toISOString(), context: 'onboarding' },
+				2000
+			)
+		).toThrow('Invalid authentication data. Please try again.');
+		expect(storage.getItem(PIN_STORAGE_KEY)).toBeNull();
 	});
 });
 

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -329,6 +329,25 @@ describe('resolveRedirectPinData', () => {
 		).toEqual({ pinId: 222, createdAt: 2000, context: 'onboarding' });
 	});
 
+	it('uses the server fallback when sessionStorage cannot be read', () => {
+		const storage: Pick<Storage, 'getItem' | 'removeItem'> = {
+			getItem: () => {
+				throw new Error('Storage blocked');
+			},
+			removeItem: () => {
+				throw new Error('Storage blocked');
+			}
+		};
+
+		expect(
+			resolveRedirectPinData(
+				storage,
+				{ pinId: 222, expiresAt: new Date(60_000).toISOString(), context: 'onboarding' },
+				2000
+			)
+		).toEqual({ pinId: 222, createdAt: 2000, context: 'onboarding' });
+	});
+
 	it('does not use the server fallback when stored PIN data is invalid', () => {
 		const storage = createSessionStorage();
 		storage.setItem(PIN_STORAGE_KEY, '{bad-json');
@@ -341,6 +360,23 @@ describe('resolveRedirectPinData', () => {
 			)
 		).toThrow('Invalid authentication data. Please try again.');
 		expect(storage.getItem(PIN_STORAGE_KEY)).toBeNull();
+	});
+
+	it('reports invalid stored PIN data when sessionStorage cannot be cleared', () => {
+		const storage: Pick<Storage, 'getItem' | 'removeItem'> = {
+			getItem: () => '{bad-json',
+			removeItem: () => {
+				throw new Error('Storage blocked');
+			}
+		};
+
+		expect(() =>
+			resolveRedirectPinData(
+				storage,
+				{ pinId: 222, expiresAt: new Date(60_000).toISOString(), context: 'onboarding' },
+				2000
+			)
+		).toThrow('Invalid authentication data. Please try again.');
 	});
 });
 


### PR DESCRIPTION
## Summary

This PR fixes the onboarding QA findings around setup-claim enforcement and Plex OAuth completion. It keeps the changes scoped to incomplete onboarding behavior and leaves post-onboarding auth/share behavior unchanged.

## Changes

- Add `/onboarding/csrf` POST compatibility aliases so the default action and `?/save` delegate to the existing CSRF origin save path.
- Require the active onboarding setup claim before admin checks on claim-bound sync and settings actions.
- Require an active setup claim during incomplete onboarding before Plex OAuth session creation, including env/configured Plex flows.
- Return the intended owner-only setup message for configured-Plex onboarding attempts by non-owner accounts without creating users or sessions.
- Add a verified server-side PIN fallback for `/auth/plex/redirect` so direct redirect flows can continue when browser `sessionStorage` is unavailable.
- Add regression coverage for onboarding action guard precedence, CSRF aliases, configured-Plex onboarding login completion, PIN fallback exposure, and redirect PIN selection.

## Verification

- `bun run check`
- `bun run check:biome`
- `bun run test`
- `bun run test tests/unit/onboarding/csrf-actions.test.ts tests/unit/onboarding/page-action-claim-errors.test.ts tests/unit/auth/login-completion.test.ts tests/unit/auth/pin-transactions.test.ts tests/unit/plex-login.test.ts`
