### PR TITLE
fix: resolve dogfood findings

### DIFF
--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -54,6 +54,12 @@ function handleSummaryKeyDown(event: KeyboardEvent) {
 	event.preventDefault();
 }
 
+function handleActionClick(event: MouseEvent, action: () => void): void {
+	event.preventDefault();
+	event.stopPropagation();
+	action();
+}
+
 // Move initial focus to the heading instead of the first button so
 // stray Enter/Space presses don't trigger navigation away from the page.
 $effect(() => {
@@ -230,7 +236,11 @@ $effect(() => {
 	{/if}
 
 	<div bind:this={buttonsRow} class="actions">
-		<button type="button" class="btn btn-secondary" onclick={onRestart}>
+		<button
+			type="button"
+			class="btn btn-secondary"
+			onclick={(event) => handleActionClick(event, onRestart)}
+		>
 			<svg
 				xmlns="http://www.w3.org/2000/svg"
 				width="20"
@@ -248,7 +258,11 @@ $effect(() => {
 			Watch Again
 		</button>
 
-		<button type="button" class="btn btn-primary" onclick={onShare}>
+		<button
+			type="button"
+			class="btn btn-primary"
+			onclick={(event) => handleActionClick(event, onShare)}
+		>
 			<svg
 				xmlns="http://www.w3.org/2000/svg"
 				width="20"
@@ -269,7 +283,11 @@ $effect(() => {
 			Share
 		</button>
 
-		<button type="button" class="btn btn-secondary" onclick={onHome}>
+		<button
+			type="button"
+			class="btn btn-secondary"
+			onclick={(event) => handleActionClick(event, onHome)}
+		>
 			<svg
 				xmlns="http://www.w3.org/2000/svg"
 				width="20"

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -39,7 +39,7 @@ import Users from '@lucide/svelte/icons/users';
 import VenetianMask from '@lucide/svelte/icons/venetian-mask';
 import X from '@lucide/svelte/icons/x';
 import Zap from '@lucide/svelte/icons/zap';
-import { type Component, untrack } from 'svelte';
+import { type Component, tick, untrack } from 'svelte';
 import { deserialize, enhance } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
 import { page } from '$app/stores';
@@ -400,6 +400,7 @@ let pendingCacheCount = $state(0);
 let loadingCount = $state(false);
 let isClearing = $state(false);
 let cacheCountResult = $state<{ label: string; count: number } | null>(null);
+let cacheCountResultElement: HTMLElement | undefined = $state();
 
 // Play history clearing dialog state
 let historyDialogOpen = $state(false);
@@ -408,6 +409,15 @@ let pendingHistoryCount = $state(0);
 let loadingHistoryCount = $state(false);
 let isClearingHistory = $state(false);
 let historyCountResult = $state<{ label: string; count: number } | null>(null);
+let historyCountResultElement: HTMLElement | undefined = $state();
+
+async function focusCountResult(getElement: () => HTMLElement | undefined): Promise<void> {
+	await tick();
+	const element = getElement();
+	if (!element) return;
+	element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+	element.focus({ preventScroll: true });
+}
 
 // Open cache clearing confirmation dialog
 async function showCacheConfirmation(year?: number) {
@@ -468,6 +478,11 @@ async function getCacheCount(year?: number) {
 				label: year !== undefined ? `${year} cache` : 'All cache',
 				count: payload.count
 			};
+			handleFormToast({
+				success: true,
+				message: `${cacheCountResult.label}: ${formatRecordCount(cacheCountResult.count)}`
+			});
+			await focusCountResult(() => cacheCountResultElement);
 		} else {
 			handleFormToast({ error: 'Failed to get cache count.' });
 		}
@@ -550,6 +565,11 @@ async function getHistoryCount(year?: number) {
 				label: year !== undefined ? `${year} history` : 'All history',
 				count: payload.count
 			};
+			handleFormToast({
+				success: true,
+				message: `${historyCountResult.label}: ${formatRecordCount(historyCountResult.count)}`
+			});
+			await focusCountResult(() => historyCountResultElement);
 		} else {
 			handleFormToast({ error: 'Failed to get play history count.' });
 		}
@@ -2503,7 +2523,13 @@ const logFieldErrors = $derived(
 						</button>
 					</div>
 					{#if cacheCountResult}
-						<p class="count-result">
+						<p
+							bind:this={cacheCountResultElement}
+							class="count-result"
+							role="status"
+							aria-live="polite"
+							tabindex="-1"
+						>
 							{cacheCountResult.label}: {formatRecordCount(cacheCountResult.count)}
 						</p>
 					{/if}
@@ -2594,7 +2620,13 @@ const logFieldErrors = $derived(
 						</button>
 					</div>
 					{#if historyCountResult}
-						<p class="count-result">
+						<p
+							bind:this={historyCountResultElement}
+							class="count-result"
+							role="status"
+							aria-live="polite"
+							tabindex="-1"
+						>
 							{historyCountResult.label}: {formatRecordCount(historyCountResult.count)}
 						</p>
 					{/if}

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -40,6 +40,7 @@ import VenetianMask from '@lucide/svelte/icons/venetian-mask';
 import X from '@lucide/svelte/icons/x';
 import Zap from '@lucide/svelte/icons/zap';
 import { type Component, tick, untrack } from 'svelte';
+import { prefersReducedMotion } from 'svelte/motion';
 import { deserialize, enhance } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
 import { page } from '$app/stores';
@@ -415,7 +416,10 @@ async function focusCountResult(getElement: () => HTMLElement | undefined): Prom
 	await tick();
 	const element = getElement();
 	if (!element) return;
-	element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+	element.scrollIntoView({
+		block: 'center',
+		behavior: prefersReducedMotion.current ? 'auto' : 'smooth'
+	});
 	element.focus({ preventScroll: true });
 }
 

--- a/src/routes/admin/wrapped/+page.svelte
+++ b/src/routes/admin/wrapped/+page.svelte
@@ -7,6 +7,7 @@ import Shield from '@lucide/svelte/icons/shield';
 import SlidersHorizontal from '@lucide/svelte/icons/sliders-horizontal';
 import Sparkles from '@lucide/svelte/icons/sparkles';
 import Star from '@lucide/svelte/icons/star';
+import { goto } from '$app/navigation';
 import type { PageData } from './$types';
 
 /**
@@ -22,6 +23,21 @@ interface Props {
 }
 
 let { data }: Props = $props();
+
+function shouldUseClientNavigation(event: MouseEvent): boolean {
+	if (!(event.currentTarget instanceof HTMLAnchorElement)) return false;
+	if (event.currentTarget.target && event.currentTarget.target !== '_self') return false;
+	return event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey;
+}
+
+function handleConfigNavigation(event: MouseEvent): void {
+	if (!shouldUseClientNavigation(event)) return;
+	const href = (event.currentTarget as HTMLAnchorElement).getAttribute('href');
+	if (!href) return;
+
+	event.preventDefault();
+	void goto(href);
+}
 </script>
 
 <svelte:head>
@@ -113,7 +129,7 @@ let { data }: Props = $props();
 		</div>
 
 		<div class="config-grid">
-			<a href="/admin/slides" class="config-card">
+			<a href="/admin/slides" class="config-card" onclick={handleConfigNavigation}>
 				<div class="config-icon-wrap">
 					<SlidersHorizontal class="config-icon" />
 				</div>
@@ -124,7 +140,7 @@ let { data }: Props = $props();
 				<ArrowRight class="config-arrow" />
 			</a>
 
-			<a href="/admin/settings?tab=privacy" class="config-card">
+			<a href="/admin/settings?tab=privacy" class="config-card" onclick={handleConfigNavigation}>
 				<div class="config-icon-wrap">
 					<Shield class="config-icon" />
 				</div>
@@ -135,13 +151,13 @@ let { data }: Props = $props();
 				<ArrowRight class="config-arrow" />
 			</a>
 
-			<a href="/admin/settings?tab=appearance" class="config-card">
+			<a href="/admin/settings?tab=appearance" class="config-card" onclick={handleConfigNavigation}>
 				<div class="config-icon-wrap">
 					<Palette class="config-icon" />
 				</div>
 				<div class="config-content">
 					<span class="config-title">Display Settings</span>
-					<span class="config-desc">Theme, logo visibility, and anonymization</span>
+					<span class="config-desc">Theme and logo visibility</span>
 				</div>
 				<ArrowRight class="config-arrow" />
 			</a>

--- a/src/routes/dashboard/settings/+page.server.ts
+++ b/src/routes/dashboard/settings/+page.server.ts
@@ -149,9 +149,16 @@ export const actions: Actions = {
 				});
 			}
 
-			await regenerateShareToken(userId, currentYear);
+			const shareToken = await regenerateShareToken(userId, currentYear);
+			const wrappedHref = await getOwnerWrappedHref(userId, currentYear);
 
-			return { success: true, message: 'Share link regenerated', action: 'regenerateToken' };
+			return {
+				success: true,
+				message: 'Share link regenerated',
+				action: 'regenerateToken',
+				shareToken,
+				wrappedHref
+			};
 		} catch (error) {
 			if (error instanceof PermissionExceededError) {
 				return fail(403, { error: error.message, action: 'regenerateToken' });

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+import { invalidateAll } from '$app/navigation';
 import { page } from '$app/stores';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import * as Tabs from '$lib/components/ui/tabs';
@@ -17,6 +18,12 @@ import type { ActionData, PageData } from './$types';
  */
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
+
+type RegenerateTokenActionData = {
+	action?: string;
+	wrappedHref?: string;
+	shareToken?: string;
+};
 
 // Tab state
 const validTabs = ['privacy', 'display', 'account'] as const;
@@ -39,6 +46,9 @@ let selectedShareMode = $state<string>(data.shareSettings.mode);
 let selectedLogoPreference = $state<'show' | 'hide'>('show');
 let isUpdating = $state(false);
 let isRegenerating = $state(false);
+let wrappedHrefOverride = $state<string | null>(null);
+// svelte-ignore state_referenced_locally
+let syncedWrappedHref = $state(data.wrappedHref);
 
 // Copy state
 let copied = $state(false);
@@ -51,6 +61,10 @@ let regenerateDialogOpen = $state(false);
 $effect(() => {
 	selectedShareMode = data.shareSettings.mode;
 	selectedLogoPreference = data.userLogoPreference === false ? 'hide' : 'show';
+	if (data.wrappedHref !== syncedWrappedHref) {
+		syncedWrappedHref = data.wrappedHref;
+		wrappedHrefOverride = null;
+	}
 });
 
 // Show toast notifications and snap radio back to server truth on rejection
@@ -108,7 +122,7 @@ const shareModeLabels: Record<string, string> = {
 // Generate share URL
 function getShareUrl(): string {
 	const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
-	return `${baseUrl}${data.wrappedHref}`;
+	return `${baseUrl}${wrappedHrefOverride ?? data.wrappedHref}`;
 }
 
 // Copy to clipboard
@@ -557,10 +571,27 @@ function getLogoModeDescription(): string {
 					action="?/regenerateToken"
 					use:enhance={() => {
 						isRegenerating = true;
-						return async ({ update }) => {
-							await update();
-							isRegenerating = false;
-							regenerateDialogOpen = false;
+						return async ({ result, update }) => {
+							try {
+								if (result.type === 'success') {
+									const payload = (result.data ?? {}) as RegenerateTokenActionData;
+									if (
+										payload.action === 'regenerateToken' &&
+										typeof payload.wrappedHref === 'string'
+									) {
+										wrappedHrefOverride = payload.wrappedHref;
+									}
+								}
+
+								await update({ reset: result.type !== 'failure' });
+
+								if (result.type === 'success') {
+									regenerateDialogOpen = false;
+									await invalidateAll();
+								}
+							} finally {
+								isRegenerating = false;
+							}
 						};
 					}}
 					style="display: contents;"

--- a/src/routes/wrapped/[year]/+page.svelte
+++ b/src/routes/wrapped/[year]/+page.svelte
@@ -140,13 +140,7 @@ function handleRestart(): void {
  * Handle return home from summary
  */
 function handleHome(): void {
-	if (data.isAdmin) {
-		goto('/admin');
-	} else if (data.isLoggedIn) {
-		goto('/dashboard');
-	} else {
-		goto('/');
-	}
+	goto('/');
 }
 
 /**

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -453,7 +453,8 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('let cacheCountResultElement: HTMLElement | undefined = $state();');
 		expect(source).toContain('let historyCountResultElement: HTMLElement | undefined = $state();');
 		expect(source).toContain('async function focusCountResult');
-		expect(source).toContain("element.scrollIntoView({ block: 'center', behavior: 'smooth' });");
+		expect(source).toContain("import { prefersReducedMotion } from 'svelte/motion';");
+		expect(source).toContain("behavior: prefersReducedMotion.current ? 'auto' : 'smooth'");
 		expect(source).toContain('element.focus({ preventScroll: true });');
 		expect(source).toContain(
 			'message: `$' + '{cacheCountResult.label}: $' + '{formatRecordCount(cacheCountResult.count)}`'

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -305,6 +305,31 @@ describe('admin UI source regressions', () => {
 		expect(dashboardSource).toContain('onclick={handleAdminNavigation}');
 	});
 
+	it('uses client navigation for wrapped config cards while preserving real hrefs', async () => {
+		const source = await readSource('src/routes/admin/wrapped/+page.svelte');
+
+		expect(source).toContain('import { goto }');
+		expect(source).toContain('function shouldUseClientNavigation');
+		expect(source).toContain('event.button === 0');
+		expect(source).toContain('!event.metaKey');
+		expect(source).toContain('!event.ctrlKey');
+		expect(source).toContain('!event.shiftKey');
+		expect(source).toContain('!event.altKey');
+		expect(source).toContain('function handleConfigNavigation');
+		expect(source).toContain('void goto(href);');
+		expect(source).toContain(
+			'<a href="/admin/slides" class="config-card" onclick={handleConfigNavigation}>'
+		);
+		expect(source).toContain(
+			'<a href="/admin/settings?tab=privacy" class="config-card" onclick={handleConfigNavigation}>'
+		);
+		expect(source).toContain(
+			'<a href="/admin/settings?tab=appearance" class="config-card" onclick={handleConfigNavigation}>'
+		);
+		expect(source).toContain('Theme and logo visibility');
+		expect(source).not.toContain('Theme, logo visibility, and anonymization');
+	});
+
 	it('stacks the slide order header controls on narrow screens', async () => {
 		const source = await readSource('src/routes/admin/slides/+page.svelte');
 
@@ -384,6 +409,64 @@ describe('admin UI source regressions', () => {
 			expect(source).not.toContain('console.debug');
 			expect(source).not.toContain('console.info');
 		}
+	});
+
+	it('keeps wrapped summary button actions from bubbling into slideshow handlers', async () => {
+		const source = await readSource('src/lib/components/wrapped/SummaryPage.svelte');
+
+		expect(source).toContain(
+			'function handleActionClick(event: MouseEvent, action: () => void): void'
+		);
+		expect(source).toContain('event.preventDefault();');
+		expect(source).toContain('event.stopPropagation();');
+		expect(source).toContain('onclick={(event) => handleActionClick(event, onRestart)}');
+		expect(source).toContain('onclick={(event) => handleActionClick(event, onShare)}');
+		expect(source).toContain('onclick={(event) => handleActionClick(event, onHome)}');
+	});
+
+	it('returns server wrapped users home to the public root', async () => {
+		const source = await readSource('src/routes/wrapped/[year]/+page.svelte');
+		const handleHome = source.match(/function handleHome\(\): void \{[\s\S]*?\n\}/)?.[0];
+
+		expect(handleHome).toBeDefined();
+		expect(handleHome).toContain("goto('/');");
+		expect(handleHome).not.toContain("goto('/admin');");
+		expect(handleHome).not.toContain("goto('/dashboard');");
+	});
+
+	it('applies regenerated dashboard share URLs before reloading page data', async () => {
+		const source = await readSource('src/routes/dashboard/settings/+page.svelte');
+
+		expect(source).toContain('let wrappedHrefOverride = $state<string | null>(null);');
+		expect(source).toContain('let syncedWrappedHref = $state(data.wrappedHref);');
+		expect(source).toContain('wrappedHrefOverride ?? data.wrappedHref');
+		expect(source).toContain("payload.action === 'regenerateToken'");
+		expect(source).toContain("typeof payload.wrappedHref === 'string'");
+		expect(source).toContain('wrappedHrefOverride = payload.wrappedHref;');
+		expect(source).toContain('regenerateDialogOpen = false;');
+		expect(source).toContain('await invalidateAll();');
+	});
+
+	it('renders accessible status feedback for data count actions', async () => {
+		const source = await readSource('src/routes/admin/settings/+page.svelte');
+
+		expect(source).toContain('let cacheCountResultElement: HTMLElement | undefined = $state();');
+		expect(source).toContain('let historyCountResultElement: HTMLElement | undefined = $state();');
+		expect(source).toContain('async function focusCountResult');
+		expect(source).toContain("element.scrollIntoView({ block: 'center', behavior: 'smooth' });");
+		expect(source).toContain('element.focus({ preventScroll: true });');
+		expect(source).toContain(
+			'message: `$' + '{cacheCountResult.label}: $' + '{formatRecordCount(cacheCountResult.count)}`'
+		);
+		expect(source).toContain(
+			'message: `$' +
+				'{historyCountResult.label}: $' +
+				'{formatRecordCount(historyCountResult.count)}`'
+		);
+		expect(source).toContain('bind:this={cacheCountResultElement}');
+		expect(source).toContain('bind:this={historyCountResultElement}');
+		expect(source.match(/role="status"/g)).toHaveLength(2);
+		expect(source.match(/aria-live="polite"/g)).toHaveLength(2);
 	});
 
 	it('explains bootstrap and claim expiry on the onboarding claim page', async () => {

--- a/tests/unit/dashboard/settings-permission.test.ts
+++ b/tests/unit/dashboard/settings-permission.test.ts
@@ -2,12 +2,13 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import { and, eq } from 'drizzle-orm';
 import { db } from '$lib/server/db/client';
 import { appSettings, shareSettings, users } from '$lib/server/db/schema';
-import { setGlobalShareDefaults } from '$lib/server/sharing/service';
+import { getShareSettingsByToken, setGlobalShareDefaults } from '$lib/server/sharing/service';
 import { ShareMode, ShareModeSource } from '$lib/server/sharing/types';
 import { actions, load } from '../../../src/routes/dashboard/settings/+page.server';
 
 type LoadArgs = Parameters<typeof load>[0];
 type UpdateShareModeAction = NonNullable<typeof actions.updateShareMode>;
+type RegenerateTokenAction = NonNullable<typeof actions.regenerateToken>;
 
 const USER_ID = 42;
 const YEAR = new Date().getFullYear();
@@ -33,6 +34,11 @@ async function invokeUpdateShareMode(mode: string) {
 	});
 	const updateShareMode = actions.updateShareMode as UpdateShareModeAction;
 	return updateShareMode({ request, locals } as unknown as Parameters<UpdateShareModeAction>[0]);
+}
+
+async function invokeRegenerateToken() {
+	const regenerateToken = actions.regenerateToken as RegenerateTokenAction;
+	return regenerateToken({ locals } as unknown as Parameters<RegenerateTokenAction>[0]);
 }
 
 describe('dashboard settings per-user share control', () => {
@@ -70,5 +76,35 @@ describe('dashboard settings per-user share control', () => {
 			.where(and(eq(shareSettings.userId, USER_ID), eq(shareSettings.year, YEAR)))
 			.limit(1);
 		expect(row[0]?.mode).toBe(ShareMode.PRIVATE_LINK);
+	});
+
+	it('returns the refreshed private href and invalidates the previous token on regenerate', async () => {
+		const oldToken = '11111111-1111-4111-8111-111111111111';
+		await db
+			.update(shareSettings)
+			.set({
+				mode: ShareMode.PRIVATE_LINK,
+				modeSource: ShareModeSource.EXPLICIT,
+				shareToken: oldToken,
+				canUserControl: true
+			})
+			.where(and(eq(shareSettings.userId, USER_ID), eq(shareSettings.year, YEAR)));
+
+		const result = (await invokeRegenerateToken()) as {
+			success?: boolean;
+			action?: string;
+			shareToken?: string;
+			wrappedHref?: string;
+			status?: number;
+		};
+
+		expect(result.status).toBeUndefined();
+		expect(result.success).toBe(true);
+		expect(result.action).toBe('regenerateToken');
+		expect(typeof result.shareToken).toBe('string');
+		expect(result.shareToken).not.toBe(oldToken);
+		expect(result.wrappedHref).toBe(`/wrapped/${YEAR}/u/${result.shareToken}`);
+		expect(await getShareSettingsByToken(oldToken)).toBeNull();
+		expect(await getShareSettingsByToken(result.shareToken!)).not.toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

This PR resolves the app-owned dogfood findings from the recent QA pass.

Changes include:

- Prevent wrapped summary action buttons from bubbling clicks into slideshow handlers, so Share, Watch Again, and Return Home behave reliably.
- Route server wrapped Return Home to the public root path.
- Return the regenerated private-link token and wrapped href from the dashboard settings action, then update the visible URL immediately on the client before invalidating page data.
- Add client-side navigation handling to admin wrapped configuration cards while preserving real href attributes and modified-click behavior.
- Update the admin wrapped Display Settings card copy to cover theme/logo only.
- Surface cache and history count results as accessible live status regions, show success toasts, and focus/scroll the result into view on small screens.
- Keep Plex OAuth console token-like output classified as provider-origin residual risk; app-owned browser auth redaction remains covered by regression tests.

## Verification

Automated checks run locally:

- bun run check
- bun run test
- bun run check:biome
- bun test tests/unit/dashboard/settings-permission.test.ts
- bun test tests/unit/admin/ui-source-regressions.test.ts
- bun test tests/unit/plex-login.test.ts tests/unit/logging/logger.test.ts tests/unit/auth/login-completion.test.ts

Manual smoke checks with agent-browser:

- Confirmed admin wrapped Display Settings card navigates at a 390x844 viewport while preserving the real href.
- Confirmed Get All Cache Count renders an accessible status result, focuses it, and keeps it visible at a 390x844 viewport.
