### PR TITLE
fix: resolve dogfood findings ISSUE-001 to ISSUE-016

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -32,18 +32,22 @@ import {
 	requestFilterHandle
 } from '$lib/server/security';
 
+// `event.url.protocol` is the single source of truth: proxyHandle rewrites
+// event.url from x-forwarded-proto only when TRUST_PROXY is enabled, so reading
+// it here keeps the HSTS decision aligned with the trust-proxy gate rather than
+// reading the raw header twice.
 const securityHeadersHandle: Handle = async ({ event, resolve }) => {
 	const response = await resolve(event);
-	return applySecurityHeaders(response, event.request);
+	return applySecurityHeaders(response, event.url.protocol === 'https:');
 };
 
-function redirectResponse(event: { request: Request }, location: string): Response {
+function redirectResponse(event: { url: URL }, location: string): Response {
 	return applySecurityHeaders(
 		new Response(null, {
 			status: 303,
 			headers: { Location: location }
 		}),
-		event.request
+		event.url.protocol === 'https:'
 	);
 }
 

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -61,8 +61,15 @@ function handleActionClick(event: MouseEvent, action: () => void): void {
 	// is a no-op" — ISSUE-013 saw all three endcard buttons fail silently with
 	// no console error and no toast. Surface failures explicitly so the next
 	// dogfood pass can attribute the regression to a specific handler.
+	// `() => void` permits handlers that return a Promise, so guard both
+	// synchronous throws and asynchronous rejections.
 	try {
-		action();
+		const result = action() as unknown;
+		if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
+			(result as Promise<unknown>).catch((error) => {
+				console.error('Summary endcard action rejected', error);
+			});
+		}
 	} catch (error) {
 		console.error('Summary endcard action threw', error);
 	}

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -65,11 +65,12 @@ function handleActionClick(event: MouseEvent, action: () => void): void {
 	// synchronous throws and asynchronous rejections.
 	try {
 		const result = action() as unknown;
-		if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
-			(result as Promise<unknown>).catch((error) => {
-				console.error('Summary endcard action rejected', error);
-			});
-		}
+		// `Promise.resolve` normalises any thenable (or non-thenable) to a real
+		// Promise, so `.catch` is guaranteed to exist even when `action()`
+		// returns a Promises/A+ thenable that lacks `.catch`, or `undefined`.
+		Promise.resolve(result).catch((error) => {
+			console.error('Summary endcard action rejected', error);
+		});
 	} catch (error) {
 		console.error('Summary endcard action threw', error);
 	}

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -57,7 +57,15 @@ function handleSummaryKeyDown(event: KeyboardEvent) {
 function handleActionClick(event: MouseEvent, action: () => void): void {
 	event.preventDefault();
 	event.stopPropagation();
-	action();
+	// Swallowed exceptions inside the click path used to look like "the button
+	// is a no-op" — ISSUE-013 saw all three endcard buttons fail silently with
+	// no console error and no toast. Surface failures explicitly so the next
+	// dogfood pass can attribute the regression to a specific handler.
+	try {
+		action();
+	} catch (error) {
+		console.error('Summary endcard action threw', error);
+	}
 }
 
 // Move initial focus to the heading instead of the first button so

--- a/src/lib/server/security/csrf-handle.ts
+++ b/src/lib/server/security/csrf-handle.ts
@@ -79,7 +79,7 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 					status: 403,
 					headers: { 'Content-Type': 'application/json' }
 				}),
-				event.request
+				event.url.protocol === 'https:'
 			);
 		}
 
@@ -99,7 +99,7 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 				status: 403,
 				headers: { 'Content-Type': 'application/json' }
 			}),
-			event.request
+			event.url.protocol === 'https:'
 		);
 	}
 
@@ -116,7 +116,7 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 				status: 403,
 				headers: { 'Content-Type': 'application/json' }
 			}),
-			event.request
+			event.url.protocol === 'https:'
 		);
 	}
 

--- a/src/lib/server/security/proxy-handle.ts
+++ b/src/lib/server/security/proxy-handle.ts
@@ -5,18 +5,17 @@ import { buildForwardedUrl, parseForwardedProtoHost } from './forwarded-headers'
 
 let proxyStartupLogged = false;
 
-// Resolve the effective URL for a request after honouring TRUST_PROXY and the
-// forwarded headers — the same decision proxyHandle uses when it mutates
-// event.url. Returns the rewritten URL or null when no rewrite should occur
-// (TRUST_PROXY=false, forwarded headers missing/invalid, etc.).
-//
-// This is the single source of truth for "did the proxy decide this is HTTPS?"
-// Handlers that run before proxyHandle in the request pipeline (such as
-// requestFilterHandle and rateLimitHandle, which can short-circuit with a
-// Response) must consult this rather than reading x-forwarded-proto directly
-// or trusting event.url.protocol — both of those would either bypass the
-// TRUST_PROXY gate or return the pre-rewrite protocol.
-async function resolveForwardedUrl(event: RequestEvent): Promise<URL | null> {
+// Module-level cache for the resolved TRUST_PROXY boolean. The setting is
+// operationally static (changes only when an admin toggles it in the UI), but
+// getTrustProxyConfigWithSource() reads the full app_settings table on every
+// call. Without this cache, every blocked/rate-limited request triggers a fresh
+// SQLite scan via isProxiedHttps() — defensive short-circuits should shed load,
+// not amplify it. Admin write sites MUST call _resetTrustProxyCache() AFTER the
+// DB write completes so subsequent requests re-resolve the new value.
+let cachedTrustProxy: boolean | null = null;
+
+async function resolveTrustProxy(): Promise<boolean> {
+	if (cachedTrustProxy !== null) return cachedTrustProxy;
 	const config = await getTrustProxyConfigWithSource();
 	const trustProxy = config.trustProxy.value === 'true';
 
@@ -31,6 +30,23 @@ async function resolveForwardedUrl(event: RequestEvent): Promise<URL | null> {
 		);
 	}
 
+	cachedTrustProxy = trustProxy;
+	return trustProxy;
+}
+
+// Resolve the effective URL for a request after honouring TRUST_PROXY and the
+// forwarded headers — the same decision proxyHandle uses when it mutates
+// event.url. Returns the rewritten URL or null when no rewrite should occur
+// (TRUST_PROXY=false, forwarded headers missing/invalid, etc.).
+//
+// This is the single source of truth for "did the proxy decide this is HTTPS?"
+// Handlers that run before proxyHandle in the request pipeline (such as
+// requestFilterHandle and rateLimitHandle, which can short-circuit with a
+// Response) must consult this rather than reading x-forwarded-proto directly
+// or trusting event.url.protocol — both of those would either bypass the
+// TRUST_PROXY gate or return the pre-rewrite protocol.
+async function resolveForwardedUrl(event: RequestEvent): Promise<URL | null> {
+	const trustProxy = await resolveTrustProxy();
 	if (!trustProxy) return null;
 
 	return buildForwardedUrl(event.url, parseForwardedProtoHost(event.request.headers));
@@ -67,4 +83,13 @@ export const proxyHandle: Handle = async ({ event, resolve }) => {
 // Test-only: reset the one-shot startup-log flag so tests can re-exercise it.
 export function _resetProxyStartupLogged(): void {
 	proxyStartupLogged = false;
+}
+
+// Invalidate the cached TRUST_PROXY decision so the next request re-reads it
+// from settings. Admin action handlers MUST call this AFTER setAppSetting()
+// completes — calling it before the write would cache the stale value again
+// on a concurrent request. JS is single-threaded so sequential await order in
+// the same handler is sufficient.
+export function _resetTrustProxyCache(): void {
+	cachedTrustProxy = null;
 }

--- a/src/lib/server/security/proxy-handle.ts
+++ b/src/lib/server/security/proxy-handle.ts
@@ -5,33 +5,40 @@ import { buildForwardedUrl, parseForwardedProtoHost } from './forwarded-headers'
 
 let proxyStartupLogged = false;
 
-// Module-level cache for the resolved TRUST_PROXY boolean. The setting is
+// Module-level cache for the resolved TRUST_PROXY decision. The setting is
 // operationally static (changes only when an admin toggles it in the UI), but
 // getTrustProxyConfigWithSource() reads the full app_settings table on every
 // call. Without this cache, every blocked/rate-limited request triggers a fresh
 // SQLite scan via isProxiedHttps() — defensive short-circuits should shed load,
 // not amplify it. Admin write sites MUST call _resetTrustProxyCache() AFTER the
 // DB write completes so subsequent requests re-resolve the new value.
-let cachedTrustProxy: boolean | null = null;
+//
+// We cache the in-flight Promise rather than the resolved boolean. This makes
+// reset-during-resolve race-safe: a concurrent _resetTrustProxyCache() nulls
+// the slot, but any request already awaiting the old promise keeps its
+// reference via closure and that promise never writes back to the slot on
+// resolution. Subsequent misses after the reset start a fresh fetch.
+let trustProxyPromise: Promise<boolean> | null = null;
 
-async function resolveTrustProxy(): Promise<boolean> {
-	if (cachedTrustProxy !== null) return cachedTrustProxy;
-	const config = await getTrustProxyConfigWithSource();
-	const trustProxy = config.trustProxy.value === 'true';
+function resolveTrustProxy(): Promise<boolean> {
+	if (trustProxyPromise !== null) return trustProxyPromise;
+	trustProxyPromise = getTrustProxyConfigWithSource().then((config) => {
+		const trustProxy = config.trustProxy.value === 'true';
 
-	if (!proxyStartupLogged && trustProxy) {
-		proxyStartupLogged = true;
-		const sourceLabel = config.trustProxy.source === 'env' ? 'environment' : 'database';
-		logger.warn(
-			`Trusting reverse-proxy x-forwarded-* headers (source: ${sourceLabel}). ` +
-				'The upstream proxy MUST strip inbound x-forwarded-* headers from clients ' +
-				'or attackers can poison event.url.host / event.url.protocol.',
-			'Proxy'
-		);
-	}
+		if (!proxyStartupLogged && trustProxy) {
+			proxyStartupLogged = true;
+			const sourceLabel = config.trustProxy.source === 'env' ? 'environment' : 'database';
+			logger.warn(
+				`Trusting reverse-proxy x-forwarded-* headers (source: ${sourceLabel}). ` +
+					'The upstream proxy MUST strip inbound x-forwarded-* headers from clients ' +
+					'or attackers can poison event.url.host / event.url.protocol.',
+				'Proxy'
+			);
+		}
 
-	cachedTrustProxy = trustProxy;
-	return trustProxy;
+		return trustProxy;
+	});
+	return trustProxyPromise;
 }
 
 // Resolve the effective URL for a request after honouring TRUST_PROXY and the
@@ -87,9 +94,14 @@ export function _resetProxyStartupLogged(): void {
 
 // Invalidate the cached TRUST_PROXY decision so the next request re-reads it
 // from settings. Admin action handlers MUST call this AFTER setAppSetting()
-// completes — calling it before the write would cache the stale value again
-// on a concurrent request. JS is single-threaded so sequential await order in
-// the same handler is sufficient.
+// completes — calling it before the write would seed the cache with a fresh
+// fetch of the OLD value if a concurrent request misses in the same tick.
+//
+// Race-safety against in-flight resolves: clearing trustProxyPromise drops
+// only the module slot. Any request that already awaited the pre-reset promise
+// keeps its reference via closure and is unaffected; that promise never writes
+// back to the slot on resolution, so it cannot pollute the cache after reset.
+// The next miss after this call starts a fresh fetch and caches the new value.
 export function _resetTrustProxyCache(): void {
-	cachedTrustProxy = null;
+	trustProxyPromise = null;
 }

--- a/src/lib/server/security/proxy-handle.ts
+++ b/src/lib/server/security/proxy-handle.ts
@@ -18,26 +18,40 @@ let proxyStartupLogged = false;
 // the slot, but any request already awaiting the old promise keeps its
 // reference via closure and that promise never writes back to the slot on
 // resolution. Subsequent misses after the reset start a fresh fetch.
+//
+// Rejections are self-evicting: if getTrustProxyConfigWithSource() rejects
+// (or the .then callback throws), the chained .catch nulls the slot and
+// re-throws. The current caller still fails fast, and the next request starts
+// a fresh fetch — so a transient DB error cannot stick a rejected promise in
+// the cache indefinitely.
 let trustProxyPromise: Promise<boolean> | null = null;
 
 function resolveTrustProxy(): Promise<boolean> {
 	if (trustProxyPromise !== null) return trustProxyPromise;
-	trustProxyPromise = getTrustProxyConfigWithSource().then((config) => {
-		const trustProxy = config.trustProxy.value === 'true';
+	trustProxyPromise = getTrustProxyConfigWithSource()
+		.then((config) => {
+			const trustProxy = config.trustProxy.value === 'true';
 
-		if (!proxyStartupLogged && trustProxy) {
-			proxyStartupLogged = true;
-			const sourceLabel = config.trustProxy.source === 'env' ? 'environment' : 'database';
-			logger.warn(
-				`Trusting reverse-proxy x-forwarded-* headers (source: ${sourceLabel}). ` +
-					'The upstream proxy MUST strip inbound x-forwarded-* headers from clients ' +
-					'or attackers can poison event.url.host / event.url.protocol.',
-				'Proxy'
-			);
-		}
+			if (!proxyStartupLogged && trustProxy) {
+				proxyStartupLogged = true;
+				const sourceLabel = config.trustProxy.source === 'env' ? 'environment' : 'database';
+				logger.warn(
+					`Trusting reverse-proxy x-forwarded-* headers (source: ${sourceLabel}). ` +
+						'The upstream proxy MUST strip inbound x-forwarded-* headers from clients ' +
+						'or attackers can poison event.url.host / event.url.protocol.',
+					'Proxy'
+				);
+			}
 
-		return trustProxy;
-	});
+			return trustProxy;
+		})
+		.catch((err) => {
+			// Evict the rejected promise so the next caller retries instead of
+			// re-throwing the same stale rejection forever. Re-throw so the
+			// current caller still observes the failure.
+			trustProxyPromise = null;
+			throw err;
+		});
 	return trustProxyPromise;
 }
 

--- a/src/lib/server/security/proxy-handle.ts
+++ b/src/lib/server/security/proxy-handle.ts
@@ -16,19 +16,22 @@ let proxyStartupLogged = false;
 // We cache the in-flight Promise rather than the resolved boolean. This makes
 // reset-during-resolve race-safe: a concurrent _resetTrustProxyCache() nulls
 // the slot, but any request already awaiting the old promise keeps its
-// reference via closure and that promise never writes back to the slot on
-// resolution. Subsequent misses after the reset start a fresh fetch.
+// reference via closure. The successful .then path never writes back to the
+// slot on resolution, so it cannot pollute the cache after reset.
 //
-// Rejections are self-evicting: if getTrustProxyConfigWithSource() rejects
-// (or the .then callback throws), the chained .catch nulls the slot and
-// re-throws. The current caller still fails fast, and the next request starts
-// a fresh fetch — so a transient DB error cannot stick a rejected promise in
-// the cache indefinitely.
+// Rejections are self-evicting with an identity check: if
+// getTrustProxyConfigWithSource() rejects (or the .then callback throws), the
+// chained .catch nulls the slot ONLY when its own promise is still the current
+// one. That guard prevents a late rejection from a pre-reset chain from
+// clobbering a freshly-populated post-reset chain. The current caller still
+// fails fast, and the next miss starts a fresh fetch — so a transient DB error
+// cannot stick a rejected promise in the cache indefinitely.
 let trustProxyPromise: Promise<boolean> | null = null;
 
 function resolveTrustProxy(): Promise<boolean> {
 	if (trustProxyPromise !== null) return trustProxyPromise;
-	trustProxyPromise = getTrustProxyConfigWithSource()
+
+	const chain: Promise<boolean> = getTrustProxyConfigWithSource()
 		.then((config) => {
 			const trustProxy = config.trustProxy.value === 'true';
 
@@ -47,11 +50,15 @@ function resolveTrustProxy(): Promise<boolean> {
 		})
 		.catch((err) => {
 			// Evict the rejected promise so the next caller retries instead of
-			// re-throwing the same stale rejection forever. Re-throw so the
-			// current caller still observes the failure.
-			trustProxyPromise = null;
+			// re-throwing the same stale rejection forever. Guard with an
+			// identity check so that if _resetTrustProxyCache() ran and another
+			// request already populated a new chain, we do NOT clobber it.
+			// Re-throw so the current caller still observes the failure.
+			if (trustProxyPromise === chain) trustProxyPromise = null;
 			throw err;
 		});
+
+	trustProxyPromise = chain;
 	return trustProxyPromise;
 }
 
@@ -113,9 +120,12 @@ export function _resetProxyStartupLogged(): void {
 //
 // Race-safety against in-flight resolves: clearing trustProxyPromise drops
 // only the module slot. Any request that already awaited the pre-reset promise
-// keeps its reference via closure and is unaffected; that promise never writes
-// back to the slot on resolution, so it cannot pollute the cache after reset.
-// The next miss after this call starts a fresh fetch and caches the new value.
+// keeps its reference via closure and is unaffected. The successful .then path
+// never writes back to the slot, and the .catch path only writes back when its
+// own promise is still the current one (identity check) — so neither a late
+// resolution nor a late rejection from a pre-reset chain can pollute the cache
+// after reset + repopulation. The next miss after this call starts a fresh
+// fetch and caches the new value.
 export function _resetTrustProxyCache(): void {
 	trustProxyPromise = null;
 }

--- a/src/lib/server/security/proxy-handle.ts
+++ b/src/lib/server/security/proxy-handle.ts
@@ -1,14 +1,22 @@
-import type { Handle } from '@sveltejs/kit';
+import type { Handle, RequestEvent } from '@sveltejs/kit';
 import { getTrustProxyConfigWithSource } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
 import { buildForwardedUrl, parseForwardedProtoHost } from './forwarded-headers';
 
 let proxyStartupLogged = false;
 
-// NOTE: this handler does NOT touch event.getClientAddress(); the production
-// adapter (svelte-adapter-bun) resolves the client IP independently. Operators
-// who need IP trust must configure their adapter / runtime separately.
-export const proxyHandle: Handle = async ({ event, resolve }) => {
+// Resolve the effective URL for a request after honouring TRUST_PROXY and the
+// forwarded headers — the same decision proxyHandle uses when it mutates
+// event.url. Returns the rewritten URL or null when no rewrite should occur
+// (TRUST_PROXY=false, forwarded headers missing/invalid, etc.).
+//
+// This is the single source of truth for "did the proxy decide this is HTTPS?"
+// Handlers that run before proxyHandle in the request pipeline (such as
+// requestFilterHandle and rateLimitHandle, which can short-circuit with a
+// Response) must consult this rather than reading x-forwarded-proto directly
+// or trusting event.url.protocol — both of those would either bypass the
+// TRUST_PROXY gate or return the pre-rewrite protocol.
+async function resolveForwardedUrl(event: RequestEvent): Promise<URL | null> {
 	const config = await getTrustProxyConfigWithSource();
 	const trustProxy = config.trustProxy.value === 'true';
 
@@ -23,11 +31,28 @@ export const proxyHandle: Handle = async ({ event, resolve }) => {
 		);
 	}
 
-	if (!trustProxy) {
-		return resolve(event);
-	}
+	if (!trustProxy) return null;
 
-	const forwardedUrl = buildForwardedUrl(event.url, parseForwardedProtoHost(event.request.headers));
+	return buildForwardedUrl(event.url, parseForwardedProtoHost(event.request.headers));
+}
+
+// Decide whether the effective request protocol is HTTPS, honouring
+// TRUST_PROXY exactly the same way proxyHandle does. Safe to call from
+// handlers that run before proxyHandle (e.g. requestFilterHandle,
+// rateLimitHandle) which need the post-proxy isHttps state to set HSTS on
+// early-return responses without re-introducing a spoofable direct read of
+// x-forwarded-proto.
+export async function isProxiedHttps(event: RequestEvent): Promise<boolean> {
+	const forwardedUrl = await resolveForwardedUrl(event);
+	const effectiveUrl = forwardedUrl ?? event.url;
+	return effectiveUrl.protocol === 'https:';
+}
+
+// NOTE: this handler does NOT touch event.getClientAddress(); the production
+// adapter (svelte-adapter-bun) resolves the client IP independently. Operators
+// who need IP trust must configure their adapter / runtime separately.
+export const proxyHandle: Handle = async ({ event, resolve }) => {
+	const forwardedUrl = await resolveForwardedUrl(event);
 	if (!forwardedUrl) return resolve(event);
 
 	Object.defineProperty(event, 'url', {

--- a/src/lib/server/security/rate-limit-handle.ts
+++ b/src/lib/server/security/rate-limit-handle.ts
@@ -79,7 +79,7 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 						}
 					}
 				),
-				event.request
+				event.url.protocol === 'https:'
 			);
 		}
 
@@ -98,7 +98,7 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 						...rateLimitHeaders
 					}
 				}),
-				event.request
+				event.url.protocol === 'https:'
 			);
 		}
 
@@ -128,7 +128,7 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 					...rateLimitHeaders
 				}
 			}),
-			event.request
+			event.url.protocol === 'https:'
 		);
 	}
 

--- a/src/lib/server/security/rate-limit-handle.ts
+++ b/src/lib/server/security/rate-limit-handle.ts
@@ -1,6 +1,7 @@
 import type { Handle } from '@sveltejs/kit';
 import { stringify } from 'devalue';
 import { checkRateLimit, RATE_LIMIT_CONFIGS, type RateLimitConfig } from '$lib/server/ratelimit';
+import { isProxiedHttps } from './proxy-handle';
 import { applySecurityHeaders } from './security-headers';
 
 function getConfigForPath(path: string, method: string): RateLimitConfig {
@@ -59,6 +60,12 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 		};
 		const isEnhancedActionRequest =
 			event.request.method === 'POST' && event.request.headers.get('x-sveltekit-action') === 'true';
+		// rateLimitHandle runs before proxyHandle, so event.url.protocol still
+		// reflects the pre-rewrite value. Resolve the effective protocol the same
+		// way proxyHandle would, so HSTS is set on early-return 429 responses for
+		// proxied HTTPS clients (matching what securityHeadersHandle does later in
+		// the pipeline for non-early-return responses).
+		const isHttps = await isProxiedHttps(event);
 
 		if (isEnhancedActionRequest) {
 			return applySecurityHeaders(
@@ -79,7 +86,7 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 						}
 					}
 				),
-				event.url.protocol === 'https:'
+				isHttps
 			);
 		}
 
@@ -98,7 +105,7 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 						...rateLimitHeaders
 					}
 				}),
-				event.url.protocol === 'https:'
+				isHttps
 			);
 		}
 
@@ -128,7 +135,7 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 					...rateLimitHeaders
 				}
 			}),
-			event.url.protocol === 'https:'
+			isHttps
 		);
 	}
 

--- a/src/lib/server/security/request-filter.ts
+++ b/src/lib/server/security/request-filter.ts
@@ -1,5 +1,6 @@
 import type { Handle } from '@sveltejs/kit';
 import { logger } from '$lib/server/logging';
+import { isProxiedHttps } from './proxy-handle';
 import { isBlockedPath, isBlockedUserAgent } from './request-filter-patterns';
 import { applySecurityHeaders } from './security-headers';
 
@@ -10,12 +11,16 @@ export const requestFilterHandle: Handle = async ({ event, resolve }) => {
 
 	if (isBlockedPath(path)) {
 		logger.debug(`Blocked scanner probe: ${path}`, 'Security', { ip });
+		// requestFilterHandle runs before proxyHandle, so event.url.protocol is
+		// still the pre-rewrite value. Consult isProxiedHttps so HSTS is applied
+		// on proxied HTTPS connections, matching what securityHeadersHandle would
+		// have done for non-early-return responses.
 		return applySecurityHeaders(
 			new Response(JSON.stringify({ error: 'Not Found' }), {
 				status: 404,
 				headers: { 'Content-Type': 'application/json' }
 			}),
-			event.url.protocol === 'https:'
+			await isProxiedHttps(event)
 		);
 	}
 
@@ -26,7 +31,7 @@ export const requestFilterHandle: Handle = async ({ event, resolve }) => {
 				status: 403,
 				headers: { 'Content-Type': 'application/json' }
 			}),
-			event.url.protocol === 'https:'
+			await isProxiedHttps(event)
 		);
 	}
 

--- a/src/lib/server/security/request-filter.ts
+++ b/src/lib/server/security/request-filter.ts
@@ -15,7 +15,7 @@ export const requestFilterHandle: Handle = async ({ event, resolve }) => {
 				status: 404,
 				headers: { 'Content-Type': 'application/json' }
 			}),
-			event.request
+			event.url.protocol === 'https:'
 		);
 	}
 
@@ -26,7 +26,7 @@ export const requestFilterHandle: Handle = async ({ event, resolve }) => {
 				status: 403,
 				headers: { 'Content-Type': 'application/json' }
 			}),
-			event.request
+			event.url.protocol === 'https:'
 		);
 	}
 

--- a/src/lib/server/security/security-headers.ts
+++ b/src/lib/server/security/security-headers.ts
@@ -1,4 +1,4 @@
-export function applySecurityHeaders(response: Response, request: Request): Response {
+export function applySecurityHeaders(response: Response, isHttps: boolean): Response {
 	response.headers.set('X-Frame-Options', 'DENY');
 	response.headers.set('X-Content-Type-Options', 'nosniff');
 	response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
@@ -6,9 +6,12 @@ export function applySecurityHeaders(response: Response, request: Request): Resp
 	// Content-Security-Policy is managed by SvelteKit's kit.csp (svelte.config.js)
 	// using nonce mode, which eliminates the need for 'unsafe-inline' on script-src.
 
-	const isHttps =
-		new URL(request.url).protocol === 'https:' ||
-		request.headers.get('x-forwarded-proto')?.includes('https');
+	// Trust the protocol decision the caller made. proxyHandle is the single
+	// gate that honours TRUST_PROXY when deciding whether to rewrite event.url
+	// from x-forwarded-proto; reading the header here would bypass that gate
+	// and let an upstream-spoofed `X-Forwarded-Proto: https` advertise HSTS on
+	// an HTTP-only deployment, letting browsers cache a permanent upgrade hint
+	// for an origin that cannot serve HTTPS.
 	if (isHttps) {
 		response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 	}

--- a/src/lib/server/sync/scheduler.ts
+++ b/src/lib/server/sync/scheduler.ts
@@ -16,6 +16,12 @@ const JOB_NAME = 'plex-sync';
 const PROGRESS_LOG_INTERVAL = 10;
 
 let schedulerInstance: Cron | null = null;
+// Tracks operator intent for the paused state. croner's `isRunning() === false`
+// is also true between scheduled ticks, so we cannot derive "paused" from
+// instance state alone (ISSUE-005). The flag flips to true on pauseSyncScheduler
+// and back to false on resume/stop/setup so the admin badge can pick "Paused"
+// versus "Inactive" deterministically.
+let pausedByOperator = false;
 
 export function setupSyncScheduler(options: SchedulerOptions = {}): Cron {
 	const {
@@ -38,6 +44,8 @@ export function setupSyncScheduler(options: SchedulerOptions = {}): Cron {
 			logger.error(`Sync job "${job.name}" failed: ${error}`, 'Scheduler');
 		}
 	};
+
+	pausedByOperator = !startImmediately;
 
 	schedulerInstance = new Cron(cronExpression, cronOptions, async () => {
 		logger.info(`Starting scheduled sync at ${new Date().toISOString()}`, 'Scheduler');
@@ -84,6 +92,7 @@ export function stopSyncScheduler(): void {
 	if (schedulerInstance) {
 		schedulerInstance.stop();
 		schedulerInstance = null;
+		pausedByOperator = false;
 		logger.info('Sync scheduler stopped', 'Scheduler');
 	}
 }
@@ -91,6 +100,7 @@ export function stopSyncScheduler(): void {
 export function pauseSyncScheduler(): void {
 	if (schedulerInstance) {
 		schedulerInstance.pause();
+		pausedByOperator = true;
 		logger.info('Sync scheduler paused', 'Scheduler');
 	}
 }
@@ -98,6 +108,7 @@ export function pauseSyncScheduler(): void {
 export function resumeSyncScheduler(): void {
 	if (schedulerInstance) {
 		schedulerInstance.resume();
+		pausedByOperator = false;
 		logger.info('Sync scheduler resumed', 'Scheduler');
 	}
 }
@@ -113,13 +124,18 @@ export function getSchedulerStatus(): SchedulerStatus {
 		};
 	}
 
+	// croner's `isRunning()` answers "is the job currently executing its
+	// callback", not "is the schedule active" — between ticks it returns false
+	// even on a fully-initialised, non-paused scheduler. Use the operator-intent
+	// flag for the badge state and `!pausedByOperator` for whether ticks are
+	// being honoured.
+	const isPaused = pausedByOperator;
+	const isActive = !isPaused;
+
 	return {
-		isRunning: schedulerInstance.isRunning(),
-		isPaused: !schedulerInstance.isRunning() && !schedulerInstance.isStopped(),
-		nextRun:
-			schedulerInstance.isStopped() || !schedulerInstance.isRunning()
-				? null
-				: (schedulerInstance.nextRun() ?? null),
+		isRunning: isActive,
+		isPaused,
+		nextRun: isActive ? (schedulerInstance.nextRun() ?? null) : null,
 		previousRun: schedulerInstance.previousRun() ?? null,
 		cronExpression: schedulerInstance.getPattern() ?? null
 	};

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -695,10 +695,28 @@ $effect(() => {
 				action="?/clearLogs"
 				use:enhance={() => {
 					isClearingLogs = true;
-					return async ({ update }) => {
+					return async ({ result, update }) => {
 						try {
 							await refreshAfterLogMutation(update);
 							clearLogsDialogOpen = false;
+							// The page-level $effect also calls handleFormToast(form), but
+							// explicit feedback inside the enhance callback guarantees a toast
+							// even on adapter quirks where the form prop never refreshes
+							// (ISSUE-010 "no toast, no action" observation).
+							if (result.type === 'success') {
+								const payload = (result.data ?? {}) as { message?: string };
+								handleFormToast({
+									success: true,
+									message: payload.message ?? 'Logs cleared'
+								});
+							} else if (result.type === 'failure') {
+								const payload = (result.data ?? {}) as { error?: string };
+								handleFormToast({ error: payload.error ?? 'Failed to clear logs.' });
+							} else if (result.type === 'error') {
+								handleFormToast({
+									error: result.error?.message ?? 'Failed to clear logs.'
+								});
+							}
 						} finally {
 							isClearingLogs = false;
 						}
@@ -730,10 +748,26 @@ $effect(() => {
 				action="?/runCleanup"
 				use:enhance={() => {
 					isRunningCleanup = true;
-					return async ({ update }) => {
+					return async ({ result, update }) => {
 						try {
 							await refreshAfterLogMutation(update);
 							runCleanupDialogOpen = false;
+							if (result.type === 'success') {
+								const payload = (result.data ?? {}) as { message?: string };
+								handleFormToast({
+									success: true,
+									message: payload.message ?? 'Retention cleanup complete'
+								});
+							} else if (result.type === 'failure') {
+								const payload = (result.data ?? {}) as { error?: string };
+								handleFormToast({
+									error: payload.error ?? 'Failed to run retention cleanup.'
+								});
+							} else if (result.type === 'error') {
+								handleFormToast({
+									error: result.error?.message ?? 'Failed to run retention cleanup.'
+								});
+							}
 						} finally {
 							isRunningCleanup = false;
 						}

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -63,6 +63,7 @@ import {
 	normalizePlexServerUrl
 } from '$lib/server/security/credentialed-url';
 import { getOriginFromRequest } from '$lib/server/security/csrf-handle';
+import { _resetTrustProxyCache } from '$lib/server/security/proxy-handle';
 import {
 	bulkApplyShareDefaults,
 	getGlobalAllowUserControl,
@@ -1081,6 +1082,9 @@ export const actions: Actions = requireAdminActions({
 
 		try {
 			await setAppSetting(AppSettingsKey.TRUST_PROXY, enabled ? 'true' : 'false');
+			// Invalidate the in-process cache AFTER the DB write so subsequent
+			// requests re-resolve the new value.
+			_resetTrustProxyCache();
 			if (enabled) {
 				logger.warn(
 					'Reverse-proxy header trust enabled by admin. Verify your upstream proxy strips inbound x-forwarded-* headers.',

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -1,3 +1,4 @@
+import { arch as osArch, platform as osPlatform } from 'node:os';
 import { fail } from '@sveltejs/kit';
 import { z } from 'zod';
 import { env } from '$env/dynamic/private';
@@ -277,6 +278,14 @@ export const load: PageServerLoad = async () => {
 		availableYears,
 		currentYear,
 		playHistoryTotalCount,
+		// System info panel (ISSUE-006) — exposed as plain primitives so the
+		// SSR JSON is small and the client doesn't need to import node:os.
+		systemInfo: {
+			uptimeSeconds: Math.floor(process.uptime()),
+			osPlatform: osPlatform(),
+			osArch: osArch(),
+			bunVersion: typeof Bun !== 'undefined' ? Bun.version : null
+		},
 		logSettings: {
 			retentionDays: logRetentionDays,
 			maxCount: logMaxCount,

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -27,7 +27,6 @@ import {
 	isPlexInsecureLocalHttpAllowed,
 	resetCsrfWarningDismissal,
 	SERVER_WRAPPED_SETTINGS_KEYS,
-	setAnonymizationMode,
 	setApiConfigAtomic,
 	setAppSetting,
 	setCachedServerName,
@@ -67,11 +66,8 @@ import {
 	bulkApplyShareDefaults,
 	getGlobalAllowUserControl,
 	getGlobalDefaultShareMode,
-	getServerWrappedShareMode,
-	setGlobalShareDefaults,
-	setServerWrappedShareMode
+	getServerWrappedShareMode
 } from '$lib/server/sharing/service';
-import type { ShareModeType } from '$lib/server/sharing/types';
 import type { Actions, PageServerLoad } from './$types';
 
 const ThemeSchema = z.enum([
@@ -86,10 +82,6 @@ const WrappedLogoModeSchema = z.enum(['always_show', 'always_hide', 'user_choice
 
 const ShareModeSchema = z.enum(['public', 'private-oauth', 'private-link']);
 const BooleanStringSchema = z.enum(['true', 'false']).transform((value) => value === 'true');
-const GlobalDefaultsSchema = z.object({
-	defaultShareMode: ShareModeSchema,
-	allowUserControl: BooleanStringSchema
-});
 // Server-wide wrapped only supports public and private-oauth (not private-link)
 const ServerWrappedModeSchema = z.enum(['public', 'private-oauth']);
 
@@ -555,24 +547,6 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	updateAnonymization: async ({ request }) => {
-		const formData = await request.formData();
-		const mode = formData.get('anonymizationMode');
-
-		const parsed = AnonymizationSchema.safeParse(mode);
-		if (!parsed.success) {
-			return fail(400, { error: 'Invalid anonymization mode' });
-		}
-
-		try {
-			await setAnonymizationMode(parsed.data as AnonymizationModeType);
-			return { success: true, message: 'Anonymization mode updated' };
-		} catch (error) {
-			const message = error instanceof Error ? error.message : 'Failed to update mode';
-			return fail(500, { error: message });
-		}
-	},
-
 	updateWrappedLogoMode: async ({ request }) => {
 		const formData = await request.formData();
 		const mode = formData.get('logoMode');
@@ -697,9 +671,11 @@ export const actions: Actions = requireAdminActions({
 
 		const parsed = LogSettingsSchema.safeParse(data);
 		if (!parsed.success) {
+			const fieldErrors = parsed.error.flatten().fieldErrors;
+			logger.warn('updateLogSettings rejected: validation failed', 'Settings', { fieldErrors });
 			return fail(400, {
 				error: 'Invalid input',
-				fieldErrors: parsed.error.flatten().fieldErrors
+				fieldErrors
 			});
 		}
 
@@ -719,32 +695,6 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	updateGlobalDefaults: async ({ request }) => {
-		const formData = await request.formData();
-
-		const data = {
-			defaultShareMode: formData.get('defaultShareMode'),
-			allowUserControl: formData.get('allowUserControl')
-		};
-
-		const parsed = GlobalDefaultsSchema.safeParse(data);
-		if (!parsed.success) {
-			return fail(400, { error: 'Invalid input', fieldErrors: parsed.error.flatten().fieldErrors });
-		}
-
-		try {
-			await setGlobalShareDefaults({
-				defaultShareMode: parsed.data.defaultShareMode as ShareModeType,
-				allowUserControl: parsed.data.allowUserControl
-			});
-
-			return { success: true, message: 'Sharing defaults updated' };
-		} catch (error) {
-			const message = error instanceof Error ? error.message : 'Failed to update defaults';
-			return fail(500, { error: message });
-		}
-	},
-
 	bulkApplyShareDefaults: async () => {
 		try {
 			const count = await bulkApplyShareDefaults();
@@ -752,27 +702,6 @@ export const actions: Actions = requireAdminActions({
 		} catch (error) {
 			const message =
 				error instanceof Error ? error.message : 'Failed to apply defaults to existing users';
-			return fail(500, { error: message });
-		}
-	},
-
-	updateServerWrappedMode: async ({ request }) => {
-		const formData = await request.formData();
-		const mode = formData.get('serverWrappedShareMode');
-
-		const parsed = ServerWrappedModeSchema.safeParse(mode);
-		if (!parsed.success) {
-			return fail(400, {
-				error: 'Invalid share mode. Server wrapped only supports public or private-oauth.'
-			});
-		}
-
-		try {
-			await setServerWrappedShareMode(parsed.data as ShareModeType);
-			return { success: true, message: 'Server wrapped share mode updated' };
-		} catch (error) {
-			const message =
-				error instanceof Error ? error.message : 'Failed to update server wrapped mode';
 			return fail(500, { error: message });
 		}
 	},
@@ -795,6 +724,9 @@ export const actions: Actions = requireAdminActions({
 					error: 'Settings changed in another tab. Please reload.'
 				});
 			}
+			logger.warn('updateServerWrappedSettings rejected: validation failed', 'Settings', {
+				fieldErrors
+			});
 			return fail(400, {
 				error: 'Invalid input',
 				fieldErrors
@@ -840,6 +772,7 @@ export const actions: Actions = requireAdminActions({
 					error: 'Settings changed in another tab. Please reload.'
 				});
 			}
+			logger.warn('updateUserDefaults rejected: validation failed', 'Settings', { fieldErrors });
 			return fail(400, {
 				error: 'Invalid input',
 				fieldErrors

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -210,7 +210,13 @@ export const load: PageServerLoad = async () => {
 		plexAllowInsecureLocalHttp,
 		serverWrappedSettingsUpdatedAt,
 		userDefaultsSettingsUpdatedAt,
-		apiConfigUpdatedAt
+		apiConfigUpdatedAt,
+		// Eager-load the total play-history count so the destructive Delete History
+		// buttons can render with a known count from first paint, instead of needing
+		// an on-click POST to ?/getPlayHistoryCount before they can show a
+		// confirmation dialog. ISSUE-003 hit the no-count path and observed the
+		// click navigating to /admin with no feedback.
+		playHistoryTotalCount
 	] = await Promise.all([
 		getApiConfigWithSources(),
 		getUITheme(),
@@ -231,7 +237,8 @@ export const load: PageServerLoad = async () => {
 		isPlexInsecureLocalHttpAllowed(),
 		getAppSettingsUpdatedAt(SERVER_WRAPPED_SETTINGS_KEYS),
 		getAppSettingsUpdatedAt(USER_DEFAULTS_SETTINGS_KEYS),
-		getAppSettingsUpdatedAt(API_CONFIG_KEYS)
+		getAppSettingsUpdatedAt(API_CONFIG_KEYS),
+		countPlayHistory()
 	]);
 
 	const currentYear = new Date().getFullYear();
@@ -269,6 +276,7 @@ export const load: PageServerLoad = async () => {
 		})),
 		availableYears,
 		currentYear,
+		playHistoryTotalCount,
 		logSettings: {
 			retentionDays: logRetentionDays,
 			maxCount: logMaxCount,

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -515,10 +515,19 @@ async function showHistoryConfirmation(year?: number) {
 	loadingHistoryCount = true;
 	pendingHistoryYear = year;
 
-	const formData = new FormData();
-	if (year !== undefined) {
-		formData.append('year', year.toString());
+	// Year-undefined ("Delete All History") uses the load-time total — the page
+	// always knows the count even if the user hasn't pressed "Get Count" first,
+	// so the dialog renders without a probe request and never has a no-count path
+	// that could look like a silent failure (ISSUE-003).
+	if (year === undefined) {
+		pendingHistoryCount = data.playHistoryTotalCount;
+		historyDialogOpen = true;
+		loadingHistoryCount = false;
+		return;
 	}
+
+	const formData = new FormData();
+	formData.append('year', year.toString());
 
 	try {
 		const response = await fetch('?/getPlayHistoryCount', {

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -361,6 +361,20 @@ function selectWrappedLogoMode(mode: WrappedLogoModeValue): void {
 	selectedWrappedLogoMode = mode;
 }
 
+function formatUptime(seconds: number): string {
+	if (!Number.isFinite(seconds) || seconds < 0) return '—';
+	const days = Math.floor(seconds / 86400);
+	const hours = Math.floor((seconds % 86400) / 3600);
+	const minutes = Math.floor((seconds % 3600) / 60);
+	const remaining = Math.floor(seconds % 60);
+	const parts: string[] = [];
+	if (days > 0) parts.push(`${days}d`);
+	if (hours > 0) parts.push(`${hours}h`);
+	if (minutes > 0) parts.push(`${minutes}m`);
+	if (parts.length === 0) parts.push(`${remaining}s`);
+	return parts.join(' ');
+}
+
 function restoreServerWrappedSettings(): void {
 	selectedAnonymization = syncedAnonymization;
 	selectedServerWrappedMode = syncedServerWrappedMode;
@@ -2757,6 +2771,35 @@ const logFieldErrors = $derived(
 						</div>
 					</form>
 				</section>
+
+				<section class="panel system-panel">
+					<div class="panel-header">
+						<div class="panel-title">
+							<Monitor class="panel-icon" />
+							<h2>System</h2>
+						</div>
+					</div>
+					<p class="panel-description">Read-only runtime information for the current process.</p>
+
+					<dl class="system-info-grid">
+						<div class="system-info-item">
+							<dt>App version</dt>
+							<dd>{data.appVersion.display}</dd>
+						</div>
+						<div class="system-info-item">
+							<dt>Uptime</dt>
+							<dd>{formatUptime(data.systemInfo.uptimeSeconds)}</dd>
+						</div>
+						<div class="system-info-item">
+							<dt>OS / arch</dt>
+							<dd>{data.systemInfo.osPlatform} / {data.systemInfo.osArch}</dd>
+						</div>
+						<div class="system-info-item">
+							<dt>Bun version</dt>
+							<dd>{data.systemInfo.bunVersion ?? 'Unknown'}</dd>
+						</div>
+					</dl>
+				</section>
 			</div>
 		{/if}
 	</div>
@@ -3326,6 +3369,38 @@ const logFieldErrors = $derived(
 			font-size: 0.75rem;
 			color: hsl(var(--destructive));
 			margin-top: 0.375rem;
+		}
+
+		.system-info-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+			gap: 1rem;
+			margin: 0;
+			padding: 0;
+		}
+
+		.system-info-item {
+			background: hsl(var(--muted) / 0.4);
+			border: 1px solid hsl(var(--border));
+			border-radius: var(--radius);
+			padding: 0.875rem 1rem;
+		}
+
+		.system-info-item dt {
+			font-size: 0.7rem;
+			font-weight: 600;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+			color: hsl(var(--muted-foreground));
+			margin: 0 0 0.25rem;
+		}
+
+		.system-info-item dd {
+			margin: 0;
+			font-size: 0.9rem;
+			font-weight: 600;
+			color: hsl(var(--foreground));
+			word-break: break-word;
 		}
 
 		.source-badge {

--- a/src/routes/admin/slides/+page.server.ts
+++ b/src/routes/admin/slides/+page.server.ts
@@ -8,6 +8,7 @@ import {
 } from '$lib/server/admin/settings.service';
 import { getAvailableYears } from '$lib/server/admin/users.service';
 import { requireAdminActions } from '$lib/server/auth/guards';
+import { logger } from '$lib/server/logging';
 import {
 	getAllSlideConfigs,
 	initializeDefaultSlideConfig,
@@ -329,6 +330,9 @@ export const actions: Actions = requireAdminActions({
 		// Validate mode
 		const validModes = Object.values(FunFactFrequency);
 		if (typeof mode !== 'string' || !validModes.includes(mode as FunFactFrequencyType)) {
+			logger.warn('setFunFactFrequency rejected: invalid mode', 'Slides', {
+				submittedMode: typeof mode === 'string' ? mode : null
+			});
 			return fail(400, { error: 'Invalid frequency mode' });
 		}
 
@@ -336,14 +340,21 @@ export const actions: Actions = requireAdminActions({
 		let customCount: number | undefined;
 		if (mode === FunFactFrequency.CUSTOM) {
 			if (typeof customCountStr !== 'string') {
+				logger.warn('setFunFactFrequency rejected: custom count missing', 'Slides');
 				return fail(400, { error: 'Custom count must be between 1 and 15' });
 			}
 			const customCountToken = customCountStr.trim();
 			if (!/^\d+$/.test(customCountToken)) {
+				logger.warn('setFunFactFrequency rejected: custom count not integer', 'Slides', {
+					submittedCount: customCountStr
+				});
 				return fail(400, { error: 'Custom count must be between 1 and 15' });
 			}
 			customCount = Number(customCountToken);
 			if (!Number.isInteger(customCount) || customCount < 1 || customCount > 15) {
+				logger.warn('setFunFactFrequency rejected: custom count out of range', 'Slides', {
+					submittedCount: customCountStr
+				});
 				return fail(400, { error: 'Custom count must be between 1 and 15' });
 			}
 		}

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -21,6 +21,15 @@ $effect(() => {
 	handleFormToast(form);
 });
 
+// ISSUE-016: surface fieldErrors next to the offending input — the toast alone
+// only reported "Validation failed", which left the user guessing which field
+// was over the 200-char limit. Mirrors the pattern used in admin/settings.
+const slideFieldErrors = $derived(
+	form && 'fieldErrors' in form
+		? ((form as { fieldErrors?: Record<string, string[] | undefined> }).fieldErrors ?? undefined)
+		: undefined
+);
+
 // Slide display names
 const SLIDE_NAMES: Record<SlideType, string> = {
 	'total-time': 'Total Watch Time',
@@ -620,7 +629,14 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 							bind:value={editorTitle}
 							required
 							placeholder="Enter slide title"
+							aria-invalid={slideFieldErrors?.title?.[0] ? 'true' : undefined}
+							aria-describedby={slideFieldErrors?.title?.[0] ? 'title-error' : undefined}
 						/>
+						{#if slideFieldErrors?.title?.[0]}
+							<span id="title-error" class="field-error" role="alert">
+								{slideFieldErrors.title[0]}
+							</span>
+						{/if}
 					</div>
 
 					<div class="form-group">
@@ -733,6 +749,13 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			max-width: 800px;
 			margin: 0 auto;
 			padding: 2rem;
+		}
+
+		.field-error {
+			display: block;
+			font-size: 0.75rem;
+			color: hsl(var(--destructive));
+			margin-top: 0.375rem;
 		}
 
 		.admin-header {

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -117,13 +117,20 @@ export const actions: Actions = requireAdminActions({
 			const result = await startBackgroundSync(backfillYear);
 
 			if (!result.started) {
-				return fail(400, { error: result.error ?? 'Failed to start sync' });
+				return fail(400, {
+					error: result.error ?? 'Failed to start sync',
+					selectedYear: backfillYear ?? null
+				});
 			}
 
+			// Echo back the year we acted on so the form can re-select it after the
+			// post-submit update() — without this, the dropdown reverts to
+			// "New Activity Only" once the sync completes (ISSUE-004).
 			return {
 				success: true,
 				started: true,
-				message: 'Sync started'
+				message: 'Sync started',
+				selectedYear: backfillYear ?? null
 			};
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to start sync';

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -134,7 +134,7 @@ export const actions: Actions = requireAdminActions({
 			};
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to start sync';
-			return fail(500, { error: message });
+			return fail(500, { error: message, selectedYear: backfillYear ?? null });
 		}
 	},
 

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -40,6 +40,16 @@ function submittedCronError(actionData: ActionData | null | undefined, expressio
 const DEFAULT_CRON_EXPRESSION = '0 0 * * *';
 
 let selectedBackfillYear = $state<string>('');
+
+// After ?/startSync returns, re-select the year we just submitted so the
+// dropdown does not revert to "New Activity Only" — ISSUE-004 observed the
+// sync continuing as incremental on the next manual run because the user
+// thought the selection had stuck.
+$effect(() => {
+	const submitted = (form as { selectedYear?: number | null } | null | undefined)?.selectedYear;
+	if (submitted === undefined) return;
+	selectedBackfillYear = submitted === null ? '' : submitted.toString();
+});
 const serverCronExpression = $derived(
 	data.schedulerStatus.cronExpression ?? DEFAULT_CRON_EXPRESSION
 );

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -581,6 +581,10 @@ function getLogoModeDescription(): string {
 									) {
 										wrappedHrefOverride = payload.wrappedHref;
 									}
+								} else if (result.type === 'error') {
+									handleFormToast({
+										error: result.error?.message ?? 'Failed to regenerate share link.'
+									});
 								}
 
 								await update({ reset: result.type !== 'failure' });

--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -17,6 +17,7 @@ import {
 	setOnboardingStep
 } from '$lib/server/onboarding';
 import { parseForwardedProtoHost } from '$lib/server/security/forwarded-headers';
+import { _resetTrustProxyCache } from '$lib/server/security/proxy-handle';
 import { createReverseProxyDiagnostic } from '$lib/server/security/reverse-proxy-diagnostic';
 import type { Actions, PageServerLoad } from './$types';
 
@@ -328,6 +329,9 @@ export const actions: Actions = {
 		}
 
 		await setAppSetting(AppSettingsKey.TRUST_PROXY, 'true');
+		// Invalidate the in-process cache AFTER the DB write so subsequent
+		// requests re-resolve the new value.
+		_resetTrustProxyCache();
 		logger.warn(
 			'Reverse-proxy header trust enabled during onboarding. Verify your upstream proxy strips inbound x-forwarded-* headers.',
 			'Onboarding'

--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -277,18 +277,25 @@ export const actions: Actions = {
 			});
 		}
 
+		// Re-ordered per ISSUE-001: the diagnostic-recommendation guard must run
+		// BEFORE the confirmRisk guard, otherwise an API-direct caller posting
+		// `confirmRisk=1` on a system the diagnostic told to leave disabled would
+		// see the wrong error message and assume the diagnostic guard had passed.
+		// Parse browserOrigin alone first so we have a normalized value for the
+		// same-origin + diagnostic calls; confirmRisk is validated last so its
+		// error message is only emitted once the diagnostic has approved enabling.
 		const formData = await request.formData();
-		const parsed = TrustProxyEnableSchema.safeParse({
-			browserOrigin: formData.get('browserOrigin'),
-			confirmRisk: formData.get('confirmRisk')
+		const browserOriginParsed = BrowserOriginSchema.safeParse({
+			browserOrigin: formData.get('browserOrigin')
 		});
-		if (!parsed.success) {
+		if (!browserOriginParsed.success) {
 			return fail(400, {
-				trustProxyError: 'Confirm the reverse-proxy header trust risk before enabling TRUST_PROXY.'
+				trustProxyError:
+					browserOriginParsed.error.issues[0]?.message ?? 'Could not read browser origin safely'
 			});
 		}
 
-		if (!isSubmittedBrowserOriginAction(request, parsed.data.browserOrigin)) {
+		if (!isSubmittedBrowserOriginAction(request, browserOriginParsed.data.browserOrigin)) {
 			return fail(403, {
 				trustProxyError: 'Reverse proxy header trust must be enabled from this browser origin'
 			});
@@ -298,13 +305,25 @@ export const actions: Actions = {
 			request,
 			rawAppUrl: request.url,
 			effectiveAppUrl: url,
-			browserOrigin: parsed.data.browserOrigin,
+			browserOrigin: browserOriginParsed.data.browserOrigin,
 			sourceAddress: getClientAddress()
 		});
 		if (diagnostic.recommendation.action !== 'enable') {
 			return fail(400, {
 				trustProxyError:
 					'The current diagnostic does not recommend enabling reverse proxy header trust.'
+			});
+		}
+
+		// Now that the diagnostic has approved enabling, require the explicit
+		// risk-acknowledgement flag. The full schema enforces confirmRisk === 'true'.
+		const parsed = TrustProxyEnableSchema.safeParse({
+			browserOrigin: browserOriginParsed.data.browserOrigin,
+			confirmRisk: formData.get('confirmRisk')
+		});
+		if (!parsed.success) {
+			return fail(400, {
+				trustProxyError: 'Confirm the reverse-proxy header trust risk before enabling TRUST_PROXY.'
 			});
 		}
 

--- a/tests/unit/admin/settings-actions.test.ts
+++ b/tests/unit/admin/settings-actions.test.ts
@@ -561,8 +561,10 @@ describe('admin updateLogSettings action — round-trip', () => {
 	it('rejects retentionDays out of range without persisting any field', async () => {
 		const result = await run(createRequest({ retentionDays: '999' }));
 		expect(result).toMatchObject({ status: 400 });
-		// maxCount + debug stay at their defaults — confirm no partial write.
-		expect(await getAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION)).toBeNull();
+		// retention + maxCount + debug stay at their defaults — confirm no partial write.
+		expect(await getLogRetentionDays()).toBe(7);
+		expect(await getLogMaxCount()).toBe(50000);
+		expect(await isDebugEnabled()).toBe(false);
 	});
 
 	it('rejects maxCount below floor without persisting any field', async () => {

--- a/tests/unit/admin/settings-actions.test.ts
+++ b/tests/unit/admin/settings-actions.test.ts
@@ -2,16 +2,23 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import { env } from '$env/dynamic/private';
 import {
 	AppSettingsKey,
+	getAnonymizationMode,
 	getAppSetting,
 	getAppSettingsUpdatedAt,
 	getWrappedLogoMode,
+	SERVER_WRAPPED_SETTINGS_KEYS,
 	setAppSetting,
 	USER_DEFAULTS_SETTINGS_KEYS,
 	WrappedLogoMode
 } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
-import { getGlobalAllowUserControl, getGlobalDefaultShareMode } from '$lib/server/sharing/service';
+import { getLogMaxCount, getLogRetentionDays, isDebugEnabled } from '$lib/server/logging';
+import {
+	getGlobalAllowUserControl,
+	getGlobalDefaultShareMode,
+	getServerWrappedShareMode
+} from '$lib/server/sharing/service';
 import { actions } from '../../../src/routes/admin/settings/+page.server';
 
 type UpdateUserDefaultsAction = NonNullable<typeof actions.updateUserDefaults>;
@@ -19,6 +26,8 @@ type UpdateApiConfigAction = NonNullable<typeof actions.updateApiConfig>;
 type ClearOpenaiModelAction = NonNullable<typeof actions.clearOpenaiModel>;
 type UpdateTrustProxyAction = NonNullable<typeof actions.updateTrustProxy>;
 type UpdateWrappedLogoModeAction = NonNullable<typeof actions.updateWrappedLogoMode>;
+type UpdateServerWrappedSettingsAction = NonNullable<typeof actions.updateServerWrappedSettings>;
+type UpdateLogSettingsAction = NonNullable<typeof actions.updateLogSettings>;
 
 const adminLocals = {
 	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
@@ -449,5 +458,115 @@ describe('admin updateWrappedLogoMode action', () => {
 			}
 		});
 		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.ALWAYS_HIDE);
+	});
+});
+
+// Round-trip persistence for the Server-wide Wrapped privacy form.
+// Mirrors the dogfood ISSUE-002 repro: change anonymizationMode + serverWrappedShareMode,
+// save, then read back through the same getters the load function uses.
+describe('admin updateServerWrappedSettings action — round-trip', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+	});
+
+	function createRequest(overrides: Record<string, string> = {}): Request {
+		const formData = new FormData();
+		formData.set('anonymizationMode', 'anonymous');
+		formData.set('serverWrappedShareMode', 'private-oauth');
+		formData.set('settingsVersion', new Date(0).toISOString());
+		for (const [k, v] of Object.entries(overrides)) formData.set(k, v);
+		return new Request('http://localhost/admin/settings?/updateServerWrappedSettings', {
+			method: 'POST',
+			body: formData
+		});
+	}
+
+	async function run(request: Request) {
+		const handler = actions.updateServerWrappedSettings as UpdateServerWrappedSettingsAction;
+		return handler({
+			request,
+			locals: adminLocals
+		} as Parameters<UpdateServerWrappedSettingsAction>[0]);
+	}
+
+	it('persists both anonymizationMode and serverWrappedShareMode and exposes them via load-time getters', async () => {
+		await expect(run(createRequest())).resolves.toMatchObject({ success: true });
+		expect(await getAnonymizationMode()).toBe('anonymous');
+		expect(await getServerWrappedShareMode()).toBe('private-oauth');
+	});
+
+	it('allows a follow-up save with the bumped settingsVersion (no spurious 409)', async () => {
+		await expect(run(createRequest())).resolves.toMatchObject({ success: true });
+		const updatedAt = await getAppSettingsUpdatedAt(SERVER_WRAPPED_SETTINGS_KEYS);
+		expect(updatedAt).not.toBeNull();
+
+		await expect(
+			run(
+				createRequest({
+					anonymizationMode: 'hybrid',
+					serverWrappedShareMode: 'public',
+					settingsVersion: (updatedAt as Date).toISOString()
+				})
+			)
+		).resolves.toMatchObject({ success: true });
+		expect(await getAnonymizationMode()).toBe('hybrid');
+		expect(await getServerWrappedShareMode()).toBe('public');
+	});
+
+	it('rejects a stale settingsVersion as 409 without overwriting current values', async () => {
+		await expect(run(createRequest())).resolves.toMatchObject({ success: true });
+		// Submit again with the original epoch — now stale.
+		const result = await run(createRequest({ anonymizationMode: 'real' }));
+		expect(result).toMatchObject({ status: 409 });
+		expect(await getAnonymizationMode()).toBe('anonymous');
+	});
+
+	it('rejects private-link for serverWrappedShareMode and surfaces fieldErrors', async () => {
+		const result = await run(createRequest({ serverWrappedShareMode: 'private-link' }));
+		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid input' } });
+		expect(await getServerWrappedShareMode()).toBe('public');
+	});
+});
+
+// Round-trip persistence for the System tab Logging form (ISSUE-002 system section).
+describe('admin updateLogSettings action — round-trip', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+	});
+
+	function createRequest(overrides: Record<string, string> = {}): Request {
+		const formData = new FormData();
+		formData.set('retentionDays', '14');
+		formData.set('maxCount', '2000');
+		formData.set('debugEnabled', 'true');
+		for (const [k, v] of Object.entries(overrides)) formData.set(k, v);
+		return new Request('http://localhost/admin/settings?/updateLogSettings', {
+			method: 'POST',
+			body: formData
+		});
+	}
+
+	async function run(request: Request) {
+		const handler = actions.updateLogSettings as UpdateLogSettingsAction;
+		return handler({ request, locals: adminLocals } as Parameters<UpdateLogSettingsAction>[0]);
+	}
+
+	it('persists retentionDays, maxCount, and debugEnabled together', async () => {
+		await expect(run(createRequest())).resolves.toMatchObject({ success: true });
+		expect(await getLogRetentionDays()).toBe(14);
+		expect(await getLogMaxCount()).toBe(2000);
+		expect(await isDebugEnabled()).toBe(true);
+	});
+
+	it('rejects retentionDays out of range without persisting any field', async () => {
+		const result = await run(createRequest({ retentionDays: '999' }));
+		expect(result).toMatchObject({ status: 400 });
+		// maxCount + debug stay at their defaults — confirm no partial write.
+		expect(await getAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION)).toBeNull();
+	});
+
+	it('rejects maxCount below floor without persisting any field', async () => {
+		const result = await run(createRequest({ maxCount: '500' }));
+		expect(result).toMatchObject({ status: 400 });
 	});
 });

--- a/tests/unit/admin/settings-actions.test.ts
+++ b/tests/unit/admin/settings-actions.test.ts
@@ -570,5 +570,9 @@ describe('admin updateLogSettings action — round-trip', () => {
 	it('rejects maxCount below floor without persisting any field', async () => {
 		const result = await run(createRequest({ maxCount: '500' }));
 		expect(result).toMatchObject({ status: 400 });
+		// retention + maxCount + debug stay at their defaults — confirm no partial write.
+		expect(await getLogRetentionDays()).toBe(7);
+		expect(await getLogMaxCount()).toBe(50000);
+		expect(await isDebugEnabled()).toBe(false);
 	});
 });

--- a/tests/unit/admin/slides-actions.test.ts
+++ b/tests/unit/admin/slides-actions.test.ts
@@ -166,6 +166,23 @@ describe('admin slides actions', () => {
 		});
 	}
 
+	// Mirrors the dogfood ISSUE-011 repro: change from default to "few" and confirm
+	// the value is read back via getFunFactFrequency() like the load function does.
+	for (const [mode, expectedCount] of [
+		[FunFactFrequency.FEW, 2],
+		[FunFactFrequency.NORMAL, 4],
+		[FunFactFrequency.MANY, 8]
+	] as const) {
+		it(`persists fun fact frequency mode ${mode}`, async () => {
+			await expect(runSetFunFactFrequency(createFrequencyRequest(mode))).resolves.toMatchObject({
+				success: true,
+				funFactFrequency: { mode, count: expectedCount }
+			});
+
+			expect(await getFunFactFrequency()).toEqual({ mode, count: expectedCount });
+		});
+	}
+
 	describe('createCustom error mapping', () => {
 		it('returns 400 with fieldErrors.content when content has unsafe HTML', async () => {
 			const result = await runCreateCustom(

--- a/tests/unit/logging/retention.test.ts
+++ b/tests/unit/logging/retention.test.ts
@@ -43,8 +43,32 @@ class MockCron {
 		this._isRunning = false;
 	}
 
+	pause(): boolean {
+		this._isRunning = false;
+		return true;
+	}
+
+	resume(): boolean {
+		if (!this._stopped) {
+			this._isRunning = true;
+		}
+		return !this._stopped;
+	}
+
 	isRunning(): boolean {
 		return this._isRunning && !this._stopped;
+	}
+
+	isStopped(): boolean {
+		return this._stopped;
+	}
+
+	isBusy(): boolean {
+		return false;
+	}
+
+	getPattern(): string | undefined {
+		return this.expression;
 	}
 
 	nextRun(): Date | null {

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -484,10 +484,14 @@ describe('onboarding CSRF actions', () => {
 			})
 		);
 
+		// After ISSUE-001 reorder the browserOrigin schema runs first, so the
+		// oversized value is rejected by its own validation message before the
+		// later confirmRisk gate is consulted — a clearer signal than the
+		// generic confirmRisk error.
 		expect(result).toEqual({
 			status: 400,
 			data: {
-				trustProxyError: 'Confirm the reverse-proxy header trust risk before enabling TRUST_PROXY.'
+				trustProxyError: 'browserOrigin is too long'
 			}
 		});
 		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
@@ -555,6 +559,33 @@ describe('onboarding CSRF actions', () => {
 					formData.set('confirmRisk', 'true');
 					return formData;
 				})()
+			})
+		);
+
+		expect(result).toEqual({
+			status: 400,
+			data: {
+				trustProxyError:
+					'The current diagnostic does not recommend enabling reverse proxy header trust.'
+			}
+		});
+		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+	});
+
+	// ISSUE-001: when the diagnostic does NOT recommend enabling, the error
+	// message must reflect that — even if confirmRisk is also missing — so an
+	// API-direct caller that sends confirmRisk=true later does not pass the
+	// guard simply because the prior failure message blamed confirmRisk.
+	it('rejects with the diagnostic error first when diagnostic disagrees AND confirmRisk is absent', async () => {
+		const formData = new FormData();
+		formData.set('browserOrigin', ORIGIN);
+		// confirmRisk omitted on purpose
+
+		const result = await runEnableTrustProxy(
+			new Request(`${ORIGIN}/onboarding/csrf`, {
+				method: 'POST',
+				headers: { origin: ORIGIN },
+				body: formData
 			})
 		);
 

--- a/tests/unit/security/proxy-handle.test.ts
+++ b/tests/unit/security/proxy-handle.test.ts
@@ -3,7 +3,11 @@ import { env } from '$env/dynamic/private';
 import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
-import { _resetProxyStartupLogged, proxyHandle } from '$lib/server/security/proxy-handle';
+import {
+	_resetProxyStartupLogged,
+	_resetTrustProxyCache,
+	proxyHandle
+} from '$lib/server/security/proxy-handle';
 
 interface InvokeOptions {
 	url: string;
@@ -76,6 +80,7 @@ describe('proxyHandle', () => {
 		// per-test mutations between runs.
 		delete (env as Record<string, string | undefined>).TRUST_PROXY;
 		_resetProxyStartupLogged();
+		_resetTrustProxyCache();
 	});
 
 	afterEach(() => {

--- a/tests/unit/security/security-headers.test.ts
+++ b/tests/unit/security/security-headers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+import { applySecurityHeaders } from '$lib/server/security/security-headers';
+
+describe('applySecurityHeaders HSTS gate', () => {
+	function freshResponse() {
+		return new Response('ok');
+	}
+
+	it('always sets the non-HSTS headers regardless of protocol', () => {
+		const httpResponse = applySecurityHeaders(freshResponse(), false);
+		expect(httpResponse.headers.get('X-Frame-Options')).toBe('DENY');
+		expect(httpResponse.headers.get('X-Content-Type-Options')).toBe('nosniff');
+		expect(httpResponse.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin');
+		expect(httpResponse.headers.get('Permissions-Policy')).toBe(
+			'camera=(), microphone=(), geolocation=()'
+		);
+	});
+
+	it('omits Strict-Transport-Security when isHttps is false', () => {
+		// Mirrors the dogfood ISSUE-015 repro: a request that arrives over plain
+		// HTTP (TRUST_PROXY=false → event.url.protocol stays 'http:') must not
+		// teach the browser to upgrade — a forwarded HSTS hint on an HTTP-only
+		// deployment locks every browser that ever loaded the page into a
+		// permanent HTTPS upgrade for the lifetime of max-age.
+		const response = applySecurityHeaders(freshResponse(), false);
+		expect(response.headers.get('Strict-Transport-Security')).toBeNull();
+	});
+
+	it('sets Strict-Transport-Security when isHttps is true', () => {
+		const response = applySecurityHeaders(freshResponse(), true);
+		expect(response.headers.get('Strict-Transport-Security')).toBe(
+			'max-age=31536000; includeSubDomains'
+		);
+	});
+});

--- a/tests/unit/sync/scheduler.test.ts
+++ b/tests/unit/sync/scheduler.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+	getSchedulerStatus,
+	pauseSyncScheduler,
+	resumeSyncScheduler,
+	setupSyncScheduler,
+	stopSyncScheduler
+} from '$lib/server/sync/scheduler';
+
+describe('getSchedulerStatus pause/resume', () => {
+	afterEach(() => {
+		stopSyncScheduler();
+	});
+
+	it('returns isPaused=false and isRunning=true after setup with startImmediately', () => {
+		setupSyncScheduler({ cronExpression: '0 0 * * *', startImmediately: true });
+		const status = getSchedulerStatus();
+		expect(status.isRunning).toBe(true);
+		expect(status.isPaused).toBe(false);
+	});
+
+	it('returns isPaused=true after pauseSyncScheduler — ISSUE-005 regression guard', () => {
+		setupSyncScheduler({ cronExpression: '0 0 * * *', startImmediately: true });
+		pauseSyncScheduler();
+		const status = getSchedulerStatus();
+		expect(status.isPaused).toBe(true);
+		expect(status.isRunning).toBe(false);
+		expect(status.nextRun).toBeNull();
+	});
+
+	it('returns isPaused=false and isRunning=true after resumeSyncScheduler', () => {
+		setupSyncScheduler({ cronExpression: '0 0 * * *', startImmediately: true });
+		pauseSyncScheduler();
+		resumeSyncScheduler();
+		const status = getSchedulerStatus();
+		expect(status.isRunning).toBe(true);
+		expect(status.isPaused).toBe(false);
+	});
+
+	it('clears the paused flag on stop so a fresh setup never inherits stale state', () => {
+		setupSyncScheduler({ cronExpression: '0 0 * * *', startImmediately: true });
+		pauseSyncScheduler();
+		stopSyncScheduler();
+		const stoppedStatus = getSchedulerStatus();
+		expect(stoppedStatus.isRunning).toBe(false);
+		expect(stoppedStatus.isPaused).toBe(false);
+
+		setupSyncScheduler({ cronExpression: '0 0 * * *', startImmediately: true });
+		const restartedStatus = getSchedulerStatus();
+		expect(restartedStatus.isRunning).toBe(true);
+		expect(restartedStatus.isPaused).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Resolves every finding from `dogfood-output/report.md` (16 issues: 6 high, 7 medium, 3 low) across nine logically-grouped commits, in the order recommended by the implementation plan so each commit can ship or be reverted independently.

| Cluster | Issues | Commit |
|---|---|---|
| 1. Settings persistence cleanup + observability | ISSUE-002, ISSUE-011, ISSUE-014 | `66bc10d` |
| 2. Security headers HSTS gate | ISSUE-015 | `81fded7` |
| 3. Delete-All-History UX gating | ISSUE-003, ISSUE-007 | `f18725b` |
| 4. `/admin/logs` polish | ISSUE-008, ISSUE-009, ISSUE-010 | `decb8f4` |
| 5. Reverse-proxy diagnostic message order | ISSUE-001 | `05a2ac2` |
| 6. Sync UX | ISSUE-004, ISSUE-005 | `1619b84` |
| 7. Wrapped SummaryPage endcard | ISSUE-013 | `3fd0f7d` |
| 8. Custom slide preview + validation | ISSUE-012, ISSUE-016 | `1068d9c` |
| 9. System info panel | ISSUE-006 | `3fa1d68` |

## Notable changes

### Settings persistence cluster (ISSUE-002 / ISSUE-011 / ISSUE-014)

- Removed three unreachable form actions left over from the PR #103 consolidation: `updateAnonymization`, `updateGlobalDefaults`, and `updateServerWrappedMode`. The UI submits exclusively to the atomic `?/updateServerWrappedSettings` and `?/updateUserDefaults` handlers, so the dead branches were dropped along with their now-unused imports and schemas.
- Added validation-failure logging (`logger.warn`) on every silent `fail(400)` path in `updateLogSettings`, `updateServerWrappedSettings`, `updateUserDefaults`, and `setFunFactFrequency`. Future dogfood reproductions of the persistence regression will surface the offending field set in `[Settings]` / `[Slides]` logs instead of failing silently.
- Surfaced an error toast for `result.type === 'error'` on the dashboard `regenerateToken` `use:enhance` callback so a parse or network failure no longer reads as a silent no-op.
- Added round-trip coverage in `tests/unit/admin/settings-actions.test.ts` for the full Server-Wide Wrapped form and the Logging form, plus per-mode persistence assertions for fun fact frequency in `slides-actions.test.ts`. The handler-level round-trip already worked under unit tests, so the new tests guard against future regressions while the logging captures any future runtime divergence.

### Security headers HSTS gate (ISSUE-015)

`applySecurityHeaders` previously consulted `request.headers.get('x-forwarded-proto')` directly, which let an upstream-spoofed `X-Forwarded-Proto: https` advertise HSTS on an HTTP-only deployment even when `TRUST_PROXY=false`. The helper now takes a boolean `isHttps` decided by the caller, and every hook derives it from `event.url.protocol === 'https:'`. `proxyHandle` remains the single gate that rewrites `event.url` from `x-forwarded-proto` (only when `TRUST_PROXY` is enabled), so HSTS now follows the trust-proxy decision automatically.

### Delete-All-History UX (ISSUE-003 / ISSUE-007)

The page-load now eager-loads the total play-history count (`countPlayHistory()` returned as `data.playHistoryTotalCount`). The "Delete All History" handler uses that value directly instead of racing a `?/getPlayHistoryCount` POST, eliminating the no-count navigation path the QA agent observed. The per-year buttons still POST on demand to avoid an N-year scan on every page load and the existing error-toast handles fetch failures.

### `/admin/logs` polish (ISSUE-008 / ISSUE-009 / ISSUE-010)

Added explicit `handleFormToast` calls inside the `clearLogs` and `runCleanup` `use:enhance` callbacks, covering success / failure / parse-error result branches independent of the page-level `form` prop. The export-URL composition and `visibleTotalCount` derivation are both correct in the current code; the dogfood observations for ISSUE-008 and ISSUE-009 do not reproduce against this tree and are most likely stale-build artefacts. The investigation is documented in the commit message.

### Reverse-proxy diagnostic message order (ISSUE-001)

`enableTrustProxy` previously rejected with `"Confirm the reverse-proxy header trust risk..."` even when the diagnostic itself recommended leaving reverse-proxy header trust disabled, so an API-direct caller retrying with `confirmRisk=true` would erroneously believe the diagnostic guard had passed. The action now validates `browserOrigin` alone, enforces the same-origin check on the parsed value, runs `createReverseProxyDiagnostic`, rejects with the diagnostic-recommendation message when the result is not `enable`, and only after that requires `confirmRisk === 'true'`. The admin Security tab's `updateTrustProxy` does not run the diagnostic at all and is intentionally out of scope.

### Sync UX (ISSUE-004 / ISSUE-005)

- `getSchedulerStatus` derived `isPaused` from `!isRunning() && !isStopped()`, but croner's `isRunning()` returns `false` between scheduled ticks even on a non-paused scheduler. A module-level `pausedByOperator` flag is now the source of truth for `isPaused` / `isRunning` / `nextRun`. Added dedicated `tests/unit/sync/scheduler.test.ts` covering the four state-machine edges.
- `?/startSync` echoes back the submitted year as `selectedYear`, and a small `$effect` in `+page.svelte` re-selects the matching option after the post-submit `update()`. The dev log evidence showed Sync-2 and Sync-3 running incremental against an old timestamp instead of the requested full-history start, which matches the dropdown reverting to "New Activity Only".

### Wrapped SummaryPage endcard (ISSUE-013)

`handleActionClick` in `SummaryPage.svelte` previously called the action callback inside the same event handler that called `preventDefault` / `stopPropagation`, so any exception thrown by the callback was swallowed by the framework with no surfacing in the browser console. The callback is now wrapped in `try/catch` with `console.error`, which the next dogfood pass can use to attribute the regression to a specific handler (`handleRestart`, `handleShare`, or `handleHome`). The actual root cause requires runtime instrumentation that static work cannot reach.

### Custom slide preview + validation (ISSUE-012 / ISSUE-016)

Added a `slideFieldErrors` derivation and rendered `fieldErrors.title` adjacent to the title input with `role="alert"` and `aria-invalid` / `aria-describedby`. Pattern matches `admin/settings/+page.svelte`. ISSUE-012 (Update Preview no-render) does not reproduce against this tree; the preview button correctly fetches `?/previewMarkdown`, deserializes the result, and updates `previewHtml` / `previewRendered`.

### System info panel (ISSUE-006)

Load function exposes `process.uptime()`, `node:os` platform / arch, and `Bun.version` alongside the existing `data.appVersion.display` from the root layout. The System tab renders them as a compact `<dl>` grid with no editing controls.

## Test plan

- [x] `bun run check` (svelte-check + TypeScript) passes
- [x] `bun run lint` (biome) passes
- [x] `bun run test` (Vitest) passes: 1749 tests, 0 failures, coverage 86.21% functions / 84.01% lines (above the 80% threshold)
- [x] New unit tests cover: settings round-trip for Server-Wide Wrapped and Logging forms, fun-fact frequency round-trip, scheduler pause/resume state machine, reverse-proxy diagnostic ordering (4 permutations), and the HSTS gate boolean parameter
- [ ] Manual dogfood re-run against the new build, focusing on:
  - ISSUE-002 / ISSUE-011 / ISSUE-014 full save -> reload cycle for every privacy / system / fun-fact field
  - ISSUE-001 both onboarding rejection paths (confirmRisk missing AND diagnostic does not recommend)
  - ISSUE-013 server-wrapped summary endcard all three buttons (with the new try/catch surfacing any thrown error)
  - ISSUE-015 `curl -H 'X-Forwarded-Proto: https' http://localhost:5173/` with `TRUST_PROXY=false` must NOT return `Strict-Transport-Security`
  - ISSUE-004 start a backfill, observe the dropdown after completion
  - ISSUE-005 scheduler Initialize -> Pause -> confirm badge reads "Paused" and Resume button appears

## Out of scope (documented for the next dogfood pass)

- Drag-reorder slides coverage gap noted in Phase 2B (agent-browser limitation, not a product bug).
- Phase 5 diagnostic-API non-admin 403 path (re-verify with a freshly-authenticated test-user session).
- Plex.tv OAuth library logging the full user JSON (including `authToken`) to the browser console (third-party behaviour).