### PR TITLE
fix: resolve dogfood findings (log-settings OCC and onboarding session revocation)

### DIFF
--- a/src/lib/server/auth/login-completion.ts
+++ b/src/lib/server/auth/login-completion.ts
@@ -12,6 +12,7 @@ import {
 import { requireServerMembership, verifyServerOwnership } from './membership';
 import { clearPinTransaction, getPinTransactionForRequest } from './pin-transactions';
 import { checkPinStatus, getPlexUserInfo } from './plex-oauth';
+import { markSessionRevalidated } from './revalidation';
 import { createSession } from './session';
 import { NotServerMemberError, PinExpiredError, SESSION_DURATION_MS } from './types';
 
@@ -125,6 +126,15 @@ export async function createSessionFromPlexToken(
 		plexToken: authToken,
 		isAdmin
 	});
+
+	// Membership/ownership was just verified above, so prime the revalidation
+	// cache for this session. Without this, the very next request (e.g. the
+	// GET /admin that follows onboarding completion) is the session's first-ever
+	// revalidation and re-probes Plex immediately; a transient /identity blip on
+	// that probe would hard-revoke a legitimately authenticated owner (observed
+	// in the dogfood: owner revoked the instant onboarding completed). Seeding
+	// does not alter the ownership/isAdmin decision made above.
+	markSessionRevalidated(sessionId, { isMember: true, isOwner: isAdmin });
 
 	cookies.set('session', sessionId, COOKIE_OPTIONS);
 

--- a/src/lib/server/auth/revalidation.ts
+++ b/src/lib/server/auth/revalidation.ts
@@ -1,6 +1,6 @@
 import { logger } from '$lib/server/logging';
 import { requiresOnboarding } from '$lib/server/onboarding';
-import { verifyServerMembership } from './membership';
+import { isTransientIdentityError, verifyServerMembership } from './membership';
 import { type MembershipResult, PlexAuthApiError } from './types';
 
 const REVALIDATION_INTERVAL_MS = 15 * 60 * 1000;
@@ -11,6 +11,11 @@ interface RevalidationEntry {
 	lastChecked: number;
 	consecutiveFailures: number;
 	firstFailureAt: number | null;
+	// Diagnostic record of the most recent membership probe. MUST NOT feed any
+	// authorization decision: isAdmin is sourced from the session/DB row, and a
+	// fresh live probe (the 'valid' branch) is the only thing allowed to change
+	// it. Trusting this cached value for authz would let a stale/seeded result
+	// grant access — keep it write-only.
 	lastResult: MembershipResult | null;
 }
 
@@ -39,6 +44,23 @@ export function needsRevalidation(sessionId: string): boolean {
 	const entry = revalidationCache.get(sessionId);
 	if (!entry) return true;
 	return Date.now() - entry.lastChecked >= REVALIDATION_INTERVAL_MS;
+}
+
+/**
+ * Prime the revalidation cache for a session whose membership was just verified
+ * (e.g. at login/session creation). Marks the session as freshly checked so
+ * `needsRevalidation` returns false for the next `REVALIDATION_INTERVAL_MS`,
+ * avoiding a redundant — and potentially flaky — immediate re-probe on the very
+ * first request after login. Resets the failure counters since the live
+ * verification just succeeded.
+ */
+export function markSessionRevalidated(sessionId: string, membership: MembershipResult): void {
+	revalidationCache.set(sessionId, {
+		lastChecked: Date.now(),
+		consecutiveFailures: 0,
+		firstFailureAt: null,
+		lastResult: membership
+	});
 }
 
 export async function revalidateMembership(
@@ -70,6 +92,43 @@ async function doRevalidation(sessionId: string, plexToken: string): Promise<Rev
 		const membership = await verifyServerMembership(plexToken);
 
 		if (!membership.isMember) {
+			// A transient reachability failure (timeout, 5xx, connection error) means
+			// the configured server could not be probed this round — NOT that the user
+			// lost membership. Route it through the same grace machinery as a thrown
+			// transient error so a single blip cannot revoke a valid session. Genuine
+			// non-membership (`not_in_resources`) still revokes immediately below, and
+			// invalid tokens (401) revoke via the catch block.
+			if (
+				membership.reason === 'not_reachable' &&
+				isTransientIdentityError(membership.identityErrorReason)
+			) {
+				const now = Date.now();
+				const consecutiveFailures = entry.consecutiveFailures + 1;
+				const firstFailureAt = entry.firstFailureAt ?? now;
+
+				revalidationCache.set(sessionId, {
+					...entry,
+					lastChecked: now,
+					consecutiveFailures,
+					firstFailureAt
+				});
+
+				logger.warn(
+					`Revalidation reachability blip for session ${sessionId.slice(0, 8)}… (attempt ${consecutiveFailures}): ${membership.identityErrorReason ?? 'not_reachable'}`,
+					'Revalidation'
+				);
+
+				if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+					return { status: 'error_grace_expired' };
+				}
+
+				if (now - firstFailureAt >= GRACE_PERIOD_MS) {
+					return { status: 'error_grace_expired' };
+				}
+
+				return { status: 'error_within_grace' };
+			}
+
 			revalidationCache.set(sessionId, {
 				...entry,
 				lastChecked: Date.now(),

--- a/src/lib/server/logging/service.ts
+++ b/src/lib/server/logging/service.ts
@@ -219,31 +219,34 @@ export async function isDebugEnabled(): Promise<boolean> {
 }
 
 export async function setLogRetentionDays(days: number): Promise<void> {
+	const now = new Date();
 	await db
 		.insert(appSettings)
-		.values({ key: LogSettingsKey.RETENTION_DAYS, value: days.toString() })
+		.values({ key: LogSettingsKey.RETENTION_DAYS, value: days.toString(), updatedAt: now })
 		.onConflictDoUpdate({
 			target: appSettings.key,
-			set: { value: days.toString() }
+			set: { value: days.toString(), updatedAt: now }
 		});
 }
 
 export async function setLogMaxCount(count: number): Promise<void> {
+	const now = new Date();
 	await db
 		.insert(appSettings)
-		.values({ key: LogSettingsKey.MAX_COUNT, value: count.toString() })
+		.values({ key: LogSettingsKey.MAX_COUNT, value: count.toString(), updatedAt: now })
 		.onConflictDoUpdate({
 			target: appSettings.key,
-			set: { value: count.toString() }
+			set: { value: count.toString(), updatedAt: now }
 		});
 }
 
 export async function setDebugEnabled(enabled: boolean): Promise<void> {
+	const now = new Date();
 	await db
 		.insert(appSettings)
-		.values({ key: LogSettingsKey.DEBUG_ENABLED, value: enabled.toString() })
+		.values({ key: LogSettingsKey.DEBUG_ENABLED, value: enabled.toString(), updatedAt: now })
 		.onConflictDoUpdate({
 			target: appSettings.key,
-			set: { value: enabled.toString() }
+			set: { value: enabled.toString(), updatedAt: now }
 		});
 }

--- a/tests/unit/admin/system-occ-update.test.ts
+++ b/tests/unit/admin/system-occ-update.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Repro test for ISSUE-006: log-settings OCC never fires on stale UPDATE.
+ *
+ * The three log setters (setLogRetentionDays, setLogMaxCount, setDebugEnabled)
+ * did NOT include `updatedAt: now` in their onConflictDoUpdate set clause.
+ * After an INSERT the DB default sets updatedAt=T1. A subsequent UPDATE keeps
+ * updatedAt=T1 (unchanged). A stale-save then submits T1 as the settingsVersion,
+ * which passes the OCC check (T1 === currentMs) and silently clobbers.
+ *
+ * Fix: add `updatedAt: now` to all three setters' set:{} block, mirroring
+ * setAppSetting in settings.service.ts.
+ */
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { getAppSettingsUpdatedAt, LOG_SETTINGS_KEYS } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import { actions } from '../../../src/routes/admin/settings/system/+page.server';
+
+type UpdateLogSettingsAction = NonNullable<typeof actions.updateLogSettings>;
+
+const adminLocals = {
+	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
+} as unknown as App.Locals;
+
+function makeRequest(fields: Record<string, string>): Request {
+	const formData = new FormData();
+	for (const [k, v] of Object.entries(fields)) formData.set(k, v);
+	return new Request('http://localhost/admin/settings/system?/updateLogSettings', {
+		method: 'POST',
+		body: formData
+	});
+}
+
+describe('system — updateLogSettings OCC on UPDATE path (ISSUE-006 repro)', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+	});
+
+	async function run(request: Request) {
+		const handler = actions.updateLogSettings as UpdateLogSettingsAction;
+		return handler({
+			request,
+			locals: adminLocals
+		} as Parameters<UpdateLogSettingsAction>[0]);
+	}
+
+	it('rejects stale settingsVersion after an UPDATE (not just after INSERT)', async () => {
+		// Step 1: INSERT — fresh DB, epoch sentinel is valid for first save.
+		await run(
+			makeRequest({
+				retentionDays: '14',
+				maxCount: '2000',
+				debugEnabled: 'true',
+				settingsVersion: new Date(0).toISOString()
+			})
+		);
+
+		// Capture the version written by the INSERT.
+		const afterInsert = await getAppSettingsUpdatedAt(LOG_SETTINGS_KEYS);
+		expect(afterInsert).not.toBeNull();
+		const preUpdateVersion = afterInsert!.toISOString();
+
+		// Tiny delay so a fixed new Date() in the UPDATE is strictly > T1.
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+		// Step 2: UPDATE — a legitimate second save using the post-INSERT version.
+		const updateResult = await run(
+			makeRequest({
+				retentionDays: '21',
+				maxCount: '3000',
+				debugEnabled: 'false',
+				settingsVersion: preUpdateVersion
+			})
+		);
+		expect(updateResult).toMatchObject({ success: true });
+
+		// Step 3: Stale-save with the PRE-UPDATE version — must be rejected as 409.
+		// BEFORE the fix: updatedAt was not advanced by the UPDATE, so
+		// submittedMs (T1) === currentMs (T1) → OCC passes → clobbers (BUG).
+		// AFTER the fix: updatedAt advances to T2 > T1 → submittedMs < currentMs → 409.
+		const staleResult = await run(
+			makeRequest({
+				retentionDays: '90',
+				maxCount: '9000',
+				debugEnabled: 'true',
+				settingsVersion: preUpdateVersion
+			})
+		);
+
+		expect(staleResult).toMatchObject({
+			status: 409,
+			data: {
+				conflict: true,
+				error: 'Settings changed in another tab. Please reload.'
+			}
+		});
+	});
+});

--- a/tests/unit/auth/revalidation-session-survival.test.ts
+++ b/tests/unit/auth/revalidation-session-survival.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import type { Cookies } from '@sveltejs/kit';
+import * as settingsService from '$lib/server/admin/settings.service';
+import * as membership from '$lib/server/auth/membership';
+import * as plexOauth from '$lib/server/auth/plex-oauth';
+import {
+	clearRevalidationEntry,
+	needsRevalidation,
+	revalidateMembership
+} from '$lib/server/auth/revalidation';
+import { PlexAuthApiError } from '$lib/server/auth/types';
+import { db } from '$lib/server/db/client';
+import { appSettings, sessions, users } from '$lib/server/db/schema';
+import * as onboarding from '$lib/server/onboarding';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken
+} from '$lib/server/onboarding/bootstrap';
+
+/**
+ * ISSUE-001 (real cause) — the admin session is *revoked* by the first-ever
+ * revalidation that fires the instant onboarding completes. Two complementary
+ * fixes:
+ *   A. Cache-seed at session creation so the immediate, redundant re-probe is
+ *      skipped (membership was just verified during login).
+ *   B. Treat a transient `not_reachable` /identity blip during revalidation as a
+ *      grace-period failure, not a hard revoke.
+ *
+ * Security guards (must hold before AND after): genuine non-membership
+ * (`not_in_resources`) and invalid tokens (401) still revoke immediately.
+ */
+
+interface TestCookies extends Cookies {
+	sets: Array<{ name: string; value?: string }>;
+}
+
+function createCookies(): TestCookies {
+	const values = new Map<string, string>();
+	const sets: Array<{ name: string; value?: string }> = [];
+	return {
+		sets,
+		get: (name: string) => values.get(name),
+		set: (name: string, value: string) => {
+			sets.push({ name, value });
+			values.set(name, value);
+		},
+		delete: (name: string) => {
+			values.delete(name);
+		}
+	} as unknown as TestCookies;
+}
+
+describe('ISSUE-001: revalidation does not revoke a freshly-verified session', () => {
+	let spies: Array<{ mockRestore(): void }> = [];
+
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		await db.delete(sessions);
+		await db.delete(users);
+		clearBootstrapToken();
+		spies = [];
+	});
+
+	afterEach(() => {
+		for (const spy of spies) spy.mockRestore();
+	});
+
+	// ----- Repro A: cache-seed at session creation ------------------------------
+	it('seeds the revalidation cache at session creation so the next request skips revalidation', async () => {
+		spies.push(
+			spyOn(settingsService, 'getApiConfigWithSources').mockResolvedValue({
+				plex: {
+					serverUrl: { value: 'http://test-plex-server:32400', source: 'env', isLocked: false },
+					token: { value: 'test-token', source: 'env', isLocked: false }
+				},
+				openai: {
+					apiKey: { value: '', source: 'default', isLocked: false },
+					baseUrl: { value: 'https://api.openai.com/v1', source: 'default', isLocked: false },
+					model: { value: 'gpt-5-mini', source: 'default', isLocked: false }
+				}
+			}),
+			spyOn(onboarding, 'requiresOnboarding').mockResolvedValue(true),
+			spyOn(membership, 'requireServerMembership').mockResolvedValue({
+				isMember: true,
+				isOwner: true,
+				serverName: 'Test Plex'
+			}),
+			spyOn(plexOauth, 'getPlexUserInfo').mockResolvedValue({
+				id: 12345,
+				uuid: 'plex-user-uuid',
+				username: 'owner',
+				email: 'owner@example.com',
+				thumb: undefined,
+				authToken: 'plex-user-token',
+				services: []
+			})
+		);
+
+		const cookies = createCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies, token)).toBe('claimed');
+
+		const { createSessionFromPlexToken } = await import('$lib/server/auth/login-completion');
+		const result = await createSessionFromPlexToken('owner-auth-token', cookies);
+		expect(result.user.isAdmin).toBe(true);
+
+		const sessionId = cookies.get('session') as string;
+		expect(sessionId).toBeTruthy();
+
+		// THE FIX: the just-verified session is marked fresh, so authHandle skips the
+		// immediate re-probe that would otherwise be the session's first revalidation.
+		expect(needsRevalidation(sessionId)).toBe(false);
+
+		clearRevalidationEntry(sessionId);
+	});
+
+	// ----- Repro B: grace for a transient reachability blip ---------------------
+	it('returns error_within_grace (not revoked) when /identity is transiently unreachable', async () => {
+		const sessionId = 'sess-grace-transient';
+		clearRevalidationEntry(sessionId);
+
+		spies.push(
+			spyOn(membership, 'verifyServerMembership').mockResolvedValue({
+				isMember: false,
+				isOwner: false,
+				reason: 'not_reachable',
+				identityErrorReason: 'Connection timed out'
+			})
+		);
+
+		const result = await revalidateMembership(sessionId, 'plex-token');
+		expect(result.status).toBe('error_within_grace');
+		expect(result.status).not.toBe('revoked');
+
+		clearRevalidationEntry(sessionId);
+	});
+
+	// ----- Security guard: genuine non-membership still revokes -----------------
+	it('still revokes immediately when the user is genuinely not in resources', async () => {
+		const sessionId = 'sess-not-in-resources';
+		clearRevalidationEntry(sessionId);
+
+		spies.push(
+			spyOn(membership, 'verifyServerMembership').mockResolvedValue({
+				isMember: false,
+				isOwner: false,
+				reason: 'not_in_resources'
+			})
+		);
+
+		const result = await revalidateMembership(sessionId, 'plex-token');
+		expect(result.status).toBe('revoked');
+
+		clearRevalidationEntry(sessionId);
+	});
+
+	// ----- Security guard: invalid token (401) still revokes --------------------
+	it('still revokes immediately on a 401 (invalid Plex token)', async () => {
+		const sessionId = 'sess-401';
+		clearRevalidationEntry(sessionId);
+
+		spies.push(
+			spyOn(membership, 'verifyServerMembership').mockRejectedValue(
+				new PlexAuthApiError('Unauthorized', 401, '/identity')
+			)
+		);
+
+		const result = await revalidateMembership(sessionId, 'plex-token');
+		expect(result.status).toBe('revoked');
+
+		clearRevalidationEntry(sessionId);
+	});
+});

--- a/tests/unit/onboarding/complete-session-propagation.test.ts
+++ b/tests/unit/onboarding/complete-session-propagation.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { type Cookies, type fail, isActionFailure } from '@sveltejs/kit';
+import { AppSettingsKey, getAppSetting } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings, sessions, users } from '$lib/server/db/schema';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken
+} from '$lib/server/onboarding/bootstrap';
+import { actions } from '../../../src/routes/onboarding/complete/+page.server';
+
+/**
+ * ISSUE-001 security guard — completing onboarding must never hand an admin
+ * session to a non-owner. The completion action gates on `locals.user.isAdmin`
+ * (resolved from the verified session) before doing anything; this test pins
+ * that a non-admin caller is rejected and gains nothing.
+ */
+
+interface CookieCall {
+	name: string;
+	value?: string;
+	options?: Record<string, unknown>;
+}
+
+interface TestCookies extends Cookies {
+	sets: CookieCall[];
+}
+
+function createCookies(): TestCookies {
+	const values = new Map<string, string>();
+	const sets: CookieCall[] = [];
+
+	return {
+		sets,
+		get: (name: string) => values.get(name),
+		set: (name: string, value: string, options?: Record<string, unknown>) => {
+			sets.push({ name, value, options });
+			values.set(name, value);
+		},
+		delete: (name: string) => {
+			values.delete(name);
+		}
+	} as unknown as TestCookies;
+}
+
+const COMPLETE_URL = new URL('http://localhost/onboarding/complete');
+
+describe('ISSUE-001: onboarding completion authorization', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+		await db.delete(sessions);
+		await db.delete(users);
+		clearBootstrapToken();
+	});
+
+	it('does NOT issue an admin session or complete onboarding for a non-owner (negative)', async () => {
+		// A valid setup claim is present, but the caller is not an admin.
+		const cookies = createCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies, token)).toBe('claimed');
+		cookies.sets.length = 0;
+
+		const nonAdminLocals = {
+			user: { id: 2, plexId: 999, username: 'guest', isAdmin: false }
+		} as unknown as App.Locals;
+
+		const result = await actions.goToDashboard?.({
+			locals: nonAdminLocals,
+			cookies,
+			url: COMPLETE_URL
+		} as unknown as Parameters<NonNullable<typeof actions.goToDashboard>>[0]);
+
+		// Rejected with 403 — no redirect, no admin grant.
+		expect(isActionFailure(result)).toBe(true);
+		expect((result as ReturnType<typeof fail>).status).toBe(403);
+
+		// No session cookie was minted for the non-owner.
+		expect(cookies.sets.find((c) => c.name === 'session')).toBeUndefined();
+
+		// Onboarding was not marked complete by an unauthorized caller.
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED)).not.toBe('true');
+	});
+});


### PR DESCRIPTION
## Summary

Reproduction-gated resolution of the six E2E dogfood findings (ISSUE-001 through ISSUE-006) from `dogfood-output/report.md`, following `.omc/plans/fix-all-findings.md` (Rev 2).

Every non-by-design finding had to clear a reproduction gate: a runnable test (or trace) that fails on the current code before any fix is authored. Findings whose repro passed unmodified were closed as NOT REPRODUCED rather than edited. The gate confirmed that **two of six findings were real bugs**; the other four were already correct, already fixed, or by-design.

## Changes

### ISSUE-006 (medium) - log-settings OCC never fired on a stale UPDATE
`setLogRetentionDays`, `setLogMaxCount`, and `setDebugEnabled` set only `{ value }` in `onConflictDoUpdate`. SQLite applies the `app_settings.updated_at` `NOT NULL DEFAULT` on INSERT but not on UPDATE, so the first save advanced `updated_at` while later UPDATEs left it stale. That let `inlineOccCheck` (`submittedMs < currentMs`) silently pass an UPDATE-then-stale save, clobbering a concurrent edit with no 409.

Fix: add `updatedAt: now` to the `set: {...}` of all three setters, mirroring `setAppSetting`. A regression test reproduces the UPDATE-then-stale clobber (was success, now `fail(409, OCC_CONFLICT_MESSAGE)`) while preserving fresh-install first-save success.

Commit: `fix(logging): advance app_settings.updated_at on log-setting UPDATEs`

### ISSUE-001 (medium) - onboarding "Go to Dashboard" landed on `/` instead of `/admin`
The dogfood log identified the real mechanism:

```
[Onboarding] Onboarding completed by cccp01
[Revalidation] Session revoked for user cccp01: User is no longer a member of the Plex server
```

`cccp01` is the server owner. On the first `GET /admin` after onboarding, `needsRevalidation()` returned true (no cache entry), so the request re-probed Plex membership immediately. A transient `/identity` blip made `verifyServerMembership` return `{ isMember: false, reason: 'not_reachable' }` (a returned value, not a thrown error), and `doRevalidation` hard-revoked on any `isMember: false` with no grace period (grace previously protected only thrown errors). The just-verified owner's session was revoked, the cookie deleted, and `/admin` bounced to `/`.

Fix (two scoped changes, both preserving every genuine-revocation path):
- `markSessionRevalidated()` seeds the revalidation cache at session creation. Membership/ownership is verified at login, so the redundant immediate re-probe is skipped for `REVALIDATION_INTERVAL_MS`.
- A grace branch routes a transient `not_reachable` result (one whose `identityErrorReason` is classified transient) through the existing grace machinery, bounded by `MAX_CONSECUTIVE_FAILURES` and `GRACE_PERIOD_MS`, instead of revoking. Genuine non-membership (`not_in_resources`) and invalid tokens (401) still revoke immediately.

`isAdmin` remains sourced from the session/DB row; the seed cannot mint or elevate privileges, and `createSessionFromPlexToken` is unchanged. This is a self-contained commit to ease a focused security review.

Commit: `fix(auth): keep freshly-onboarded owner sessions through transient revalidation`

Security review: an independent reviewer pass returned APPROVE at risk level LOW, with no critical, high, or medium findings, confirming no revocation path is weakened and the grace window is strictly bounded.

## Findings closed without code changes

- **ISSUE-002 (low)** - credentialed OpenAI base URL message. All write/validation surfaces route through `normalizeOpenAIBaseUrl`, which rejects credentials before the HTTPS check; the correct message already wins. No bypassing surface exists. NOT REPRODUCED.
- **ISSUE-003 (low)** - ENV lock badge on the env-preconfigured Connect step. The badge is correctly gated by `{#if data.hasEnvConfig}` and the server-selector branch is mutually exclusive. The dogfood ran without Plex ENV vars, so the observed non-ENV flow was expected. No bug.
- **ISSUE-004 (medium)** - user-id enumeration delta (existing private id returns 403, missing id returns 404). Accepted as by-design: access is correctly denied and only id existence leaks; the 403 is tied to F-015 and the 404 prevents orphan `share_settings` rows. Adjudication note retained in `.omc/handoffs/`.
- **ISSUE-005 (medium)** - privacy "Save server-wide settings" persisting nothing. The action-to-DB round-trip persists correctly (`getAppSetting('server_wrapped_share_mode')` reflects the change). The dogfood observation predates PR #122, which rewrote the privacy form binding. NOT REPRODUCED on current code.

## Verification

- Full test suite: 1951 pass, 0 fail (baseline 1945; +6 from new repro and regression tests)
- `bun run check:biome`: clean
- `bun run check` (svelte-check): 0 errors, 0 warnings
- Preserved: F-015 token-path 404s, CSRF, ownership verification

## Follow-ups (not in this PR)

- Optional atomic-OCC refactor for log settings to also close the same-millisecond interleave race.
- Broader settings-form save-then-reload audit (the ISSUE-005 class).
- Pre-existing dependency advisories surfaced by `bun audit` (for example `marked`, `devalue` via SvelteKit) are unrelated to this change.
