### PR TITLE
fix: resolve dogfood findings and harden share_settings integrity

### DIFF
--- a/drizzle/0008_share_settings_cached_stats_fk.sql
+++ b/drizzle/0008_share_settings_cached_stats_fk.sql
@@ -1,0 +1,34 @@
+DELETE FROM `cached_stats` WHERE `user_id` IS NOT NULL AND `user_id` NOT IN (SELECT `id` FROM `users`);--> statement-breakpoint
+DELETE FROM `share_settings` WHERE `user_id` NOT IN (SELECT `id` FROM `users`);--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_cached_stats` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer,
+	`year` integer NOT NULL,
+	`stats_type` text NOT NULL,
+	`stats_json` text NOT NULL,
+	`calculated_at` integer,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_cached_stats`("id", "user_id", "year", "stats_type", "stats_json", "calculated_at") SELECT "id", "user_id", "year", "stats_type", "stats_json", "calculated_at" FROM `cached_stats`;--> statement-breakpoint
+DROP TABLE `cached_stats`;--> statement-breakpoint
+ALTER TABLE `__new_cached_stats` RENAME TO `cached_stats`;--> statement-breakpoint
+CREATE INDEX `idx_cached_stats_lookup` ON `cached_stats` (`user_id`,`year`,`stats_type`);--> statement-breakpoint
+CREATE TABLE `__new_share_settings` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`year` integer NOT NULL,
+	`mode` text DEFAULT 'public' NOT NULL,
+	`mode_source` text DEFAULT 'explicit' NOT NULL,
+	`share_token` text,
+	`can_user_control` integer DEFAULT false,
+	`show_logo` integer,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_share_settings`("id", "user_id", "year", "mode", "mode_source", "share_token", "can_user_control", "show_logo") SELECT "id", "user_id", "year", "mode", "mode_source", "share_token", "can_user_control", "show_logo" FROM `share_settings`;--> statement-breakpoint
+DROP TABLE `share_settings`;--> statement-breakpoint
+ALTER TABLE `__new_share_settings` RENAME TO `share_settings`;--> statement-breakpoint
+CREATE UNIQUE INDEX `share_settings_share_token_unique` ON `share_settings` (`share_token`);--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/drizzle/0008_share_settings_cached_stats_fk.sql
+++ b/drizzle/0008_share_settings_cached_stats_fk.sql
@@ -1,20 +1,5 @@
-DELETE FROM `cached_stats` WHERE `user_id` IS NOT NULL AND `user_id` NOT IN (SELECT `id` FROM `users`);--> statement-breakpoint
 DELETE FROM `share_settings` WHERE `user_id` NOT IN (SELECT `id` FROM `users`);--> statement-breakpoint
 PRAGMA foreign_keys=OFF;--> statement-breakpoint
-CREATE TABLE `__new_cached_stats` (
-	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
-	`user_id` integer,
-	`year` integer NOT NULL,
-	`stats_type` text NOT NULL,
-	`stats_json` text NOT NULL,
-	`calculated_at` integer,
-	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
-);
---> statement-breakpoint
-INSERT INTO `__new_cached_stats`("id", "user_id", "year", "stats_type", "stats_json", "calculated_at") SELECT "id", "user_id", "year", "stats_type", "stats_json", "calculated_at" FROM `cached_stats`;--> statement-breakpoint
-DROP TABLE `cached_stats`;--> statement-breakpoint
-ALTER TABLE `__new_cached_stats` RENAME TO `cached_stats`;--> statement-breakpoint
-CREATE INDEX `idx_cached_stats_lookup` ON `cached_stats` (`user_id`,`year`,`stats_type`);--> statement-breakpoint
 CREATE TABLE `__new_share_settings` (
 	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
 	`user_id` integer NOT NULL,

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -93,21 +93,7 @@
           "isUnique": false
         }
       },
-      "foreignKeys": {
-        "cached_stats_user_id_users_id_fk": {
-          "name": "cached_stats_user_id_users_id_fk",
-          "tableFrom": "cached_stats",
-          "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
+      "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "checkConstraints": {}

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,877 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "96441e7d-d890-454a-8466-b41fb09b02bc",
+  "prevId": "1e90b822-1e25-472e-a4ff-707cdc209633",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cached_stats": {
+      "name": "cached_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stats_type": {
+          "name": "stats_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stats_json": {
+          "name": "stats_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cached_stats_lookup": {
+          "name": "idx_cached_stats_lookup",
+          "columns": [
+            "user_id",
+            "year",
+            "stats_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "cached_stats_user_id_users_id_fk": {
+          "name": "cached_stats_user_id_users_id_fk",
+          "tableFrom": "cached_stats",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_slides": {
+      "name": "custom_slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "logs": {
+      "name": "logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_logs_timestamp": {
+          "name": "idx_logs_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "idx_logs_level": {
+          "name": "idx_logs_level",
+          "columns": [
+            "level"
+          ],
+          "isUnique": false
+        },
+        "idx_logs_level_timestamp": {
+          "name": "idx_logs_level_timestamp",
+          "columns": [
+            "level",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metadata_cache": {
+      "name": "metadata_cache",
+      "columns": {
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetch_failed": {
+          "name": "fetch_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pin_transactions": {
+      "name": "pin_transactions",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pin_id": {
+          "name": "pin_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_verified": {
+          "name": "callback_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_pin_transactions_expires_at": {
+          "name": "idx_pin_transactions_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "play_history": {
+      "name": "play_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "history_key": {
+          "name": "history_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_section_id": {
+          "name": "library_section_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_title": {
+          "name": "grandparent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_rating_key": {
+          "name": "grandparent_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_thumb": {
+          "name": "grandparent_thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_title": {
+          "name": "parent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "play_history_history_key_unique": {
+          "name": "play_history_history_key_unique",
+          "columns": [
+            "history_key"
+          ],
+          "isUnique": true
+        },
+        "idx_play_history_rating_key": {
+          "name": "idx_play_history_rating_key",
+          "columns": [
+            "rating_key"
+          ],
+          "isUnique": false
+        },
+        "idx_play_history_account_id": {
+          "name": "idx_play_history_account_id",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "idx_play_history_viewed_at": {
+          "name": "idx_play_history_viewed_at",
+          "columns": [
+            "viewed_at"
+          ],
+          "isUnique": false
+        },
+        "idx_play_history_account_viewed": {
+          "name": "idx_play_history_account_viewed",
+          "columns": [
+            "account_id",
+            "viewed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plex_accounts": {
+      "name": "plex_accounts",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_id": {
+          "name": "plex_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_token": {
+          "name": "plex_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_settings": {
+      "name": "share_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "mode_source": {
+          "name": "mode_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'explicit'"
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "can_user_control": {
+          "name": "can_user_control",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_logo": {
+          "name": "show_logo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "share_settings_share_token_unique": {
+          "name": "share_settings_share_token_unique",
+          "columns": [
+            "share_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_settings_user_id_users_id_fk": {
+          "name": "share_settings_user_id_users_id_fk",
+          "tableFrom": "share_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_config": {
+      "name": "slide_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slide_type": {
+          "name": "slide_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_status": {
+      "name": "sync_status",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "records_processed": {
+          "name": "records_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "plex_id": {
+          "name": "plex_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_plex_id_unique": {
+          "name": "users_plex_id_unique",
+          "columns": [
+            "plex_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1777051200000,
       "tag": "0007_app_settings_updated_at_ms",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1778757213667,
+      "tag": "0008_share_settings_cached_stats_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -519,6 +519,7 @@ function handleSlideAnimationComplete(): void {}
 			justify-content: center;
 			padding: 3rem 1.5rem;
 			padding-top: 4rem; /* Space for progress bar */
+			overflow-y: auto;
 		}
 
 		.previous-slide {

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -325,7 +325,7 @@ $effect(() => {
 
 <style>
 	.summary-page {
-			min-height: 100vh;
+			min-height: 100%;
 			display: flex;
 			flex-direction: column;
 			align-items: center;

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -56,7 +56,7 @@ export const cachedStats = sqliteTable(
 	'cached_stats',
 	{
 		id: integer('id').primaryKey({ autoIncrement: true }),
-		userId: integer('user_id'),
+		userId: integer('user_id').references(() => users.id, { onDelete: 'cascade' }),
 		year: integer('year').notNull(),
 		statsType: text('stats_type').notNull(),
 		statsJson: text('stats_json').notNull(),
@@ -67,7 +67,9 @@ export const cachedStats = sqliteTable(
 
 export const shareSettings = sqliteTable('share_settings', {
 	id: integer('id').primaryKey({ autoIncrement: true }),
-	userId: integer('user_id').notNull(),
+	userId: integer('user_id')
+		.notNull()
+		.references(() => users.id, { onDelete: 'cascade' }),
 	year: integer('year').notNull(),
 	mode: text('mode').notNull().default('public'),
 	modeSource: text('mode_source').notNull().default('explicit'),

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -56,7 +56,8 @@ export const cachedStats = sqliteTable(
 	'cached_stats',
 	{
 		id: integer('id').primaryKey({ autoIncrement: true }),
-		userId: integer('user_id').references(() => users.id, { onDelete: 'cascade' }),
+		// Stores the Plex account id used by stats, not the local users.id.
+		userId: integer('user_id'),
 		year: integer('year').notNull(),
 		statsType: text('stats_type').notNull(),
 		statsJson: text('stats_json').notNull(),

--- a/src/lib/utils/submit-action.ts
+++ b/src/lib/utils/submit-action.ts
@@ -33,8 +33,8 @@ export async function submitAction<T = unknown>(
 		// wire format (e.g. a proxy/WAF returned HTML, a rate limiter returned
 		// plain text, or the body was truncated). Map this to a typed error
 		// outcome so callers can rely on the `SubmitOutcome<T>` contract.
-		const message = err instanceof Error ? err.message : 'Invalid action response';
-		return { type: 'error', error: { message } };
+		console.error('[submitAction] deserialize failed:', err);
+		return { type: 'error', error: { message: 'An unexpected error occurred' } };
 	}
 
 	if (result.type === 'success') {

--- a/src/lib/utils/submit-action.ts
+++ b/src/lib/utils/submit-action.ts
@@ -1,0 +1,39 @@
+import type { ActionResult } from '@sveltejs/kit';
+import { deserialize } from '$app/forms';
+
+export type SubmitOutcome<T> =
+	| { type: 'success'; data: T }
+	| { type: 'failure'; data: { error?: string } & Partial<T> }
+	| { type: 'error'; error: { message?: string } }
+	| { type: 'redirect'; location: string };
+
+/**
+ * Submit a SvelteKit form action programmatically and return the parsed result.
+ *
+ * SvelteKit only returns the action wire format (parseable by `deserialize`) when
+ * the request carries the `x-sveltekit-action: true` header. Without it the server
+ * responds with an HTML page and `deserialize()` throws. This helper guarantees the
+ * header is set and normalizes the response shape for callers.
+ */
+export async function submitAction<T = unknown>(
+	action: string,
+	body?: FormData
+): Promise<SubmitOutcome<T>> {
+	const response = await fetch(action, {
+		method: 'POST',
+		headers: { 'x-sveltekit-action': 'true' },
+		body: body ?? new FormData()
+	});
+	const result = deserialize(await response.text()) as ActionResult;
+
+	if (result.type === 'success') {
+		return { type: 'success', data: (result.data ?? {}) as T };
+	}
+	if (result.type === 'failure') {
+		return { type: 'failure', data: (result.data ?? {}) as { error?: string } & Partial<T> };
+	}
+	if (result.type === 'redirect') {
+		return { type: 'redirect', location: result.location };
+	}
+	return { type: 'error', error: { message: result.error?.message } };
+}

--- a/src/lib/utils/submit-action.ts
+++ b/src/lib/utils/submit-action.ts
@@ -24,7 +24,18 @@ export async function submitAction<T = unknown>(
 		headers: { 'x-sveltekit-action': 'true' },
 		body: body ?? new FormData()
 	});
-	const result = deserialize(await response.text()) as ActionResult;
+
+	let result: ActionResult;
+	try {
+		result = deserialize(await response.text()) as ActionResult;
+	} catch (err) {
+		// `deserialize` throws when the response body is not the SvelteKit action
+		// wire format (e.g. a proxy/WAF returned HTML, a rate limiter returned
+		// plain text, or the body was truncated). Map this to a typed error
+		// outcome so callers can rely on the `SubmitOutcome<T>` contract.
+		const message = err instanceof Error ? err.message : 'Invalid action response';
+		return { type: 'error', error: { message } };
+	}
 
 	if (result.type === 'success') {
 		return { type: 'success', data: (result.data ?? {}) as T };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -163,7 +163,9 @@ function handleCancelRedirect(): void {
 					class="username-form"
 				>
 					<div class="username-input-group">
+						<label for="username-input" class="sr-only">Plex username</label>
 						<input
+							id="username-input"
 							type="text"
 							name="username"
 							bind:value={username}
@@ -339,6 +341,18 @@ function handleCancelRedirect(): void {
 			gap: 0.5rem;
 			flex-wrap: wrap;
 			justify-content: center;
+		}
+
+		.sr-only {
+			position: absolute;
+			width: 1px;
+			height: 1px;
+			padding: 0;
+			margin: -1px;
+			overflow: hidden;
+			clip: rect(0, 0, 0, 0);
+			white-space: nowrap;
+			border: 0;
 		}
 
 		.username-input {

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -41,12 +41,13 @@ import X from '@lucide/svelte/icons/x';
 import Zap from '@lucide/svelte/icons/zap';
 import { type Component, tick, untrack } from 'svelte';
 import { prefersReducedMotion } from 'svelte/motion';
-import { deserialize, enhance } from '$app/forms';
+import { enhance } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
 import { page } from '$app/stores';
 import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import * as Tabs from '$lib/components/ui/tabs';
 import { handleFormToast } from '$lib/utils/form-toast';
+import { submitAction } from '$lib/utils/submit-action';
 import type { ActionData, PageData } from './$types';
 
 // Valid tab values
@@ -205,24 +206,15 @@ async function confirmBulkApplyShareDefaults() {
 	isBulkApplyingUserControl = true;
 
 	try {
-		const response = await fetch('?/bulkApplyShareDefaults', {
-			method: 'POST',
-			body: new FormData()
-		});
-		const result = deserialize(await response.text());
-
+		const result = await submitAction<{ success: boolean; message: string }>(
+			'?/bulkApplyShareDefaults'
+		);
 		if (result.type === 'success') {
-			const payload = (result.data ?? {
-				success: true,
-				message: 'Defaults applied to all users.'
-			}) as { success: boolean; message: string };
-			handleFormToast(payload);
+			handleFormToast(result.data ?? { success: true, message: 'Defaults applied to all users.' });
 		} else if (result.type === 'failure') {
-			handleFormToast({
-				error: (result.data as { error?: string })?.error ?? 'Failed to apply defaults.'
-			});
+			handleFormToast({ error: result.data.error ?? 'Failed to apply defaults.' });
 		} else if (result.type === 'error') {
-			handleFormToast({ error: result.error?.message ?? 'Failed to apply defaults.' });
+			handleFormToast({ error: result.error.message ?? 'Failed to apply defaults.' });
 		}
 	} catch (error) {
 		const message = error instanceof Error ? error.message : 'Failed to apply defaults.';
@@ -448,15 +440,11 @@ async function showCacheConfirmation(year?: number) {
 	}
 
 	try {
-		const response = await fetch('?/getCacheCount', {
-			method: 'POST',
-			body: formData
-		});
-		const result = deserialize(await response.text());
-		const payload =
-			result.type === 'success'
-				? ((result.data ?? {}) as { success?: boolean; count?: number; year?: number })
-				: {};
+		const result = await submitAction<{ success?: boolean; count?: number; year?: number }>(
+			'?/getCacheCount',
+			formData
+		);
+		const payload = result.type === 'success' ? result.data : {};
 		if (payload.count !== undefined) {
 			pendingCacheCount = payload.count;
 			cacheDialogOpen = true;
@@ -482,15 +470,11 @@ async function getCacheCount(year?: number) {
 	}
 
 	try {
-		const response = await fetch('?/getCacheCount', {
-			method: 'POST',
-			body: formData
-		});
-		const result = deserialize(await response.text());
-		const payload =
-			result.type === 'success'
-				? ((result.data ?? {}) as { success?: boolean; count?: number; year?: number })
-				: {};
+		const result = await submitAction<{ success?: boolean; count?: number; year?: number }>(
+			'?/getCacheCount',
+			formData
+		);
+		const payload = result.type === 'success' ? result.data : {};
 		if (payload.count !== undefined) {
 			cacheCountResult = {
 				label: year !== undefined ? `${year} cache` : 'All cache',
@@ -544,15 +528,11 @@ async function showHistoryConfirmation(year?: number) {
 	formData.append('year', year.toString());
 
 	try {
-		const response = await fetch('?/getPlayHistoryCount', {
-			method: 'POST',
-			body: formData
-		});
-		const result = deserialize(await response.text());
-		const payload =
-			result.type === 'success'
-				? ((result.data ?? {}) as { success?: boolean; count?: number; year?: number })
-				: {};
+		const result = await submitAction<{ success?: boolean; count?: number; year?: number }>(
+			'?/getPlayHistoryCount',
+			formData
+		);
+		const payload = result.type === 'success' ? result.data : {};
 		if (payload.count !== undefined) {
 			pendingHistoryCount = payload.count;
 			historyDialogOpen = true;
@@ -578,15 +558,11 @@ async function getHistoryCount(year?: number) {
 	}
 
 	try {
-		const response = await fetch('?/getPlayHistoryCount', {
-			method: 'POST',
-			body: formData
-		});
-		const result = deserialize(await response.text());
-		const payload =
-			result.type === 'success'
-				? ((result.data ?? {}) as { success?: boolean; count?: number; year?: number })
-				: {};
+		const result = await submitAction<{ success?: boolean; count?: number; year?: number }>(
+			'?/getPlayHistoryCount',
+			formData
+		);
+		const payload = result.type === 'success' ? result.data : {};
 		if (payload.count !== undefined) {
 			historyCountResult = {
 				label: year !== undefined ? `${year} history` : 'All history',
@@ -977,13 +953,13 @@ const logFieldErrors = $derived(
 										plexAllowInsecureLocalHttp ? 'true' : 'false'
 									);
 									try {
-										const response = await fetch('?/testPlexConnection', {
-											method: 'POST',
-											body: formData
-										});
-										const result = deserialize(await response.text());
+										const result = await submitAction<{
+											success?: boolean;
+											message?: string;
+											error?: string;
+										}>('?/testPlexConnection', formData);
 										if (result.type === 'success' || result.type === 'failure') {
-											const data = result.data as { success?: boolean; message?: string; error?: string };
+											const data = result.data;
 											handleFormToast(data);
 											testConnectionResult = data.error
 												? { type: 'error', message: data.error }
@@ -993,7 +969,7 @@ const logFieldErrors = $derived(
 													};
 										} else if (result.type === 'error') {
 											const message =
-												result.error?.message ?? 'An error occurred while testing connection';
+												result.error.message ?? 'An error occurred while testing connection';
 											handleFormToast({ error: message });
 											testConnectionResult = { type: 'error', message };
 										} else {
@@ -1204,17 +1180,13 @@ const logFieldErrors = $derived(
 									formData.set('openaiBaseUrl', openaiBaseUrl);
 									formData.set('openaiModel', openaiModel);
 									try {
-										const response = await fetch('?/testAIConnection', {
-											method: 'POST',
-											body: formData
-										});
-										const result = deserialize(await response.text());
+										const result = await submitAction<{
+											success?: boolean;
+											message?: string;
+											error?: string;
+										}>('?/testAIConnection', formData);
 										if (result.type === 'success' || result.type === 'failure') {
-											const data = result.data as {
-												success?: boolean;
-												message?: string;
-												error?: string;
-											};
+											const data = result.data;
 											handleFormToast(data);
 											testAIResult = data.error
 												? { type: 'error', message: data.error }
@@ -1224,7 +1196,7 @@ const logFieldErrors = $derived(
 													};
 										} else if (result.type === 'error') {
 											const message =
-												result.error?.message ?? 'An error occurred while testing connection';
+												result.error.message ?? 'An error occurred while testing connection';
 											handleFormToast({ error: message });
 											testAIResult = { type: 'error', message };
 										} else {
@@ -1460,6 +1432,11 @@ const logFieldErrors = $derived(
 										await update({ invalidateAll: true });
 									} else {
 										await update();
+										if (result.type === 'error') {
+											handleFormToast({
+												error: result.error?.message ?? 'Failed to update logo mode.'
+											});
+										}
 									}
 								} finally {
 									if (result.type === 'failure' || result.type === 'error') {

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -210,7 +210,7 @@ async function confirmBulkApplyShareDefaults() {
 			'?/bulkApplyShareDefaults'
 		);
 		if (result.type === 'success') {
-			handleFormToast(result.data ?? { success: true, message: 'Defaults applied to all users.' });
+			handleFormToast(result.data);
 		} else if (result.type === 'failure') {
 			handleFormToast({ error: result.data.error ?? 'Failed to apply defaults.' });
 		} else if (result.type === 'error') {

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 import Plus from '@lucide/svelte/icons/plus';
 import { untrack } from 'svelte';
-import { deserialize, enhance } from '$app/forms';
+import { enhance } from '$app/forms';
 import type { SlideType } from '$lib/components/slides/types';
 import { DEFAULT_SLIDE_ORDER } from '$lib/components/slides/types';
 import { handleFormToast } from '$lib/utils/form-toast';
+import { submitAction } from '$lib/utils/submit-action';
 import type { ActionData, PageData } from './$types';
 
 /**
@@ -689,25 +690,22 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 								formData.append('content', editorContent);
 
 								try {
-									const response = await fetch('?/previewMarkdown', {
-										method: 'POST',
-										body: formData
-									});
-									const result = deserialize(await response.text());
+									const result = await submitAction<{ html?: string }>(
+										'?/previewMarkdown',
+										formData
+									);
 									if (result.type === 'success') {
-										const data = (result.data ?? {}) as { html?: string };
-										previewHtml = data.html ?? '';
-										previewRendered = typeof data.html === 'string';
+										previewHtml = result.data.html ?? '';
+										previewRendered = typeof result.data.html === 'string';
 										previewError = previewRendered ? '' : 'Failed to render Markdown';
 									} else if (result.type === 'failure') {
-										const data = (result.data ?? {}) as { error?: string };
 										previewHtml = '';
 										previewRendered = false;
-										previewError = data.error ?? 'Failed to render Markdown';
+										previewError = result.data.error ?? 'Failed to render Markdown';
 									} else if (result.type === 'error') {
 										previewHtml = '';
 										previewRendered = false;
-										previewError = result.error?.message ?? 'Failed to render Markdown';
+										previewError = result.error.message ?? 'Failed to render Markdown';
 									}
 								} catch (error) {
 									console.error('Failed to render Markdown preview:', error);

--- a/src/routes/onboarding/+layout.svelte
+++ b/src/routes/onboarding/+layout.svelte
@@ -103,7 +103,8 @@ $effect(() => {
 			min-height: 100dvh;
 			width: 100%;
 			position: relative;
-			overflow: clip;
+			overflow-x: clip;
+			overflow-y: auto;
 			display: flex;
 			flex-direction: column;
 			background: hsl(var(--background));

--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -140,6 +140,21 @@ function formatFunFactFrequency(config: { mode: string; count: number }): string
 	return `${formatThemeName(config.mode)} (${config.count})`;
 }
 
+async function requireOnboardingCompleteClaim(
+	cookies: Parameters<NonNullable<Actions['goToDashboard']>>[0]['cookies'],
+	url: URL
+) {
+	try {
+		await requireActiveOnboardingClaim(cookies, { requestUrl: url });
+	} catch (err) {
+		if (err instanceof OnboardingClaimRequiredError) {
+			return fail(403, { error: err.message });
+		}
+		throw err;
+	}
+	return null;
+}
+
 /**
  * Form actions
  */
@@ -147,7 +162,10 @@ export const actions: Actions = {
 	/**
 	 * Go to dashboard
 	 */
-	goToDashboard: async ({ locals, cookies }) => {
+	goToDashboard: async ({ locals, cookies, url }) => {
+		const guardResult = await requireOnboardingCompleteClaim(cookies, url);
+		if (guardResult) return guardResult;
+
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
 		}

--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -45,11 +45,6 @@ export const load: PageServerLoad = async ({ parent, locals, url, cookies }) => 
 	const parentData = await parent();
 	const notice = url.searchParams.get('notice');
 
-	await completeOnboarding();
-	clearOnboardingClaimCookie(cookies);
-
-	logger.info(`Onboarding completed by ${locals.user?.username || 'unknown'}`, 'Onboarding');
-
 	// Get sync status (may still be running)
 	const syncRunning = await isSyncRunning();
 	const syncProgress = getSyncProgress();
@@ -152,10 +147,13 @@ export const actions: Actions = {
 	/**
 	 * Go to dashboard
 	 */
-	goToDashboard: async ({ locals }) => {
+	goToDashboard: async ({ locals, cookies }) => {
 		if (!locals.user?.isAdmin) {
 			return fail(403, { error: 'Admin access required' });
 		}
+		await completeOnboarding();
+		clearOnboardingClaimCookie(cookies);
+		logger.info(`Onboarding completed by ${locals.user?.username || 'unknown'}`, 'Onboarding');
 		redirect(303, '/admin');
 	}
 };

--- a/src/routes/onboarding/csrf/+page.svelte
+++ b/src/routes/onboarding/csrf/+page.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
 import ExternalLink from '@lucide/svelte/icons/external-link';
-import type { ActionResult } from '@sveltejs/kit';
 import { animate, stagger } from 'motion';
-import { deserialize } from '$app/forms';
 import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
+import { submitAction } from '$lib/utils/submit-action';
 import type { ActionData, PageData } from './$types';
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
@@ -122,19 +121,14 @@ async function runDiagnostic() {
 	formData.set('browserOrigin', browserOrigin);
 
 	try {
-		const response = await fetch('?/diagnoseReverseProxy', {
-			method: 'POST',
-			body: formData
-		});
-		const text = await response.text();
-		const result: ActionResult = deserialize(text);
+		const result = await submitAction<{
+			reverseProxyDiagnostic?: ReverseProxyDiagnosticView;
+			diagnosticError?: string;
+		}>('?/diagnoseReverseProxy', formData);
 
 		if (result.type === 'success') {
-			const payload = result.data as
-				| { reverseProxyDiagnostic?: ReverseProxyDiagnosticView }
-				| undefined;
-			if (payload?.reverseProxyDiagnostic) {
-				reverseProxyDiagnostic = payload.reverseProxyDiagnostic;
+			if (result.data.reverseProxyDiagnostic) {
+				reverseProxyDiagnostic = result.data.reverseProxyDiagnostic;
 				diagnosticStatus = 'success';
 			} else {
 				diagnosticStatus = 'failure';
@@ -142,8 +136,7 @@ async function runDiagnostic() {
 			}
 		} else if (result.type === 'failure') {
 			diagnosticStatus = 'failure';
-			const payload = result.data as { diagnosticError?: string } | undefined;
-			diagnosticError = payload?.diagnosticError ?? 'Diagnostic failed';
+			diagnosticError = result.data.diagnosticError ?? 'Diagnostic failed';
 		} else {
 			diagnosticStatus = 'failure';
 			diagnosticError = 'Unexpected diagnostic response';
@@ -171,20 +164,14 @@ async function runTest() {
 	formData.set('csrfOrigin', csrfOriginInput);
 
 	try {
-		const response = await fetch('?/testOrigin', {
-			method: 'POST',
-			body: formData
-		});
-		const text = await response.text();
-		const result: ActionResult = deserialize(text);
+		const result = await submitAction<{ testError?: string }>('?/testOrigin', formData);
 
 		if (result.type === 'success') {
 			testResult = 'success';
 			testedOrigin = csrfOriginInput ?? null;
 		} else if (result.type === 'failure') {
 			testResult = 'failure';
-			const data = result.data as { testError?: string } | undefined;
-			testError = data?.testError ?? 'Test failed';
+			testError = result.data.testError ?? 'Test failed';
 		} else {
 			testResult = 'failure';
 			testError = 'Unexpected response';

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -635,6 +635,7 @@ function formatServerUrl(url: string | null): string {
 							<span>Sign in with Plex</span>
 						{/if}
 					</button>
+					<a class="redirect-fallback" href="?auth=redirect">Use redirect instead</a>
 				</div>
 			{:else if isNonAdminUser}
 				<div class="error-card animate-item">
@@ -690,6 +691,7 @@ function formatServerUrl(url: string | null): string {
 							<span>Sign in with Plex</span>
 						{/if}
 					</button>
+					<a class="redirect-fallback" href="?auth=redirect">Use redirect instead</a>
 				</div>
 			{:else if isNonAdminUser}
 				<div class="error-card animate-item">
@@ -1327,6 +1329,21 @@ function formatServerUrl(url: string | null): string {
 			border-top-color: rgba(0, 0, 0, 0.7);
 			border-radius: 50%;
 			animation: spin 0.8s linear infinite;
+		}
+
+		.redirect-fallback {
+			display: inline-block;
+			margin-top: 0.75rem;
+			font-size: 0.85rem;
+			color: rgba(255, 255, 255, 0.55);
+			text-decoration: underline;
+			text-underline-offset: 3px;
+			transition: color 0.2s ease;
+		}
+
+		.redirect-fallback:hover,
+		.redirect-fallback:focus-visible {
+			color: rgba(255, 255, 255, 0.85);
 		}
 
 		/* Success Card */

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 import { animate } from 'motion';
 import { tick, untrack } from 'svelte';
-import { deserialize, enhance } from '$app/forms';
+import { enhance } from '$app/forms';
 import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
 import { handleFormToast } from '$lib/utils/form-toast';
+import { submitAction } from '$lib/utils/submit-action';
 import { loadThemeFont } from '$lib/utils/theme-fonts';
 import type { ActionData, PageData } from './$types';
 
@@ -671,17 +672,13 @@ function getThemeColors(themeValue: string) {
 												formData.set('openaiBaseUrl', openaiBaseUrl);
 												formData.set('openaiModel', openaiModel);
 												try {
-													const response = await fetch('?/testAIConnection', {
-														method: 'POST',
-														body: formData
-													});
-													const result = deserialize(await response.text());
+													const result = await submitAction<{
+														success?: boolean;
+														message?: string;
+														error?: string;
+													}>('?/testAIConnection', formData);
 													if (result.type === 'success' || result.type === 'failure') {
-														const payload = result.data as {
-															success?: boolean;
-															message?: string;
-															error?: string;
-														};
+														const payload = result.data;
 														handleFormToast(payload);
 														testAIResult = payload.error
 															? { type: 'error', message: payload.error }
@@ -691,7 +688,7 @@ function getThemeColors(themeValue: string) {
 																};
 													} else if (result.type === 'error') {
 														const message =
-															result.error?.message ?? 'An error occurred while testing connection';
+															result.error.message ?? 'An error occurred while testing connection';
 														handleFormToast({ error: message });
 														testAIResult = { type: 'error', message };
 													} else {

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -66,7 +66,16 @@ async function resolveUserIdFromIdentifier(
 	}
 
 	const userId = Number(identifier);
-	return Number.isSafeInteger(userId) && userId > 0 ? userId : null;
+	if (!Number.isSafeInteger(userId) || userId <= 0) {
+		return null;
+	}
+
+	const userRow = await db
+		.select({ id: users.id })
+		.from(users)
+		.where(eq(users.id, userId))
+		.limit(1);
+	return userRow[0]?.id ?? null;
 }
 
 export const load: PageServerLoad = async ({ params, locals, parent, setHeaders }) => {
@@ -114,6 +123,20 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 			error(404, "We couldn't find a Wrapped page for that link.");
 		}
 		userId = parsedId;
+
+		// Verify the user actually exists before any code path that may create
+		// share_settings rows for them (checkWrappedAccess -> getOrCreateShareSettings).
+		// Preserves the F-015 anti-enumeration story (unknown id -> 404) and blocks
+		// the route by which a stray numeric id (e.g. a Plex id) became a
+		// share_settings.user_id orphan.
+		const userExists = await db
+			.select({ id: users.id })
+			.from(users)
+			.where(eq(users.id, userId))
+			.limit(1);
+		if (!userExists[0]) {
+			error(404, "We couldn't find a Wrapped page for that link.");
+		}
 
 		try {
 			await checkWrappedAccess({

--- a/tests/unit/db/schema.test.ts
+++ b/tests/unit/db/schema.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test';
+import { getTableConfig } from 'drizzle-orm/sqlite-core';
+import { cachedStats, shareSettings } from '$lib/server/db/schema';
+
+describe('database schema foreign keys', () => {
+	it('does not constrain cached stats user_id to local users', () => {
+		const config = getTableConfig(cachedStats);
+
+		expect(config.foreignKeys).toHaveLength(0);
+	});
+
+	it('keeps share settings user_id constrained to local users', () => {
+		const config = getTableConfig(shareSettings);
+		const foreignKey = config.foreignKeys[0];
+		const reference = foreignKey?.reference();
+
+		expect(config.foreignKeys).toHaveLength(1);
+		expect(foreignKey?.getName()).toBe('share_settings_user_id_users_id_fk');
+		expect(reference?.columns.map((column) => column.name)).toEqual(['user_id']);
+		expect(reference?.foreignColumns.map((column) => column.name)).toEqual(['id']);
+		expect(foreignKey?.onDelete).toBe('cascade');
+	});
+});

--- a/tests/unit/onboarding/csrf-page-source.test.ts
+++ b/tests/unit/onboarding/csrf-page-source.test.ts
@@ -54,7 +54,8 @@ describe('onboarding CSRF page source', () => {
 	it('runs onboarding reverse proxy diagnostics through the CSRF page action only', async () => {
 		const source = await readPageSource();
 
-		expect(source).toContain("fetch('?/diagnoseReverseProxy'");
+		expect(source).toContain('submitAction<');
+		expect(source).toContain("'?/diagnoseReverseProxy'");
 		expect(source).toContain('action="?/enableTrustProxy"');
 		expect(source).not.toContain('/api/security');
 	});

--- a/tests/unit/onboarding/page-action-claim-errors.test.ts
+++ b/tests/unit/onboarding/page-action-claim-errors.test.ts
@@ -8,6 +8,7 @@ import {
 	createBootstrapToken,
 	ONBOARDING_CLAIM_REQUIRED_MESSAGE
 } from '$lib/server/onboarding/bootstrap';
+import { actions as completeActions } from '../../../src/routes/onboarding/complete/+page.server';
 import { actions as plexActions } from '../../../src/routes/onboarding/plex/+page.server';
 import { actions as settingsActions } from '../../../src/routes/onboarding/settings/+page.server';
 import { actions as syncActions } from '../../../src/routes/onboarding/sync/+page.server';
@@ -34,7 +35,8 @@ const claimCheckedActions = [
 	['settings.testAIConnection', settingsActions.testAIConnection],
 	['sync.startSync', syncActions.startSync],
 	['sync.cancelSync', syncActions.cancelSync],
-	['sync.continue', syncActions.continue]
+	['sync.continue', syncActions.continue],
+	['complete.goToDashboard', completeActions.goToDashboard]
 ] as const;
 
 const adminRequiredActions = [
@@ -43,7 +45,8 @@ const adminRequiredActions = [
 	['settings.testAIConnection', settingsActions.testAIConnection],
 	['sync.startSync', syncActions.startSync],
 	['sync.cancelSync', syncActions.cancelSync],
-	['sync.continue', syncActions.continue]
+	['sync.continue', syncActions.continue],
+	['complete.goToDashboard', completeActions.goToDashboard]
 ] as const;
 
 function makeCookies(errorToThrow?: Error): Cookies {

--- a/tests/unit/server/sharing/resolve-user-id.test.ts
+++ b/tests/unit/server/sharing/resolve-user-id.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { isHttpError } from '@sveltejs/kit';
+import { db } from '$lib/server/db/client';
+import {
+	appSettings,
+	cachedStats,
+	playHistory,
+	shareSettings,
+	slideConfig,
+	users
+} from '$lib/server/db/schema';
+import { setGlobalShareDefaults } from '$lib/server/sharing/service';
+import { ShareMode } from '$lib/server/sharing/types';
+import { actions, load } from '../../../../src/routes/wrapped/[year]/u/[identifier]/+page.server';
+
+type LoadArgs = Parameters<typeof load>[0];
+type UpdateShareModeAction = NonNullable<typeof actions.updateShareMode>;
+type RegenerateTokenAction = NonNullable<typeof actions.regenerateToken>;
+
+const YEAR = 2024;
+const EXISTING_USER_ID = 42;
+const UNKNOWN_USER_ID = 9999999;
+
+async function seedUser(): Promise<void> {
+	await db.insert(users).values({
+		id: EXISTING_USER_ID,
+		plexId: 100042,
+		accountId: 200042,
+		username: 'alice',
+		isAdmin: false
+	});
+}
+
+async function resetTables(): Promise<void> {
+	await db.delete(shareSettings);
+	await db.delete(appSettings);
+	await db.delete(users);
+	await db.delete(cachedStats);
+	await db.delete(playHistory);
+	await db.delete(slideConfig);
+}
+
+async function invokeUpdateShareMode(identifier: string) {
+	const formData = new FormData();
+	formData.set('mode', ShareMode.PUBLIC);
+	const request = new Request('https://obzorarr.example/wrapped', {
+		method: 'POST',
+		body: formData
+	});
+	const updateShareMode = actions.updateShareMode as UpdateShareModeAction;
+	return updateShareMode({
+		request,
+		params: { year: String(YEAR), identifier },
+		locals: {
+			user: {
+				id: EXISTING_USER_ID,
+				plexId: 100042,
+				username: 'alice',
+				isAdmin: true
+			}
+		}
+	} as unknown as Parameters<UpdateShareModeAction>[0]);
+}
+
+async function invokeRegenerateToken(identifier: string) {
+	const regenerateToken = actions.regenerateToken as RegenerateTokenAction;
+	return regenerateToken({
+		params: { year: String(YEAR), identifier },
+		locals: {
+			user: {
+				id: EXISTING_USER_ID,
+				plexId: 100042,
+				username: 'alice',
+				isAdmin: true
+			}
+		}
+	} as unknown as Parameters<RegenerateTokenAction>[0]);
+}
+
+async function invokeLoad(identifier: string) {
+	return load({
+		params: { year: String(YEAR), identifier },
+		locals: {},
+		parent: async () => ({ availableYears: [YEAR] }),
+		setHeaders: () => {}
+	} as unknown as LoadArgs);
+}
+
+describe('resolveUserIdFromIdentifier (unknown numeric ids)', () => {
+	beforeEach(async () => {
+		await resetTables();
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PUBLIC,
+			allowUserControl: true
+		});
+		await seedUser();
+	});
+
+	it('updateShareMode returns fail(400) for an unknown numeric identifier', async () => {
+		const result = await invokeUpdateShareMode(String(UNKNOWN_USER_ID));
+
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'Invalid user identifier' }
+		});
+
+		const rows = await db.select().from(shareSettings);
+		expect(rows.length).toBe(0);
+	});
+
+	it('regenerateToken returns fail(400) for an unknown numeric identifier', async () => {
+		const result = await invokeRegenerateToken(String(UNKNOWN_USER_ID));
+
+		expect(result).toMatchObject({
+			status: 400,
+			data: { error: 'Invalid user identifier' }
+		});
+
+		const rows = await db.select().from(shareSettings);
+		expect(rows.length).toBe(0);
+	});
+
+	it('load throws 404 for an unknown numeric identifier and creates no share_settings row', async () => {
+		let caught: unknown;
+		try {
+			await invokeLoad(String(UNKNOWN_USER_ID));
+		} catch (err) {
+			caught = err;
+		}
+
+		expect(isHttpError(caught)).toBe(true);
+		if (!isHttpError(caught)) throw caught;
+		expect(caught.status).toBe(404);
+
+		const rows = await db.select().from(shareSettings);
+		expect(rows.filter((r) => r.userId === UNKNOWN_USER_ID).length).toBe(0);
+	});
+
+	it('updateShareMode succeeds for an existing user (sanity check)', async () => {
+		const adminUser = {
+			id: EXISTING_USER_ID,
+			plexId: 100042,
+			username: 'alice',
+			isAdmin: true
+		};
+		const formData = new FormData();
+		formData.set('mode', ShareMode.PUBLIC);
+		const request = new Request('https://obzorarr.example/wrapped', {
+			method: 'POST',
+			body: formData
+		});
+		const updateShareMode = actions.updateShareMode as UpdateShareModeAction;
+		const result = await updateShareMode({
+			request,
+			params: { year: String(YEAR), identifier: String(EXISTING_USER_ID) },
+			locals: { user: adminUser }
+		} as unknown as Parameters<UpdateShareModeAction>[0]);
+
+		expect((result as { success?: boolean }).success).toBe(true);
+	});
+});

--- a/tests/unit/stats/engine-cache.test.ts
+++ b/tests/unit/stats/engine-cache.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { db } from '$lib/server/db/client';
+import { cachedStats, playHistory, plexAccounts, users } from '$lib/server/db/schema';
+import { calculateUserStats } from '$lib/server/stats/engine';
+import { createPlayHistoryRecord, createTimestamp } from '../../helpers/factories';
+
+describe('stats engine cache keys', () => {
+	beforeEach(async () => {
+		await db.delete(cachedStats);
+		await db.delete(playHistory);
+		await db.delete(plexAccounts);
+		await db.delete(users);
+	});
+
+	it('caches user stats by Plex account id instead of local user id', async () => {
+		const localUserId = 17;
+		const accountId = 200042;
+		const year = 2024;
+
+		await db.insert(users).values({
+			id: localUserId,
+			plexId: 900042,
+			accountId,
+			username: 'plex-user',
+			isAdmin: false
+		});
+
+		const record = createPlayHistoryRecord({
+			historyKey: 'history-cache-account-id',
+			ratingKey: 'movie-cache-account-id',
+			accountId,
+			viewedAt: createTimestamp(year, 3, 15),
+			duration: 3600
+		});
+		await db.insert(playHistory).values({
+			historyKey: record.historyKey,
+			ratingKey: record.ratingKey,
+			title: record.title,
+			type: record.type,
+			viewedAt: record.viewedAt,
+			accountId: record.accountId,
+			librarySectionId: record.librarySectionId,
+			thumb: record.thumb,
+			duration: record.duration,
+			grandparentTitle: record.grandparentTitle,
+			grandparentRatingKey: record.grandparentRatingKey,
+			grandparentThumb: record.grandparentThumb,
+			parentTitle: record.parentTitle,
+			genres: record.genres,
+			releaseYear: record.releaseYear
+		});
+
+		const stats = await calculateUserStats(accountId, year, { forceRecalculate: true });
+		const cacheRows = await db.select().from(cachedStats);
+
+		expect(stats.userId).toBe(accountId);
+		expect(cacheRows).toHaveLength(1);
+		expect(cacheRows[0]?.userId).toBe(accountId);
+		expect(cacheRows[0]?.userId).not.toBe(localUserId);
+	});
+});

--- a/tests/unit/utils/submit-action.test.ts
+++ b/tests/unit/utils/submit-action.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// Mock $app/forms before importing the helper that depends on it.
+mock.module('$app/forms', () => ({
+	deserialize: (text: string) => {
+		const parsed = JSON.parse(text);
+		// SvelteKit's `data` field is a `devalue`-encoded string; for tests we
+		// pass plain objects through the parsed payload so the helper sees the
+		// same shape callers do at runtime.
+		if (parsed?.data && typeof parsed.data === 'string') {
+			try {
+				const decoded = JSON.parse(parsed.data);
+				return { ...parsed, data: Array.isArray(decoded) ? hydrateDevalue(decoded) : decoded };
+			} catch {
+				return parsed;
+			}
+		}
+		return parsed;
+	}
+}));
+
+function hydrateDevalue(input: unknown[]): unknown {
+	const head = input[0];
+	if (typeof head !== 'object' || head === null) return head;
+	const result: Record<string, unknown> = {};
+	for (const [key, idx] of Object.entries(head as Record<string, number>)) {
+		result[key] = input[idx];
+	}
+	return result;
+}
+
+const { submitAction } = await import('$lib/utils/submit-action');
+
+type FetchFn = typeof fetch;
+
+const originalFetch = globalThis.fetch;
+
+function installMockFetch(
+	impl: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+) {
+	globalThis.fetch = mock(impl) as unknown as FetchFn;
+}
+
+describe('submitAction', () => {
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	beforeEach(() => {
+		// reset
+	});
+
+	it('sends POST with x-sveltekit-action header', async () => {
+		let capturedInit: RequestInit | undefined;
+		installMockFetch(async (_input, init) => {
+			capturedInit = init;
+			return new Response(JSON.stringify({ type: 'success', status: 200, data: '[null]' }), {
+				status: 200
+			});
+		});
+
+		await submitAction('?/noop');
+
+		expect(capturedInit?.method).toBe('POST');
+		const headers = new Headers(capturedInit?.headers);
+		expect(headers.get('x-sveltekit-action')).toBe('true');
+	});
+
+	it('returns success outcome with parsed data', async () => {
+		installMockFetch(
+			async () =>
+				new Response(
+					JSON.stringify({
+						type: 'success',
+						status: 200,
+						data: '[{"count":1},42]'
+					}),
+					{ status: 200 }
+				)
+		);
+
+		const result = await submitAction<{ count: number }>('?/getCount');
+		expect(result.type).toBe('success');
+		if (result.type === 'success') {
+			expect(result.data).toEqual({ count: 42 });
+		}
+	});
+
+	it('returns failure outcome with error data', async () => {
+		installMockFetch(
+			async () =>
+				new Response(
+					JSON.stringify({
+						type: 'failure',
+						status: 400,
+						data: '[{"error":1},"bad input"]'
+					}),
+					{ status: 400 }
+				)
+		);
+
+		const result = await submitAction<{ error?: string }>('?/badForm');
+		expect(result.type).toBe('failure');
+		if (result.type === 'failure') {
+			expect(result.data.error).toBe('bad input');
+		}
+	});
+
+	it('returns error outcome when the wire format reports an error', async () => {
+		installMockFetch(
+			async () =>
+				new Response(
+					JSON.stringify({
+						type: 'error',
+						error: { message: 'boom' },
+						status: 500
+					}),
+					{ status: 500 }
+				)
+		);
+
+		const result = await submitAction('?/explodes');
+		expect(result.type).toBe('error');
+		if (result.type === 'error') {
+			expect(result.error.message).toBe('boom');
+		}
+	});
+
+	it('propagates fetch network errors', async () => {
+		installMockFetch(async () => {
+			throw new Error('network down');
+		});
+
+		await expect(submitAction('?/anything')).rejects.toThrow('network down');
+	});
+
+	it('accepts a FormData body', async () => {
+		let capturedBody: BodyInit | null | undefined;
+		installMockFetch(async (_input, init) => {
+			capturedBody = init?.body;
+			return new Response(JSON.stringify({ type: 'success', status: 200, data: '[null]' }), {
+				status: 200
+			});
+		});
+
+		const fd = new FormData();
+		fd.set('year', '2024');
+		await submitAction('?/withBody', fd);
+
+		expect(capturedBody).toBe(fd);
+	});
+});


### PR DESCRIPTION
## Summary

Addresses all eight dogfood findings (3 high / 3 medium / 2 low) and the
`share_settings.user_id = 677042263` data-integrity drift flagged in the
latest dogfood pass. Adds a shared submit helper that fixes the silent
client-action failure root cause and locks down the FK gap that allowed
Plex IDs to become `share_settings`/`cached_stats` orphans.

## Application fixes

### High

- **ISSUE-001 - Go to Dashboard no-op (`src/routes/onboarding/complete/+page.server.ts`)**
  The completion `load()` was clearing the onboarding claim cookie on
  every GET, so by the time the action POSTed, `requireActiveOnboardingClaim`
  rejected the call and the action's `redirect(303, '/admin')` never
  fired. Moved `completeOnboarding()` and `clearOnboardingClaimCookie()`
  into the `goToDashboard` action; `load()` is now idempotent. The
  back-button guard still blocks re-entry because the source page's
  `load` no longer re-runs after the redirect.

- **ISSUE-004 - Logo Mode silent revert (`src/routes/admin/settings/+page.svelte`)**
  The Logo Mode `use:enhance` callback wrapped its work in `try/finally`
  but never called `handleFormToast` on non-success outcomes, so any
  future failure stayed silent. Added an explicit
  `handleFormToast({ error })` branch on `result.type === 'error'`,
  matching the established pattern in the test-connection callbacks.

- **ISSUE-005 / ISSUE-006 - Silent action calls**
  Root cause: SvelteKit only emits the parseable action wire format
  when the request carries `x-sveltekit-action: true`. Bare
  `fetch('?/...')` calls received an HTML page; `deserialize()` then
  threw and the UI landed in the failure branch with no toast.
  Introduced `src/lib/utils/submit-action.ts`, a small helper that
  sets the header, parses the response, and normalizes SvelteKit's
  `ActionResult` into a `SubmitOutcome<T>` discriminated union.
  Migrated nine call sites:

  | File | Action |
  |------|--------|
  | `admin/settings/+page.svelte` | `bulkApplyShareDefaults`, `getCacheCount` x2, `getPlayHistoryCount` x2, `testPlexConnection`, `testAIConnection` |
  | `admin/slides/+page.svelte` | `previewMarkdown` |
  | `onboarding/settings/+page.svelte` | `testAIConnection` |
  | `onboarding/csrf/+page.svelte` | `diagnoseReverseProxy`, `testOrigin` |

  The REST call to `/api/security/reverse-proxy-diagnostic` was left
  untouched - it is not an action and the JSON contract is correct.

### Medium

- **ISSUE-002 - Start Sync below fold (`src/routes/onboarding/+layout.svelte`)**
  `.onboarding-layout` was `overflow: clip`, hiding any content past
  the viewport with no scrollbar. Changed to
  `overflow-x: clip; overflow-y: auto` so tall onboarding steps
  scroll naturally. Fixed-position overlays (vignette/noise) are
  unaffected.

- **ISSUE-007 - Summary page buttons clipped**
  `StoryMode`'s `.story-mode` is `overflow: hidden` and `.slide` is
  absolutely positioned with no scroll; SummaryPage's own
  `overflow-y: auto` was masked by the parent's clip. Added
  `overflow-y: auto` to `.slide` and changed `.summary-page`
  `min-height: 100vh` to `min-height: 100%` so it sizes to its
  `.slide` frame.

### Low

- **ISSUE-003 - Plex sign-in fallback (`src/routes/onboarding/plex/+page.svelte`)**
  Added an always-visible \"Use redirect instead\" link beneath both
  Sign in with Plex buttons (linking to `?auth=redirect`). The
  existing popup-blocked auto-detection in `auth-mode.ts` and the
  `PopupBlockedModal` are unchanged.

- **ISSUE-008 - Username input label (`src/routes/+page.svelte`)**
  Wrapped the landing input with `<label for=\"username-input\" class=\"sr-only\">Plex username</label>`,
  added a matching `.sr-only` style. WCAG 1.3.1 / 4.1.2 conformance
  without affecting the placeholder UX.

## Data integrity - `share_settings` / `cached_stats` FK gap

- **Schema (`src/lib/server/db/schema.ts`)**
  `cachedStats.userId` and `shareSettings.userId` now declare
  `references(() => users.id, { onDelete: 'cascade' })`.

- **Identifier validation (`src/routes/wrapped/[year]/u/[identifier]/+page.server.ts`)**
  `resolveUserIdFromIdentifier` now confirms the user exists in
  `users` before returning the numeric id. The load function also
  performs an explicit existence check before any code path that
  would call `getOrCreateShareSettings` (notably
  `checkWrappedAccess`). Unknown ids still return 404 - the F-015
  anti-enumeration response is preserved.

- **Migration `drizzle/0008_share_settings_cached_stats_fk.sql`**
  Follows the recreate-and-copy idiom from earlier migrations:
  1. `DELETE FROM cached_stats / share_settings WHERE user_id` is
     orphaned (runs before `PRAGMA foreign_keys=OFF` so drizzle's
     copy does not silently carry orphans across).
  2. Recreate each table with the new FK definition.
  3. `INSERT ... SELECT *`, `DROP`, `RENAME`, recreate indices.
  4. `PRAGMA foreign_keys=ON` at the end.

  End-to-end verified against an in-memory DB containing the exact
  dogfood-observed orphan (`user_id = 677042263`): the row was
  cleaned, post-migration inserts with non-existent `user_id` are
  rejected, and cascade delete removes user rows correctly.

## Tests

- `tests/unit/utils/submit-action.test.ts` - covers success / failure /
  error / network-throw branches, header presence, and FormData
  forwarding using a mocked `$app/forms` and a mocked `fetch`.
- `tests/unit/server/sharing/resolve-user-id.test.ts` - verifies
  `updateShareMode` and `regenerateToken` return `fail(400)` for
  unknown numeric identifiers (and create no `share_settings` rows),
  `load` throws 404 for unknown ids, and the existing-user path is
  still happy.
- `tests/unit/onboarding/csrf-page-source.test.ts` - updated to
  expect the new `submitAction(...)` pattern instead of raw
  `fetch('?/diagnoseReverseProxy'`.

Full suite: **1759 pass / 0 fail**. Coverage: **85.99% functions /
83.94% lines** (threshold is 80% / 80%).

## Verification

- [x] `bun run check` clean.
- [x] `bun run lint` clean.
- [x] `bun run test` (1759 / 1759 pass).
- [x] `bun run db:generate` reports no schema diff after the change.
- [x] Migration tested against an in-memory DB with the orphan row -
      orphan removed, FK enforced, cascade delete works.

## Test plan

- [ ] Fresh onboarding: at `/onboarding/complete`, **Go to Dashboard**
      lands on `/admin` in one click.
- [ ] At `/onboarding/sync` (1280x720), the **Start Sync** button is
      reachable by scroll.
- [ ] At `/onboarding/plex`, click **Use redirect instead** -> the
      redirect-flow OAuth completes.
- [ ] At `/admin/settings` -> Appearance, save **Logo Mode**, reload -
      value persists. Force a network failure -> a toast surfaces.
- [ ] At `/admin/settings` -> Privacy, **Apply Defaults to All Users**
      surfaces the success toast.
- [ ] At `/admin/slides`, **Update Preview** renders Markdown in the
      preview pane.
- [ ] At `/wrapped/{year}` Summary page (1280x720, 1024x600, 390x844),
      **Watch Again / Share / Return Home** are reachable.
- [ ] Landing page accessibility tree shows the username `<input>`
      with the accessible name \"Plex username\".
- [ ] Direct nav to `/wrapped/{year}/u/9999999` (any unused numeric
      id) returns **404** and creates **no** `share_settings` row.
- [ ] After running `0008` against a copy of the dev DB with the
      known orphan: the row is removed and FK is enforced.

## Out of scope

- Phase 6 sections D (double-submit) and E (two-tab conflicting writes)
  - coverage gap, not a found defect.
- `/api/sync/status/stream` SSE heartbeat - separately recommended in
  the dogfood report, no failure observed yet.
- shadcn-svelte `Input` / `Label` primitives - not present in the
  current UI kit; ISSUE-008 is fixed inline.