### PR TITLE
fix: remove default onboarding csrf action

### DIFF
--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -187,8 +187,6 @@ export const load: PageServerLoad = async ({ request, parent }) => {
 };
 
 export const actions: Actions = {
-	default: saveCsrfOrigin,
-
 	testOrigin: async ({ request, cookies, url }) => {
 		const guardResult = await requireOnboardingCsrfAction(cookies, url, 'testError');
 		if (guardResult) return guardResult;

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -27,7 +27,6 @@ const ORIGIN = 'http://localhost:5173';
 const OVERSIZED_BROWSER_ORIGIN = `https://wrapped.example.com/${'a'.repeat(2049)}`;
 type SaveOriginAction = NonNullable<typeof actions.saveOrigin>;
 type SaveAction = NonNullable<typeof actions.save>;
-type DefaultAction = NonNullable<typeof actions.default>;
 type SkipCsrfAction = NonNullable<typeof actions.skipCsrf>;
 type TestOriginAction = NonNullable<typeof actions.testOrigin>;
 type DiagnoseReverseProxyAction = NonNullable<typeof actions.diagnoseReverseProxy>;
@@ -138,15 +137,6 @@ async function runSave(request: Request) {
 	} as unknown as Parameters<SaveAction>[0]);
 }
 
-async function runDefault(request: Request) {
-	const defaultAction = actions.default as DefaultAction;
-	return defaultAction({
-		request,
-		cookies,
-		url: new URL(request.url)
-	} as unknown as Parameters<DefaultAction>[0]);
-}
-
 async function runTestOrigin(request: Request) {
 	const testOrigin = actions.testOrigin as TestOriginAction;
 	return testOrigin({ request, cookies } as unknown as Parameters<TestOriginAction>[0]);
@@ -208,6 +198,17 @@ describe('onboarding CSRF actions', () => {
 	afterEach(() => {
 		if (previousTrustProxyEnv === undefined) delete envRecord().TRUST_PROXY;
 		else envRecord().TRUST_PROXY = previousTrustProxyEnv;
+	});
+
+	it('does not export a default action alongside named actions', () => {
+		expect('default' in actions).toBe(false);
+		expect(actions.default).toBeUndefined();
+		expect(typeof actions.testOrigin).toBe('function');
+		expect(typeof actions.save).toBe('function');
+		expect(typeof actions.saveOrigin).toBe('function');
+		expect(typeof actions.skipCsrf).toBe('function');
+		expect(typeof actions.diagnoseReverseProxy).toBe('function');
+		expect(typeof actions.enableTrustProxy).toBe('function');
 	});
 
 	it('test origin succeeds when the submitted origin matches the browser origin', async () => {
@@ -290,21 +291,10 @@ describe('onboarding CSRF actions', () => {
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.PLEX);
 	});
 
-	it('saves a matching CSRF origin through the default action', async () => {
-		await expectRedirect(() => runDefault(createFormRequest(ORIGIN)), '/onboarding/plex');
-
-		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
-		expect(await getOnboardingStep()).toBe(OnboardingSteps.PLEX);
-	});
-
-	it('returns setup-claim-required for save aliases without an active claim', async () => {
+	it('returns setup-claim-required for the save alias without an active claim', async () => {
 		cookies = createCookies();
 
 		expect(await runSave(createFormRequest(ORIGIN))).toEqual({
-			status: 403,
-			data: { error: ONBOARDING_CLAIM_REQUIRED_MESSAGE }
-		});
-		expect(await runDefault(createFormRequest(ORIGIN))).toEqual({
 			status: 403,
 			data: { error: ONBOARDING_CLAIM_REQUIRED_MESSAGE }
 		});


### PR DESCRIPTION
## Summary

Fixes the onboarding CSRF form-action runtime failure caused by exporting both a default action and named actions from the same SvelteKit page.

SvelteKit rejects that mixed action shape at runtime, which caused named onboarding CSRF actions such as `?/diagnoseReverseProxy`, `?/testOrigin`, and `?/saveOrigin` to return 500s before their handlers could complete. The CSRF page UI already posts to named actions, so this removes the unsupported default action and keeps the named aliases intact.

## Changes

- Removed the `default` action export from `src/routes/onboarding/csrf/+page.server.ts`.
- Kept the named actions used by the UI: `testOrigin`, `save`, `saveOrigin`, `skipCsrf`, `diagnoseReverseProxy`, and `enableTrustProxy`.
- Updated CSRF action unit tests to stop treating the unnamed/default POST path as supported.
- Added a regression test asserting that the CSRF page does not export `actions.default` alongside named actions.

## Verification

- Confirmed the new regression test failed before the fix because `actions.default` existed.
- Ran `bun test --env-file=.env.test tests/unit/onboarding/csrf-actions.test.ts` with 36 passing tests.
- Ran `bun run check` with 0 errors and 0 warnings.
- Ran `bun run check:biome` successfully.
- Reproduced the original named action paths against the dev server:
  - `?/diagnoseReverseProxy` returned a SvelteKit action success payload instead of 500.
  - `?/testOrigin` returned a clear origin mismatch failure payload instead of 500.
  - `?/saveOrigin` redirected to `/onboarding/plex` instead of 500.
- Re-tested with `agent-browser` against the previous dogfood failure path. The diagnostic rendered, mismatch showed the specific error, and save advanced to `/onboarding/plex`.
- A GPT-5.5 medium subagent independently verified the same browser path with `agent-browser` and did not observe the old SvelteKit default-action error.

## Notes

The unnamed/default POST path is intentionally unsupported for this page. The `save` named alias remains in place for compatibility.
