### PR TITLE
fix: surface landing lookup sync failures

### DIFF
--- a/src/lib/stores/sync-status.svelte.ts
+++ b/src/lib/stores/sync-status.svelte.ts
@@ -1,18 +1,10 @@
 import { browser } from '$app/environment';
-import type { LiveSyncProgress } from '$lib/server/sync/progress';
-
-interface SimpleProgress {
-	phase: 'fetching' | 'enriching';
-	recordsProcessed: number;
-	enrichmentTotal?: number;
-	enrichmentProcessed?: number;
-}
-
-interface SSEEventData {
-	type: 'connected' | 'update' | 'completed' | 'failed' | 'cancelled' | 'idle';
-	inProgress: boolean;
-	progress: SimpleProgress | null;
-}
+import type {
+	LiveSyncProgress,
+	SyncStatusStreamEvent,
+	SyncStatusStreamProgress,
+	SyncTerminalEventType
+} from '$lib/sync/types';
 
 export interface InitialSyncStatus {
 	inProgress: boolean;
@@ -20,18 +12,19 @@ export interface InitialSyncStatus {
 }
 
 export interface SyncStatusStoreOptions {
-	onSyncComplete?: () => void | Promise<void>;
+	onSyncComplete?: (event: SyncTerminalEventType) => void | Promise<void>;
+	shouldHandleTerminalEvent?: (event: SyncTerminalEventType) => boolean;
 }
 
 // Converts simplified SSE progress to LiveSyncProgress-compatible format
-function toCompatibleProgress(simple: SimpleProgress | null): LiveSyncProgress | null {
+function toCompatibleProgress(simple: SyncStatusStreamProgress | null): LiveSyncProgress | null {
 	if (!simple) return null;
 
 	return {
 		syncId: 0, // Not used by SyncIndicator
 		status: 'running',
 		recordsProcessed: simple.recordsProcessed,
-		recordsInserted: 0, // Not used by SyncIndicator
+		recordsInserted: simple.recordsInserted ?? 0, // Not used by SyncIndicator
 		recordsSkipped: 0, // Not used by SyncIndicator
 		currentPage: 0, // Not used by SyncIndicator
 		startedAt: new Date(), // Not used by SyncIndicator
@@ -47,13 +40,15 @@ export class SyncStatusStore {
 
 	private eventSource: EventSource | null = null;
 	private connected = false;
-	private onSyncComplete?: () => void | Promise<void>;
+	private onSyncComplete?: (event: SyncTerminalEventType) => void | Promise<void>;
+	private shouldHandleTerminalEvent?: (event: SyncTerminalEventType) => boolean;
 	private wasSyncing = false;
 
 	initialize(initialStatus: InitialSyncStatus, options?: SyncStatusStoreOptions): void {
 		this.inProgress = initialStatus.inProgress;
 		this.progress = initialStatus.progress;
 		this.onSyncComplete = options?.onSyncComplete;
+		this.shouldHandleTerminalEvent = options?.shouldHandleTerminalEvent;
 		this.wasSyncing = initialStatus.inProgress;
 
 		if (browser) {
@@ -74,7 +69,7 @@ export class SyncStatusStore {
 
 		this.eventSource.onmessage = (event) => {
 			try {
-				const data: SSEEventData = JSON.parse(event.data);
+				const data: SyncStatusStreamEvent = JSON.parse(event.data);
 
 				if (data.type === 'connected' || data.type === 'update') {
 					this.inProgress = data.inProgress;
@@ -88,11 +83,14 @@ export class SyncStatusStore {
 					data.type === 'cancelled' ||
 					data.type === 'idle'
 				) {
-					if (this.wasSyncing && this.onSyncComplete) {
+					const shouldHandle =
+						this.wasSyncing || this.shouldHandleTerminalEvent?.(data.type) === true;
+					if (shouldHandle && this.onSyncComplete) {
 						const callback = this.onSyncComplete;
+						const terminalEvent = data.type;
 						setTimeout(async () => {
 							try {
-								await callback();
+								await callback(terminalEvent);
 							} catch {
 								// Silently ignore callback errors
 							}

--- a/src/lib/stores/sync-status.svelte.ts
+++ b/src/lib/stores/sync-status.svelte.ts
@@ -83,18 +83,20 @@ export class SyncStatusStore {
 					data.type === 'cancelled' ||
 					data.type === 'idle'
 				) {
-					const shouldHandle =
-						this.wasSyncing || this.shouldHandleTerminalEvent?.(data.type) === true;
-					if (shouldHandle && this.onSyncComplete) {
-						const callback = this.onSyncComplete;
-						const terminalEvent = data.type;
-						setTimeout(async () => {
-							try {
-								await callback(terminalEvent);
-							} catch {
-								// Silently ignore callback errors
-							}
-						}, 500);
+					if (this.onSyncComplete) {
+						const shouldHandle =
+							this.wasSyncing || this.shouldHandleTerminalEvent?.(data.type) === true;
+						if (shouldHandle) {
+							const callback = this.onSyncComplete;
+							const terminalEvent = data.type;
+							setTimeout(async () => {
+								try {
+									await callback(terminalEvent);
+								} catch {
+									// Silently ignore callback errors
+								}
+							}, 500);
+						}
 					}
 					this.inProgress = false;
 					this.progress = null;

--- a/src/lib/stores/sync-status.svelte.ts
+++ b/src/lib/stores/sync-status.svelte.ts
@@ -84,8 +84,13 @@ export class SyncStatusStore {
 					data.type === 'idle'
 				) {
 					if (this.onSyncComplete) {
-						const shouldHandle =
-							this.wasSyncing || this.shouldHandleTerminalEvent?.(data.type) === true;
+						let predicateResult = false;
+						try {
+							predicateResult = this.shouldHandleTerminalEvent?.(data.type) === true;
+						} catch {
+							// Treat predicate errors as "don't handle"
+						}
+						const shouldHandle = this.wasSyncing || predicateResult;
 						if (shouldHandle) {
 							const callback = this.onSyncComplete;
 							const terminalEvent = data.type;

--- a/src/lib/sync/types.ts
+++ b/src/lib/sync/types.ts
@@ -2,6 +2,30 @@ export type LiveSyncStatus = 'running' | 'completed' | 'failed' | 'cancelled';
 
 export type SyncPhase = 'fetching' | 'enriching';
 
+export type SyncTerminalEventType = 'completed' | 'failed' | 'cancelled' | 'idle';
+
+export type SyncStatusStreamEventType = 'connected' | 'update' | SyncTerminalEventType;
+
+export interface SyncStatusStreamProgress {
+	phase: SyncPhase;
+	recordsProcessed: number;
+	recordsInserted?: number;
+	enrichmentTotal?: number;
+	enrichmentProcessed?: number;
+}
+
+export type SyncStatusStreamEvent =
+	| {
+			type: 'connected' | 'update';
+			inProgress: boolean;
+			progress: SyncStatusStreamProgress | null;
+	  }
+	| {
+			type: SyncTerminalEventType;
+			inProgress: false;
+			progress: null;
+	  };
+
 export interface LiveSyncProgress {
 	syncId: number;
 	status: LiveSyncStatus;

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,10 +1,14 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
+import { logger } from '$lib/server/logging';
 import { getEffectiveShareMode } from '$lib/server/sharing/service';
 import { ShareMode } from '$lib/server/sharing/types';
 import { triggerLiveSyncIfNeeded } from '$lib/server/sync/live-sync';
 import { findUserByUsername } from '$lib/server/sync/plex-accounts.service';
 import type { Actions, PageServerLoad } from './$types';
+
+const LOOKUP_LIVE_SYNC_COOKIE = 'lookup_live_sync';
+const LOOKUP_LIVE_SYNC_COOKIE_MAX_AGE_SECONDS = 60;
 
 const UsernameSchema = z.object({
 	username: z
@@ -24,7 +28,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 };
 
 export const actions: Actions = {
-	lookupUser: async ({ request }) => {
+	lookupUser: async ({ request, cookies }) => {
 		const formData = await request.formData();
 		const rawUsername = formData.get('username')?.toString() ?? '';
 
@@ -56,7 +60,25 @@ export const actions: Actions = {
 			return fail(404, publicLookupFailure);
 		}
 
-		triggerLiveSyncIfNeeded('landing-page-lookup').catch(() => {});
+		try {
+			const liveSyncResult = await triggerLiveSyncIfNeeded('landing-page-lookup');
+
+			if (liveSyncResult.reason === 'error') {
+				logger.warn('Lookup-triggered live sync failed to start', 'LandingLookup');
+			}
+
+			if (liveSyncResult.triggered || liveSyncResult.syncInProgress) {
+				cookies.set(LOOKUP_LIVE_SYNC_COOKIE, '1', {
+					path: '/wrapped',
+					httpOnly: true,
+					sameSite: 'lax',
+					maxAge: LOOKUP_LIVE_SYNC_COOKIE_MAX_AGE_SECONDS
+				});
+			}
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'Unknown error';
+			logger.error(`Lookup-triggered live sync failed: ${message}`, 'LandingLookup');
+		}
 
 		redirect(303, `/wrapped/${currentYear}/u/${userResult.userId}`);
 	}

--- a/src/routes/api/sync/status/stream/+server.ts
+++ b/src/routes/api/sync/status/stream/+server.ts
@@ -1,4 +1,5 @@
 import { getSyncProgress, type LiveSyncProgress } from '$lib/server/sync/progress';
+import type { SyncStatusStreamEvent, SyncStatusStreamProgress } from '$lib/sync/types';
 import type { RequestHandler } from './$types';
 
 /**
@@ -122,7 +123,7 @@ export const GET: RequestHandler = async ({ request }) => {
 	});
 };
 
-function simplifyProgress(progress: LiveSyncProgress | null): SimpleProgress | null {
+function simplifyProgress(progress: LiveSyncProgress | null): SyncStatusStreamProgress | null {
 	if (!progress || (progress.status !== 'running' && progress.status !== 'completed')) return null;
 
 	return {
@@ -134,22 +135,6 @@ function simplifyProgress(progress: LiveSyncProgress | null): SimpleProgress | n
 	};
 }
 
-function formatSSE(data: SSEEvent): string {
+function formatSSE(data: SyncStatusStreamEvent): string {
 	return `data: ${JSON.stringify(data)}\n\n`;
 }
-
-interface SimpleProgress {
-	phase: 'fetching' | 'enriching';
-	recordsProcessed: number;
-	recordsInserted: number;
-	enrichmentTotal?: number;
-	enrichmentProcessed?: number;
-}
-
-type SSEEvent =
-	| { type: 'connected'; inProgress: boolean; progress: SimpleProgress | null }
-	| { type: 'update'; inProgress: boolean; progress: SimpleProgress | null }
-	| { type: 'completed'; inProgress: false; progress: null }
-	| { type: 'failed'; inProgress: false; progress: null }
-	| { type: 'cancelled'; inProgress: false; progress: null }
-	| { type: 'idle'; inProgress: false; progress: null };

--- a/src/routes/wrapped/+layout.server.ts
+++ b/src/routes/wrapped/+layout.server.ts
@@ -3,7 +3,14 @@ import { getAvailableYears } from '$lib/server/admin/users.service';
 import { getSyncStatus } from '$lib/server/sync/live-sync';
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = async () => {
+const LOOKUP_LIVE_SYNC_COOKIE = 'lookup_live_sync';
+
+export const load: LayoutServerLoad = async ({ cookies }) => {
+	const lookupSyncTriggered = cookies.get(LOOKUP_LIVE_SYNC_COOKIE) === '1';
+	if (lookupSyncTriggered) {
+		cookies.delete(LOOKUP_LIVE_SYNC_COOKIE, { path: '/wrapped' });
+	}
+
 	const [wrappedTheme, syncStatus, availableYears] = await Promise.all([
 		getWrappedTheme(),
 		getSyncStatus(),
@@ -13,6 +20,7 @@ export const load: LayoutServerLoad = async () => {
 	return {
 		wrappedTheme,
 		syncStatus,
-		availableYears
+		availableYears,
+		lookupSyncTriggered
 	};
 };

--- a/src/routes/wrapped/+layout.svelte
+++ b/src/routes/wrapped/+layout.svelte
@@ -91,8 +91,9 @@ async function hideLoadingWithMinDelay(): Promise<void> {
  * 2. Refresh data
  * 3. Hide overlay with minimum delay
  */
-function consumeLookupSyncMarker(): boolean {
+function consumeLookupSyncMarker(event: SyncTerminalEventType): boolean {
 	if (!lookupSyncFeedbackPending) return false;
+	if (event !== 'failed') return false;
 	lookupSyncFeedbackPending = false;
 	return true;
 }

--- a/src/routes/wrapped/+layout.svelte
+++ b/src/routes/wrapped/+layout.svelte
@@ -132,6 +132,7 @@ $effect(() => {
 
 	if (!lookupSyncStarted) {
 		lookupSyncMarkerSeen = false;
+		lookupSyncFeedbackPending = false;
 	}
 });
 

--- a/src/routes/wrapped/+layout.svelte
+++ b/src/routes/wrapped/+layout.svelte
@@ -4,7 +4,9 @@ import { untrack } from 'svelte';
 import { browser } from '$app/environment';
 import { invalidateAll } from '$app/navigation';
 import SyncLoadingOverlay from '$lib/components/SyncLoadingOverlay.svelte';
+import { toast } from '$lib/services/toast';
 import { createSyncStatusStore, type SyncStatusStore } from '$lib/stores/sync-status.svelte';
+import type { SyncTerminalEventType } from '$lib/sync/types';
 import type { LayoutData } from './$types';
 
 /**
@@ -23,7 +25,17 @@ interface Props {
 	data: LayoutData;
 }
 
+type LayoutDataWithLookupSync = LayoutData & {
+	lookupSyncStarted?: boolean;
+	lookupSyncTriggered?: boolean;
+};
+
 let { children, data }: Props = $props();
+
+function hasLookupSyncMarker(layoutData: LayoutData): boolean {
+	const lookupData = layoutData as LayoutDataWithLookupSync;
+	return Boolean(lookupData.lookupSyncTriggered ?? lookupData.lookupSyncStarted);
+}
 
 // ==========================================================================
 // Constants
@@ -31,6 +43,8 @@ let { children, data }: Props = $props();
 
 /** Minimum time to show loading overlay for consistent UX */
 const MIN_LOADING_DISPLAY_MS = 300;
+const FAILED_LIVE_SYNC_MESSAGE =
+	"Couldn't refresh your viewing history from Plex. Showing your most recent data.";
 
 // ==========================================================================
 // Loading State
@@ -44,6 +58,14 @@ let loadingStartTime = $state(Date.now());
 
 /** Whether sync completion has been handled (prevents double-handling) */
 let syncCompletionHandled = $state(false);
+
+const initialLookupSyncMarker = untrack(() => hasLookupSyncMarker(data));
+
+/** Whether the current page load came from a landing-page lookup sync trigger */
+let lookupSyncFeedbackPending = $state(initialLookupSyncMarker);
+
+/** Prevents repeatedly re-arming the same server-provided lookup marker */
+let lookupSyncMarkerSeen = $state(initialLookupSyncMarker);
 
 // ==========================================================================
 // Sync Status Store
@@ -69,7 +91,15 @@ async function hideLoadingWithMinDelay(): Promise<void> {
  * 2. Refresh data
  * 3. Hide overlay with minimum delay
  */
-async function handleSyncComplete(): Promise<void> {
+function consumeLookupSyncMarker(): boolean {
+	if (!lookupSyncFeedbackPending) return false;
+	lookupSyncFeedbackPending = false;
+	return true;
+}
+
+async function handleSyncComplete(event: SyncTerminalEventType): Promise<void> {
+	lookupSyncFeedbackPending = false;
+
 	// Prevent double handling
 	if (syncCompletionHandled) return;
 	syncCompletionHandled = true;
@@ -82,11 +112,27 @@ async function handleSyncComplete(): Promise<void> {
 		// Refresh data while overlay is still visible
 		await invalidateAll();
 	} finally {
+		if (event === 'failed') {
+			toast.error(FAILED_LIVE_SYNC_MESSAGE);
+		}
 		// Hide overlay after data refresh (with minimum delay)
 		await hideLoadingWithMinDelay();
 		syncCompletionHandled = false;
 	}
 }
+
+$effect(() => {
+	const lookupSyncStarted = hasLookupSyncMarker(data);
+
+	if (lookupSyncStarted && !lookupSyncMarkerSeen) {
+		lookupSyncFeedbackPending = true;
+		lookupSyncMarkerSeen = true;
+	}
+
+	if (!lookupSyncStarted) {
+		lookupSyncMarkerSeen = false;
+	}
+});
 
 // Create sync status store with reactive access to data.syncStatus
 // Using $effect ensures:
@@ -115,7 +161,8 @@ $effect(() => {
 			progress: syncStatus.progress
 		},
 		{
-			onSyncComplete: handleSyncComplete
+			onSyncComplete: handleSyncComplete,
+			shouldHandleTerminalEvent: consumeLookupSyncMarker
 		}
 	);
 	syncStatusStore = store;

--- a/tests/unit/landing-lookup.test.ts
+++ b/tests/unit/landing-lookup.test.ts
@@ -1,15 +1,42 @@
-import { beforeEach, describe, expect, it } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { isRedirect } from '@sveltejs/kit';
 import { db } from '$lib/server/db/client';
 import { appSettings, plexAccounts, shareSettings, users } from '$lib/server/db/schema';
+import { logger } from '$lib/server/logging';
 import { setGlobalShareDefaults } from '$lib/server/sharing/service';
 import { ShareMode, ShareModeSource } from '$lib/server/sharing/types';
-import { actions } from '../../src/routes/+page.server';
+import type { LiveSyncResult } from '$lib/server/sync/live-sync';
+import * as liveSync from '$lib/server/sync/live-sync';
 
+let liveSyncResult: LiveSyncResult = {
+	triggered: false,
+	syncInProgress: false,
+	reason: 'disabled'
+};
+let liveSyncCalls: string[] = [];
+
+const triggerLiveSyncSpy = spyOn(liveSync, 'triggerLiveSyncIfNeeded');
+triggerLiveSyncSpy.mockImplementation(async (source: string) => {
+	liveSyncCalls.push(source);
+	return liveSyncResult;
+});
+
+const { actions } = await import('../../src/routes/+page.server');
 type LookupAction = NonNullable<typeof actions.lookupUser>;
 
 const USER_ID = 42;
 const YEAR = new Date().getFullYear();
+
+interface CookieCall {
+	name: string;
+	value: string;
+	options?: unknown;
+}
+
+interface TestCookies {
+	sets: CookieCall[];
+	set: (name: string, value: string, options?: unknown) => void;
+}
 
 async function seedUser(mode?: (typeof ShareMode)[keyof typeof ShareMode]): Promise<void> {
 	await db.insert(plexAccounts).values({
@@ -38,7 +65,16 @@ async function seedUser(mode?: (typeof ShareMode)[keyof typeof ShareMode]): Prom
 	}
 }
 
-async function invokeLookup(username: string, ip: string) {
+function createCookies(): TestCookies {
+	return {
+		sets: [],
+		set(name: string, value: string, options?: unknown) {
+			this.sets.push({ name, value, options });
+		}
+	};
+}
+
+async function invokeLookup(username: string, ip: string, cookies: TestCookies = createCookies()) {
 	const formData = new FormData();
 	formData.set('username', username);
 	const request = new Request('https://obzorarr.example/', {
@@ -49,17 +85,28 @@ async function invokeLookup(username: string, ip: string) {
 	const lookupUser = actions.lookupUser as LookupAction;
 	return lookupUser({
 		request,
+		cookies,
 		getClientAddress: () => ip,
 		setHeaders: () => {}
 	} as unknown as Parameters<LookupAction>[0]);
 }
 
 describe('landing username lookup', () => {
+	afterAll(() => {
+		triggerLiveSyncSpy.mockRestore();
+	});
+
 	beforeEach(async () => {
 		await db.delete(shareSettings);
 		await db.delete(appSettings);
 		await db.delete(users);
 		await db.delete(plexAccounts);
+		liveSyncCalls = [];
+		liveSyncResult = { triggered: false, syncInProgress: false, reason: 'disabled' };
+		triggerLiveSyncSpy.mockImplementation(async (source: string) => {
+			liveSyncCalls.push(source);
+			return liveSyncResult;
+		});
 	});
 
 	it('redirects anonymous lookup only for effectively public wrapped pages', async () => {
@@ -73,6 +120,65 @@ describe('landing username lookup', () => {
 			expect(isRedirect(error)).toBe(true);
 			if (!isRedirect(error)) throw error;
 			expect(error.location).toBe(`/wrapped/${YEAR}/u/${USER_ID}`);
+		}
+	});
+
+	it('sets a short-lived wrapped marker when public lookup starts live sync', async () => {
+		liveSyncResult = {
+			triggered: true,
+			syncInProgress: true
+		};
+		const cookies = createCookies();
+		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
+		await seedUser();
+
+		try {
+			await invokeLookup('alice', '198.51.100.5', cookies);
+			throw new Error('Expected redirect');
+		} catch (error) {
+			expect(isRedirect(error)).toBe(true);
+			if (!isRedirect(error)) throw error;
+		}
+
+		expect(liveSyncCalls).toEqual(['landing-page-lookup']);
+		expect(cookies.sets).toEqual([
+			{
+				name: 'lookup_live_sync',
+				value: '1',
+				options: {
+					path: '/wrapped',
+					httpOnly: true,
+					sameSite: 'lax',
+					maxAge: 60
+				}
+			}
+		]);
+	});
+
+	it('logs trigger startup failures without setting the lookup marker', async () => {
+		liveSyncResult = {
+			triggered: false,
+			syncInProgress: false,
+			reason: 'error'
+		};
+		const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+		const cookies = createCookies();
+		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
+		await seedUser();
+
+		try {
+			await invokeLookup('alice', '198.51.100.6', cookies);
+			throw new Error('Expected redirect');
+		} catch (error) {
+			expect(isRedirect(error)).toBe(true);
+			if (!isRedirect(error)) throw error;
+			expect(warnSpy).toHaveBeenCalledWith(
+				'Lookup-triggered live sync failed to start',
+				'LandingLookup'
+			);
+			expect(cookies.sets).toHaveLength(0);
+		} finally {
+			warnSpy.mockRestore();
 		}
 	});
 

--- a/tests/unit/landing-lookup.test.ts
+++ b/tests/unit/landing-lookup.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { isRedirect } from '@sveltejs/kit';
 import { db } from '$lib/server/db/client';
 import { appSettings, plexAccounts, shareSettings, users } from '$lib/server/db/schema';
@@ -15,11 +15,7 @@ let liveSyncResult: LiveSyncResult = {
 };
 let liveSyncCalls: string[] = [];
 
-const triggerLiveSyncSpy = spyOn(liveSync, 'triggerLiveSyncIfNeeded');
-triggerLiveSyncSpy.mockImplementation(async (source: string) => {
-	liveSyncCalls.push(source);
-	return liveSyncResult;
-});
+let triggerLiveSyncSpy: ReturnType<typeof spyOn<typeof liveSync, 'triggerLiveSyncIfNeeded'>>;
 
 const { actions } = await import('../../src/routes/+page.server');
 type LookupAction = NonNullable<typeof actions.lookupUser>;
@@ -92,10 +88,6 @@ async function invokeLookup(username: string, ip: string, cookies: TestCookies =
 }
 
 describe('landing username lookup', () => {
-	afterAll(() => {
-		triggerLiveSyncSpy.mockRestore();
-	});
-
 	beforeEach(async () => {
 		await db.delete(shareSettings);
 		await db.delete(appSettings);
@@ -103,10 +95,15 @@ describe('landing username lookup', () => {
 		await db.delete(plexAccounts);
 		liveSyncCalls = [];
 		liveSyncResult = { triggered: false, syncInProgress: false, reason: 'disabled' };
+		triggerLiveSyncSpy = spyOn(liveSync, 'triggerLiveSyncIfNeeded');
 		triggerLiveSyncSpy.mockImplementation(async (source: string) => {
 			liveSyncCalls.push(source);
 			return liveSyncResult;
 		});
+	});
+
+	afterEach(() => {
+		triggerLiveSyncSpy.mockRestore();
 	});
 
 	it('redirects anonymous lookup only for effectively public wrapped pages', async () => {

--- a/tests/unit/sync-status-store.test.ts
+++ b/tests/unit/sync-status-store.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { createSyncStatusStore } from '$lib/stores/sync-status.svelte';
+import type { SyncStatusStreamEvent } from '$lib/sync/types';
+
+class TestEventSource {
+	static instances: TestEventSource[] = [];
+
+	onopen: (() => void) | null = null;
+	onmessage: ((event: MessageEvent<string>) => void) | null = null;
+	onerror: (() => void) | null = null;
+	closed = false;
+
+	constructor(readonly url: string) {
+		TestEventSource.instances.push(this);
+	}
+
+	close(): void {
+		this.closed = true;
+	}
+
+	emit(data: SyncStatusStreamEvent): void {
+		this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent<string>);
+	}
+}
+
+const originalEventSource = globalThis.EventSource;
+const originalStateRune = (globalThis as unknown as { $state?: <T>(value: T) => T }).$state;
+
+function installEventSource(): void {
+	(globalThis as unknown as { EventSource: typeof EventSource }).EventSource =
+		TestEventSource as unknown as typeof EventSource;
+}
+
+function waitForTerminalCallback(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 550));
+}
+
+function connectStore(store: ReturnType<typeof createSyncStatusStore>): void {
+	(store as unknown as { connect: () => void }).connect();
+}
+
+describe('sync status store terminal events', () => {
+	beforeEach(() => {
+		TestEventSource.instances = [];
+		installEventSource();
+		(globalThis as unknown as { $state: <T>(value: T) => T }).$state = (value) => value;
+	});
+
+	afterEach(() => {
+		(globalThis as unknown as { EventSource: typeof EventSource }).EventSource =
+			originalEventSource;
+		if (originalStateRune) {
+			(globalThis as unknown as { $state?: <T>(value: T) => T }).$state = originalStateRune;
+		} else {
+			delete (globalThis as unknown as { $state?: <T>(value: T) => T }).$state;
+		}
+	});
+
+	it('handles a failed terminal event when the lookup marker asks for it', async () => {
+		const handledEvents: string[] = [];
+		const completedEvents: string[] = [];
+		const store = createSyncStatusStore(
+			{ inProgress: false, progress: null },
+			{
+				shouldHandleTerminalEvent: (event) => {
+					handledEvents.push(event);
+					return event === 'failed';
+				},
+				onSyncComplete: (event) => {
+					completedEvents.push(event);
+				}
+			}
+		);
+		connectStore(store);
+
+		TestEventSource.instances[0]?.emit({ type: 'failed', inProgress: false, progress: null });
+		await waitForTerminalCallback();
+		store.disconnect();
+
+		expect(handledEvents).toEqual(['failed']);
+		expect(completedEvents).toEqual(['failed']);
+		expect(store.inProgress).toBe(false);
+		expect(store.progress).toBeNull();
+	});
+
+	it('leaves an unobserved successful terminal event silent', async () => {
+		const completedEvents: string[] = [];
+		const store = createSyncStatusStore(
+			{ inProgress: false, progress: null },
+			{
+				shouldHandleTerminalEvent: (event) => event === 'failed',
+				onSyncComplete: (event) => {
+					completedEvents.push(event);
+				}
+			}
+		);
+		connectStore(store);
+
+		TestEventSource.instances[0]?.emit({ type: 'completed', inProgress: false, progress: null });
+		await waitForTerminalCallback();
+		store.disconnect();
+
+		expect(completedEvents).toEqual([]);
+		expect(store.inProgress).toBe(false);
+		expect(store.progress).toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes the landing-page public username lookup feedback path when a lookup-triggered live sync fails because Plex is unreachable.

Changes include:
- Starts the lookup-triggered live-sync trigger path before redirecting, without waiting for the full Plex history sync.
- Adds a short-lived lookup-sync marker so wrapped pages can surface rapid failures that occur before the SSE client observes an in-progress state.
- Propagates sync terminal event types through the client sync-status store.
- Shows one generic wrapped-page error toast when a lookup-triggered or observed live sync fails.
- Keeps successful, idle, and cancelled terminal events silent.
- Uses client-safe shared sync types from `$lib/sync/types` for client-side sync status code.
- Adds focused regression coverage for landing lookup and sync-status store behavior.

## Verification

- `bun test --env-file=.env.test tests/unit/landing-lookup.test.ts`
- Focused lookup/store regression tests
- `bun run check`
- `bun run check:biome`
- `bun run test`

All automated checks passed during final verifier review.

## Residual Risk

A manual browser repro with an unreachable Plex server was not run in this workspace. Browser/Plex integration confidence comes from static review plus automated tests.