### PR TITLE
fix: resolve dogfood 2026-05-14 findings (ISSUE-002 through ISSUE-008)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -65,6 +65,17 @@
 	--slide-glass-blur: 20px;
 	--slide-glow-color: hsl(var(--primary) / 0.4);
 	--slide-accent-glow: hsl(var(--accent) / 0.3);
+
+	/* WCAG 2.1 SC 2.5.5 minimum touch target. 2.75rem = 44px at the default
+	   16px root font, the standard mobile-accessibility threshold. Apply via
+	   the `.tap-target` utility below — any interactive element that should
+	   pass touch-target audits gets `min-width`/`min-height` from this token. */
+	--min-tap-size: 2.75rem;
+}
+
+.tap-target {
+	min-width: var(--min-tap-size);
+	min-height: var(--min-tap-size);
 }
 
 /* Dark mode class (same as :root since app is dark-only) */

--- a/src/lib/components/wrapped/ModeToggle.svelte
+++ b/src/lib/components/wrapped/ModeToggle.svelte
@@ -76,8 +76,12 @@ function handleKeyDown(event: KeyboardEvent): void {
 			z-index: 100;
 			display: flex;
 			align-items: center;
+			justify-content: center;
 			gap: 0.5rem;
 			padding: 0.5rem 1rem;
+			/* WCAG 2.1 SC 2.5.5: keep both axes at or above 44×44 logical px. */
+			min-width: var(--min-tap-size);
+			min-height: var(--min-tap-size);
 			background: rgba(0, 0, 0, 0.7);
 			backdrop-filter: blur(8px);
 			border: 1px solid rgba(255, 255, 255, 0.1);
@@ -127,6 +131,11 @@ function handleKeyDown(event: KeyboardEvent): void {
 				top: 0.75rem;
 				right: 3rem;
 				padding: 0.5rem;
+				/* Force the circular mobile button to the tap-target floor —
+				   the previous min-width/-height inherited from the default
+				   layout were being clipped by padding alone. */
+				width: var(--min-tap-size);
+				height: var(--min-tap-size);
 				border-radius: 50%;
 			}
 

--- a/src/lib/components/wrapped/ScrollMode.svelte
+++ b/src/lib/components/wrapped/ScrollMode.svelte
@@ -277,8 +277,10 @@ function handleKeyDown(event: KeyboardEvent): void {
 			top: 1rem;
 			right: 1rem;
 			z-index: 101;
-			width: 2.5rem;
-			height: 2.5rem;
+			width: var(--min-tap-size);
+			height: var(--min-tap-size);
+			min-width: var(--min-tap-size);
+			min-height: var(--min-tap-size);
 			display: flex;
 			align-items: center;
 			justify-content: center;
@@ -327,13 +329,15 @@ function handleKeyDown(event: KeyboardEvent): void {
 			.close-button {
 				top: 0.75rem;
 				right: 0.75rem;
-				width: 2rem;
-				height: 2rem;
+				/* Hold the tap-target floor on mobile — the previous 2rem
+				   square (32px) failed WCAG 2.1 SC 2.5.5. */
+				width: var(--min-tap-size);
+				height: var(--min-tap-size);
 			}
 
 			.close-button svg {
-				width: 1rem;
-				height: 1rem;
+				width: 1.25rem;
+				height: 1.25rem;
 			}
 		}
 

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -39,6 +39,12 @@ let {
 const EDGE_ZONE_PERCENT = 0.15;
 const SWIPE_THRESHOLD = 50;
 const ANIMATION_DURATION = 450;
+// Throttle keydown to ~10 events/sec. Held-down arrow keys repeat at the OS
+// rate (often 30+/sec), which queues up against the in-flight motion-library
+// animation calls and saturates the main thread. The `isTransitioning` gate
+// only blocks during an animation; this gate also caps the rate between
+// animations so the slideshow advances at a human-readable pace.
+const KEYDOWN_THROTTLE_MS = 100;
 type AnimationHandle = { stop: () => void; finished: Promise<void> };
 
 const navigation = createSlideState();
@@ -71,6 +77,7 @@ let activeEnterAnim: AnimationHandle | null = $state(null);
 let activeExitAnim: AnimationHandle | null = $state(null);
 let transitionTimeout: ReturnType<typeof setTimeout> | null = $state(null);
 let transitionToken = 0;
+let lastKeyTime = 0;
 
 $effect(() => {
 	return () => {
@@ -288,6 +295,16 @@ function handleTouchEnd(event: TouchEvent): void {
 
 function handleKeyDown(event: KeyboardEvent): void {
 	if (isTransitioning) return;
+
+	// Drop key repeats arriving faster than the throttle window. The OS auto-
+	// repeats held arrow keys at 30+/sec which piles up against the animations
+	// and freezes the main thread.
+	const now = Date.now();
+	if (now - lastKeyTime < KEYDOWN_THROTTLE_MS) {
+		event.preventDefault();
+		return;
+	}
+	lastKeyTime = now;
 
 	switch (event.key) {
 		case 'ArrowRight':
@@ -560,8 +577,10 @@ function handleSlideAnimationComplete(): void {}
 			top: 1rem;
 			right: 1rem;
 			z-index: 101;
-			width: 2.5rem;
-			height: 2.5rem;
+			width: var(--min-tap-size);
+			height: var(--min-tap-size);
+			min-width: var(--min-tap-size);
+			min-height: var(--min-tap-size);
 			display: flex;
 			align-items: center;
 			justify-content: center;
@@ -605,13 +624,15 @@ function handleSlideAnimationComplete(): void {}
 			.close-button {
 				top: 0.75rem;
 				right: 0.75rem;
-				width: 2rem;
-				height: 2rem;
+				/* Hold the tap-target floor on mobile too — the previous 2rem
+				   square (32px) failed WCAG 2.1 SC 2.5.5. */
+				width: var(--min-tap-size);
+				height: var(--min-tap-size);
 			}
 
 			.close-button svg {
-				width: 1rem;
-				height: 1rem;
+				width: 1.25rem;
+				height: 1.25rem;
 			}
 		}
 
@@ -684,8 +705,8 @@ function handleSlideAnimationComplete(): void {}
 			}
 
 			.close-button {
-				width: 2.75rem;
-				height: 2.75rem;
+				width: var(--min-tap-size);
+				height: var(--min-tap-size);
 			}
 
 			.close-button svg {

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -296,6 +296,24 @@ function handleTouchEnd(event: TouchEvent): void {
 function handleKeyDown(event: KeyboardEvent): void {
 	if (isTransitioning) return;
 
+	// Only the navigation keys below are owned by this handler. Tab, browser
+	// shortcuts, and any other key must fall through untouched so they don't
+	// have their default behaviour suppressed or poison the throttle window.
+	switch (event.key) {
+		case 'ArrowRight':
+		case 'ArrowDown':
+		case ' ':
+		case 'Enter':
+		case 'ArrowLeft':
+		case 'ArrowUp':
+		case 'Escape':
+		case 'Home':
+		case 'End':
+			break;
+		default:
+			return;
+	}
+
 	// Drop key repeats arriving faster than the throttle window. The OS auto-
 	// repeats held arrow keys at 30+/sec which piles up against the animations
 	// and freezes the main thread.

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -317,7 +317,7 @@ function handleKeyDown(event: KeyboardEvent): void {
 	// Drop key repeats arriving faster than the throttle window. The OS auto-
 	// repeats held arrow keys at 30+/sec which piles up against the animations
 	// and freezes the main thread.
-	const now = Date.now();
+	const now = performance.now();
 	if (now - lastKeyTime < KEYDOWN_THROTTLE_MS) {
 		event.preventDefault();
 		return;

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -254,7 +254,8 @@ $effect(() => {
 	<div bind:this={buttonsRow} class="actions">
 		<button
 			type="button"
-			class="btn btn-secondary"
+			class="btn btn-secondary tap-target"
+			aria-label="Watch Again"
 			onclick={(event) => handleActionClick(event, onRestart)}
 		>
 			<svg
@@ -267,6 +268,8 @@ $effect(() => {
 				stroke-width="2"
 				stroke-linecap="round"
 				stroke-linejoin="round"
+				aria-hidden="true"
+				focusable="false"
 			>
 				<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
 				<path d="M3 3v5h5" />
@@ -276,7 +279,8 @@ $effect(() => {
 
 		<button
 			type="button"
-			class="btn btn-primary"
+			class="btn btn-primary tap-target"
+			aria-label="Share"
 			onclick={(event) => handleActionClick(event, onShare)}
 		>
 			<svg
@@ -289,6 +293,8 @@ $effect(() => {
 				stroke-width="2"
 				stroke-linecap="round"
 				stroke-linejoin="round"
+				aria-hidden="true"
+				focusable="false"
 			>
 				<circle cx="18" cy="5" r="3" />
 				<circle cx="6" cy="12" r="3" />
@@ -301,7 +307,8 @@ $effect(() => {
 
 		<button
 			type="button"
-			class="btn btn-secondary"
+			class="btn btn-secondary tap-target"
+			aria-label="Return Home"
 			onclick={(event) => handleActionClick(event, onHome)}
 		>
 			<svg
@@ -314,6 +321,8 @@ $effect(() => {
 				stroke-width="2"
 				stroke-linecap="round"
 				stroke-linejoin="round"
+				aria-hidden="true"
+				focusable="false"
 			>
 				<path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
 				<polyline points="9 22 9 12 15 12 15 22" />

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -363,8 +363,11 @@ function handleCsrfWarningDismissed() {
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			width: 40px;
-			height: 40px;
+			/* WCAG 2.1 SC 2.5.5 floor — was 40×40, now 44×44 via the shared token. */
+			width: var(--min-tap-size);
+			height: var(--min-tap-size);
+			min-width: var(--min-tap-size);
+			min-height: var(--min-tap-size);
 			background: transparent;
 			border: none;
 			color: hsl(var(--foreground));

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -70,6 +70,7 @@ import {
 	getGlobalDefaultShareMode,
 	getServerWrappedShareMode
 } from '$lib/server/sharing/service';
+import { getAppVersion } from '$lib/server/version';
 import type { Actions, PageServerLoad } from './$types';
 
 const ThemeSchema = z.enum([
@@ -279,6 +280,10 @@ export const load: PageServerLoad = async () => {
 		availableYears,
 		currentYear,
 		playHistoryTotalCount,
+		// Returned explicitly here so the System tab's "App version" row renders
+		// even if the root layout data merge ever changes shape — the System tab
+		// reads `data.appVersion.display` directly.
+		appVersion: getAppVersion(),
 		// System info panel (ISSUE-006) — exposed as plain primitives so the
 		// SSR JSON is small and the client doesn't need to import node:os.
 		systemInfo: {

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -2684,8 +2684,19 @@ const logFieldErrors = $derived(
 										return;
 									}
 
-									restoreLogSettings();
 									await update();
+									// Only restore server-truth when the failure does not
+									// carry per-field errors. On Zod validation failures we
+									// keep the user's invalid input visible so the field
+									// errors line up with what they typed.
+									const hasFieldErrors =
+										result.type === 'failure' &&
+										result.data != null &&
+										typeof result.data === 'object' &&
+										'fieldErrors' in result.data;
+									if (!hasFieldErrors) {
+										restoreLogSettings();
+									}
 								} finally {
 									isSavingLogSettings = false;
 								}

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -377,6 +377,12 @@ function restoreUserDefaults(): void {
 	allowUserControl = syncedAllowUserControl;
 }
 
+function restoreLogSettings(): void {
+	logRetentionDays = data.logSettings.retentionDays;
+	logMaxCount = data.logSettings.maxCount;
+	logDebugEnabled = data.logSettings.debugEnabled;
+}
+
 // Show toast notifications for form responses
 $effect(() => {
 	handleFormToast(form);
@@ -1511,8 +1517,15 @@ const logFieldErrors = $derived(
 										return;
 									}
 
+									// On failure (including 409 OCC conflicts), restore the radio
+									// buttons to the synced value, surface the error via the form
+									// prop, AND invalidate the load so the hidden settingsVersion
+									// refreshes. Without the invalidate, a stale settingsVersion
+									// would re-trigger 409 on the user's next click and the UI
+									// would silently revert again with no visible cause.
 									restoreServerWrappedSettings();
 									await update();
+									await invalidateAll();
 								} finally {
 									isSavingServerWrappedSettings = false;
 								}
@@ -1691,8 +1704,12 @@ const logFieldErrors = $derived(
 										return;
 									}
 
+									// Mirror the server-wide form: restore the controls, surface
+									// the error, and refresh the OCC settingsVersion so retrying
+									// isn't permanently locked into 409.
 									restoreUserDefaults();
 									await update();
+									await invalidateAll();
 								} finally {
 									isSavingUserDefaults = false;
 								}
@@ -2659,8 +2676,15 @@ const logFieldErrors = $derived(
 						action="?/updateLogSettings"
 						use:enhance={() => {
 							isSavingLogSettings = true;
-							return async ({ update }) => {
+							return async ({ result, update }) => {
 								try {
+									if (result.type === 'success') {
+										await update({ invalidateAll: true });
+										await invalidateAll();
+										return;
+									}
+
+									restoreLogSettings();
 									await update();
 								} finally {
 									isSavingLogSettings = false;
@@ -3100,6 +3124,9 @@ const logFieldErrors = $derived(
 			align-items: center;
 			gap: 0.5rem;
 			padding: 0.75rem 1.25rem;
+			/* WCAG 2.1 SC 2.5.5 floor — keeps the vertical hit-area at 44px
+			   even when the active tab pill shrinks under wider viewports. */
+			min-height: var(--min-tap-size);
 			background: transparent;
 			border: none;
 			border-radius: 8px;
@@ -3477,7 +3504,13 @@ const logFieldErrors = $derived(
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			width: 42px;
+			/* WCAG 2.1 SC 2.5.5 floor — was 42px wide with no min-height,
+			   so the rendered hit-area was 42×(input height). Lift to 44×44
+			   minimum so the show/hide secret and clear-input affordances
+			   pass touch-target audits. */
+			min-width: var(--min-tap-size);
+			min-height: var(--min-tap-size);
+			padding: 0 0.5rem;
 			background: hsl(var(--muted));
 			border: 1px solid hsl(var(--border));
 			border-radius: 8px;

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -684,10 +684,23 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 						<h3>Preview</h3>
 						<button
 							type="button"
-							class="preview-button"
+							class="preview-button tap-target"
 							onclick={async () => {
+								// Short-circuit when there is nothing to render. Without this
+								// guard the server returns html: '' for empty input and the
+								// preview region falls through to {@html ''} — visible
+								// outcome is the placeholder text staying put with no
+								// indication the button was clicked (dogfood ISSUE-004).
+								const content = editorContent ?? '';
+								if (content.trim().length === 0) {
+									previewHtml = '';
+									previewRendered = false;
+									previewError = 'Enter some Markdown content first.';
+									return;
+								}
+
 								const formData = new FormData();
-								formData.append('content', editorContent);
+								formData.append('content', content);
 
 								try {
 									const result = await submitAction<{ html?: string }>(
@@ -695,9 +708,16 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 										formData
 									);
 									if (result.type === 'success') {
-										previewHtml = result.data.html ?? '';
-										previewRendered = typeof result.data.html === 'string';
-										previewError = previewRendered ? '' : 'Failed to render Markdown';
+										const html = typeof result.data.html === 'string' ? result.data.html : '';
+										previewHtml = html;
+										// Render the preview region whenever the server returned
+										// success, even if html is empty (e.g. sanitizer stripped
+										// everything). An explicit empty-state line inside the
+										// rendered region is clearer than silently reverting to
+										// the "Click 'Update Preview' …" placeholder, which made
+										// the button look broken.
+										previewRendered = true;
+										previewError = '';
 									} else if (result.type === 'failure') {
 										previewHtml = '';
 										previewRendered = false;
@@ -722,8 +742,12 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 							{#if previewError}
 								<p class="preview-error">{previewError}</p>
 							{:else if previewRendered}
-								<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-								{@html previewHtml}
+								{#if previewHtml.length > 0}
+									<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+									{@html previewHtml}
+								{:else}
+									<p class="preview-placeholder">Markdown rendered to an empty result.</p>
+								{/if}
 							{:else}
 								<p class="preview-placeholder">Click "Update Preview" to see rendered Markdown</p>
 							{/if}

--- a/src/routes/wrapped/[year]/+page.svelte
+++ b/src/routes/wrapped/[year]/+page.svelte
@@ -133,6 +133,15 @@ function handleRestart(): void {
 	showSummary = false;
 	viewMode = 'story';
 	currentSlideIndex = 0;
+	// Clear the URL hash before the StoryMode remount. Otherwise the freshly
+	// mounted StoryMode reads the stale `#slide=N` (from the user reaching the
+	// summary) via readInitialSlideIndex and the slideshow restarts at the
+	// last slide instead of slide 0.
+	if (browser && routerReady) {
+		const url = new URL(window.location.href);
+		url.hash = '#slide=0';
+		replaceState(url, {});
+	}
 	storyKey++; // Force StoryMode remount
 }
 

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.svelte
@@ -139,6 +139,15 @@ function handleRestart(): void {
 	showSummary = false;
 	viewMode = 'story';
 	currentSlideIndex = 0;
+	// Clear the URL hash before the StoryMode remount. Otherwise the freshly
+	// mounted StoryMode reads the stale `#slide=N` (from the user reaching the
+	// summary) via readInitialSlideIndex and the slideshow restarts at the
+	// last slide instead of slide 0.
+	if (browser && routerReady) {
+		const url = new URL(window.location.href);
+		url.hash = '#slide=0';
+		replaceState(url, {});
+	}
 	storyKey++; // Force StoryMode remount
 }
 

--- a/tests/unit/dogfood-fixes.test.ts
+++ b/tests/unit/dogfood-fixes.test.ts
@@ -105,7 +105,7 @@ describe('dogfood ISSUE-008 — StoryMode keydown throttle', () => {
 		);
 		expect(handleKeyDownStart).toBeGreaterThan(-1);
 		const handleKeyDownSlice = source.slice(handleKeyDownStart, handleKeyDownStart + 1200);
-		expect(handleKeyDownSlice).toContain('const now = Date.now();');
+		expect(handleKeyDownSlice).toContain('const now = performance.now();');
 		expect(handleKeyDownSlice).toContain('if (now - lastKeyTime < KEYDOWN_THROTTLE_MS) {');
 		expect(handleKeyDownSlice).toContain('lastKeyTime = now;');
 	});

--- a/tests/unit/dogfood-fixes.test.ts
+++ b/tests/unit/dogfood-fixes.test.ts
@@ -20,7 +20,7 @@ describe('dogfood ISSUE-003 — admin log settings persistence', () => {
 
 		const enhanceStart = source.indexOf('action="?/updateLogSettings"');
 		expect(enhanceStart).toBeGreaterThan(-1);
-		const enhanceSlice = source.slice(enhanceStart, enhanceStart + 800);
+		const enhanceSlice = source.slice(enhanceStart, enhanceStart + 1200);
 		expect(enhanceSlice).toContain('await update({ invalidateAll: true });');
 		expect(enhanceSlice).toContain('await invalidateAll();');
 		expect(enhanceSlice).toContain('restoreLogSettings();');
@@ -104,7 +104,7 @@ describe('dogfood ISSUE-008 — StoryMode keydown throttle', () => {
 			'function handleKeyDown(event: KeyboardEvent): void {'
 		);
 		expect(handleKeyDownStart).toBeGreaterThan(-1);
-		const handleKeyDownSlice = source.slice(handleKeyDownStart, handleKeyDownStart + 800);
+		const handleKeyDownSlice = source.slice(handleKeyDownStart, handleKeyDownStart + 1200);
 		expect(handleKeyDownSlice).toContain('const now = Date.now();');
 		expect(handleKeyDownSlice).toContain('if (now - lastKeyTime < KEYDOWN_THROTTLE_MS) {');
 		expect(handleKeyDownSlice).toContain('lastKeyTime = now;');

--- a/tests/unit/dogfood-fixes.test.ts
+++ b/tests/unit/dogfood-fixes.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'bun:test';
+
+/**
+ * Source-regression tests for the 2026-05-14 dogfood fixes. Each test pins
+ * the structural change to the source so a future refactor can't silently
+ * regress the dogfood-reported behaviour.
+ */
+async function readSource(path: string): Promise<string> {
+	return Bun.file(path).text();
+}
+
+describe('dogfood ISSUE-003 — admin log settings persistence', () => {
+	it('runs invalidateAll on success and restores state on failure', async () => {
+		const source = await readSource('src/routes/admin/settings/+page.svelte');
+
+		expect(source).toContain('function restoreLogSettings(): void {');
+		expect(source).toContain('logRetentionDays = data.logSettings.retentionDays;');
+		expect(source).toContain('logMaxCount = data.logSettings.maxCount;');
+		expect(source).toContain('logDebugEnabled = data.logSettings.debugEnabled;');
+
+		const enhanceStart = source.indexOf('action="?/updateLogSettings"');
+		expect(enhanceStart).toBeGreaterThan(-1);
+		const enhanceSlice = source.slice(enhanceStart, enhanceStart + 800);
+		expect(enhanceSlice).toContain('await update({ invalidateAll: true });');
+		expect(enhanceSlice).toContain('await invalidateAll();');
+		expect(enhanceSlice).toContain('restoreLogSettings();');
+	});
+
+	it('returns appVersion from the admin settings load function', async () => {
+		const source = await readSource('src/routes/admin/settings/+page.server.ts');
+		expect(source).toContain("import { getAppVersion } from '$lib/server/version';");
+		expect(source).toContain('appVersion: getAppVersion()');
+	});
+});
+
+describe('dogfood ISSUE-002 — server-wide wrapped + user defaults persistence', () => {
+	it('invalidates on the failure path so OCC settingsVersion refreshes', async () => {
+		const source = await readSource('src/routes/admin/settings/+page.svelte');
+
+		const serverWrappedStart = source.indexOf('action="?/updateServerWrappedSettings"');
+		expect(serverWrappedStart).toBeGreaterThan(-1);
+		const serverWrappedSlice = source.slice(serverWrappedStart, serverWrappedStart + 1200);
+		expect(serverWrappedSlice).toContain('restoreServerWrappedSettings();');
+		// Two await invalidateAll() calls in the block: one in the success
+		// branch, one after restore in the failure branch.
+		const occurrences = serverWrappedSlice.match(/await invalidateAll\(\);/g);
+		expect(occurrences?.length).toBeGreaterThanOrEqual(2);
+
+		const userDefaultsStart = source.indexOf('action="?/updateUserDefaults"');
+		expect(userDefaultsStart).toBeGreaterThan(-1);
+		const userDefaultsSlice = source.slice(userDefaultsStart, userDefaultsStart + 1200);
+		expect(userDefaultsSlice).toContain('restoreUserDefaults();');
+		const userOccurrences = userDefaultsSlice.match(/await invalidateAll\(\);/g);
+		expect(userOccurrences?.length).toBeGreaterThanOrEqual(2);
+	});
+});
+
+describe('dogfood ISSUE-005 — Watch Again must return to slide 0', () => {
+	it('server-wide wrapped clears the URL hash before remounting StoryMode', async () => {
+		const source = await readSource('src/routes/wrapped/[year]/+page.svelte');
+
+		const restartStart = source.indexOf('function handleRestart(): void {');
+		expect(restartStart).toBeGreaterThan(-1);
+		const restartSlice = source.slice(restartStart, restartStart + 600);
+		expect(restartSlice).toContain('currentSlideIndex = 0;');
+		expect(restartSlice).toContain("url.hash = '#slide=0';");
+		expect(restartSlice).toContain('replaceState(url, {});');
+		// Hash mutation must happen before the storyKey bump.
+		expect(restartSlice.indexOf("url.hash = '#slide=0'")).toBeLessThan(
+			restartSlice.indexOf('storyKey++')
+		);
+	});
+
+	it('per-user wrapped clears the URL hash before remounting StoryMode', async () => {
+		const source = await readSource('src/routes/wrapped/[year]/u/[identifier]/+page.svelte');
+
+		const restartStart = source.indexOf('function handleRestart(): void {');
+		expect(restartStart).toBeGreaterThan(-1);
+		const restartSlice = source.slice(restartStart, restartStart + 600);
+		expect(restartSlice).toContain('currentSlideIndex = 0;');
+		expect(restartSlice).toContain("url.hash = '#slide=0';");
+		expect(restartSlice).toContain('replaceState(url, {});');
+		expect(restartSlice.indexOf("url.hash = '#slide=0'")).toBeLessThan(
+			restartSlice.indexOf('storyKey++')
+		);
+	});
+
+	it('SummaryPage buttons carry explicit aria-labels', async () => {
+		const source = await readSource('src/lib/components/wrapped/SummaryPage.svelte');
+		expect(source).toContain('aria-label="Watch Again"');
+		expect(source).toContain('aria-label="Share"');
+		expect(source).toContain('aria-label="Return Home"');
+	});
+});
+
+describe('dogfood ISSUE-008 — StoryMode keydown throttle', () => {
+	it('throttles keydown to one event per KEYDOWN_THROTTLE_MS window', async () => {
+		const source = await readSource('src/lib/components/wrapped/StoryMode.svelte');
+
+		expect(source).toContain('const KEYDOWN_THROTTLE_MS = 100;');
+		expect(source).toContain('let lastKeyTime = 0;');
+
+		const handleKeyDownStart = source.indexOf(
+			'function handleKeyDown(event: KeyboardEvent): void {'
+		);
+		expect(handleKeyDownStart).toBeGreaterThan(-1);
+		const handleKeyDownSlice = source.slice(handleKeyDownStart, handleKeyDownStart + 800);
+		expect(handleKeyDownSlice).toContain('const now = Date.now();');
+		expect(handleKeyDownSlice).toContain('if (now - lastKeyTime < KEYDOWN_THROTTLE_MS) {');
+		expect(handleKeyDownSlice).toContain('lastKeyTime = now;');
+	});
+});
+
+describe('dogfood ISSUE-004 — Update Preview renders markdown', () => {
+	it('short-circuits empty content and renders an empty-result message when needed', async () => {
+		const source = await readSource('src/routes/admin/slides/+page.svelte');
+
+		expect(source).toContain('Enter some Markdown content first.');
+		expect(source).toContain('Markdown rendered to an empty result.');
+		// previewRendered is now always set on success (no more typeof-based gate
+		// that flipped to false when the html came back undefined).
+		expect(source).toContain('previewRendered = true;');
+		expect(source).toContain('if (content.trim().length === 0) {');
+	});
+});
+
+describe('dogfood ISSUE-007 — --min-tap-size token rolled out everywhere', () => {
+	it('declares the token and a .tap-target utility in app.css', async () => {
+		const source = await readSource('src/app.css');
+		expect(source).toContain('--min-tap-size: 2.75rem;');
+		expect(source).toContain('.tap-target {');
+		expect(source).toContain('min-width: var(--min-tap-size);');
+		expect(source).toContain('min-height: var(--min-tap-size);');
+	});
+
+	it('applies the token to wrapped close buttons and the mode toggle', async () => {
+		for (const path of [
+			'src/lib/components/wrapped/StoryMode.svelte',
+			'src/lib/components/wrapped/ScrollMode.svelte',
+			'src/lib/components/wrapped/ModeToggle.svelte'
+		]) {
+			const source = await readSource(path);
+			expect(source).toContain('var(--min-tap-size)');
+		}
+	});
+
+	it('applies the token to admin chrome controls', async () => {
+		const layoutSource = await readSource('src/routes/admin/+layout.svelte');
+		expect(layoutSource).toContain('width: var(--min-tap-size);');
+		expect(layoutSource).toContain('height: var(--min-tap-size);');
+
+		const settingsSource = await readSource('src/routes/admin/settings/+page.svelte');
+		// `.tab-button` got a min-height floor; `.input-action` got both axes.
+		const tabButtonIdx = settingsSource.indexOf('.tab-button {');
+		expect(tabButtonIdx).toBeGreaterThan(-1);
+		expect(settingsSource.slice(tabButtonIdx, tabButtonIdx + 600)).toContain(
+			'min-height: var(--min-tap-size);'
+		);
+		const inputActionIdx = settingsSource.indexOf('.input-action {');
+		expect(inputActionIdx).toBeGreaterThan(-1);
+		const inputActionSlice = settingsSource.slice(inputActionIdx, inputActionIdx + 600);
+		expect(inputActionSlice).toContain('min-width: var(--min-tap-size);');
+		expect(inputActionSlice).toContain('min-height: var(--min-tap-size);');
+	});
+});


### PR DESCRIPTION
## Summary

Resolves the seven actionable findings filed in the 2026-05-14 dogfood run. ISSUE-006 is closed as a false-positive (the non-admin redirect target is by-design). ISSUE-001 is closed as not-reproducible from code analysis, with documentation appended to the local dogfood report.

## Fixes

### ISSUE-002 - Server-Wide Wrapped + User Sharing Defaults revert on reload
`src/routes/admin/settings/+page.svelte` (both privacy forms). The failure-path enhance handler now calls `await invalidateAll()` after `restore...()` + `update()`, so an OCC 409 refreshes the hidden `settingsVersion`. Without that refresh, the user's next click resubmits the same stale version and lands on another silent 409, which presented in the dogfood report as "the UI reverts to Public with no visible error."

### ISSUE-003 - Logging settings revert on reload + blank "App version"
- `src/routes/admin/settings/+page.svelte`: log-settings form now mirrors the privacy-tab enhance pattern. On success, `await update({ invalidateAll: true })` + `await invalidateAll()` re-runs the load so the page reads back the just-written values. On failure, a new `restoreLogSettings()` helper resets `logRetentionDays` / `logMaxCount` / `logDebugEnabled` from `data.logSettings`, preventing the stale `$effect` from overwriting still-on-screen values.
- `src/routes/admin/settings/+page.server.ts`: explicitly returns `appVersion: getAppVersion()` from the load function so the System tab no longer depends on root-layout data merging for `data.appVersion.display`.

### ISSUE-004 - "Update Preview" in custom slide creator does nothing
`src/routes/admin/slides/+page.svelte`:
1. Short-circuit empty editor content with "Enter some Markdown content first." so the button click always produces visible feedback (previously the empty case silently rendered `{@html ''}` into the preview region, indistinguishable from the placeholder).
2. Success branch sets `previewRendered = true` unconditionally; the previous `typeof result.data.html === 'string'` gate flipped to false when the response omitted `html`, leaving the user with neither preview nor clear error.
3. Render branch distinguishes empty output ("Markdown rendered to an empty result.") from the never-clicked placeholder.

### ISSUE-005 - "Watch Again" navigates to last slide instead of first
- `src/routes/wrapped/[year]/+page.svelte` and `src/routes/wrapped/[year]/u/[identifier]/+page.svelte`: `handleRestart` imperatively clears the URL hash to `#slide=0` via `replaceState(url, {})` before bumping `storyKey`, so the freshly-mounted `StoryMode` reads the corrected hash through `readInitialSlideIndex()` instead of the stale `#slide=N` written by the `$effect` when the user reached the summary.
- `src/lib/components/wrapped/SummaryPage.svelte`: Watch Again / Share / Return Home buttons carry explicit `aria-label`s and the `tap-target` class; inline SVGs are marked `aria-hidden="true" focusable="false"`.

### ISSUE-007 - Touch targets below 44x44 on mobile
New `--min-tap-size: 2.75rem` token + `.tap-target` utility declared in `src/app.css` (WCAG 2.1 SC 2.5.5 floor). Applied at every reported violation:
- `src/lib/components/wrapped/StoryMode.svelte` close button (default + mobile + desktop media blocks)
- `src/lib/components/wrapped/ScrollMode.svelte` close button (default + mobile media block)
- `src/lib/components/wrapped/ModeToggle.svelte` `.mode-toggle` (default + mobile media block)
- `src/routes/admin/+layout.svelte` `.menu-button`
- `src/routes/admin/settings/+page.svelte` `.tab-button` (min-height) and `.input-action` (both axes)
- `src/lib/components/wrapped/SummaryPage.svelte` action buttons (`tap-target` class)
- `src/routes/admin/slides/+page.svelte` "Update Preview" button (`tap-target` class)

### ISSUE-008 - Rapid keydown saturates main thread
`src/lib/components/wrapped/StoryMode.svelte`: new `KEYDOWN_THROTTLE_MS = 100` and module-scope `lastKeyTime` watermark. `handleKeyDown` drops events arriving within 100ms of the previous accepted one (after the existing `isTransitioning` early return), capping the slideshow's effective key-rate at approximately 10/sec regardless of the OS auto-repeat rate.

### ISSUE-001 - Onboarding Configure substep selections not in completion summary
Closed as not-reproducible from code analysis. Substep state vars (`uiTheme`, `wrappedTheme`, `anonymizationMode`, `wrappedLogoMode`, `defaultShareMode`, `allowUserControl`) are written by the substep onclick handlers, mirrored verbatim into the form's hidden inputs, and read by `?/saveSettings` which writes each via the corresponding setter. The completion page reads the same keys back. No binding mismatch is visible. The local dogfood report records this for the next manual browser-verification pass.

### ISSUE-006 - `/admin/users` redirect target for non-admins
Closed as a false-positive. Non-admins hitting `/admin/*` are redirected to `/dashboard`, enforced by `authorizationHandle` in `src/hooks.server.ts`. By-design; no code change.

## Tests

`tests/unit/dogfood-fixes.test.ts` adds 11 source-regression tests pinning each structural change so a future refactor cannot silently regress the dogfood-reported behaviour. The pattern matches the existing `tests/unit/admin/ui-source-regressions.test.ts` style (read the file, assert key strings + ordering).

## Test plan

- [x] `bun run check` clean (0 errors, 0 warnings, 1682 files).
- [x] `bun run test` 1776 pass, 0 fail. Coverage threshold (80% line/function) maintained.
- [x] `bun run check:biome` clean.
- [ ] Manual: reset DB, complete onboarding, log in as admin, then reproduce each dogfood-report repro and confirm the bug is gone:
  - [ ] ISSUE-002: `/admin/settings?tab=privacy` -> set Server-Wide Wrapped Access to Private OAuth -> save -> hard reload. Repeat for User Sharing Defaults.
  - [ ] ISSUE-003: `/admin/settings?tab=system` -> change Retention Period to 30, Maximum Count to 10000, toggle Debug -> save -> hard reload. Confirm "App version" displays a non-empty version string.
  - [ ] ISSUE-001: restart onboarding from scratch -> pick non-default Appearance + Privacy substeps -> advance to Done -> confirm completion summary reflects the choices (or document not-reproducible).
  - [ ] ISSUE-005: `/wrapped/2026` -> press End -> ArrowRight to summary -> click Watch Again -> confirm URL hash is `#slide=0` and slide 0 renders.
  - [ ] ISSUE-008: hold ArrowRight for 2s on `/wrapped/2026` -> no main-thread freeze; transitions advance at the throttle rate.
  - [ ] ISSUE-004: `/admin/slides` -> Add Custom Slide -> enter `**bold** and a [link](https://example.com)` -> click Update Preview -> confirm sanitized HTML renders.
  - [ ] ISSUE-007: 390x844 viewport, navigate `/wrapped/2026` and `/admin/settings` -> every reported control measures at least 44px in both dimensions.