### PR TITLE
fix: resolve dogfood qa regressions

### DIFF
--- a/src/lib/server/logging/redactor.ts
+++ b/src/lib/server/logging/redactor.ts
@@ -1,4 +1,5 @@
 const REDACTED = '<redacted>';
+const SENSITIVE_METADATA_KEY = /^(?:authToken|token|accessToken|secret|password|cookie|session)$/i;
 
 const SENSITIVE_QUERY_PARAM =
 	/([?&](?:token|access_token|auth_token|api_key|apikey|key|x-plex-token)=)[^&#\s"'`]+/gi;
@@ -22,7 +23,10 @@ export function redactLogMessage(message: string): string {
 
 export function redactLogMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
 	return Object.fromEntries(
-		Object.entries(metadata).map(([key, value]) => [key, redactMetadataValue(value)])
+		Object.entries(metadata).map(([key, value]) => [
+			key,
+			SENSITIVE_METADATA_KEY.test(key) ? REDACTED : redactMetadataValue(value)
+		])
 	);
 }
 

--- a/src/lib/server/logging/redactor.ts
+++ b/src/lib/server/logging/redactor.ts
@@ -1,5 +1,6 @@
 const REDACTED = '<redacted>';
-const SENSITIVE_METADATA_KEY = /^(?:authToken|token|accessToken|secret|password|cookie|session)$/i;
+const SENSITIVE_METADATA_KEY =
+	/^(?:authToken|auth_token|token|accessToken|access_token|secret|password|cookie|set-cookie|session|authorization|x-plex-token|plexToken|apiKey|api_key|apikey)$/i;
 
 const SENSITIVE_QUERY_PARAM =
 	/([?&](?:token|access_token|auth_token|api_key|apikey|key|x-plex-token)=)[^&#\s"'`]+/gi;

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -51,6 +51,10 @@ let syncedFrequencyKey = $state(
 	untrack(() => `${data.funFactFrequency.mode}:${data.funFactFrequency.count}`)
 );
 
+function selectFrequencyMode(mode: typeof data.funFactFrequency.mode): void {
+	selectedFrequencyMode = mode;
+}
+
 // Avoid resetting the radio while the user is selecting Custom before submit.
 $effect(() => {
 	const frequencyKey = `${data.funFactFrequency.mode}:${data.funFactFrequency.count}`;
@@ -476,7 +480,13 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 		>
 			<div class="frequency-options">
 				<label class="frequency-option">
-					<input type="radio" name="mode" value="few" bind:group={selectedFrequencyMode} />
+					<input
+						type="radio"
+						name="mode"
+						value="few"
+						checked={selectedFrequencyMode === 'few'}
+						onchange={() => selectFrequencyMode('few')}
+					/>
 					<span class="frequency-label">
 						<span class="frequency-name">Few</span>
 						<span class="frequency-desc">2 fun facts</span>
@@ -484,7 +494,13 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 				</label>
 
 				<label class="frequency-option">
-					<input type="radio" name="mode" value="normal" bind:group={selectedFrequencyMode} />
+					<input
+						type="radio"
+						name="mode"
+						value="normal"
+						checked={selectedFrequencyMode === 'normal'}
+						onchange={() => selectFrequencyMode('normal')}
+					/>
 					<span class="frequency-label">
 						<span class="frequency-name">Normal</span>
 						<span class="frequency-desc">4 fun facts</span>
@@ -492,7 +508,13 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 				</label>
 
 				<label class="frequency-option">
-					<input type="radio" name="mode" value="many" bind:group={selectedFrequencyMode} />
+					<input
+						type="radio"
+						name="mode"
+						value="many"
+						checked={selectedFrequencyMode === 'many'}
+						onchange={() => selectFrequencyMode('many')}
+					/>
 					<span class="frequency-label">
 						<span class="frequency-name">Many</span>
 						<span class="frequency-desc">8 fun facts</span>
@@ -500,7 +522,13 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 				</label>
 
 				<label class="frequency-option">
-					<input type="radio" name="mode" value="custom" bind:group={selectedFrequencyMode} />
+					<input
+						type="radio"
+						name="mode"
+						value="custom"
+						checked={selectedFrequencyMode === 'custom'}
+						onchange={() => selectFrequencyMode('custom')}
+					/>
 					<span class="frequency-label">
 						<span class="frequency-name">Custom</span>
 						<span class="frequency-desc">1-15 fun facts</span>

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -13,6 +13,7 @@ import type { ActionData, PageData } from './$types';
  */
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
+let failedAvatarUserIds = $state<Set<number>>(new Set());
 
 // Show toast notifications for form responses
 $effect(() => {
@@ -46,6 +47,14 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 		default:
 			return 'Default';
 	}
+}
+
+function hasVisibleAvatar(user: (typeof data.users)[number]): boolean {
+	return !!user.thumb && !failedAvatarUserIds.has(user.id);
+}
+
+function markAvatarFailed(userId: number): void {
+	failedAvatarUserIds = new Set(failedAvatarUserIds).add(userId);
 }
 </script>
 
@@ -104,8 +113,13 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 								<td>
 										<div class="user-cell">
 											<span class="user-avatar-link" aria-hidden="true">
-												{#if user.thumb}
-													<img src={user.thumb} alt="" class="user-avatar" />
+												{#if hasVisibleAvatar(user)}
+													<img
+														src={user.thumb ?? ''}
+														alt=""
+														class="user-avatar"
+														onerror={() => markAvatarFailed(user.id)}
+													/>
 												{:else}
 													<span class="user-avatar placeholder">&#9787;</span>
 												{/if}
@@ -197,8 +211,13 @@ function getShareModeLabel(mode: string | null, source: string | null): string {
 							<div class="mobile-user-row">
 							<div class="mobile-user-main">
 								<span class="user-avatar-link" aria-hidden="true">
-									{#if user.thumb}
-										<img src={user.thumb} alt="" class="user-avatar" />
+									{#if hasVisibleAvatar(user)}
+										<img
+											src={user.thumb ?? ''}
+											alt=""
+											class="user-avatar"
+											onerror={() => markAvatarFailed(user.id)}
+										/>
 									{:else}
 										<span class="user-avatar placeholder">&#9787;</span>
 									{/if}

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -160,6 +160,7 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain("checked={selectedFrequencyMode === 'many'}");
 		expect(source).toContain("checked={selectedFrequencyMode === 'custom'}");
 		expect(source).toContain("onchange={() => selectFrequencyMode('few')}");
+		expect(source).toContain("onchange={() => selectFrequencyMode('normal')}");
 		expect(source).toContain("onchange={() => selectFrequencyMode('many')}");
 		expect(source).toContain("onchange={() => selectFrequencyMode('custom')}");
 		expect(source).not.toContain('bind:group={selectedFrequencyMode}');

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -152,6 +152,17 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain(
 			'syncedFrequencyKey = `$' + '{frequency.mode}:$' + '{frequency.count}`;'
 		);
+		expect(source).toContain(
+			'function selectFrequencyMode(mode: typeof data.funFactFrequency.mode): void'
+		);
+		expect(source).toContain("checked={selectedFrequencyMode === 'few'}");
+		expect(source).toContain("checked={selectedFrequencyMode === 'normal'}");
+		expect(source).toContain("checked={selectedFrequencyMode === 'many'}");
+		expect(source).toContain("checked={selectedFrequencyMode === 'custom'}");
+		expect(source).toContain("onchange={() => selectFrequencyMode('few')}");
+		expect(source).toContain("onchange={() => selectFrequencyMode('many')}");
+		expect(source).toContain("onchange={() => selectFrequencyMode('custom')}");
+		expect(source).not.toContain('bind:group={selectedFrequencyMode}');
 		expect(source).not.toContain('class="frequency-options" onclick');
 	});
 
@@ -238,7 +249,14 @@ describe('admin UI source regressions', () => {
 
 		expect(source).toContain('<span class="user-avatar-link" aria-hidden="true">');
 		expect(source).not.toContain('<a href={user.wrappedHref} class="user-avatar-link">');
-		expect(source).toContain('<img src={user.thumb} alt="" class="user-avatar" />');
+		expect(source).toContain(
+			'function hasVisibleAvatar(user: (typeof data.users)[number]): boolean'
+		);
+		expect(source).toContain('function markAvatarFailed(userId: number): void');
+		expect(source).toContain('{#if hasVisibleAvatar(user)}');
+		expect(source).toContain('onerror={() => markAvatarFailed(user.id)}');
+		expect(source.match(/onerror=\{\(\) => markAvatarFailed\(user\.id\)\}/g)).toHaveLength(2);
+		expect(source).toContain('<span class="user-avatar placeholder">&#9787;</span>');
 		expect(source).toContain('{#if user.hasWatchHistory}');
 		expect(source).toContain('<a href={user.wrappedHref} class="user-name">');
 		expect(source).toContain('class="preview-link"');

--- a/tests/unit/logging/logger.test.ts
+++ b/tests/unit/logging/logger.test.ts
@@ -148,7 +148,19 @@ describe('Logger', () => {
 				await logger.debug(
 					'GET https://user:pass@example.com/?X-Plex-Token=secret Authorization: Bearer secret Cookie: session=secret',
 					'Debug',
-					{ url: 'https://example.com/?token=secret' }
+					{
+						url: 'https://example.com/?token=secret',
+						authToken: 'provider-auth-token',
+						token: 'provider-token',
+						accessToken: 'provider-access-token',
+						secret: 'provider-secret',
+						password: 'provider-password',
+						cookie: 'provider-cookie',
+						session: 'provider-session',
+						nested: {
+							authToken: 'nested-provider-auth-token'
+						}
+					}
 				);
 				await logger.forceFlush();
 			} finally {
@@ -161,7 +173,16 @@ describe('Logger', () => {
 			expect(debugLog?.message).not.toContain('secret');
 			expect(debugLog?.message).not.toContain('user:pass');
 			expect(calls[0]).toBe(`[Debug] ${debugLog?.message}`);
-			expect(debugLog?.metadata).not.toContain('secret');
+			expect(debugLog?.metadata).not.toContain('session=secret');
+			expect(debugLog?.metadata).not.toContain('token=secret');
+			expect(debugLog?.metadata).not.toContain('provider-secret');
+			expect(debugLog?.metadata).not.toContain('provider-auth-token');
+			expect(debugLog?.metadata).not.toContain('provider-token');
+			expect(debugLog?.metadata).not.toContain('provider-access-token');
+			expect(debugLog?.metadata).not.toContain('provider-password');
+			expect(debugLog?.metadata).not.toContain('provider-cookie');
+			expect(debugLog?.metadata).not.toContain('provider-session');
+			expect(debugLog?.metadata).not.toContain('nested-provider-auth-token');
 		});
 
 		it('caches debug enabled setting', async () => {

--- a/tests/unit/logging/logger.test.ts
+++ b/tests/unit/logging/logger.test.ts
@@ -153,12 +153,20 @@ describe('Logger', () => {
 						authToken: 'provider-auth-token',
 						token: 'provider-token',
 						accessToken: 'provider-access-token',
+						access_token: 'provider-snake-access-token',
+						auth_token: 'provider-snake-auth-token',
+						authorization: 'Bearer provider-authorization-token',
+						'X-Plex-Token': 'provider-plex-token',
+						apiKey: 'provider-api-key',
+						api_key: 'provider-snake-api-key',
 						secret: 'provider-secret',
 						password: 'provider-password',
 						cookie: 'provider-cookie',
+						'Set-Cookie': 'provider-set-cookie',
 						session: 'provider-session',
 						nested: {
-							authToken: 'nested-provider-auth-token'
+							authToken: 'nested-provider-auth-token',
+							auth_token: 'nested-provider-snake-auth-token'
 						}
 					}
 				);
@@ -173,16 +181,33 @@ describe('Logger', () => {
 			expect(debugLog?.message).not.toContain('secret');
 			expect(debugLog?.message).not.toContain('user:pass');
 			expect(calls[0]).toBe(`[Debug] ${debugLog?.message}`);
+			const metadata = JSON.parse(debugLog?.metadata ?? '{}') as Record<string, unknown>;
+			expect(metadata.access_token).toBe('<redacted>');
+			expect(metadata.auth_token).toBe('<redacted>');
+			expect(metadata.authorization).toBe('<redacted>');
+			expect(metadata['X-Plex-Token']).toBe('<redacted>');
+			expect(metadata.apiKey).toBe('<redacted>');
+			expect(metadata.api_key).toBe('<redacted>');
+			expect(metadata['Set-Cookie']).toBe('<redacted>');
+			expect((metadata.nested as Record<string, unknown>).auth_token).toBe('<redacted>');
 			expect(debugLog?.metadata).not.toContain('session=secret');
 			expect(debugLog?.metadata).not.toContain('token=secret');
 			expect(debugLog?.metadata).not.toContain('provider-secret');
 			expect(debugLog?.metadata).not.toContain('provider-auth-token');
+			expect(debugLog?.metadata).not.toContain('provider-snake-access-token');
+			expect(debugLog?.metadata).not.toContain('provider-snake-auth-token');
+			expect(debugLog?.metadata).not.toContain('provider-authorization-token');
+			expect(debugLog?.metadata).not.toContain('provider-plex-token');
+			expect(debugLog?.metadata).not.toContain('provider-api-key');
+			expect(debugLog?.metadata).not.toContain('provider-snake-api-key');
 			expect(debugLog?.metadata).not.toContain('provider-token');
 			expect(debugLog?.metadata).not.toContain('provider-access-token');
 			expect(debugLog?.metadata).not.toContain('provider-password');
 			expect(debugLog?.metadata).not.toContain('provider-cookie');
+			expect(debugLog?.metadata).not.toContain('provider-set-cookie');
 			expect(debugLog?.metadata).not.toContain('provider-session');
 			expect(debugLog?.metadata).not.toContain('nested-provider-auth-token');
+			expect(debugLog?.metadata).not.toContain('nested-provider-snake-auth-token');
 		});
 
 		it('caches debug enabled setting', async () => {

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -153,6 +153,12 @@ function createSessionStorage(): MemoryStorage {
 	};
 }
 
+function createConsoleRecorder(consoleCalls: string[]) {
+	return mock((...messages: unknown[]) => {
+		consoleCalls.push(messages.map((message) => Bun.inspect(message, { depth: 10 })).join(' '));
+	});
+}
+
 interface MockLocation {
 	origin: string;
 	href: string;
@@ -193,6 +199,8 @@ describe('startPlexLoginRedirect', () => {
 	let originalConsoleLog: typeof console.log;
 	let originalConsoleDebug: typeof console.debug;
 	let originalConsoleInfo: typeof console.info;
+	let originalConsoleWarn: typeof console.warn;
+	let originalConsoleError: typeof console.error;
 	let consoleCalls: string[];
 
 	beforeEach(() => {
@@ -203,12 +211,14 @@ describe('startPlexLoginRedirect', () => {
 		originalConsoleLog = console.log;
 		originalConsoleDebug = console.debug;
 		originalConsoleInfo = console.info;
-		const recordConsole = mock((message: unknown) => {
-			consoleCalls.push(String(message));
-		});
+		originalConsoleWarn = console.warn;
+		originalConsoleError = console.error;
+		const recordConsole = createConsoleRecorder(consoleCalls);
 		console.log = recordConsole as typeof console.log;
 		console.debug = recordConsole as typeof console.debug;
 		console.info = recordConsole as typeof console.info;
+		console.warn = recordConsole as typeof console.warn;
+		console.error = recordConsole as typeof console.error;
 	});
 
 	afterEach(() => {
@@ -216,6 +226,8 @@ describe('startPlexLoginRedirect', () => {
 		console.log = originalConsoleLog;
 		console.debug = originalConsoleDebug;
 		console.info = originalConsoleInfo;
+		console.warn = originalConsoleWarn;
+		console.error = originalConsoleError;
 	});
 
 	it('fetches PIN with same-origin redirectUrl, persists pin to sessionStorage, navigates to authUrl', async () => {
@@ -439,6 +451,8 @@ describe('startPlexLoginPopup', () => {
 	let originalConsoleLog: typeof console.log;
 	let originalConsoleDebug: typeof console.debug;
 	let originalConsoleInfo: typeof console.info;
+	let originalConsoleWarn: typeof console.warn;
+	let originalConsoleError: typeof console.error;
 	let consoleCalls: string[];
 
 	beforeEach(() => {
@@ -446,12 +460,14 @@ describe('startPlexLoginPopup', () => {
 		originalConsoleLog = console.log;
 		originalConsoleDebug = console.debug;
 		originalConsoleInfo = console.info;
-		const recordConsole = mock((message: unknown) => {
-			consoleCalls.push(String(message));
-		});
+		originalConsoleWarn = console.warn;
+		originalConsoleError = console.error;
+		const recordConsole = createConsoleRecorder(consoleCalls);
 		console.log = recordConsole as typeof console.log;
 		console.debug = recordConsole as typeof console.debug;
 		console.info = recordConsole as typeof console.info;
+		console.warn = recordConsole as typeof console.warn;
+		console.error = recordConsole as typeof console.error;
 	});
 
 	afterEach(() => {
@@ -459,6 +475,8 @@ describe('startPlexLoginPopup', () => {
 		console.log = originalConsoleLog;
 		console.debug = originalConsoleDebug;
 		console.info = originalConsoleInfo;
+		console.warn = originalConsoleWarn;
+		console.error = originalConsoleError;
 	});
 
 	it('ignores stale poll failures once login completion has started', async () => {

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -190,15 +190,32 @@ function createTimerMocks(onInterval: (callback: () => Promise<void>) => void) {
 describe('startPlexLoginRedirect', () => {
 	let location: MockLocation;
 	let sessionStorage: MemoryStorage;
+	let originalConsoleLog: typeof console.log;
+	let originalConsoleDebug: typeof console.debug;
+	let originalConsoleInfo: typeof console.info;
+	let consoleCalls: string[];
 
 	beforeEach(() => {
 		const origin = 'https://obzorarr.example';
 		location = { origin, href: `${origin}/` };
 		sessionStorage = createSessionStorage();
+		consoleCalls = [];
+		originalConsoleLog = console.log;
+		originalConsoleDebug = console.debug;
+		originalConsoleInfo = console.info;
+		const recordConsole = mock((message: unknown) => {
+			consoleCalls.push(String(message));
+		});
+		console.log = recordConsole as typeof console.log;
+		console.debug = recordConsole as typeof console.debug;
+		console.info = recordConsole as typeof console.info;
 	});
 
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
+		console.log = originalConsoleLog;
+		console.debug = originalConsoleDebug;
+		console.info = originalConsoleInfo;
 	});
 
 	it('fetches PIN with same-origin redirectUrl, persists pin to sessionStorage, navigates to authUrl', async () => {
@@ -243,6 +260,44 @@ describe('startPlexLoginRedirect', () => {
 		expect(typeof parsed.createdAt).toBe('number');
 
 		expect(location.href).toBe('https://app.plex.tv/auth#?code=ABCD');
+	});
+
+	it('does not log or persist raw provider-shaped PIN payload fields', async () => {
+		globalThis.fetch = mock(
+			async () =>
+				new Response(
+					JSON.stringify({
+						pinId: 4242,
+						authUrl: 'https://app.plex.tv/auth#?code=ABCD',
+						authToken: 'provider-auth-token',
+						token: 'provider-token',
+						accessToken: 'provider-access-token',
+						secret: 'provider-secret'
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				)
+		) as unknown as typeof fetch;
+
+		await startPlexLoginRedirect({
+			context: 'landing',
+			onError: () => {},
+			location,
+			storage: sessionStorage
+		});
+
+		const browserOwnedText = `${consoleCalls.join('\n')}\n${sessionStorage.getItem(PIN_STORAGE_KEY) ?? ''}`;
+		for (const forbidden of [
+			'authToken',
+			'token',
+			'accessToken',
+			'secret',
+			'provider-auth-token',
+			'provider-token',
+			'provider-access-token',
+			'provider-secret'
+		]) {
+			expect(browserOwnedText).not.toContain(forbidden);
+		}
 	});
 
 	it('records the onboarding context when supplied', async () => {
@@ -381,8 +436,29 @@ describe('resolveRedirectPinData', () => {
 });
 
 describe('startPlexLoginPopup', () => {
+	let originalConsoleLog: typeof console.log;
+	let originalConsoleDebug: typeof console.debug;
+	let originalConsoleInfo: typeof console.info;
+	let consoleCalls: string[];
+
+	beforeEach(() => {
+		consoleCalls = [];
+		originalConsoleLog = console.log;
+		originalConsoleDebug = console.debug;
+		originalConsoleInfo = console.info;
+		const recordConsole = mock((message: unknown) => {
+			consoleCalls.push(String(message));
+		});
+		console.log = recordConsole as typeof console.log;
+		console.debug = recordConsole as typeof console.debug;
+		console.info = recordConsole as typeof console.info;
+	});
+
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
+		console.log = originalConsoleLog;
+		console.debug = originalConsoleDebug;
+		console.info = originalConsoleInfo;
 	});
 
 	it('ignores stale poll failures once login completion has started', async () => {
@@ -468,6 +544,98 @@ describe('startPlexLoginPopup', () => {
 		expect(onError).not.toHaveBeenCalled();
 		expect(onPopupBlocked).not.toHaveBeenCalled();
 		expect(callbackCalls).toBe(0);
+	});
+
+	it('returns only sanitized user fields and never logs provider-shaped poll payloads', async () => {
+		let resolveIntervalRegistered: () => void = () => {};
+		const intervalRegistered = new Promise<void>((resolve) => {
+			resolveIntervalRegistered = resolve;
+		});
+		const intervalCallbacks: Array<() => Promise<void>> = [];
+		const timers = createTimerMocks((callback) => {
+			intervalCallbacks.push(callback);
+			resolveIntervalRegistered();
+		});
+
+		const popup: MockPopupWindow = { closed: false, close: mock(() => {}) };
+		const browserWindow: MockWindow = {
+			location: { origin: 'https://obzorarr.example', href: 'https://obzorarr.example/' },
+			open: mock(() => popup) as unknown as MockWindow['open']
+		};
+
+		globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
+			const url = typeof input === 'string' ? input : input.toString();
+			if (url === '/auth/plex' && init?.method === 'POST') {
+				return new Response(
+					JSON.stringify({
+						type: 'AUTH_COMPLETE',
+						authToken: 'provider-auth-token',
+						token: 'provider-token',
+						accessToken: 'provider-access-token',
+						secret: 'provider-secret',
+						user: {
+							id: 7,
+							plexId: '123456',
+							username: 'owner',
+							email: 'owner@example.com',
+							isAdmin: true,
+							authToken: 'nested-auth-token'
+						},
+						redirectTo: '/admin'
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				);
+			}
+			return new Response(
+				JSON.stringify({
+					pinId: 42,
+					authUrl: 'https://app.plex.tv/auth#?code=ABCD'
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } }
+			);
+		}) as unknown as typeof fetch;
+
+		const receivedUsers: unknown[] = [];
+		const onSuccess = mock(async (user: unknown) => {
+			receivedUsers.push(user);
+		});
+		const onError = mock(() => {});
+		const onPopupBlocked = mock(() => {});
+
+		startPlexLoginPopup({
+			context: 'landing',
+			onSuccess,
+			onError,
+			onPopupBlocked,
+			window: browserWindow,
+			timers
+		});
+		await intervalRegistered;
+		await (intervalCallbacks[0] as () => Promise<void>)();
+
+		expect(receivedUsers).toEqual([{ username: 'owner', isAdmin: true }]);
+		expect(onError).not.toHaveBeenCalled();
+		expect(onPopupBlocked).not.toHaveBeenCalled();
+
+		const browserOwnedText = `${consoleCalls.join('\n')}\n${JSON.stringify(receivedUsers)}`;
+		for (const forbidden of [
+			'AUTH_COMPLETE',
+			'authToken',
+			'token',
+			'accessToken',
+			'secret',
+			'plexId',
+			'email',
+			'provider-auth-token',
+			'provider-token',
+			'provider-access-token',
+			'provider-secret',
+			'nested-auth-token',
+			'owner@example.com',
+			'123456'
+		]) {
+			expect(browserOwnedText).not.toContain(forbidden);
+		}
 	});
 
 	it('surfaces server message and stops polling on 403 (NotServerMemberError)', async () => {

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -159,6 +159,43 @@ function createConsoleRecorder(consoleCalls: string[]) {
 	});
 }
 
+let consoleRecordingLock: Promise<void> = Promise.resolve();
+
+async function recordConsoleCalls(run: () => void | Promise<void>): Promise<string[]> {
+	const previousRecording = consoleRecordingLock;
+	let releaseRecording: () => void = () => {};
+	consoleRecordingLock = new Promise<void>((resolve) => {
+		releaseRecording = resolve;
+	});
+	await previousRecording;
+
+	const consoleCalls: string[] = [];
+	const originalConsoleLog = console.log;
+	const originalConsoleDebug = console.debug;
+	const originalConsoleInfo = console.info;
+	const originalConsoleWarn = console.warn;
+	const originalConsoleError = console.error;
+	const recordConsole = createConsoleRecorder(consoleCalls);
+	console.log = recordConsole as typeof console.log;
+	console.debug = recordConsole as typeof console.debug;
+	console.info = recordConsole as typeof console.info;
+	console.warn = recordConsole as typeof console.warn;
+	console.error = recordConsole as typeof console.error;
+
+	try {
+		await run();
+	} finally {
+		console.log = originalConsoleLog;
+		console.debug = originalConsoleDebug;
+		console.info = originalConsoleInfo;
+		console.warn = originalConsoleWarn;
+		console.error = originalConsoleError;
+		releaseRecording();
+	}
+
+	return consoleCalls;
+}
+
 interface MockLocation {
 	origin: string;
 	href: string;
@@ -196,38 +233,15 @@ function createTimerMocks(onInterval: (callback: () => Promise<void>) => void) {
 describe('startPlexLoginRedirect', () => {
 	let location: MockLocation;
 	let sessionStorage: MemoryStorage;
-	let originalConsoleLog: typeof console.log;
-	let originalConsoleDebug: typeof console.debug;
-	let originalConsoleInfo: typeof console.info;
-	let originalConsoleWarn: typeof console.warn;
-	let originalConsoleError: typeof console.error;
-	let consoleCalls: string[];
 
 	beforeEach(() => {
 		const origin = 'https://obzorarr.example';
 		location = { origin, href: `${origin}/` };
 		sessionStorage = createSessionStorage();
-		consoleCalls = [];
-		originalConsoleLog = console.log;
-		originalConsoleDebug = console.debug;
-		originalConsoleInfo = console.info;
-		originalConsoleWarn = console.warn;
-		originalConsoleError = console.error;
-		const recordConsole = createConsoleRecorder(consoleCalls);
-		console.log = recordConsole as typeof console.log;
-		console.debug = recordConsole as typeof console.debug;
-		console.info = recordConsole as typeof console.info;
-		console.warn = recordConsole as typeof console.warn;
-		console.error = recordConsole as typeof console.error;
 	});
 
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
-		console.log = originalConsoleLog;
-		console.debug = originalConsoleDebug;
-		console.info = originalConsoleInfo;
-		console.warn = originalConsoleWarn;
-		console.error = originalConsoleError;
 	});
 
 	it('fetches PIN with same-origin redirectUrl, persists pin to sessionStorage, navigates to authUrl', async () => {
@@ -290,12 +304,14 @@ describe('startPlexLoginRedirect', () => {
 				)
 		) as unknown as typeof fetch;
 
-		await startPlexLoginRedirect({
-			context: 'landing',
-			onError: () => {},
-			location,
-			storage: sessionStorage
-		});
+		const consoleCalls = await recordConsoleCalls(() =>
+			startPlexLoginRedirect({
+				context: 'landing',
+				onError: () => {},
+				location,
+				storage: sessionStorage
+			})
+		);
 
 		const browserOwnedText = `${consoleCalls.join('\n')}\n${sessionStorage.getItem(PIN_STORAGE_KEY) ?? ''}`;
 		for (const forbidden of [
@@ -448,35 +464,8 @@ describe('resolveRedirectPinData', () => {
 });
 
 describe('startPlexLoginPopup', () => {
-	let originalConsoleLog: typeof console.log;
-	let originalConsoleDebug: typeof console.debug;
-	let originalConsoleInfo: typeof console.info;
-	let originalConsoleWarn: typeof console.warn;
-	let originalConsoleError: typeof console.error;
-	let consoleCalls: string[];
-
-	beforeEach(() => {
-		consoleCalls = [];
-		originalConsoleLog = console.log;
-		originalConsoleDebug = console.debug;
-		originalConsoleInfo = console.info;
-		originalConsoleWarn = console.warn;
-		originalConsoleError = console.error;
-		const recordConsole = createConsoleRecorder(consoleCalls);
-		console.log = recordConsole as typeof console.log;
-		console.debug = recordConsole as typeof console.debug;
-		console.info = recordConsole as typeof console.info;
-		console.warn = recordConsole as typeof console.warn;
-		console.error = recordConsole as typeof console.error;
-	});
-
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
-		console.log = originalConsoleLog;
-		console.debug = originalConsoleDebug;
-		console.info = originalConsoleInfo;
-		console.warn = originalConsoleWarn;
-		console.error = originalConsoleError;
 	});
 
 	it('ignores stale poll failures once login completion has started', async () => {
@@ -620,16 +609,18 @@ describe('startPlexLoginPopup', () => {
 		const onError = mock(() => {});
 		const onPopupBlocked = mock(() => {});
 
-		startPlexLoginPopup({
-			context: 'landing',
-			onSuccess,
-			onError,
-			onPopupBlocked,
-			window: browserWindow,
-			timers
+		const consoleCalls = await recordConsoleCalls(async () => {
+			startPlexLoginPopup({
+				context: 'landing',
+				onSuccess,
+				onError,
+				onPopupBlocked,
+				window: browserWindow,
+				timers
+			});
+			await intervalRegistered;
+			await (intervalCallbacks[0] as () => Promise<void>)();
 		});
-		await intervalRegistered;
-		await (intervalCallbacks[0] as () => Promise<void>)();
 
 		expect(receivedUsers).toEqual([{ username: 'owner', isAdmin: true }]);
 		expect(onError).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

This PR fixes the three QA findings from the dogfood report with targeted changes and regression coverage.

## Changes

- Harden Obzorarr-owned auth logging by redacting metadata values for sensitive auth-shaped keys, including `authToken`, `token`, `accessToken`, `secret`, `password`, `cookie`, and `session`.
- Preserve the existing sanitized Plex login browser contract and add tests proving provider-shaped payload fields are not logged or surfaced by Obzorarr client auth helpers.
- Replace fragile `bind:group` handling for admin Slides fun fact frequency radios with explicit checked state and `onchange` handlers while preserving native form submission.
- Add per-user avatar load-error state on the admin Users page so failed Plex avatar URLs fall back to the existing decorative placeholder in both desktop and mobile layouts.
- Extend source regression tests for the radio behavior and avatar fallback paths.

## Verification

- `bun test tests/unit/plex-login.test.ts`
- `bun test tests/unit/admin/slides-actions.test.ts`
- `bun test tests/unit/admin/ui-source-regressions.test.ts`
- `bun test tests/unit/logging/logger.test.ts`
- `bun run check`
- `bun run test`
- `bun run check:biome`

## Notes

Any remaining token-bearing browser console entries from `app.plex.tv` during a real OAuth flow are provider-origin and outside Obzorarr-owned scripts. Obzorarr-owned browser code now has regression coverage against logging or returning raw provider-shaped auth payloads.
