### PR TITLE
fix: harden wrapped sharing privacy controls

### DIFF
--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { untrack } from 'svelte';
 import { enhance } from '$app/forms';
-import { goto } from '$app/navigation';
+import { goto, invalidateAll } from '$app/navigation';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import { ShareModePrivacyLevel, type ShareModeType } from '$lib/sharing/types';
 
@@ -45,11 +45,13 @@ function isBelowFloor(mode: ShareModeType): boolean {
 let copied = $state(false);
 let copyTimeout: ReturnType<typeof setTimeout> | undefined;
 let isUpdating = $state(false);
+let isRefreshing = $state(false);
 let localMode = $state<ShareModeType>(untrack(() => shareSettings?.mode ?? 'public'));
 let localShareToken = $state<string | null | undefined>(untrack(() => shareSettings?.shareToken));
 
 const displayMode = $derived(localMode);
 const displayShareToken = $derived(localShareToken);
+const controlsDisabled = $derived(isUpdating || isRefreshing);
 
 // Computed URL based on mode
 const shareUrl = $derived.by(() => {
@@ -120,8 +122,22 @@ async function copyUrl(): Promise<void> {
 	}
 }
 
+async function refreshShareData(): Promise<void> {
+	if (isRefreshing) return;
+
+	isRefreshing = true;
+	try {
+		await invalidateAll();
+	} finally {
+		isRefreshing = false;
+	}
+}
+
 function handleOpenChange(value: boolean): void {
 	open = value;
+	if (value) {
+		void refreshShareData();
+	}
 	onOpenChange?.(value);
 }
 
@@ -150,6 +166,17 @@ function applyShareActionData(data: unknown): void {
 function restoreLocalShareState(): void {
 	localMode = shareSettings?.mode ?? 'public';
 	localShareToken = shareSettings?.shareToken;
+}
+
+function submitModeChange(event: Event, mode: ShareModeType): void {
+	if (controlsDisabled || isBelowFloor(mode)) {
+		event.preventDefault();
+		restoreLocalShareState();
+		return;
+	}
+
+	localMode = mode;
+	(event.currentTarget as HTMLInputElement).form?.requestSubmit();
 }
 
 function currentRouteIdentifier(): string | null {
@@ -324,7 +351,10 @@ $effect(() => {
 									applyShareActionData(result.data);
 									if (await navigateAfterTokenRouteUpdate(result.data)) return;
 								} else {
-									restoreLocalShareState();
+									if (result.type === 'failure') {
+										applyShareActionData(result.data);
+									}
+									await invalidateAll();
 								}
 								await update();
 							} finally {
@@ -346,11 +376,8 @@ $effect(() => {
 									name="mode"
 									value={mode}
 									checked={displayMode === mode}
-									disabled={isUpdating || isBelowFloor(mode as ShareModeType)}
-									onchange={(e) => {
-										localMode = mode as ShareModeType;
-										e.currentTarget.form?.requestSubmit();
-									}}
+									disabled={controlsDisabled || isBelowFloor(mode as ShareModeType)}
+									onchange={(e) => submitModeChange(e, mode as ShareModeType)}
 								/>
 								<div class="mode-content">
 									<span class="mode-label">{modeLabels[mode as ShareModeType].label}</span>
@@ -406,7 +433,7 @@ $effect(() => {
 						}}
 						class="regenerate-form"
 					>
-						<button type="submit" class="btn-link" disabled={isUpdating}>
+						<button type="submit" class="btn-link" disabled={controlsDisabled}>
 							<svg
 								xmlns="http://www.w3.org/2000/svg"
 								width="14"

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -128,6 +128,8 @@ async function refreshShareData(): Promise<void> {
 	isRefreshing = true;
 	try {
 		await invalidateAll();
+	} catch (error) {
+		console.warn('Failed to refresh share data:', error);
 	} finally {
 		isRefreshing = false;
 	}

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -356,7 +356,11 @@ $effect(() => {
 									if (result.type === 'failure') {
 										applyShareActionData(result.data);
 									}
-									await invalidateAll();
+									try {
+										await invalidateAll();
+									} catch (error) {
+										console.warn('Failed to refresh share data after share mode update:', error);
+									}
 								}
 								await update();
 							} finally {

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -99,6 +99,8 @@ const modeLabels: Record<ShareModeType, { label: string; description: string }> 
 };
 
 async function copyUrl(): Promise<void> {
+	if (controlsDisabled) return;
+
 	try {
 		await navigator.clipboard.writeText(shareUrl);
 		copied = true;
@@ -288,15 +290,18 @@ $effect(() => {
 					id="share-url"
 					type="text"
 					readonly
-					value={shareUrl}
+					disabled={controlsDisabled}
+					value={controlsDisabled ? '' : shareUrl}
+					placeholder={controlsDisabled ? 'Refreshing link...' : undefined}
 					class="url-input"
 					onclick={(e) => e.currentTarget.select()}
 				/>
 				<button
 					type="button"
 					class="copy-btn"
+					disabled={controlsDisabled}
 					onclick={copyUrl}
-					aria-label={copied ? 'Copied!' : 'Copy link'}
+					aria-label={controlsDisabled ? 'Refreshing link' : copied ? 'Copied!' : 'Copy link'}
 				>
 					{#if copied}
 						<svg
@@ -553,6 +558,16 @@ $effect(() => {
 		.copy-btn:hover {
 			background-color: rgba(255, 255, 255, 0.1);
 			border-color: hsl(var(--primary));
+		}
+
+		.copy-btn:disabled {
+			cursor: not-allowed;
+			opacity: 0.6;
+		}
+
+		.copy-btn:disabled:hover {
+			background-color: hsl(var(--background));
+			border-color: hsl(var(--border));
 		}
 
 		.copy-btn .icon.check {

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -355,6 +355,8 @@ $effect(() => {
 								} else {
 									if (result.type === 'failure') {
 										applyShareActionData(result.data);
+									} else {
+										restoreLocalShareState();
 									}
 									try {
 										await invalidateAll();

--- a/src/routes/wrapped/[year]/+page.server.ts
+++ b/src/routes/wrapped/[year]/+page.server.ts
@@ -19,7 +19,9 @@ import { getServerStatsWithAnonymization } from '$lib/server/stats/engine';
 import { triggerLiveSyncIfNeeded } from '$lib/server/sync/live-sync';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ params, locals }) => {
+export const load: PageServerLoad = async ({ params, locals, setHeaders }) => {
+	setHeaders({ 'cache-control': 'no-store' });
+
 	const year = parseInt(params.year, 10);
 	if (Number.isNaN(year) || year < 2000 || year > 2100) {
 		error(404, 'Invalid year');

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -69,7 +69,9 @@ async function resolveUserIdFromIdentifier(
 	return Number.isSafeInteger(userId) && userId > 0 ? userId : null;
 }
 
-export const load: PageServerLoad = async ({ params, locals, parent }) => {
+export const load: PageServerLoad = async ({ params, locals, parent, setHeaders }) => {
+	setHeaders({ 'cache-control': 'no-store' });
+
 	const year = parseInt(params.year, 10);
 	if (Number.isNaN(year) || year < 2000 || year > 2100) {
 		error(404, 'Invalid year');
@@ -309,7 +311,23 @@ export const actions: Actions = {
 			};
 		} catch (err) {
 			if (err instanceof PermissionExceededError) {
-				return fail(403, { error: err.message });
+				const [currentSettings, globalFloor] = await Promise.all([
+					getOrCreateShareSettings({ userId, year }),
+					getGlobalDefaultShareMode()
+				]);
+				return fail(403, {
+					error: err.message,
+					currentMode: currentSettings.mode,
+					globalFloor,
+					canonicalUrl: `/wrapped/${year}/u/${userId}`,
+					shareSettings: {
+						mode: currentSettings.mode,
+						storedMode: currentSettings.storedMode,
+						modeSource: currentSettings.modeSource,
+						shareToken: currentSettings.shareToken,
+						canUserControl: currentSettings.canUserControl || locals.user.isAdmin
+					}
+				});
 			}
 			const message = err instanceof Error ? err.message : 'Failed to update share settings';
 			return fail(500, { error: message });

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -431,6 +431,9 @@ describe('admin UI source regressions', () => {
 		expect(updateShareModeForm).toBeDefined();
 		expect(updateShareModeForm).toContain('applyShareActionData(result.data);');
 		expect(updateShareModeForm).toContain('await invalidateAll();');
+		expect(updateShareModeForm).toContain(
+			"console.warn('Failed to refresh share data after share mode update:', error);"
+		);
 		expect(updateShareModeForm).not.toContain('restoreLocalShareState();');
 	});
 

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -391,6 +391,7 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('const controlsDisabled = $derived(isUpdating || isRefreshing);');
 		expect(source).toContain('async function refreshShareData()');
 		expect(source).toContain('await invalidateAll();');
+		expect(source).toContain("console.warn('Failed to refresh share data:', error);");
 		expect(source).toContain('void refreshShareData();');
 		expect(source).toContain('disabled={controlsDisabled || isBelowFloor(mode as ShareModeType)}');
 		expect(source).toContain('disabled={controlsDisabled}');

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -422,7 +422,7 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('onchange={(e) => submitModeChange(e, mode as ShareModeType)}');
 	});
 
-	it('invalidates wrapped share modal page data after failed mode updates', async () => {
+	it('restores wrapped share modal local state after error mode updates', async () => {
 		const source = await readSource('src/lib/components/wrapped/ShareModal.svelte');
 		const updateShareModeForm = source.match(
 			/action="\?\/updateShareMode"[\s\S]*?<div class="mode-options"/
@@ -434,7 +434,7 @@ describe('admin UI source regressions', () => {
 		expect(updateShareModeForm).toContain(
 			"console.warn('Failed to refresh share data after share mode update:', error);"
 		);
-		expect(updateShareModeForm).not.toContain('restoreLocalShareState();');
+		expect(updateShareModeForm).toContain('restoreLocalShareState();');
 	});
 
 	it('does not log Plex auth payloads from app-owned browser auth code', async () => {

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -378,9 +378,22 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('let localMode = $state<ShareModeType>');
 		expect(source).toContain('let localShareToken = $state<string | null | undefined>');
 		expect(source).toContain('checked={displayMode === mode}');
-		expect(source).toContain('localMode = mode as ShareModeType;');
+		expect(source).toContain('localMode = mode;');
 		expect(source).not.toContain('checked={isUpdating ?');
 		expect(source).not.toContain('optimisticMode');
+	});
+
+	it('refreshes wrapped share modal data on open before enabling controls', async () => {
+		const source = await readSource('src/lib/components/wrapped/ShareModal.svelte');
+
+		expect(source).toContain("import { goto, invalidateAll } from '$app/navigation';");
+		expect(source).toContain('let isRefreshing = $state(false);');
+		expect(source).toContain('const controlsDisabled = $derived(isUpdating || isRefreshing);');
+		expect(source).toContain('async function refreshShareData()');
+		expect(source).toContain('await invalidateAll();');
+		expect(source).toContain('void refreshShareData();');
+		expect(source).toContain('disabled={controlsDisabled || isBelowFloor(mode as ShareModeType)}');
+		expect(source).toContain('disabled={controlsDisabled}');
 	});
 
 	it('disables share modes that are more permissive than the server privacy floor', async () => {
@@ -396,6 +409,28 @@ describe('admin UI source regressions', () => {
 			expect(source).toContain('isBelowFloor');
 			expect(source).toContain('floor-note');
 		}
+	});
+
+	it('guards wrapped share modal onchange from submitting below-floor modes', async () => {
+		const source = await readSource('src/lib/components/wrapped/ShareModal.svelte');
+
+		expect(source).toContain('function submitModeChange(event: Event, mode: ShareModeType)');
+		expect(source).toContain('if (controlsDisabled || isBelowFloor(mode))');
+		expect(source).toContain('event.preventDefault();');
+		expect(source).toContain('restoreLocalShareState();');
+		expect(source).toContain('onchange={(e) => submitModeChange(e, mode as ShareModeType)}');
+	});
+
+	it('invalidates wrapped share modal page data after failed mode updates', async () => {
+		const source = await readSource('src/lib/components/wrapped/ShareModal.svelte');
+		const updateShareModeForm = source.match(
+			/action="\?\/updateShareMode"[\s\S]*?<div class="mode-options"/
+		)?.[0];
+
+		expect(updateShareModeForm).toBeDefined();
+		expect(updateShareModeForm).toContain('applyShareActionData(result.data);');
+		expect(updateShareModeForm).toContain('await invalidateAll();');
+		expect(updateShareModeForm).not.toContain('restoreLocalShareState();');
 	});
 
 	it('does not log Plex auth payloads from app-owned browser auth code', async () => {

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -385,6 +385,10 @@ describe('admin UI source regressions', () => {
 
 	it('refreshes wrapped share modal data on open before enabling controls', async () => {
 		const source = await readSource('src/lib/components/wrapped/ShareModal.svelte');
+		const copyUrlSource = source.match(
+			/async function copyUrl\(\)[\s\S]*?async function refreshShareData/
+		);
+		const urlSection = source.match(/<!-- Copy URL Section -->[\s\S]*?<!-- Share Mode Controls/);
 
 		expect(source).toContain("import { goto, invalidateAll } from '$app/navigation';");
 		expect(source).toContain('let isRefreshing = $state(false);');
@@ -395,6 +399,11 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('void refreshShareData();');
 		expect(source).toContain('disabled={controlsDisabled || isBelowFloor(mode as ShareModeType)}');
 		expect(source).toContain('disabled={controlsDisabled}');
+		expect(copyUrlSource).toBeDefined();
+		expect(copyUrlSource?.[0]).toContain('if (controlsDisabled) return;');
+		expect(urlSection).toBeDefined();
+		expect(urlSection?.[0]).toContain('disabled={controlsDisabled}');
+		expect(urlSection?.[0]).toContain("value={controlsDisabled ? '' : shareUrl}");
 	});
 
 	it('disables share modes that are more permissive than the server privacy floor', async () => {

--- a/tests/unit/sharing/server-wrapped-route.test.ts
+++ b/tests/unit/sharing/server-wrapped-route.test.ts
@@ -4,9 +4,13 @@ import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
 import { setServerWrappedShareMode } from '$lib/server/sharing/service';
 import { ShareMode } from '$lib/server/sharing/types';
+import { actions as adminSettingsActions } from '../../../src/routes/admin/settings/+page.server';
 import { load } from '../../../src/routes/wrapped/[year]/+page.server';
 
 type ServerWrappedLoad = typeof load;
+type UpdateServerWrappedSettingsAction = NonNullable<
+	typeof adminSettingsActions.updateServerWrappedSettings
+>;
 
 describe('server wrapped route access', () => {
 	beforeEach(async () => {
@@ -20,14 +24,69 @@ describe('server wrapped route access', () => {
 			await load({
 				params: { year: '2024' },
 				locals: {},
-				url: new URL('http://localhost/wrapped/2024')
-			} as Parameters<ServerWrappedLoad>[0]);
+				url: new URL('http://localhost/wrapped/2024'),
+				setHeaders: () => {}
+			} as unknown as Parameters<ServerWrappedLoad>[0]);
 			expect.unreachable('Expected server wrapped load to throw');
 		} catch (error) {
 			expect(isHttpError(error)).toBe(true);
 			if (!isHttpError(error)) throw error;
 			expect(error.status).toBe(403);
 			expect(error.body.message).toContain('Sign in');
+		}
+	});
+
+	it('sets no-store cache control on server wrapped loads', async () => {
+		await setServerWrappedShareMode(ShareMode.PRIVATE_OAUTH);
+		const headers: Record<string, string> = {};
+
+		try {
+			await load({
+				params: { year: '2024' },
+				locals: {},
+				url: new URL('http://localhost/wrapped/2024'),
+				setHeaders: (values: Record<string, string>) => Object.assign(headers, values)
+			} as unknown as Parameters<ServerWrappedLoad>[0]);
+			expect.unreachable('Expected server wrapped load to throw');
+		} catch (error) {
+			expect(isHttpError(error)).toBe(true);
+		}
+
+		expect(headers['cache-control']).toBe('no-store');
+	});
+
+	it('denies anonymous loads after admin saves server wrapped as private-oauth', async () => {
+		const formData = new FormData();
+		formData.set('anonymizationMode', 'real');
+		formData.set('serverWrappedShareMode', ShareMode.PRIVATE_OAUTH);
+		formData.set('settingsVersion', new Date(0).toISOString());
+		const request = new Request('https://obzorarr.example/admin/settings', {
+			method: 'POST',
+			body: formData
+		});
+		const updateServerWrappedSettings =
+			adminSettingsActions.updateServerWrappedSettings as UpdateServerWrappedSettingsAction;
+
+		const result = await updateServerWrappedSettings({
+			request,
+			locals: {
+				user: { id: 1, plexId: 100001, username: 'admin', isAdmin: true }
+			}
+		} as Parameters<UpdateServerWrappedSettingsAction>[0]);
+		expect(result).toMatchObject({ success: true });
+
+		try {
+			await load({
+				params: { year: '2024' },
+				locals: {},
+				url: new URL('http://localhost/wrapped/2024'),
+				setHeaders: () => {}
+			} as unknown as Parameters<ServerWrappedLoad>[0]);
+			expect.unreachable('Expected server wrapped load to throw after settings update');
+		} catch (error) {
+			expect(isHttpError(error)).toBe(true);
+			if (!isHttpError(error)) throw error;
+			expect(error.status).toBe(403);
 		}
 	});
 });

--- a/tests/unit/sharing/wrapped-identifier-loader.test.ts
+++ b/tests/unit/sharing/wrapped-identifier-loader.test.ts
@@ -80,11 +80,15 @@ async function invokeLoad(params: {
 	identifier: string;
 	availableYears: number[];
 	currentUser?: TestUser;
+	headers?: Record<string, string>;
 }): Promise<LoadData> {
 	const result = await load({
 		params: { year: String(params.year), identifier: params.identifier },
 		locals: params.currentUser ? { user: params.currentUser } : {},
-		parent: async () => ({ availableYears: params.availableYears })
+		parent: async () => ({ availableYears: params.availableYears }),
+		setHeaders: (values: Record<string, string>) => {
+			if (params.headers) Object.assign(params.headers, values);
+		}
 	} as unknown as LoadArgs);
 	return result as LoadData;
 }
@@ -115,7 +119,8 @@ async function expectServerWrappedStatus(year: string, expectedStatus: number): 
 	try {
 		await loadServerWrapped({
 			params: { year },
-			locals: {}
+			locals: {},
+			setHeaders: () => {}
 		} as unknown as ServerLoadArgs);
 		expect.unreachable(`Expected server wrapped status ${expectedStatus} for ${year}`);
 	} catch (err) {
@@ -127,6 +132,24 @@ describe('wrapped/[year] loader: year bounds', () => {
 	it('returns 404 for years outside the supported range', async () => {
 		await expectServerWrappedStatus('1999', 404);
 		await expectServerWrappedStatus('2101', 404);
+	});
+
+	it('sets no-store cache control on user wrapped loads', async () => {
+		const headers: Record<string, string> = {};
+
+		try {
+			await invokeLoad({
+				year: 1999,
+				identifier: '1',
+				availableYears: [1999],
+				headers
+			});
+			expect.unreachable('Expected user wrapped load to throw');
+		} catch (err) {
+			expect((err as { status?: number }).status).toBe(404);
+		}
+
+		expect(headers['cache-control']).toBe('no-store');
 	});
 });
 
@@ -611,6 +634,61 @@ describe('wrapped/[year]/u/[identifier] actions: token URL + floor-elevated mode
 		// Without the fix this would be: { status: 400, data: { error: 'Invalid user identifier' } }
 		const status = (result as { status?: number }).status;
 		expect(status).not.toBe(400);
+	});
+
+	it('rejects below-floor share modes for owners and returns server truth', async () => {
+		const result = await invokeUpdateShareMode({
+			identifier: TOKEN,
+			mode: ShareMode.PUBLIC,
+			currentUser: {
+				id: USER_ID,
+				plexId: 100042,
+				username: `user-${USER_ID}`,
+				isAdmin: false
+			}
+		});
+
+		expect(result).toMatchObject({
+			status: 403,
+			data: {
+				currentMode: ShareMode.PRIVATE_LINK,
+				globalFloor: ShareMode.PRIVATE_OAUTH,
+				shareSettings: {
+					mode: ShareMode.PRIVATE_LINK,
+					storedMode: ShareMode.PRIVATE_LINK,
+					shareToken: TOKEN
+				}
+			}
+		});
+	});
+
+	it('rejects below-floor share modes for admins and returns server truth', async () => {
+		const ADMIN_ID = 7;
+		await seedUser(ADMIN_ID, 100007, 200007);
+
+		const result = await invokeUpdateShareMode({
+			identifier: TOKEN,
+			mode: ShareMode.PUBLIC,
+			currentUser: {
+				id: ADMIN_ID,
+				plexId: 100007,
+				username: `user-${ADMIN_ID}`,
+				isAdmin: true
+			}
+		});
+
+		expect(result).toMatchObject({
+			status: 403,
+			data: {
+				currentMode: ShareMode.PRIVATE_LINK,
+				globalFloor: ShareMode.PRIVATE_OAUTH,
+				shareSettings: {
+					mode: ShareMode.PRIVATE_LINK,
+					storedMode: ShareMode.PRIVATE_LINK,
+					canUserControl: true
+				}
+			}
+		});
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes wrapped sharing privacy regressions where stale browser/page data could keep exposing or submitting outdated sharing settings after the privacy floor, server wrapped access mode, or share tokens changed.

## Changes

- Add `Cache-Control: no-store` to both server-wide and per-user wrapped page loads so privacy-sensitive wrapped pages are not reused from browser cache after access settings change.
- Refresh wrapped share modal page data with `invalidateAll()` when the modal opens and keep share controls disabled while refresh or update work is in flight.
- Keep share mode options visible while enforcing the global privacy floor by disabling below-floor modes and guarding radio `onchange` submissions against stale DOM or automation.
- Return current server truth from `updateShareMode` permission-floor failures, including current mode, global floor, canonical URL, and share settings, so the modal can recover from stale local state.
- Preserve existing sharing semantics: `public < private-link < private-oauth`, invalid private-link tokens still return 404, and anonymous private-oauth access still returns 403.

## Verification

- `bun test tests/unit/sharing/server-wrapped-route.test.ts tests/unit/sharing/wrapped-identifier-loader.test.ts tests/unit/admin/ui-source-regressions.test.ts`
- `bun run check`
- `bun run test`
- `bun run check:biome`
