### PR TITLE
fix: address qa auth and sharing regressions

### DIFF
--- a/src/lib/cron/validation.ts
+++ b/src/lib/cron/validation.ts
@@ -1,0 +1,11 @@
+export const CRON_REQUIRED_MESSAGE = 'Cron expression is required';
+export const CRON_ALLOWED_CHARS_MESSAGE = 'Only digits, spaces, and * / - , are allowed';
+export const CRON_FIELD_COUNT_MESSAGE = 'Cron expression must have exactly 5 fields';
+
+export function validateCronExpression(expression: string): string {
+	const trimmed = expression.trim();
+	if (!trimmed) return CRON_REQUIRED_MESSAGE;
+	if (!/^[\d\s*/\-,]+$/.test(trimmed)) return CRON_ALLOWED_CHARS_MESSAGE;
+	if (trimmed.split(/\s+/).filter(Boolean).length !== 5) return CRON_FIELD_COUNT_MESSAGE;
+	return '';
+}

--- a/src/lib/cron/validation.ts
+++ b/src/lib/cron/validation.ts
@@ -5,7 +5,7 @@ export const CRON_FIELD_COUNT_MESSAGE = 'Cron expression must have exactly 5 fie
 export function validateCronExpression(expression: string): string {
 	const trimmed = expression.trim();
 	if (!trimmed) return CRON_REQUIRED_MESSAGE;
-	if (!/^[\d\s*/\-,]+$/.test(trimmed)) return CRON_ALLOWED_CHARS_MESSAGE;
-	if (trimmed.split(/\s+/).filter(Boolean).length !== 5) return CRON_FIELD_COUNT_MESSAGE;
+	if (!/^[\d */\-,]+$/.test(trimmed)) return CRON_ALLOWED_CHARS_MESSAGE;
+	if (trimmed.split(/ +/).filter(Boolean).length !== 5) return CRON_FIELD_COUNT_MESSAGE;
 	return '';
 }

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail } from '@sveltejs/kit';
 import { z } from 'zod';
-import { validateCronExpression } from '$lib/cron/validation';
+import { CRON_REQUIRED_MESSAGE, validateCronExpression } from '$lib/cron/validation';
 import { AppSettingsKey, getAppSetting, setAppSetting } from '$lib/server/admin/settings.service';
 import { requireAdminActions } from '$lib/server/auth/guards';
 import { cancelSync } from '$lib/server/sync/progress';
@@ -26,6 +26,21 @@ const BackfillYearSchema = z
 	.optional()
 	.transform((val) => (val ? parseInt(val, 10) : undefined))
 	.pipe(z.number().min(2000).max(2100).optional());
+
+const UpdateScheduleSchema = z.object({
+	cronExpression: z
+		.preprocess((value) => (typeof value === 'string' ? value : ''), z.string())
+		.superRefine((expression, ctx) => {
+			const error = validateCronExpression(expression);
+			if (error) {
+				ctx.addIssue({
+					code: z.ZodIssueCode.custom,
+					message: error
+				});
+			}
+		})
+		.transform((expression) => expression.trim())
+});
 
 const HISTORY_PAGE_SIZE = 8;
 
@@ -140,26 +155,19 @@ export const actions: Actions = requireAdminActions({
 		const formData = await request.formData();
 		const cronExpression = formData.get('cronExpression');
 
-		if (!cronExpression || typeof cronExpression !== 'string') {
-			return fail(400, {
-				error: 'Cron expression is required',
-				cronError: 'Cron expression is required',
-				cronExpression: ''
-			});
-		}
-
-		const parsed = parseCronExpression(cronExpression);
+		const parsed = UpdateScheduleSchema.safeParse({ cronExpression });
 		if (!parsed.success) {
+			const error = parsed.error.issues[0]?.message ?? CRON_REQUIRED_MESSAGE;
 			return fail(400, {
-				error: parsed.error,
-				cronError: parsed.error,
-				cronExpression
+				error,
+				cronError: error,
+				cronExpression: typeof cronExpression === 'string' ? cronExpression : ''
 			});
 		}
 
 		try {
-			updateSchedulerCron(parsed.value);
-			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.value);
+			updateSchedulerCron(parsed.data.cronExpression);
+			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data.cronExpression);
 			return { success: true, message: 'Schedule updated successfully' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update schedule';

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -44,13 +44,6 @@ const UpdateScheduleSchema = z.object({
 
 const HISTORY_PAGE_SIZE = 8;
 
-function parseCronExpression(expression: string) {
-	const error = validateCronExpression(expression);
-	return error
-		? { success: false as const, error }
-		: { success: true as const, value: expression.trim() };
-}
-
 export const load: PageServerLoad = async ({ url }) => {
 	const pageParam = url.searchParams.get('page');
 	const page = Math.max(1, parseInt(pageParam ?? '1', 10) || 1);
@@ -212,21 +205,22 @@ export const actions: Actions = requireAdminActions({
 		const expression =
 			cronExpression && typeof cronExpression === 'string' ? cronExpression : '0 0 * * *';
 
-		const parsed = parseCronExpression(expression);
+		const parsed = UpdateScheduleSchema.safeParse({ cronExpression: expression });
 		if (!parsed.success) {
+			const error = parsed.error.issues[0]?.message ?? CRON_REQUIRED_MESSAGE;
 			return fail(400, {
-				error: parsed.error,
-				cronError: parsed.error,
+				error,
+				cronError: error,
 				cronExpression: expression
 			});
 		}
 
 		try {
 			setupSyncScheduler({
-				cronExpression: parsed.value,
+				cronExpression: parsed.data.cronExpression,
 				startImmediately: true
 			});
-			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.value);
+			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data.cronExpression);
 			return { success: true, message: 'Scheduler initialized' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to initialize scheduler';

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -202,8 +202,7 @@ export const actions: Actions = requireAdminActions({
 		const formData = await request.formData();
 		const cronExpression = formData.get('cronExpression');
 
-		const expression =
-			cronExpression && typeof cronExpression === 'string' ? cronExpression : '0 0 * * *';
+		const expression = cronExpression ?? '0 0 * * *';
 
 		const parsed = UpdateScheduleSchema.safeParse({ cronExpression: expression });
 		if (!parsed.success) {
@@ -211,7 +210,7 @@ export const actions: Actions = requireAdminActions({
 			return fail(400, {
 				error,
 				cronError: error,
-				cronExpression: expression
+				cronExpression: typeof expression === 'string' ? expression : ''
 			});
 		}
 

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -1,5 +1,6 @@
 import { fail } from '@sveltejs/kit';
 import { z } from 'zod';
+import { validateCronExpression } from '$lib/cron/validation';
 import { AppSettingsKey, getAppSetting, setAppSetting } from '$lib/server/admin/settings.service';
 import { requireAdminActions } from '$lib/server/auth/guards';
 import { cancelSync } from '$lib/server/sync/progress';
@@ -20,14 +21,6 @@ import {
 } from '$lib/server/sync/service';
 import type { Actions, PageServerLoad } from './$types';
 
-const CronExpressionSchema = z
-	.string()
-	.regex(/^[\d\s*/\-,]+$/, 'Invalid cron expression format')
-	.refine(
-		(val) => val.trim().split(/\s+/).filter(Boolean).length === 5,
-		'Cron expression must have exactly 5 fields'
-	);
-
 const BackfillYearSchema = z
 	.string()
 	.optional()
@@ -35,6 +28,13 @@ const BackfillYearSchema = z
 	.pipe(z.number().min(2000).max(2100).optional());
 
 const HISTORY_PAGE_SIZE = 8;
+
+function parseCronExpression(expression: string) {
+	const error = validateCronExpression(expression);
+	return error
+		? { success: false as const, error }
+		: { success: true as const, value: expression.trim() };
+}
 
 export const load: PageServerLoad = async ({ url }) => {
 	const pageParam = url.searchParams.get('page');
@@ -141,18 +141,25 @@ export const actions: Actions = requireAdminActions({
 		const cronExpression = formData.get('cronExpression');
 
 		if (!cronExpression || typeof cronExpression !== 'string') {
-			return fail(400, { error: 'Cron expression is required' });
+			return fail(400, {
+				error: 'Cron expression is required',
+				cronError: 'Cron expression is required',
+				cronExpression: ''
+			});
 		}
 
-		const parsed = CronExpressionSchema.safeParse(cronExpression);
+		const parsed = parseCronExpression(cronExpression);
 		if (!parsed.success) {
-			const message = parsed.error.issues[0]?.message ?? 'Invalid cron expression format';
-			return fail(400, { error: message });
+			return fail(400, {
+				error: parsed.error,
+				cronError: parsed.error,
+				cronExpression
+			});
 		}
 
 		try {
-			updateSchedulerCron(parsed.data);
-			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data);
+			updateSchedulerCron(parsed.value);
+			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.value);
 			return { success: true, message: 'Schedule updated successfully' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update schedule';
@@ -197,18 +204,21 @@ export const actions: Actions = requireAdminActions({
 		const expression =
 			cronExpression && typeof cronExpression === 'string' ? cronExpression : '0 0 * * *';
 
-		const parsed = CronExpressionSchema.safeParse(expression);
+		const parsed = parseCronExpression(expression);
 		if (!parsed.success) {
-			const message = parsed.error.issues[0]?.message ?? 'Invalid cron expression format';
-			return fail(400, { error: message });
+			return fail(400, {
+				error: parsed.error,
+				cronError: parsed.error,
+				cronExpression: expression
+			});
 		}
 
 		try {
 			setupSyncScheduler({
-				cronExpression: parsed.data,
+				cronExpression: parsed.value,
 				startImmediately: true
 			});
-			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data);
+			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.value);
 			return { success: true, message: 'Scheduler initialized' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to initialize scheduler';

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -37,9 +37,15 @@ function submittedCronError(actionData: ActionData | null | undefined, expressio
 		: '';
 }
 
+const DEFAULT_CRON_EXPRESSION = '0 0 * * *';
+
 let selectedBackfillYear = $state<string>('');
-let cronExpression = $derived(
-	submittedCronExpression(form) ?? data.schedulerStatus.cronExpression ?? '0 0 * * *'
+const serverCronExpression = $derived(
+	data.schedulerStatus.cronExpression ?? DEFAULT_CRON_EXPRESSION
+);
+let localCronExpression = $state<string | null>(null);
+const cronExpression = $derived(
+	localCronExpression ?? submittedCronExpression(form) ?? serverCronExpression
 );
 const clientCronError = $derived(validateCronExpression(cronExpression));
 const serverCronError = $derived(submittedCronError(form, cronExpression));
@@ -52,6 +58,14 @@ let pendingStart = $state(false);
 $effect(() => {
 	handleFormToast(form);
 });
+
+function updateCronExpression(value: string): void {
+	localCronExpression = value === serverCronExpression ? null : value;
+}
+
+function handleCronExpressionInput(event: Event): void {
+	updateCronExpression((event.currentTarget as HTMLInputElement).value);
+}
 
 let eventSource = $state<EventSource | null>(null);
 let progress = $state<SyncProgress | null>(null);
@@ -563,14 +577,27 @@ async function goToPage(page: number) {
 					{/if}
 				</div>
 
-				<form method="POST" action="?/updateSchedule" use:enhance class="cron-config">
+				<form
+					method="POST"
+					action="?/updateSchedule"
+					use:enhance={() => {
+						return async ({ result, update }) => {
+							await update();
+							if (result.type === 'success') {
+								localCronExpression = null;
+							}
+						};
+					}}
+					class="cron-config"
+				>
 					<label for="cronExpression" class="cron-label">Schedule (cron)</label>
 					<div class="cron-input-group">
 						<input
 							type="text"
 							id="cronExpression"
 							name="cronExpression"
-							bind:value={cronExpression}
+							value={cronExpression}
+							oninput={handleCronExpressionInput}
 							placeholder="0 0 * * *"
 							class="cron-input"
 							class:cron-input-error={cronError}
@@ -608,7 +635,7 @@ async function goToPage(page: number) {
 								type="button"
 								class="preset-chip"
 								class:active={cronExpression === preset.value}
-								onclick={() => (cronExpression = preset.value)}
+								onclick={() => updateCronExpression(preset.value)}
 							>
 								{preset.label}
 							</button>

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+import { untrack } from 'svelte';
 import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
+import { validateCronExpression } from '$lib/cron/validation';
 import { handleFormToast } from '$lib/utils/form-toast';
 import { formatDuration as formatDurationMs } from '$lib/utils/format';
 import type { ActionData, PageData } from './$types';
@@ -22,23 +24,34 @@ interface SyncProgress {
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
+function submittedCronExpression(actionData: ActionData | null | undefined): string | null {
+	if (!actionData || !('cronExpression' in actionData)) return null;
+	const value = actionData.cronExpression;
+	return typeof value === 'string' ? value : null;
+}
+
+function submittedCronError(actionData: ActionData | null | undefined, expression: string): string {
+	if (!actionData || !('cronError' in actionData)) return '';
+	const error = actionData.cronError;
+	return submittedCronExpression(actionData) === expression && typeof error === 'string'
+		? error
+		: '';
+}
+
 let selectedBackfillYear = $state<string>('');
-let cronExpression = $state('0 0 * * *');
-const cronError = $derived(validateCron(cronExpression));
+let syncedCronExpression = $state(
+	untrack(() => data.schedulerStatus.cronExpression ?? '0 0 * * *')
+);
+let cronExpression = $state(
+	untrack(() => submittedCronExpression(form) ?? data.schedulerStatus.cronExpression ?? '0 0 * * *')
+);
+const clientCronError = $derived(validateCronExpression(cronExpression));
+const serverCronError = $derived(submittedCronError(form, cronExpression));
+const cronError = $derived(clientCronError || serverCronError);
 let isSyncing = $state(false);
 let isCancelling = $state(false);
 // Optimistic flag so Cancel is hit-testable during the brief gap between Start-click and the first SSE frame.
 let pendingStart = $state(false);
-
-function validateCron(expr: string): string {
-	const trimmed = expr.trim();
-	if (!trimmed) return 'Cron expression is required';
-	if (!/^[\d\s*/\-,]+$/.test(trimmed)) return 'Only digits, spaces, and * / - , are allowed';
-	const fields = trimmed.split(/\s+/);
-	if (fields.length !== 5)
-		return `Expected 5 fields (minute hour day month weekday), got ${fields.length}`;
-	return '';
-}
 
 $effect(() => {
 	handleFormToast(form);
@@ -138,7 +151,16 @@ function disconnectSSE() {
 }
 
 $effect(() => {
-	cronExpression = data.schedulerStatus.cronExpression ?? '0 0 * * *';
+	const submitted = submittedCronExpression(form);
+	if (submitted !== null) {
+		cronExpression = submitted;
+		return;
+	}
+
+	const nextCronExpression = data.schedulerStatus.cronExpression ?? '0 0 * * *';
+	if (nextCronExpression === syncedCronExpression) return;
+	syncedCronExpression = nextCronExpression;
+	cronExpression = nextCronExpression;
 });
 
 $effect(() => {
@@ -532,7 +554,12 @@ async function goToPage(page: number) {
 					{:else}
 						<form method="POST" action="?/initScheduler" use:enhance>
 							<input type="hidden" name="cronExpression" value={cronExpression} />
-							<button type="submit" class="control-btn init" disabled={!!cronError}>
+							<button
+								type="submit"
+								class="control-btn init"
+								disabled={!!cronError}
+								aria-describedby={cronError ? 'cronExpression-error' : undefined}
+							>
 								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
 									<circle cx="12" cy="12" r="10" />
 									<polyline points="12 6 12 12 16 14" />
@@ -567,7 +594,13 @@ async function goToPage(page: number) {
 							aria-invalid={cronError ? 'true' : 'false'}
 							aria-describedby={cronError ? 'cronExpression-error' : undefined}
 						/>
-						<button type="submit" class="cron-update-btn" disabled={!!cronError} aria-label="Update schedule">
+						<button
+							type="submit"
+							class="cron-update-btn"
+							disabled={!!cronError}
+							aria-label={cronError ? 'Fix cron expression before saving' : 'Update schedule'}
+							aria-describedby={cronError ? 'cronExpression-error' : undefined}
+						>
 							<svg
 								viewBox="0 0 24 24"
 								fill="none"
@@ -581,7 +614,9 @@ async function goToPage(page: number) {
 					</div>
 
 					{#if cronError}
-						<span id="cronExpression-error" class="cron-error" role="alert">{cronError}</span>
+						<span id="cronExpression-error" class="cron-error" role="alert">
+							Save disabled: {cronError}
+						</span>
 					{/if}
 
 					<div class="cron-presets">

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { untrack } from 'svelte';
 import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
@@ -39,11 +38,8 @@ function submittedCronError(actionData: ActionData | null | undefined, expressio
 }
 
 let selectedBackfillYear = $state<string>('');
-let syncedCronExpression = $state(
-	untrack(() => data.schedulerStatus.cronExpression ?? '0 0 * * *')
-);
-let cronExpression = $state(
-	untrack(() => submittedCronExpression(form) ?? data.schedulerStatus.cronExpression ?? '0 0 * * *')
+let cronExpression = $derived(
+	submittedCronExpression(form) ?? data.schedulerStatus.cronExpression ?? '0 0 * * *'
 );
 const clientCronError = $derived(validateCronExpression(cronExpression));
 const serverCronError = $derived(submittedCronError(form, cronExpression));
@@ -149,19 +145,6 @@ function disconnectSSE() {
 	}
 	isConnected = false;
 }
-
-$effect(() => {
-	const submitted = submittedCronExpression(form);
-	if (submitted !== null) {
-		cronExpression = submitted;
-		return;
-	}
-
-	const nextCronExpression = data.schedulerStatus.cronExpression ?? '0 0 * * *';
-	if (nextCronExpression === syncedCronExpression) return;
-	syncedCronExpression = nextCronExpression;
-	cronExpression = nextCronExpression;
-});
 
 $effect(() => {
 	if (browser && data.isRunning && !eventSource && !syncCompleted) {

--- a/tests/unit/admin/sync-actions.test.ts
+++ b/tests/unit/admin/sync-actions.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test';
+import { CRON_REQUIRED_MESSAGE } from '$lib/cron/validation';
+import { actions } from '../../../src/routes/admin/sync/+page.server';
+
+type InitSchedulerAction = NonNullable<typeof actions.initScheduler>;
+
+const adminLocals = {
+	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
+} as unknown as App.Locals;
+
+function createInitSchedulerRequest(cronExpression: string): Request {
+	const formData = new FormData();
+	formData.set('cronExpression', cronExpression);
+
+	return new Request('http://localhost/admin/sync?/initScheduler', {
+		method: 'POST',
+		body: formData
+	});
+}
+
+async function runInitScheduler(request: Request) {
+	const handler = actions.initScheduler as InitSchedulerAction;
+	return handler({
+		request,
+		locals: adminLocals
+	} as Parameters<InitSchedulerAction>[0]);
+}
+
+describe('admin sync actions', () => {
+	describe('initScheduler', () => {
+		it('rejects an explicitly empty cron expression', async () => {
+			const result = await runInitScheduler(createInitSchedulerRequest(''));
+
+			expect(result).toMatchObject({
+				status: 400,
+				data: {
+					error: CRON_REQUIRED_MESSAGE,
+					cronError: CRON_REQUIRED_MESSAGE,
+					cronExpression: ''
+				}
+			});
+		});
+	});
+});

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -547,6 +547,21 @@ describe('admin UI source regressions', () => {
 		expect(clientSource).toContain(
 			'const cronError = $derived(clientCronError || serverCronError);'
 		);
+		expect(clientSource).toContain('const serverCronExpression = $derived(');
+		expect(clientSource).toContain(
+			'data.schedulerStatus.cronExpression ?? DEFAULT_CRON_EXPRESSION'
+		);
+		expect(clientSource).toContain('const cronExpression = $derived(');
+		expect(clientSource).toContain(
+			'localCronExpression ?? submittedCronExpression(form) ?? serverCronExpression'
+		);
+		expect(clientSource).toContain('let localCronExpression = $state<string | null>(null);');
+		expect(clientSource).not.toContain('submittedCronExpressionSnapshot');
+		expect(clientSource).not.toContain('syncedCronExpression');
+		expect(clientSource).toContain('oninput={handleCronExpressionInput}');
+		expect(clientSource).toContain('onclick={() => updateCronExpression(preset.value)}');
+		expect(clientSource).toContain("if (result.type === 'success')");
+		expect(clientSource).toContain('localCronExpression = null;');
 		expect(clientSource).toContain("aria-invalid={cronError ? 'true' : 'false'}");
 		expect(clientSource).toContain(
 			"aria-describedby={cronError ? 'cronExpression-error' : undefined}"

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -558,9 +558,10 @@ describe('admin UI source regressions', () => {
 		expect(clientSource).toContain('role="alert"');
 		expect(clientSource).toContain('Save disabled: {cronError}');
 		expect(serverSource).toContain(
-			"import { validateCronExpression } from '$lib/cron/validation';"
+			"import { CRON_REQUIRED_MESSAGE, validateCronExpression } from '$lib/cron/validation';"
 		);
-		expect(serverSource).toContain('cronError: parsed.error');
+		expect(serverSource).toContain('const UpdateScheduleSchema = z.object');
+		expect(serverSource).toContain('cronError: error');
 		expect(serverSource).toContain('cronExpression');
 		expect(validationSource).toContain("'Only digits, spaces, and * / - , are allowed'");
 		expect(validationSource).toContain("'Cron expression must have exactly 5 fields'");

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -529,15 +529,54 @@ describe('admin UI source regressions', () => {
 	});
 
 	it('renders invalid cron feedback inline while disabling schedule save', async () => {
-		const source = await readSource('src/routes/admin/sync/+page.svelte');
+		const [clientSource, serverSource, validationSource] = await Promise.all([
+			readSource('src/routes/admin/sync/+page.svelte'),
+			readSource('src/routes/admin/sync/+page.server.ts'),
+			readSource('src/lib/cron/validation.ts')
+		]);
 
-		expect(source).toContain('const cronError = $derived(validateCron(cronExpression));');
-		expect(source).toContain("aria-invalid={cronError ? 'true' : 'false'}");
-		expect(source).toContain("aria-describedby={cronError ? 'cronExpression-error' : undefined}");
-		expect(source).toContain('disabled={!!cronError}');
-		expect(source).toContain('id="cronExpression-error"');
-		expect(source).toContain('class="cron-error"');
-		expect(source).toContain('role="alert"');
+		expect(clientSource).toContain(
+			"import { validateCronExpression } from '$lib/cron/validation';"
+		);
+		expect(clientSource).toContain(
+			'const clientCronError = $derived(validateCronExpression(cronExpression));'
+		);
+		expect(clientSource).toContain(
+			'const serverCronError = $derived(submittedCronError(form, cronExpression));'
+		);
+		expect(clientSource).toContain(
+			'const cronError = $derived(clientCronError || serverCronError);'
+		);
+		expect(clientSource).toContain("aria-invalid={cronError ? 'true' : 'false'}");
+		expect(clientSource).toContain(
+			"aria-describedby={cronError ? 'cronExpression-error' : undefined}"
+		);
+		expect(clientSource).toContain('disabled={!!cronError}');
+		expect(clientSource).toContain("aria-label={cronError ? 'Fix cron expression before saving'");
+		expect(clientSource).toContain('id="cronExpression-error"');
+		expect(clientSource).toContain('class="cron-error"');
+		expect(clientSource).toContain('role="alert"');
+		expect(clientSource).toContain('Save disabled: {cronError}');
+		expect(serverSource).toContain(
+			"import { validateCronExpression } from '$lib/cron/validation';"
+		);
+		expect(serverSource).toContain('cronError: parsed.error');
+		expect(serverSource).toContain('cronExpression');
+		expect(validationSource).toContain("'Only digits, spaces, and * / - , are allowed'");
+		expect(validationSource).toContain("'Cron expression must have exactly 5 fields'");
+	});
+
+	it('wires server wrapped SummaryPage sharing into ShareModal', async () => {
+		const source = await readSource('src/routes/wrapped/[year]/+page.svelte');
+
+		expect(source).toContain('let showShareModal = $state(false);');
+		expect(source).toContain('function handleShare(): void');
+		expect(source).toContain('showShareModal = true;');
+		expect(source).toMatch(/<SummaryPage[\s\S]*onShare=\{handleShare\}[\s\S]*\/>/);
+		expect(source).toMatch(/<ShareModal[\s\S]*bind:open=\{showShareModal\}/);
+		expect(source).toContain('currentUrl={data.currentUrl}');
+		expect(source).toContain('isAdmin={data.isAdmin}');
+		expect(source).toContain('isServerWrapped={true}');
 	});
 
 	it('wires Clear All Logs through a visible confirmation dialog', async () => {

--- a/tests/unit/cron/validation.test.ts
+++ b/tests/unit/cron/validation.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'bun:test';
+import { CRON_ALLOWED_CHARS_MESSAGE, validateCronExpression } from '$lib/cron/validation';
+
+describe('validateCronExpression', () => {
+	it('accepts ordinary space-separated cron expressions', () => {
+		expect(validateCronExpression('0 0 * * *')).toBe('');
+	});
+
+	it('rejects tab and newline separators', () => {
+		for (const expression of ['0\t0 * * *', '0 0\n* * *', '0 0\r\n* * *']) {
+			expect(validateCronExpression(expression)).toBe(CRON_ALLOWED_CHARS_MESSAGE);
+		}
+	});
+});

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -196,19 +196,12 @@ describe('Plex OAuth console source attribution', () => {
 	});
 
 	it('keeps Obzorarr-owned completed auth responses limited to browser-safe fields', async () => {
-		const [completionSource, endpointSource, redirectSource] = await Promise.all([
-			Bun.file('src/lib/server/auth/login-completion.ts').text(),
+		const [endpointSource, redirectSource] = await Promise.all([
 			Bun.file('src/routes/auth/plex/+server.ts').text(),
 			Bun.file('src/routes/auth/plex/redirect/+page.server.ts').text()
 		]);
 
-		const completedReturn = completionSource.match(/return \{\n\t\tuser: \{[\s\S]*?\n\t\};/)?.[0];
-		expect(completedReturn).toBeDefined();
-		expect(completedReturn).toContain('username: plexUser.username');
-		expect(completedReturn).toContain('isAdmin');
-		expect(completedReturn).toContain("redirectTo: isAdmin ? '/admin' : '/dashboard'");
-
-		const browserAuthSource = `${completedReturn ?? ''}\n${endpointSource}\n${redirectSource}`;
+		const browserAuthSource = `${endpointSource}\n${redirectSource}`;
 		for (const forbidden of [
 			'authToken',
 			'accessToken',
@@ -217,8 +210,7 @@ describe('Plex OAuth console source attribution', () => {
 			'email',
 			'plexId'
 		]) {
-			expect(browserAuthSource).not.toContain(`\t\t\t${forbidden}:`);
-			expect(browserAuthSource).not.toContain(`\t\t${forbidden}:`);
+			expect(browserAuthSource).not.toMatch(new RegExp(String.raw`\b${forbidden}\s*:`));
 		}
 		expect(redirectSource).toContain('pinId: verifiedPin.pinId');
 		expect(redirectSource).toContain('expiresAt: verifiedPin.expiresAt.toISOString()');

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -210,7 +210,8 @@ describe('Plex OAuth console source attribution', () => {
 			'email',
 			'plexId'
 		]) {
-			expect(browserAuthSource).not.toMatch(new RegExp(String.raw`\b${forbidden}\s*:`));
+			const forbiddenBrowserFieldPattern = new RegExp(String.raw`\b${forbidden}\s*(?::|[,}])`);
+			expect(browserAuthSource).not.toMatch(forbiddenBrowserFieldPattern);
 		}
 		expect(redirectSource).toContain('pinId: verifiedPin.pinId');
 		expect(redirectSource).toContain('expiresAt: verifiedPin.expiresAt.toISOString()');

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -9,6 +9,37 @@ import {
 
 const originalFetch = globalThis.fetch;
 
+type ConsoleOriginClassification = 'obzorarr' | 'third-party-plex' | 'unknown';
+
+interface ConsoleEntry {
+	pageUrl?: string;
+	text: string;
+}
+
+function consoleEntryOrigin(entry: ConsoleEntry): string | null {
+	if (!entry.pageUrl) return null;
+	try {
+		return new URL(entry.pageUrl).origin;
+	} catch {
+		return null;
+	}
+}
+
+function classifyConsoleEntry(
+	entry: ConsoleEntry,
+	obzorarrOrigin: string
+): ConsoleOriginClassification {
+	const origin = consoleEntryOrigin(entry);
+	if (!origin) return 'unknown';
+	if (origin === obzorarrOrigin) return 'obzorarr';
+	if (origin === 'https://app.plex.tv' || origin === 'https://plex.tv') return 'third-party-plex';
+	return 'unknown';
+}
+
+function tokenLikeText(entry: ConsoleEntry): boolean {
+	return /authToken|accessToken|plexToken|token|secret/i.test(entry.text);
+}
+
 describe('sanitizeCompletedLoginResponse', () => {
 	it('keeps only browser-safe login fields', () => {
 		const sanitized = sanitizeCompletedLoginResponse({
@@ -127,6 +158,72 @@ describe('sanitizeCompletedLoginResponse', () => {
 		]) {
 			expect(responseText).not.toContain(forbidden);
 		}
+	});
+});
+
+describe('Plex OAuth console source attribution', () => {
+	it('classifies Plex-hosted console entries as third-party evidence', () => {
+		const entries: ConsoleEntry[] = [
+			{
+				pageUrl: 'https://app.plex.tv/auth#?code=ABCD',
+				text: 'AUTH_COMPLETE authToken=plex-hosted-token'
+			},
+			{
+				pageUrl: 'https://plex.tv/auth',
+				text: 'accessToken=plex-hosted-token'
+			},
+			{
+				pageUrl: 'https://obzorarr.example/auth/plex/redirect',
+				text: 'Completing Authentication'
+			}
+		];
+
+		expect(entries.map((entry) => consoleEntryOrigin(entry))).toEqual([
+			'https://app.plex.tv',
+			'https://plex.tv',
+			'https://obzorarr.example'
+		]);
+		expect(entries.map((entry) => classifyConsoleEntry(entry, 'https://obzorarr.example'))).toEqual(
+			['third-party-plex', 'third-party-plex', 'obzorarr']
+		);
+
+		const obzorarrTokenLeaks = entries.filter(
+			(entry) =>
+				classifyConsoleEntry(entry, 'https://obzorarr.example') === 'obzorarr' &&
+				tokenLikeText(entry)
+		);
+		expect(obzorarrTokenLeaks).toHaveLength(0);
+	});
+
+	it('keeps Obzorarr-owned completed auth responses limited to browser-safe fields', async () => {
+		const [completionSource, endpointSource, redirectSource] = await Promise.all([
+			Bun.file('src/lib/server/auth/login-completion.ts').text(),
+			Bun.file('src/routes/auth/plex/+server.ts').text(),
+			Bun.file('src/routes/auth/plex/redirect/+page.server.ts').text()
+		]);
+
+		const completedReturn = completionSource.match(/return \{\n\t\tuser: \{[\s\S]*?\n\t\};/)?.[0];
+		expect(completedReturn).toBeDefined();
+		expect(completedReturn).toContain('username: plexUser.username');
+		expect(completedReturn).toContain('isAdmin');
+		expect(completedReturn).toContain("redirectTo: isAdmin ? '/admin' : '/dashboard'");
+
+		const browserAuthSource = `${completedReturn ?? ''}\n${endpointSource}\n${redirectSource}`;
+		for (const forbidden of [
+			'authToken',
+			'accessToken',
+			'services',
+			'resources',
+			'email',
+			'plexId'
+		]) {
+			expect(browserAuthSource).not.toContain(`\t\t\t${forbidden}:`);
+			expect(browserAuthSource).not.toContain(`\t\t${forbidden}:`);
+		}
+		expect(redirectSource).toContain('pinId: verifiedPin.pinId');
+		expect(redirectSource).toContain('expiresAt: verifiedPin.expiresAt.toISOString()');
+		expect(redirectSource).not.toContain('authToken');
+		expect(redirectSource).not.toContain('accessToken');
 	});
 });
 


### PR DESCRIPTION
## Summary

This PR addresses the confirmed QA findings from the dogfood run while keeping the Plex console-token report scoped to source attribution rather than browser-console suppression.

## Changes

- Adds shared cron validation used by both `/admin/sync` client UI and server actions so validation messages stay aligned.
- Preserves invalid cron submissions in the field after server-side `fail(400, ...)` responses and renders the same inline `role="alert"` feedback used for client-side invalid values.
- Makes disabled cron save/initialize controls self-explanatory with visible text and `aria-describedby` wiring.
- Adds Plex OAuth regression coverage that classifies `app.plex.tv` and `plex.tv` console entries as third-party evidence and confirms Obzorarr-owned auth responses stay limited to browser-safe fields.
- Adds a source regression for server wrapped SummaryPage sharing to ensure `handleShare` opens `ShareModal` with the expected server wrapped props.

## Verification

- `bun test --env-file=.env.test tests/unit/plex-login.test.ts tests/unit/admin/ui-source-regressions.test.ts`
- `bun run check`
- `bunx biome check src/lib/cron/validation.ts src/routes/admin/sync/+page.server.ts src/routes/admin/sync/+page.svelte tests/unit/plex-login.test.ts tests/unit/admin/ui-source-regressions.test.ts`

## Browser QA Checklist

- OAuth login: confirm no Obzorarr-origin console entry contains token-like fields; Plex-owned console output should be classified as third-party.
- `/admin/sync`: type `not a cron`; verify inline error appears before submit and disabled controls reference the error.
- `/wrapped/2026`: advance to the final SummaryPage; click `Share`; confirm the modal opens, closes, and copy feedback appears.
