### PR TITLE
fix(dogfood): resolve round-2 findings (CSP avatar, ENV badge, share-modal members-only, OCC toast)

### DIFF
--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -69,6 +69,13 @@ const shareUrl = $derived.by(() => {
 	return `${origin}${baseUrl}`;
 });
 
+// Server Members (private-oauth) mode has no shareable link: access is gated on
+// Plex server membership, and the page identifier is the enumerable numeric user
+// id (NOT a secret token). Surfacing that integer URL as a "Share Link" is a
+// false affordance and the human-visible symptom of ISSUE-004, so we show a
+// members-only notice instead of a copyable URL. Access control is unchanged.
+const isMembersOnly = $derived(displayMode === 'private-oauth');
+
 // Can show share mode controls
 const canControlShare = $derived(
 	(isOwner || isAdmin) && (shareSettings?.canUserControl || isAdmin) && !isServerWrapped
@@ -283,6 +290,33 @@ $effect(() => {
 		</AlertDialog.Header>
 
 		<!-- Copy URL Section -->
+		{#if isMembersOnly}
+			<div class="url-section">
+				<span class="label">Share Link</span>
+				<div class="members-only-notice">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="18"
+						height="18"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						class="members-only-icon"
+						aria-hidden="true"
+					>
+						<rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+						<path d="M7 11V7a5 5 0 0 1 10 0v4" />
+					</svg>
+					<p class="members-only-text">
+						Visible to Plex server members only. There's no shareable link — members can open
+						this Wrapped after signing in with their Plex account.
+					</p>
+				</div>
+			</div>
+		{:else}
 		<div class="url-section">
 			<label for="share-url" class="label">Share Link</label>
 			<div class="url-row">
@@ -341,6 +375,7 @@ $effect(() => {
 				<span class="copied-feedback">Copied to clipboard!</span>
 			{/if}
 		</div>
+		{/if}
 
 		<!-- Share Mode Controls (conditional) -->
 		{#if canControlShare && availableModes.length > 0}
@@ -579,6 +614,29 @@ $effect(() => {
 			margin-top: 0.375rem;
 			font-size: 0.75rem;
 			color: #22c55e;
+		}
+
+		.members-only-notice {
+			display: flex;
+			align-items: flex-start;
+			gap: 0.625rem;
+			padding: 0.75rem 0.875rem;
+			border: 1px solid oklch(var(--border));
+			border-radius: 8px;
+			background-color: oklch(var(--muted) / 0.4);
+		}
+
+		.members-only-icon {
+			flex-shrink: 0;
+			margin-top: 0.0625rem;
+			color: oklch(var(--muted-foreground));
+		}
+
+		.members-only-text {
+			margin: 0;
+			font-size: 0.8125rem;
+			line-height: 1.45;
+			color: oklch(var(--muted-foreground));
 		}
 
 		.share-modes {

--- a/src/routes/admin/settings/connections/+page.svelte
+++ b/src/routes/admin/settings/connections/+page.svelte
@@ -6,7 +6,11 @@ import ShieldAlertIcon from '@lucide/svelte/icons/shield-alert';
 import SparklesIcon from '@lucide/svelte/icons/sparkles';
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
-import { SettingsActionBar, SettingsToggleRow } from '$lib/components/settings/index.js';
+import {
+	SettingsActionBar,
+	SettingsStatusPill,
+	SettingsToggleRow
+} from '$lib/components/settings/index.js';
 import { Button } from '$lib/components/ui/button/index.js';
 import {
 	Card,
@@ -101,7 +105,12 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 				class="space-y-4"
 			>
 				<div class="space-y-2">
-					<Label for="plexServerUrl">Plex server URL</Label>
+					<div class="flex items-center gap-2">
+						<Label for="plexServerUrl">Plex server URL</Label>
+						{#if plexServerUrlLocked}
+							<SettingsStatusPill tone="warning">ENV</SettingsStatusPill>
+						{/if}
+					</div>
 					<Input
 						id="plexServerUrl"
 						name="plexServerUrl"
@@ -116,12 +125,17 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 				</div>
 
 				<div class="space-y-2">
-					<Label for="plexToken">
-						Plex token
-						{#if settings.plexToken.hasValue}
-							<span class="text-xs text-muted-foreground">(stored — leave blank to keep)</span>
+					<div class="flex items-center gap-2">
+						<Label for="plexToken">
+							Plex token
+							{#if settings.plexToken.hasValue}
+								<span class="text-xs text-muted-foreground">(stored — leave blank to keep)</span>
+							{/if}
+						</Label>
+						{#if plexTokenLocked}
+							<SettingsStatusPill tone="warning">ENV</SettingsStatusPill>
 						{/if}
-					</Label>
+					</div>
 					<Input
 						id="plexToken"
 						name="plexToken"
@@ -244,12 +258,17 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 				class="space-y-4"
 			>
 				<div class="space-y-2">
-					<Label for="openaiApiKey">
-						OpenAI API key
-						{#if settings.openaiApiKey.hasValue}
-							<span class="text-xs text-muted-foreground">(stored — leave blank to keep)</span>
+					<div class="flex items-center gap-2">
+						<Label for="openaiApiKey">
+							OpenAI API key
+							{#if settings.openaiApiKey.hasValue}
+								<span class="text-xs text-muted-foreground">(stored — leave blank to keep)</span>
+							{/if}
+						</Label>
+						{#if openaiApiKeyLocked}
+							<SettingsStatusPill tone="warning">ENV</SettingsStatusPill>
 						{/if}
-					</Label>
+					</div>
 					<Input
 						id="openaiApiKey"
 						name="openaiApiKey"
@@ -262,7 +281,12 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 				</div>
 
 				<div class="space-y-2">
-					<Label for="openaiBaseUrl">Base URL (optional)</Label>
+					<div class="flex items-center gap-2">
+						<Label for="openaiBaseUrl">Base URL (optional)</Label>
+						{#if openaiBaseUrlLocked}
+							<SettingsStatusPill tone="warning">ENV</SettingsStatusPill>
+						{/if}
+					</div>
 					<Input
 						id="openaiBaseUrl"
 						name="openaiBaseUrl"
@@ -274,7 +298,12 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 				</div>
 
 				<div class="space-y-2">
-					<Label for="openaiModel">Model</Label>
+					<div class="flex items-center gap-2">
+						<Label for="openaiModel">Model</Label>
+						{#if openaiModelLocked}
+							<SettingsStatusPill tone="warning">ENV</SettingsStatusPill>
+						{/if}
+					</div>
 					<Input
 						id="openaiModel"
 						name="openaiModel"

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -7,6 +7,7 @@ import ShieldUserIcon from '@lucide/svelte/icons/shield-user';
 import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 import UserCogIcon from '@lucide/svelte/icons/user-cog';
 import UsersIcon from '@lucide/svelte/icons/users';
+import type { ActionResult } from '@sveltejs/kit';
 import { superForm } from 'sveltekit-superforms';
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
@@ -37,9 +38,26 @@ interface Props {
 
 let { data }: Props = $props();
 
+// An OCC stale-write returns fail(409, { form, conflict, error }) AFTER validation,
+// so the returned `form` is still valid — `onUpdated` would otherwise fire a false
+// "Saved" success toast while the write was actually discarded (ISSUE-006). Detect
+// the conflict in `onUpdate`, surface the server's reload message, and cancel() so
+// the success path never runs and the stale settingsVersion stays put for reload.
+function surfaceOccConflict(event: { result: ActionResult; cancel: () => void }): void {
+	const { result } = event;
+	if (result.type === 'failure' && (result.data as { conflict?: boolean } | undefined)?.conflict) {
+		const message =
+			(result.data as { error?: string } | undefined)?.error ??
+			'Settings changed in another tab. Please reload.';
+		handleFormToast({ error: message });
+		event.cancel();
+	}
+}
+
 // svelte-ignore state_referenced_locally
 const serverWrappedForm = superForm(data.serverWrappedForm, {
 	resetForm: false,
+	onUpdate: surfaceOccConflict,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
 			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
@@ -57,6 +75,7 @@ const {
 // svelte-ignore state_referenced_locally
 const userDefaultsForm = superForm(data.userDefaultsForm, {
 	resetForm: false,
+	onUpdate: surfaceOccConflict,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
 			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
@@ -74,6 +93,7 @@ const {
 // svelte-ignore state_referenced_locally
 const publicLandingLookupForm = superForm(data.publicLandingLookupForm, {
 	resetForm: false,
+	onUpdate: surfaceOccConflict,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
 			handleFormToast({ success: true, message: updated.message ?? 'Saved' });

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -15,6 +15,10 @@ const config = {
 					'https://plex.tv',
 					'https://*.plex.direct',
 					'https://secure.gravatar.com',
+					// Plex proxies some user avatars through WordPress/Gravatar's image CDN
+					// (i0.wp.com); without this the avatar is blocked and logs a CSP
+					// violation on /admin (ISSUE-002).
+					'https://i0.wp.com',
 					'data:'
 				],
 				'style-src': ['self', 'unsafe-inline', 'https://fonts.googleapis.com'],

--- a/tests/unit/sharing/wrapped-identifier-loader.test.ts
+++ b/tests/unit/sharing/wrapped-identifier-loader.test.ts
@@ -9,7 +9,7 @@ import {
 	slideConfig,
 	users
 } from '$lib/server/db/schema';
-import { setGlobalShareDefaults } from '$lib/server/sharing/service';
+import { getOwnerWrappedHref, setGlobalShareDefaults } from '$lib/server/sharing/service';
 import { ShareMode, ShareModeSource } from '$lib/server/sharing/types';
 import { load as loadServerWrapped } from '../../../src/routes/wrapped/[year]/+page.server';
 import { actions, load } from '../../../src/routes/wrapped/[year]/u/[identifier]/+page.server';
@@ -768,5 +768,109 @@ describe('wrapped/[year]/u/[identifier] actions: token regeneration', () => {
 			availableYears: [YEAR]
 		});
 		expect(data.userId).toBe(USER_ID);
+	});
+});
+
+/**
+ * ISSUE-004 (D) contract-lock: the "Server Members" (private-oauth) access boundary
+ * is auth, NOT the URL identifier. These tests freeze that contract so a future
+ * change can't silently regress it. NO tokenization, NO normalization — the
+ * enumerable integer id and the intentional 403-vs-404 split are by-design (F-015).
+ * See .omc/research/dogfood-d-threatmodel-2026-05-30.md.
+ */
+describe('wrapped/[year]/u/[identifier] loader: ISSUE-004 private-oauth contract-lock', () => {
+	const MEMBER_ID = 2;
+	const UNKNOWN_ID = 999;
+	const YEAR = 2024;
+
+	beforeEach(async () => {
+		await db.delete(shareSettings);
+		await db.delete(appSettings);
+		await db.delete(users);
+		await db.delete(cachedStats);
+		await db.delete(playHistory);
+		await db.delete(slideConfig);
+
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_OAUTH,
+			allowUserControl: false
+		});
+	});
+
+	it('returns 404 for an UNKNOWN numeric id and mints NO share_settings row (anti-enumeration, no orphan)', async () => {
+		// Unknown id: no users row, no share_settings row. The loader's existence
+		// check (+page.server.ts:132-139) must 404 BEFORE getOrCreateShareSettings,
+		// so no row is created for a non-existent user.
+		await expectLoadStatus(
+			{ year: YEAR, identifier: String(UNKNOWN_ID), currentUser: undefined },
+			404
+		);
+
+		const rows = await db.select().from(shareSettings).where(eq(shareSettings.userId, UNKNOWN_ID));
+		expect(rows.length).toBe(0);
+	});
+
+	it('allows a signed-in server member (non-owner) to view a known private-oauth numeric id (200)', async () => {
+		const OWNER_ID = 5;
+		await seedUser(OWNER_ID, 100005, 200005);
+		await seedUser(MEMBER_ID, 100002, 200002);
+		await seedShareSettings({
+			userId: OWNER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_OAUTH,
+			token: null
+		});
+
+		const data = await invokeLoad({
+			year: YEAR,
+			identifier: String(OWNER_ID),
+			availableYears: [YEAR],
+			currentUser: {
+				id: MEMBER_ID,
+				plexId: 100002,
+				username: `user-${MEMBER_ID}`,
+				isAdmin: false
+			}
+		});
+
+		expect(data.userId).toBe(OWNER_ID);
+		// Members get the canonical (integer) page; never a copyable token.
+		expect(data.shareSettings.shareToken).toBeNull();
+	});
+
+	it('getOwnerWrappedHref emits the integer URL (no token) for private-oauth and a token URL only for private-link', async () => {
+		const OWNER_ID = 5;
+		await seedUser(OWNER_ID, 100005, 200005);
+
+		// private-oauth: integer URL, no token minted/emitted.
+		await seedShareSettings({
+			userId: OWNER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_OAUTH,
+			token: null
+		});
+		const oauthHref = await getOwnerWrappedHref(OWNER_ID, YEAR);
+		expect(oauthHref).toBe(`/wrapped/${YEAR}/u/${OWNER_ID}`);
+		expect(await getStoredToken(OWNER_ID, YEAR)).toBeNull();
+
+		// Flip to private-link (with a token) under a PUBLIC floor so the effective
+		// mode stays private-link (a private-oauth floor would correctly elevate it
+		// back to the integer URL — covered by the floor tests above). The token URL
+		// is emitted only when the effective mode is genuinely private-link.
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PUBLIC,
+			allowUserControl: false
+		});
+		const LINK_TOKEN = '550e8400-e29b-41d4-a716-446655442222';
+		await db
+			.update(shareSettings)
+			.set({
+				mode: ShareMode.PRIVATE_LINK,
+				modeSource: ShareModeSource.EXPLICIT,
+				shareToken: LINK_TOKEN
+			})
+			.where(and(eq(shareSettings.userId, OWNER_ID), eq(shareSettings.year, YEAR)));
+		const linkHref = await getOwnerWrappedHref(OWNER_ID, YEAR);
+		expect(linkHref).toBe(`/wrapped/${YEAR}/u/${LINK_TOKEN}`);
 	});
 });


### PR DESCRIPTION
## Summary

Diagnose-first remediation of the 2026-05-30 dogfood report (`dogfood-output/report.md`, run `obzorarr-20260530-154617`). Each finding was reproduced/proven against source before any code change. Two of the five findings turned out to be non-bugs and are closed with a note and/or contract-lock tests rather than behavioral changes.

Implements the ralplan-consensus plan `.omc/plans/fix-dogfood-findings-2026-05-30.md` (Planner -> Architect -> Critic). The most significant consensus outcome: the original "tokenize private-oauth share URLs" proposal for ISSUE-004 was **invalidated** — it would invert a load-bearing token invariant for zero access-control benefit (auth, not the URL identifier, is the confidentiality boundary). D was rewritten threat-model-first.

## Findings and actions

| ID | Severity | Action |
|----|----------|--------|
| ISSUE-002 (A) | low | Fix: allowlist Plex avatar CDN host in CSP |
| ISSUE-003 (B) | medium | Fix (UI): add visible ENV lock badge |
| ISSUE-001 (C) | low | No-op (by-design) + note |
| ISSUE-004 (D) | medium | Re-scoped: ShareModal members-only state + contract-lock tests; no access change |
| ISSUE-006 (E) | low | Fix (client): surface OCC 409 conflict instead of false success |
| ISSUE-005 | — | Withdrawn (explicit no-op) |

### A — CSP blocks Plex avatar (`i0.wp.com`)
Plex proxies some user avatars through WordPress/Gravatar's `i0.wp.com` CDN, which was not in the `img-src` allowlist, so the admin-dashboard avatar was blocked with a CSP violation. Added `https://i0.wp.com` to `img-src` in `svelte.config.js`; all other hosts and directives are unchanged.

### B — Connections page lacks an ENV-lock indicator
Diagnosis: `resolveConfigValue` already returns `isLocked: true` for authoritative env values, and the Connections page already disables those inputs and shows "Locked by environment variable." The only gap was a missing *visible* badge. Added the existing (previously unused) `SettingsStatusPill` rendering an `ENV` badge on each Plex/OpenAI field whose `isLocked` is true. No resolver or action logic changed.

### C — Onboarding Connect ENV badge / "verified" text (no-op)
Diagnosis: the onboarding env-mode UI already renders the `ENV` badge, the "Admin access verified. Ready to continue." panel, hides the manual server selector (`showServerSelector = !data.hasEnvConfig`), and routes Continue through `?/verifyAdmin`. The QA run observed the manual flow only because its `.env` used placeholder values (for example `http://localhost:32400`), which `isAuthoritativeEnvValue` intentionally rejects, so `hasPlexEnvConfig()` returns false (the existing ISSUE-004 placeholder guard). This is by-design; no code change. The root contract is already locked by `settings.service.test.ts` (env-vs-placeholder / `hasPlexEnvConfig` cases).

### D — Enumerable integer DB id as the per-user share identifier
Threat-model (full note retained in branch research): authentication is the confidentiality boundary, not the URL identifier. The numeric loader path returns 404 for unknown ids *before* any `share_settings` row is created, 403 for a known id in an auth-gated mode, and 200 for a signed-in member — all by-design under the documented F-015 anti-enumeration contract. The residual is an enumerable integer identifier plus a 403/404 existence oracle (information disclosure), not an access bypass.

- Dropped tokenization entirely; no change to access-control or token machinery (`toShareSettings`, `getShareSettings`, `getOwnerWrappedHref`, `updateShareSettings`, `bulkApplyShareDefaults`, `setGlobalShareDefaults`), and no migration.
- ShareModal now renders a "members-only, no shareable link" state for `private-oauth` instead of surfacing the raw integer URL (closes the human-visible symptom). Public and private-link URL behavior is unchanged.
- Added dual-path contract-lock regression tests: unknown numeric id in a non-public mode returns 404 and mints zero `share_settings` rows; a signed-in server member resolves a known private-oauth numeric id (200); `getOwnerWrappedHref` emits the integer URL for private-oauth and a token URL only for private-link.

Response-normalization (collapsing the 403/404 split) is deferred pending F-015 owner sign-off, as it would contradict the documented contract and risk masking real 404s.

### E — OCC stale write silently discarded
The server `?/updateServerWrappedSettings` action already returns `fail(409, { conflict, error })` on a stale `settingsVersion`. The bug was client-side: a 409 returns a *valid* form, so the superForm `onUpdated` handler fired a false "Saved" success toast while the write was discarded. Added a shared `surfaceOccConflict` `onUpdate` guard that detects the conflict, shows the reload message, and cancels the update so the false success never runs. Applied to all three privacy superForms (server-wrapped, user-defaults, public-landing-lookup), which shared the same latent bug. The server contract is unchanged.

## Verification

- `bun run check` (svelte-kit sync + svelte-check): 0 errors, 0 warnings
- `bun run check:biome` (lint + format): clean
- `bun run test` (`--env-file=.env.test`): 1954 pass, 0 fail across 111 files, including 3 new D contract-lock tests
- Independent architect review: approved (confirmed the D access-control/token files have zero diff, ShareModal branching is well-formed, the new tests are non-tautological, and the E fix uses correct superForms lifecycle semantics)

## Scope

Five files changed (`+230 / -15`): `svelte.config.js`, `src/routes/admin/settings/connections/+page.svelte`, `src/lib/components/wrapped/ShareModal.svelte`, `src/routes/admin/settings/privacy/+page.svelte`, `tests/unit/sharing/wrapped-identifier-loader.test.ts`.

## Follow-ups (out of scope)

- D-opt-b response-normalization: product decision pending F-015 owner sign-off.
- `?/updateShareMode` OCC gap (per-user concurrency surface lacks `settingsVersion`/`inlineOccCheck`).
- A2 avatar proxy via `/plex/thumb`: escalate only if the external-thumb host set becomes open-ended.