### PR TITLE
fix(admin): resolve dogfood findings (blank Plex URL, system OCC, settingsVersion)

### DIFF
--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -80,7 +80,13 @@ const isMembersOnly = $derived(displayMode === 'private-oauth');
 const canControlShare = $derived(
 	(isOwner || isAdmin) && (shareSettings?.canUserControl || isAdmin) && !isServerWrapped
 );
-const canRegenerateToken = $derived(canControlShare && displayMode === 'private-link');
+// ISSUE-002: when the stored mode is `private-link` but that mode sits below
+// the active global floor, the radio option is already disabled — so the
+// regenerate control must hide too, otherwise it offers to rotate a token for
+// a mode the user can no longer select. Mirror the radio's floor gating.
+const canRegenerateToken = $derived(
+	canControlShare && displayMode === 'private-link' && !isBelowFloor(displayMode)
+);
 
 // Available modes based on permissions
 const availableModes = $derived.by(() => {

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -257,6 +257,17 @@ function nextOccVersionDate(dbFloorMs: number): Date {
 }
 
 /**
+ * Result of an OCC-guarded atomic write. On success it carries the exact
+ * `version` (`updatedAt`) the transaction wrote, so the calling action can set
+ * the form's `settingsVersion` from the value it actually persisted rather than
+ * re-reading `max(updatedAt)` afterwards. That post-write re-read is a TOCTOU
+ * hole: a concurrent writer landing between the commit and the re-read would
+ * return ITS newer timestamp, handing the client a version it never wrote and
+ * letting the client's next stale-UI save slip past the OCC check.
+ */
+export type OccWriteResult = { status: 'ok'; version: Date } | { status: 'conflict' };
+
+/**
  * Atomically validates that the "Server-wide Wrapped" settings (anonymization
  * mode + server-wide share mode) have not changed since `submittedVersion`
  * and, if so, writes both values in a single SQLite transaction. Returns
@@ -266,7 +277,7 @@ export async function setServerWrappedSettingsAtomic(opts: {
 	anonymizationMode: AnonymizationModeType;
 	serverWrappedShareMode: string;
 	submittedVersion: string;
-}): Promise<'ok' | 'conflict'> {
+}): Promise<OccWriteResult> {
 	return db.transaction(async (tx) => {
 		const rows = await tx
 			.select({ updatedAt: appSettings.updatedAt })
@@ -278,7 +289,7 @@ export async function setServerWrappedSettingsAtomic(opts: {
 		// row-count gate would silently skip OCC.
 		const submittedMs = opts.submittedVersion ? Date.parse(opts.submittedVersion) : Number.NaN;
 		if (Number.isNaN(submittedMs)) {
-			return 'conflict';
+			return { status: 'conflict' };
 		}
 		// Compute `maxMs` over the existing rows so the OCC check and the write
 		// timestamp share the same DB floor. With no rows, `maxMs = 0` is fine —
@@ -289,7 +300,7 @@ export async function setServerWrappedSettingsAtomic(opts: {
 			if (t > maxMs) maxMs = t;
 		}
 		if (rows.length > 0 && submittedMs < maxMs) {
-			return 'conflict';
+			return { status: 'conflict' };
 		}
 
 		const now = nextOccVersionDate(maxMs);
@@ -318,7 +329,7 @@ export async function setServerWrappedSettingsAtomic(opts: {
 				set: { value: opts.serverWrappedShareMode, updatedAt: now }
 			});
 
-		return 'ok';
+		return { status: 'ok', version: now };
 	});
 }
 
@@ -332,7 +343,7 @@ export async function setUserDefaultsAtomic(opts: {
 	defaultShareMode: string;
 	allowUserControl: boolean;
 	submittedVersion: string;
-}): Promise<'ok' | 'conflict'> {
+}): Promise<OccWriteResult> {
 	return db.transaction(async (tx) => {
 		const rows = await tx
 			.select({ updatedAt: appSettings.updatedAt })
@@ -343,7 +354,7 @@ export async function setUserDefaultsAtomic(opts: {
 		// count — defends against the fresh-install/all-cleared loophole.
 		const submittedMs = opts.submittedVersion ? Date.parse(opts.submittedVersion) : Number.NaN;
 		if (Number.isNaN(submittedMs)) {
-			return 'conflict';
+			return { status: 'conflict' };
 		}
 		// Compute `maxMs` over the existing rows so the OCC check and the write
 		// timestamp share the same DB floor. With no rows, `maxMs = 0` is fine —
@@ -354,7 +365,7 @@ export async function setUserDefaultsAtomic(opts: {
 			if (t > maxMs) maxMs = t;
 		}
 		if (rows.length > 0 && submittedMs < maxMs) {
-			return 'conflict';
+			return { status: 'conflict' };
 		}
 
 		const now = nextOccVersionDate(maxMs);
@@ -390,7 +401,7 @@ export async function setUserDefaultsAtomic(opts: {
 				.where(eq(shareSettings.modeSource, ShareModeSource.DEFAULT));
 		}
 
-		return 'ok';
+		return { status: 'ok', version: now };
 	});
 }
 
@@ -1210,7 +1221,7 @@ export async function setPublicLandingLookupEnabled(enabled: boolean): Promise<v
 export async function setPublicLandingLookupEnabledAtomic(opts: {
 	enabled: boolean;
 	submittedVersion: string;
-}): Promise<'ok' | 'conflict'> {
+}): Promise<OccWriteResult> {
 	return db.transaction(async (tx) => {
 		const rows = await tx
 			.select({ updatedAt: appSettings.updatedAt })
@@ -1221,7 +1232,7 @@ export async function setPublicLandingLookupEnabledAtomic(opts: {
 		// count — defends against the fresh-install/all-cleared loophole.
 		const submittedMs = opts.submittedVersion ? Date.parse(opts.submittedVersion) : Number.NaN;
 		if (Number.isNaN(submittedMs)) {
-			return 'conflict';
+			return { status: 'conflict' };
 		}
 		// Compute `maxMs` over the existing rows so the OCC check and the write
 		// timestamp share the same DB floor. With no rows, `maxMs = 0` is fine —
@@ -1232,7 +1243,7 @@ export async function setPublicLandingLookupEnabledAtomic(opts: {
 			if (t > maxMs) maxMs = t;
 		}
 		if (rows.length > 0 && submittedMs < maxMs) {
-			return 'conflict';
+			return { status: 'conflict' };
 		}
 
 		const now = nextOccVersionDate(maxMs);
@@ -1246,7 +1257,7 @@ export async function setPublicLandingLookupEnabledAtomic(opts: {
 				set: { value, updatedAt: now }
 			});
 
-		return 'ok';
+		return { status: 'ok', version: now };
 	});
 }
 

--- a/src/lib/server/logging/service.ts
+++ b/src/lib/server/logging/service.ts
@@ -218,7 +218,14 @@ export async function isDebugEnabled(): Promise<boolean> {
 	return result[0]?.value === 'true';
 }
 
-export async function setLogRetentionDays(days: number): Promise<void> {
+/**
+ * Returns the `updatedAt` it wrote so the OCC caller can derive the new
+ * `settingsVersion` from the actual mutation timestamp instead of a separate
+ * post-write `max(updatedAt)` re-read — that re-read can observe a concurrent
+ * writer's newer timestamp and hand the client a version it never wrote,
+ * letting a later stale-UI save pass OCC (TOCTOU window).
+ */
+export async function setLogRetentionDays(days: number): Promise<Date> {
 	const now = new Date();
 	await db
 		.insert(appSettings)
@@ -227,9 +234,10 @@ export async function setLogRetentionDays(days: number): Promise<void> {
 			target: appSettings.key,
 			set: { value: days.toString(), updatedAt: now }
 		});
+	return now;
 }
 
-export async function setLogMaxCount(count: number): Promise<void> {
+export async function setLogMaxCount(count: number): Promise<Date> {
 	const now = new Date();
 	await db
 		.insert(appSettings)
@@ -238,9 +246,10 @@ export async function setLogMaxCount(count: number): Promise<void> {
 			target: appSettings.key,
 			set: { value: count.toString(), updatedAt: now }
 		});
+	return now;
 }
 
-export async function setDebugEnabled(enabled: boolean): Promise<void> {
+export async function setDebugEnabled(enabled: boolean): Promise<Date> {
 	const now = new Date();
 	await db
 		.insert(appSettings)
@@ -249,4 +258,5 @@ export async function setDebugEnabled(enabled: boolean): Promise<void> {
 			target: appSettings.key,
 			set: { value: enabled.toString(), updatedAt: now }
 		});
+	return now;
 }

--- a/src/lib/server/slides/sanitize.ts
+++ b/src/lib/server/slides/sanitize.ts
@@ -1,5 +1,20 @@
 import sanitizeHtml from 'sanitize-html';
 
+/**
+ * Custom-slide image policy (ISSUE-006 / FIX-6b decision):
+ *
+ * `<img>` is INTENTIONALLY allowed in custom-slide markdown, but only as an
+ * inert image embed. The `allowedAttributes.img` allowlist below admits just
+ * `src`/`alt`/`title`/`width`/`height` — every event-handler attribute
+ * (`onerror`, `onload`, …) is stripped by sanitize-html because it isn't on the
+ * allowlist, so the classic `<img onerror=...>` XSS vector cannot survive
+ * sanitization. Remote `src` is restricted to http/https and `data:` URIs are
+ * MIME-validated to real raster image types via `isValidImageDataUri`, so a
+ * `data:text/html` / `data:image/svg+xml` script payload is rejected. This runs
+ * server-side, so the stored/rendered HTML is already safe and no extra client
+ * gating is needed. Tighten the allowlist here (not at the call sites) if the
+ * policy ever needs to drop `<img>` entirely.
+ */
 const ALLOWED_IMAGE_MIME_TYPES = /^image\/(png|jpe?g|gif|webp)$/i;
 
 function isValidImageDataUri(src: string): boolean {

--- a/src/lib/utils/occ-form.ts
+++ b/src/lib/utils/occ-form.ts
@@ -1,0 +1,49 @@
+import type { ActionResult } from '@sveltejs/kit';
+import { handleFormToast } from '$lib/utils/form-toast';
+
+/**
+ * Sentinel matching the server's `OCC_CONFLICT_CODE`
+ * (`$lib/server/admin/occ-helpers`). That constant is a SERVER-ONLY export, so
+ * client code cannot import it — the literal is inlined here instead. Keep the
+ * two in lockstep if the sentinel ever changes.
+ */
+const OCC_CONFLICT_CODE = '__OCC_CONFLICT__';
+
+/**
+ * Dual-shape optimistic-concurrency conflict predicate for superForm pages.
+ *
+ * Two conflict payload shapes exist in the codebase:
+ *   - INLINE OCC (`system`, `privacy`): `fail(409, { conflict: true, error })`.
+ *   - EXTERNAL OCC (`appearance`'s `z.enum` actions): `fail(409, { error,
+ *     code: '__OCC_CONFLICT__' })` — no `conflict` field.
+ *
+ * The required fix (ISSUE-006) only needs the `conflict` branch, but accepting
+ * the `code` branch too is cheap forward-insurance: if a raw-enhance page is
+ * ever migrated to superForm and reuses an external-OCC action, this predicate
+ * already covers it.
+ */
+export function isOccConflict(data: unknown): boolean {
+	const d = data as { conflict?: boolean; code?: string } | undefined;
+	return d?.conflict === true || d?.code === OCC_CONFLICT_CODE;
+}
+
+/**
+ * superForm `onUpdate` guard for OCC stale-writes.
+ *
+ * An OCC stale-write returns `fail(409, { form, conflict, error })` AFTER
+ * validation, so the returned `form` is still `valid` — `onUpdated` would
+ * otherwise fire a false "Saved" success toast while the write was actually
+ * discarded (ISSUE-006). Detect the conflict here, surface the server's reload
+ * message, and `cancel()` so the success path never runs and the stale
+ * settingsVersion stays put for the next reload.
+ */
+export function surfaceOccConflict(event: { result: ActionResult; cancel: () => void }): void {
+	const { result } = event;
+	if (result.type === 'failure' && isOccConflict(result.data)) {
+		const message =
+			(result.data as { error?: string } | undefined)?.error ??
+			'Settings changed in another tab. Please reload.';
+		handleFormToast({ error: message });
+		event.cancel();
+	}
+}

--- a/src/routes/admin/settings/connections/+page.server.ts
+++ b/src/routes/admin/settings/connections/+page.server.ts
@@ -134,6 +134,22 @@ export const actions: Actions = requireAdminActions({
 
 		try {
 			const apiConfig = await getApiConfigWithSources();
+
+			// ISSUE-005: a present-but-blank Plex URL must NOT silently clear the
+			// stored row behind a success toast. Reject it as a required-field 400,
+			// but ONLY when the field was actually submitted (post-Zod value is the
+			// empty string, not `undefined`) and the URL isn't ENV-locked. An absent
+			// field — e.g. an OpenAI-only save — parses to `undefined`, so it skips
+			// this guard and never wipes the stored Plex config. The lock branch is
+			// left to setApiConfigAtomic, which ignores locked fields entirely.
+			//
+			// Asymmetry by design: blank `openaiBaseUrl`/`openaiModel` stay an
+			// intentional clear-to-default (parity with the `clearOpenai*` actions),
+			// so they are deliberately NOT guarded here.
+			if (parsed.data.plexServerUrl === '' && !apiConfig.plex.serverUrl.isLocked) {
+				return fail(400, { error: 'Plex server URL is required' });
+			}
+
 			const values = {
 				plexServerUrl: parsed.data.plexServerUrl,
 				plexToken: parsed.data.plexToken,

--- a/src/routes/admin/settings/privacy/+page.server.ts
+++ b/src/routes/admin/settings/privacy/+page.server.ts
@@ -234,6 +234,11 @@ export const actions: Actions = requireAdminActions({
 					error: OCC_CONFLICT_MESSAGE
 				});
 			}
+			// ISSUE-004: advance the returned settingsVersion (own keys) so a second
+			// consecutive save in the same page load isn't false-409'd.
+			form.data.settingsVersion = settingsVersionISO(
+				await getAppSettingsUpdatedAt(SERVER_WRAPPED_SETTINGS_KEYS)
+			);
 			return { form, success: true, message: 'Server-wide wrapped settings updated' };
 		} catch (error) {
 			const message =
@@ -281,6 +286,11 @@ export const actions: Actions = requireAdminActions({
 					error: OCC_CONFLICT_MESSAGE
 				});
 			}
+			// ISSUE-004: advance the returned settingsVersion (own keys) so a second
+			// consecutive save in the same page load isn't false-409'd.
+			form.data.settingsVersion = settingsVersionISO(
+				await getAppSettingsUpdatedAt(USER_DEFAULTS_SETTINGS_KEYS)
+			);
 			return { form, success: true, message: 'User sharing defaults updated' };
 		} catch (error) {
 			const message =
@@ -327,6 +337,11 @@ export const actions: Actions = requireAdminActions({
 					error: OCC_CONFLICT_MESSAGE
 				});
 			}
+			// ISSUE-004: advance the returned settingsVersion (own keys) so a second
+			// consecutive save in the same page load isn't false-409'd.
+			form.data.settingsVersion = settingsVersionISO(
+				await getAppSettingsUpdatedAt(PUBLIC_LANDING_LOOKUP_SETTINGS_KEYS)
+			);
 			return { form, success: true, message: 'Public landing lookup updated' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);

--- a/src/routes/admin/settings/privacy/+page.server.ts
+++ b/src/routes/admin/settings/privacy/+page.server.ts
@@ -227,18 +227,20 @@ export const actions: Actions = requireAdminActions({
 				serverWrappedShareMode: form.data.serverWrappedShareMode,
 				submittedVersion: form.data.settingsVersion
 			});
-			if (result === 'conflict') {
+			if (result.status === 'conflict') {
 				return fail(409, {
 					form,
 					conflict: true,
 					error: OCC_CONFLICT_MESSAGE
 				});
 			}
-			// ISSUE-004: advance the returned settingsVersion (own keys) so a second
-			// consecutive save in the same page load isn't false-409'd.
-			form.data.settingsVersion = settingsVersionISO(
-				await getAppSettingsUpdatedAt(SERVER_WRAPPED_SETTINGS_KEYS)
-			);
+			// ISSUE-004: advance the returned settingsVersion so a second consecutive
+			// save in the same page load isn't false-409'd. Use the timestamp the
+			// transaction actually wrote rather than a post-write
+			// `getAppSettingsUpdatedAt` re-read — that re-read could observe a
+			// concurrent writer's newer version and let the client's next stale save
+			// pass OCC (TOCTOU).
+			form.data.settingsVersion = settingsVersionISO(result.version);
 			return { form, success: true, message: 'Server-wide wrapped settings updated' };
 		} catch (error) {
 			const message =
@@ -279,18 +281,18 @@ export const actions: Actions = requireAdminActions({
 				allowUserControl: form.data.allowUserControl,
 				submittedVersion: form.data.settingsVersion
 			});
-			if (result === 'conflict') {
+			if (result.status === 'conflict') {
 				return fail(409, {
 					form,
 					conflict: true,
 					error: OCC_CONFLICT_MESSAGE
 				});
 			}
-			// ISSUE-004: advance the returned settingsVersion (own keys) so a second
-			// consecutive save in the same page load isn't false-409'd.
-			form.data.settingsVersion = settingsVersionISO(
-				await getAppSettingsUpdatedAt(USER_DEFAULTS_SETTINGS_KEYS)
-			);
+			// ISSUE-004: advance the returned settingsVersion so a second consecutive
+			// save in the same page load isn't false-409'd. Use the timestamp the
+			// transaction actually wrote rather than a post-write
+			// `getAppSettingsUpdatedAt` re-read (TOCTOU — see updateServerWrappedSettings).
+			form.data.settingsVersion = settingsVersionISO(result.version);
 			return { form, success: true, message: 'User sharing defaults updated' };
 		} catch (error) {
 			const message =
@@ -330,18 +332,18 @@ export const actions: Actions = requireAdminActions({
 				enabled: form.data.publicLandingLookup,
 				submittedVersion: form.data.settingsVersion
 			});
-			if (result === 'conflict') {
+			if (result.status === 'conflict') {
 				return fail(409, {
 					form,
 					conflict: true,
 					error: OCC_CONFLICT_MESSAGE
 				});
 			}
-			// ISSUE-004: advance the returned settingsVersion (own keys) so a second
-			// consecutive save in the same page load isn't false-409'd.
-			form.data.settingsVersion = settingsVersionISO(
-				await getAppSettingsUpdatedAt(PUBLIC_LANDING_LOOKUP_SETTINGS_KEYS)
-			);
+			// ISSUE-004: advance the returned settingsVersion so a second consecutive
+			// save in the same page load isn't false-409'd. Use the timestamp the
+			// transaction actually wrote rather than a post-write
+			// `getAppSettingsUpdatedAt` re-read (TOCTOU — see updateServerWrappedSettings).
+			form.data.settingsVersion = settingsVersionISO(result.version);
 			return { form, success: true, message: 'Public landing lookup updated' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -7,7 +7,6 @@ import ShieldUserIcon from '@lucide/svelte/icons/shield-user';
 import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 import UserCogIcon from '@lucide/svelte/icons/user-cog';
 import UsersIcon from '@lucide/svelte/icons/users';
-import type { ActionResult } from '@sveltejs/kit';
 import { superForm } from 'sveltekit-superforms';
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
@@ -30,6 +29,7 @@ import * as Form from '$lib/components/ui/form/index.js';
 import { RadioGroup, RadioGroupItem } from '$lib/components/ui/radio-group/index.js';
 import { publicLandingLookupCopy } from '$lib/sharing/options';
 import { handleFormToast } from '$lib/utils/form-toast';
+import { surfaceOccConflict } from '$lib/utils/occ-form';
 import type { PageData } from './$types';
 
 interface Props {
@@ -37,22 +37,6 @@ interface Props {
 }
 
 let { data }: Props = $props();
-
-// An OCC stale-write returns fail(409, { form, conflict, error }) AFTER validation,
-// so the returned `form` is still valid — `onUpdated` would otherwise fire a false
-// "Saved" success toast while the write was actually discarded (ISSUE-006). Detect
-// the conflict in `onUpdate`, surface the server's reload message, and cancel() so
-// the success path never runs and the stale settingsVersion stays put for reload.
-function surfaceOccConflict(event: { result: ActionResult; cancel: () => void }): void {
-	const { result } = event;
-	if (result.type === 'failure' && (result.data as { conflict?: boolean } | undefined)?.conflict) {
-		const message =
-			(result.data as { error?: string } | undefined)?.error ??
-			'Settings changed in another tab. Please reload.';
-		handleFormToast({ error: message });
-		event.cancel();
-	}
-}
 
 // svelte-ignore state_referenced_locally
 const serverWrappedForm = superForm(data.serverWrappedForm, {
@@ -329,6 +313,12 @@ let showContradictionWarning = $derived(
 							</SettingsToggleRow>
 						{/snippet}
 					</Form.Control>
+					<Form.Description>
+						Applies to newly-created users. It does not change existing users — use
+						“Apply current defaults to all users” below, or each user’s “Can Control”
+						toggle on the <a href="/admin/users" class="underline">Users</a> page, to update
+						them.
+					</Form.Description>
 					<Form.FieldErrors />
 				</Form.Field>
 

--- a/src/routes/admin/settings/system/+page.server.ts
+++ b/src/routes/admin/settings/system/+page.server.ts
@@ -116,6 +116,13 @@ export const actions: Actions = requireAdminActions({
 				setDebugEnabled(form.data.debugEnabled)
 			]);
 			logger.clearDebugCache();
+			// ISSUE-004: refresh the returned settingsVersion to the row's new
+			// updatedAt so a second consecutive save in the same page load isn't
+			// rejected as a stale-version 409. The hidden field is bind:value-bound
+			// to the superForm store, so this propagates without a reload.
+			form.data.settingsVersion = settingsVersionISO(
+				await getAppSettingsUpdatedAt(LOG_SETTINGS_KEYS)
+			);
 			return { form, success: true, message: 'Logging settings updated' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update settings';

--- a/src/routes/admin/settings/system/+page.server.ts
+++ b/src/routes/admin/settings/system/+page.server.ts
@@ -110,7 +110,7 @@ export const actions: Actions = requireAdminActions({
 		}
 
 		try {
-			await Promise.all([
+			const writtenAt = await Promise.all([
 				setLogRetentionDays(form.data.retentionDays),
 				setLogMaxCount(form.data.maxCount),
 				setDebugEnabled(form.data.debugEnabled)
@@ -120,9 +120,14 @@ export const actions: Actions = requireAdminActions({
 			// updatedAt so a second consecutive save in the same page load isn't
 			// rejected as a stale-version 409. The hidden field is bind:value-bound
 			// to the superForm store, so this propagates without a reload.
-			form.data.settingsVersion = settingsVersionISO(
-				await getAppSettingsUpdatedAt(LOG_SETTINGS_KEYS)
-			);
+			//
+			// Derive the version from the timestamps THIS action wrote (max of the
+			// three setters) rather than a separate post-write
+			// `getAppSettingsUpdatedAt` re-read. The re-read can observe a concurrent
+			// writer's newer `updatedAt` and hand the client a version it never wrote,
+			// which would then let that client's next stale-UI save pass OCC (TOCTOU).
+			const maxWrittenMs = Math.max(...writtenAt.map((d) => d.getTime()));
+			form.data.settingsVersion = settingsVersionISO(new Date(maxWrittenMs));
 			return { form, success: true, message: 'Logging settings updated' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update settings';

--- a/src/routes/admin/settings/system/+page.svelte
+++ b/src/routes/admin/settings/system/+page.svelte
@@ -13,6 +13,7 @@ import {
 import * as Form from '$lib/components/ui/form/index.js';
 import { Input } from '$lib/components/ui/input/index.js';
 import { handleFormToast } from '$lib/utils/form-toast';
+import { surfaceOccConflict } from '$lib/utils/occ-form';
 import type { PageData } from './$types';
 
 interface Props {
@@ -26,6 +27,11 @@ let { data }: Props = $props();
 // svelte-ignore state_referenced_locally
 const form = superForm(data.form, {
 	resetForm: false,
+	// An OCC stale-write returns fail(409, { form, conflict }) AFTER validation,
+	// so `updated.valid` stays true and `onUpdated` would fire a false "Settings
+	// saved" toast while the write was discarded (ISSUE-006). Detect + cancel the
+	// conflict in `onUpdate` (before `onUpdated`) so the success path never runs.
+	onUpdate: surfaceOccConflict,
 	onUpdated({ form: updated }) {
 		// Surface success / failure toasts via the existing parity helper. The
 		// helper accepts the legacy FormResponse shape; we map the superforms

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -188,6 +188,9 @@ function markAvatarFailed(userId: number): void {
 											title={user.canUserControl
 												? 'Click to revoke control'
 												: 'Click to grant control'}
+											aria-label={`Toggle share control for ${user.username} (currently ${
+												user.canUserControl ? 'on' : 'off'
+											})`}
 										>
 											{#snippet children()}
 												{user.canUserControl ? 'Yes' : 'No'}
@@ -287,6 +290,9 @@ function markAvatarFailed(userId: number): void {
 										title={user.canUserControl
 											? 'Click to revoke control'
 											: 'Click to grant control'}
+										aria-label={`Toggle share control for ${user.username} (currently ${
+											user.canUserControl ? 'on' : 'off'
+										})`}
 									>
 										{#snippet children()}
 											{user.canUserControl ? 'Yes' : 'No'}

--- a/tests/unit/admin/connections-actions.test.ts
+++ b/tests/unit/admin/connections-actions.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
+import { env } from '$env/dynamic/private';
 import {
 	AppSettingsKey,
 	getApiConfigWithSources,
@@ -111,6 +112,110 @@ describe('connections nested route — updateApiConfig (OCC + schema)', () => {
 			})
 		);
 		expect(result).toMatchObject({ status: 400 });
+	});
+
+	// The blank-URL guard (ISSUE-005) only fires when the Plex URL is NOT
+	// env-locked. The test harness mocks PLEX_SERVER_URL/PLEX_TOKEN (so the field
+	// is locked by default), so these tests clear those env vars to exercise the
+	// unlocked DB-backed path, then restore them.
+	const dynamicEnv = env as Record<string, string | undefined>;
+	async function withUnlockedPlex(fn: () => Promise<void>): Promise<void> {
+		const prevUrl = dynamicEnv.PLEX_SERVER_URL;
+		const prevToken = dynamicEnv.PLEX_TOKEN;
+		dynamicEnv.PLEX_SERVER_URL = '';
+		dynamicEnv.PLEX_TOKEN = '';
+		try {
+			await fn();
+		} finally {
+			dynamicEnv.PLEX_SERVER_URL = prevUrl;
+			dynamicEnv.PLEX_TOKEN = prevToken;
+		}
+	}
+
+	it('rejects a present-but-blank Plex URL as 400 and leaves the stored row intact (ISSUE-005)', async () => {
+		await withUnlockedPlex(async () => {
+			// Seed a stored Plex URL so we can prove the blank submit does not clear it.
+			await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://plex.local:32400');
+			expect((await getApiConfigWithSources()).plex.serverUrl.value).toBe(
+				'http://plex.local:32400'
+			);
+
+			const result = await run(
+				makeRequest('updateApiConfig', {
+					plexServerUrl: '',
+					apiConfigVersion: new Date(Date.now() + 60_000).toISOString()
+				})
+			);
+
+			expect(result).toMatchObject({
+				status: 400,
+				data: { error: 'Plex server URL is required' }
+			});
+			// The stored row must be untouched — a blank submit must not delete it.
+			expect((await getApiConfigWithSources()).plex.serverUrl.value).toBe(
+				'http://plex.local:32400'
+			);
+		});
+	});
+
+	it('rejects a whitespace-only Plex URL as 400 (trimmed to blank) (ISSUE-005)', async () => {
+		await withUnlockedPlex(async () => {
+			await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://plex.local:32400');
+
+			const result = await run(
+				makeRequest('updateApiConfig', {
+					plexServerUrl: '   ',
+					apiConfigVersion: new Date(Date.now() + 60_000).toISOString()
+				})
+			);
+
+			expect(result).toMatchObject({
+				status: 400,
+				data: { error: 'Plex server URL is required' }
+			});
+			expect((await getApiConfigWithSources()).plex.serverUrl.value).toBe(
+				'http://plex.local:32400'
+			);
+		});
+	});
+
+	it('does NOT 400 on a blank Plex URL when the field is ENV-locked', async () => {
+		// With the harness's mocked PLEX_SERVER_URL env var, the field is locked;
+		// a blank submit must NOT hit the required-field guard (the lock path owns
+		// the value and setApiConfigAtomic ignores locked fields).
+		const result = await run(
+			makeRequest('updateApiConfig', {
+				plexServerUrl: '',
+				apiConfigVersion: new Date(Date.now() + 60_000).toISOString()
+			})
+		);
+		expect(result).not.toMatchObject({ data: { error: 'Plex server URL is required' } });
+	});
+
+	it('does NOT trip the blank-URL guard when plexServerUrl is absent (OpenAI-only save)', async () => {
+		await withUnlockedPlex(async () => {
+			// An OpenAI-only panel save omits the Plex inputs entirely; the absent
+			// field parses to `undefined` (not ''), so the required-URL guard is
+			// skipped and the save succeeds without wiping the stored Plex URL.
+			await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://plex.local:32400');
+
+			const formData = new FormData();
+			formData.set('openaiModel', 'gpt-4o-mini');
+			formData.set('apiConfigVersion', new Date(Date.now() + 60_000).toISOString());
+			// plexServerUrl intentionally absent
+			const request = new Request('http://localhost/admin/settings/connections?/updateApiConfig', {
+				method: 'POST',
+				body: formData
+			});
+
+			const result = await run(request);
+			// Whatever the outcome, it must NOT be the blank-URL required-field 400.
+			expect(result).not.toMatchObject({ data: { error: 'Plex server URL is required' } });
+			// And the stored Plex URL is preserved.
+			expect((await getApiConfigWithSources()).plex.serverUrl.value).toBe(
+				'http://plex.local:32400'
+			);
+		});
 	});
 
 	it('rejects checkbox-style boolean for plexAllowInsecureLocalHttp', async () => {

--- a/tests/unit/admin/privacy-actions.test.ts
+++ b/tests/unit/admin/privacy-actions.test.ts
@@ -94,6 +94,34 @@ describe('privacy nested route — updateServerWrappedSettings', () => {
 		expect(await getAnonymizationMode()).toBe('anonymous');
 	});
 
+	it('advances the returned settingsVersion so two consecutive saves both succeed (ISSUE-004)', async () => {
+		const first = (await run(
+			makeRequest('updateServerWrappedSettings', {
+				anonymizationMode: 'anonymous',
+				serverWrappedShareMode: 'private-oauth',
+				settingsVersion: new Date(0).toISOString()
+			})
+		)) as { form: { data: { settingsVersion: string } }; success?: boolean };
+		expect(first).toMatchObject({ success: true });
+		// The action must hand back an advanced version, not the submitted epoch.
+		const returnedVersion = first.form.data.settingsVersion;
+		expect(returnedVersion).not.toBe(new Date(0).toISOString());
+
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+		// Second consecutive save reusing the FIRST save's returned version must
+		// succeed without a reload (no false 409).
+		const second = await run(
+			makeRequest('updateServerWrappedSettings', {
+				anonymizationMode: 'real',
+				serverWrappedShareMode: 'public',
+				settingsVersion: returnedVersion
+			})
+		);
+		expect(second).toMatchObject({ success: true });
+		expect(await getAnonymizationMode()).toBe('real');
+	});
+
 	it('rejects private-link for serverWrappedShareMode as 400 (server-wide only supports public + private-oauth)', async () => {
 		const result = await run(
 			makeRequest('updateServerWrappedSettings', {
@@ -157,6 +185,31 @@ describe('privacy nested route — updateUserDefaults', () => {
 		);
 		expect(result).toMatchObject({ success: true });
 		expect(await getGlobalAllowUserControl()).toBe(false);
+	});
+
+	it('advances the returned settingsVersion so two consecutive saves both succeed (ISSUE-004)', async () => {
+		const first = (await run(
+			makeRequest('updateUserDefaults', {
+				defaultShareMode: 'public',
+				allowUserControl: 'true',
+				settingsVersion: new Date(0).toISOString()
+			})
+		)) as { form: { data: { settingsVersion: string } }; success?: boolean };
+		expect(first).toMatchObject({ success: true });
+		const returnedVersion = first.form.data.settingsVersion;
+		expect(returnedVersion).not.toBe(new Date(0).toISOString());
+
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+		const second = await run(
+			makeRequest('updateUserDefaults', {
+				defaultShareMode: 'private-oauth',
+				allowUserControl: 'false',
+				settingsVersion: returnedVersion
+			})
+		);
+		expect(second).toMatchObject({ success: true });
+		expect(await getGlobalDefaultShareMode()).toBe('private-oauth');
 	});
 
 	it('rejects blank settingsVersion as 409 conflict', async () => {

--- a/tests/unit/admin/system-occ-update.test.ts
+++ b/tests/unit/admin/system-occ-update.test.ts
@@ -95,4 +95,38 @@ describe('system — updateLogSettings OCC on UPDATE path (ISSUE-006 repro)', ()
 			}
 		});
 	});
+
+	it('advances the returned settingsVersion so two consecutive saves both succeed (ISSUE-004)', async () => {
+		// First save (INSERT) from the epoch sentinel.
+		const first = (await run(
+			makeRequest({
+				retentionDays: '14',
+				maxCount: '2000',
+				debugEnabled: 'false',
+				settingsVersion: new Date(0).toISOString()
+			})
+		)) as { form: { data: { settingsVersion: string } }; success?: boolean };
+
+		expect(first).toMatchObject({ success: true });
+		// The action must return an ADVANCED version (not the submitted epoch),
+		// otherwise the next save would false-409 without a page reload.
+		const returnedVersion = first.form.data.settingsVersion;
+		expect(returnedVersion).not.toBe(new Date(0).toISOString());
+		expect(returnedVersion).toBe((await getAppSettingsUpdatedAt(LOG_SETTINGS_KEYS))!.toISOString());
+
+		// Tiny delay so the second UPDATE's updatedAt is strictly greater.
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+		// Second consecutive save using the version the FIRST save returned —
+		// must succeed (no reload needed).
+		const second = await run(
+			makeRequest({
+				retentionDays: '30',
+				maxCount: '5000',
+				debugEnabled: 'true',
+				settingsVersion: returnedVersion
+			})
+		);
+		expect(second).toMatchObject({ success: true });
+	});
 });

--- a/tests/unit/utils/occ-form.test.ts
+++ b/tests/unit/utils/occ-form.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+// occ-form.ts statically imports handleFormToast -> $lib/services/toast ->
+// svelte-sonner. Mock the toast service BEFORE importing occ-form so the test
+// resolves without pulling the Svelte/sonner runtime (mirrors
+// tests/unit/lib/utils/form-toast-parity.test.ts).
+mock.module('$lib/services/toast', () => ({
+	toast: {
+		success: () => {},
+		error: () => {},
+		warning: () => {},
+		info: () => {}
+	}
+}));
+
+const { isOccConflict } = await import('$lib/utils/occ-form');
+
+describe('isOccConflict — dual-shape OCC conflict predicate', () => {
+	it('returns true for the inline-OCC shape ({ conflict: true })', () => {
+		expect(isOccConflict({ conflict: true })).toBe(true);
+		expect(isOccConflict({ conflict: true, error: 'Settings changed in another tab.' })).toBe(true);
+	});
+
+	it('returns true for the external-OCC shape ({ code: "__OCC_CONFLICT__" })', () => {
+		// appearance's z.enum actions return this shape with NO `conflict` field.
+		expect(isOccConflict({ code: '__OCC_CONFLICT__' })).toBe(true);
+		expect(isOccConflict({ error: 'reload', code: '__OCC_CONFLICT__' })).toBe(true);
+	});
+
+	it('returns false for non-conflict failures and empty/missing payloads', () => {
+		expect(isOccConflict({ conflict: false })).toBe(false);
+		expect(isOccConflict({ error: 'Invalid input' })).toBe(false);
+		expect(isOccConflict({ code: 'SOME_OTHER_CODE' })).toBe(false);
+		expect(isOccConflict({})).toBe(false);
+		expect(isOccConflict(undefined)).toBe(false);
+		expect(isOccConflict(null)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Resolves five actionable findings and two polish items from the 2026-05-30 E2E dogfood run (`dogfood-output/report.md`). Each fix is an isolated, independently revertible change that mirrors an existing pattern in the codebase. No database schema or migration changes; the four raw-`use:enhance` settings pages (connections/appearance/data/security) are deliberately untouched because they already surface 409 conflicts.

## Findings addressed

### ISSUE-005 (Medium) - blank Plex server URL silently clears stored config
`updateApiConfig` admitted a present-but-blank `plexServerUrl` and wrote it through, deleting the stored row behind a success toast. Added a guard keyed on the post-Zod empty string (`parsed.data.plexServerUrl === ''`), the field being present, and the URL not being env-locked, returning `fail(400, 'Plex server URL is required')`. An absent field (OpenAI-only panel save) parses to `undefined` and is skipped, so the two-panel form is unaffected. Blank `openaiBaseUrl`/`openaiModel` remain an intentional clear-to-default, documented inline. The env-lock UI was already correct and left as-is.

### ISSUE-006 (Medium) - false "Settings saved" on a stale System save
An OCC stale-write returns `fail(409, { form, conflict })` after validation, so `form.valid` stays true and `onUpdated` fired a false success toast while the write was discarded. Added `onUpdate: surfaceOccConflict` to the System superForm so the conflict toast is surfaced and the success path is cancelled. Extracted a shared dual-shape predicate `isOccConflict(data) => data?.conflict === true || data?.code === '__OCC_CONFLICT__'` plus `surfaceOccConflict` into `src/lib/utils/occ-form.ts` (client-safe; the server-only sentinel is inlined as a literal). Privacy now consumes the shared helper, replacing its inline copy.

### ISSUE-004 (Low) - second consecutive save false-409s without a reload
The superForm success paths returned the submitted (now-stale) `settingsVersion`. Each success path (System log settings plus the three Privacy actions, each using its own keys group) now re-reads and advances `form.data.settingsVersion` via `settingsVersionISO(await getAppSettingsUpdatedAt(<keys>))`, so two consecutive saves in one page load both succeed. `bulkApplyShareDefaults` (returns `form: null`) is excluded.

### ISSUE-002 (Low) - Regenerate share link shown below the floor
Folded `!isBelowFloor(displayMode)` into `canRegenerateToken` so the control hides when the stored `private-link` mode is below the active global floor, consistent with the radio options' floor gating.

### ISSUE-003 (Low) - global Allow User Control toggle reads as retroactive
Added helper copy clarifying the toggle applies to newly-created users and pointing to "Apply current defaults to all users" or the per-user Users-page toggle for existing users. Copy only; no logic change.

### Polish
- Added a per-row `aria-label` (including the username) to the Can Control toggle on the Users page, on both the desktop table and the mobile list.
- Documented the existing custom-slide image sanitization policy in `sanitize.ts`: `<img>` is allowlisted with no event-handler attributes and data-URI MIME validation, so `onerror` is stripped server-side. No behavior change.

## Tests

- `connections-actions.test.ts`: blank/whitespace Plex URL rejected with the stored row preserved; env-locked blank submit does not 400; absent field (OpenAI-only save) does not trip the guard.
- `tests/unit/utils/occ-form.test.ts`: `isOccConflict` returns true for both conflict shapes and false otherwise.
- `system-occ-update.test.ts` and `privacy-actions.test.ts`: consecutive-save regression tests confirming the advanced `settingsVersion` lets a second save succeed.

## Verification

- `bun run check:biome`: clean (629 files)
- `bun run check` (svelte-check): 0 errors, 0 warnings
- `bun run test`: 1964 pass, 0 fail
