### PR TITLE
fix: resolve dogfood findings (ISSUE-001…018)

### DIFF
--- a/src/lib/components/slides/DistributionSlide.svelte
+++ b/src/lib/components/slides/DistributionSlide.svelte
@@ -11,7 +11,12 @@ import {
 } from '$lib/utils/animation-presets';
 import BaseSlide from './BaseSlide.svelte';
 import type { SlideMessagingContext } from './messaging-context';
-import { createPersonalContext, getPossessive, getSubject } from './messaging-context';
+import {
+	createPersonalContext,
+	getPossessive,
+	getSubject,
+	getWatchVerb
+} from './messaging-context';
 import type { DistributionSlideProps } from './types';
 
 interface Props extends DistributionSlideProps {
@@ -63,6 +68,7 @@ const showDualView = $derived(
 // Get messaging helpers
 const subject = $derived(getSubject(messagingContext));
 const possessive = $derived(getPossessive(messagingContext));
+const watchVerb = $derived(getWatchVerb(messagingContext));
 
 // Month labels
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
@@ -319,7 +325,7 @@ function formatPlays(plays: number): string {
 
 					<!-- Hourly Chart -->
 					<div class="chart-section">
-						<h3 class="section-title">When {subject} Watch</h3>
+						<h3 class="section-title">When {subject} {watchVerb}</h3>
 						<div class="chart-container hourly">
 							{#each hourlyData as item, i}
 								<div class="bar-wrapper" class:peak={i === hourlyPeakIndex}>

--- a/src/lib/components/slides/messaging-context.ts
+++ b/src/lib/components/slides/messaging-context.ts
@@ -34,6 +34,13 @@ export function getAreVerb(ctx: SlideMessagingContext): string {
 	return ctx.serverName ? 'is' : 'are';
 }
 
+export function getWatchVerb(ctx: SlideMessagingContext): string {
+	if (!ctx.isServerWrapped) {
+		return 'watch';
+	}
+	return ctx.serverName ? 'watches' : 'watch';
+}
+
 export function createPersonalContext(): SlideMessagingContext {
 	return {
 		isServerWrapped: false,

--- a/src/lib/cron/validation.ts
+++ b/src/lib/cron/validation.ts
@@ -57,7 +57,8 @@ function isFieldInRange(token: string, min: number, max: number): boolean {
 		);
 	}
 
-	// Plain integer
+	// Plain integer — reject empty token (Number('') === 0 would falsely pass for min=0 fields)
+	if (!token) return false;
 	const num = Number(token);
 	return Number.isInteger(num) && num >= min && num <= max;
 }

--- a/src/lib/cron/validation.ts
+++ b/src/lib/cron/validation.ts
@@ -1,11 +1,73 @@
 export const CRON_REQUIRED_MESSAGE = 'Cron expression is required';
 export const CRON_ALLOWED_CHARS_MESSAGE = 'Only digits, spaces, and * / - , are allowed';
 export const CRON_FIELD_COUNT_MESSAGE = 'Cron expression must have exactly 5 fields';
+export const CRON_RANGE_MESSAGE = 'Cron expression contains an out-of-range value';
+
+// [min, max] for each of the 5 cron fields (minute, hour, dom, month, dow)
+const FIELD_RANGES: [number, number][] = [
+	[0, 59], // minute
+	[0, 23], // hour
+	[1, 31], // day-of-month
+	[1, 12], // month
+	[0, 7] //  day-of-week (0 and 7 both mean Sunday)
+];
+
+/**
+ * Returns true when every atomic numeric token in the cron field token falls
+ * within [min, max]. Handles *, step (/), range (-), and list (,).
+ */
+function isFieldInRange(token: string, min: number, max: number): boolean {
+	// Wildcard — always valid
+	if (token === '*') return true;
+
+	// Step — e.g. "*/5" or "1-5/2" or "0/15"
+	if (token.includes('/')) {
+		const [base, step] = token.split('/');
+		// Step value must be a positive integer
+		const stepNum = Number(step);
+		if (!step || !Number.isInteger(stepNum) || stepNum < 1) return false;
+		if (base === undefined) return false;
+		// Base can be "*", a plain number, or a range
+		if (base !== '*' && !isFieldInRange(base, min, max)) return false;
+		return true;
+	}
+
+	// List — e.g. "1,3,5"
+	if (token.includes(',')) {
+		return token.split(',').every((part) => isFieldInRange(part, min, max));
+	}
+
+	// Range — e.g. "1-5"
+	if (token.includes('-')) {
+		const [lo, hi] = token.split('-').map(Number);
+		return (
+			lo !== undefined &&
+			hi !== undefined &&
+			Number.isInteger(lo) &&
+			Number.isInteger(hi) &&
+			lo >= min &&
+			hi <= max &&
+			lo <= hi
+		);
+	}
+
+	// Plain integer
+	const num = Number(token);
+	return Number.isInteger(num) && num >= min && num <= max;
+}
 
 export function validateCronExpression(expression: string): string {
 	const trimmed = expression.trim();
 	if (!trimmed) return CRON_REQUIRED_MESSAGE;
 	if (!/^[\d */\-,]+$/.test(trimmed)) return CRON_ALLOWED_CHARS_MESSAGE;
-	if (trimmed.split(/ +/).filter(Boolean).length !== 5) return CRON_FIELD_COUNT_MESSAGE;
+	const fields = trimmed.split(/ +/).filter(Boolean);
+	if (fields.length !== 5) return CRON_FIELD_COUNT_MESSAGE;
+	for (let i = 0; i < 5; i++) {
+		const range = FIELD_RANGES[i];
+		const field = fields[i];
+		if (!range || field === undefined) return CRON_RANGE_MESSAGE;
+		const [min, max] = range;
+		if (!isFieldInRange(field, min, max)) return CRON_RANGE_MESSAGE;
+	}
 	return '';
 }

--- a/src/lib/cron/validation.ts
+++ b/src/lib/cron/validation.ts
@@ -22,12 +22,15 @@ function isFieldInRange(token: string, min: number, max: number): boolean {
 
 	// Step — e.g. "*/5" or "1-5/2" or "0/15"
 	if (token.includes('/')) {
-		const [base, step] = token.split('/');
+		const parts = token.split('/');
+		// Exactly one "/" — reject tokens like "*/5/2"
+		if (parts.length !== 2) return false;
+		const [base, step] = parts;
 		// Step value must be a positive integer
 		const stepNum = Number(step);
 		if (!step || !Number.isInteger(stepNum) || stepNum < 1) return false;
-		if (base === undefined) return false;
-		// Base can be "*", a plain number, or a range
+		// Base must be present (reject "/5") — can be "*", a plain number, or a range
+		if (!base) return false;
 		if (base !== '*' && !isFieldInRange(base, min, max)) return false;
 		return true;
 	}
@@ -39,7 +42,10 @@ function isFieldInRange(token: string, min: number, max: number): boolean {
 
 	// Range — e.g. "1-5"
 	if (token.includes('-')) {
-		const [lo, hi] = token.split('-').map(Number);
+		const parts = token.split('-');
+		// Exactly two non-empty segments — reject "-1", "1-", "1-5-2"
+		if (parts.length !== 2 || !parts[0] || !parts[1]) return false;
+		const [lo, hi] = parts.map(Number);
 		return (
 			lo !== undefined &&
 			hi !== undefined &&

--- a/src/lib/server/sync/plex-accounts.service.ts
+++ b/src/lib/server/sync/plex-accounts.service.ts
@@ -227,7 +227,12 @@ export async function syncPlexAccounts(): Promise<number> {
 	try {
 		const ownerData = await getPlexUserInfo(config.token);
 
-		// Server owner has accountId = 1 in play history
+		// Server owner is local SystemAccount id 1 in play_history. The Plex Media
+		// Server stamps `/status/sessions/history/all` rows with the *local*
+		// SystemAccount id (owner == 1), a different id space from the plex.tv
+		// global id in `ownerData.id`. Do not "fix" this to the plex.tv id — the
+		// owner's own watches never carry it, so their personal Wrapped would be
+		// permanently empty (see ISSUE-010).
 		accounts.push({
 			accountId: 1,
 			plexId: ownerData.id,

--- a/src/lib/server/sync/scheduler.ts
+++ b/src/lib/server/sync/scheduler.ts
@@ -230,12 +230,27 @@ export async function startBackgroundSync(
 	return { started: true };
 }
 
-export function updateSchedulerCron(cronExpression: string, timezone?: string): Cron {
+export function updateSchedulerCron(cronExpression: string, timezone?: string): Cron | null {
+	// Preserve the prior run-state when only the cron changes (ISSUE-012):
+	// - INACTIVE (no instance): stay inactive — do NOT create or start an
+	//   instance. The new expression is persisted to app_settings
+	//   (SYNC_CRON_EXPRESSION) by the caller and is picked up the next time the
+	//   scheduler is initialised, so the runtime state stays "Inactive" instead
+	//   of silently flipping to active/paused (the original ISSUE-012 defect).
+	// - PAUSED: re-setup in paused mode so the new expression is applied but the
+	//   scheduler keeps its paused state.
+	// - ACTIVE (running, not paused): re-setup running so it keeps firing on the
+	//   new expression.
+	if (schedulerInstance === null) {
+		return null;
+	}
+	const prior = getSchedulerStatus();
+	const wasActive = prior.isRunning && !prior.isPaused;
 	return setupSyncScheduler({
 		cronExpression,
 		timezone: timezone ?? DEFAULT_TIMEZONE,
 		protect: true,
-		startImmediately: true
+		startImmediately: wasActive
 	});
 }
 

--- a/src/routes/admin/settings/appearance/+page.server.ts
+++ b/src/routes/admin/settings/appearance/+page.server.ts
@@ -1,6 +1,6 @@
 import { fail } from '@sveltejs/kit';
 import { zod4 } from 'sveltekit-superforms/adapters';
-import { superValidate } from 'sveltekit-superforms/server';
+import { setMessage, superValidate } from 'sveltekit-superforms/server';
 import { z } from 'zod';
 import {
 	inlineOccCheck,
@@ -126,6 +126,11 @@ export const actions: Actions = requireAdminActions({
 		const formData = await request.formData();
 		if (!formData.has('uiTheme')) {
 			const form = await superValidate(formData, zod4(UIThemeSchema), { id: 'uiTheme' });
+			// superValidate coerces the absent required enum to its first member, so
+			// `form.valid` is still true here. setMessage(..., { status: 400 }) flips
+			// form.valid=false and sets form.message so the client toast reports the
+			// failure (it branches on form.valid / form.message) instead of a false save.
+			setMessage(form, 'Invalid theme selection', { status: 400 });
 			return fail(400, { form, error: 'Invalid theme selection' });
 		}
 		const form = await superValidate(formData, zod4(UIThemeSchema), { id: 'uiTheme' });
@@ -167,6 +172,9 @@ export const actions: Actions = requireAdminActions({
 		const formData = await request.formData();
 		if (!formData.has('wrappedTheme')) {
 			const form = await superValidate(formData, zod4(WrappedThemeSchema), { id: 'wrappedTheme' });
+			// See updateUITheme: setMessage flips form.valid=false + sets the message
+			// so the client toast reports the failure, not a false save.
+			setMessage(form, 'Invalid theme selection', { status: 400 });
 			return fail(400, { form, error: 'Invalid theme selection' });
 		}
 		const form = await superValidate(formData, zod4(WrappedThemeSchema), { id: 'wrappedTheme' });
@@ -208,6 +216,9 @@ export const actions: Actions = requireAdminActions({
 			const form = await superValidate(formData, zod4(WrappedLogoModeSchema), {
 				id: 'wrappedLogoMode'
 			});
+			// See updateUITheme: setMessage flips form.valid=false + sets the message
+			// so the client toast reports the failure, not a false save.
+			setMessage(form, 'Invalid logo mode', { status: 400 });
 			return fail(400, { form, error: 'Invalid logo mode' });
 		}
 		const form = await superValidate(formData, zod4(WrappedLogoModeSchema), {

--- a/src/routes/admin/settings/appearance/+page.server.ts
+++ b/src/routes/admin/settings/appearance/+page.server.ts
@@ -1,8 +1,9 @@
 import { fail } from '@sveltejs/kit';
+import { zod4 } from 'sveltekit-superforms/adapters';
+import { superValidate } from 'sveltekit-superforms/server';
 import { z } from 'zod';
 import {
-	externalOccCheck,
-	OCC_CONFLICT_CODE,
+	inlineOccCheck,
 	OCC_CONFLICT_MESSAGE,
 	settingsVersionISO
 } from '$lib/server/admin/occ-helpers';
@@ -26,25 +27,43 @@ import { wrappedLogoOptions } from '$lib/sharing/options';
 import type { Actions, PageServerLoad } from './$types';
 
 /**
- * OCC strategy: EXTERNAL for both theme schemas + the logo-mode schema.
- * Top-level `z.enum` schemas; the action validates `settingsVersion` from
- * formData against the current row BEFORE `safeParse`. Mirrors the
- * monolith's three z.enum actions verbatim — see v3 plan §A5 Table D2.
+ * OCC strategy: INLINE `settingsVersion` (Superforms). Migrated from the
+ * top-level `z.enum` + `externalOccCheck` shape to match privacy's canonical
+ * pattern (ISSUE-015): each form carries an inline `settingsVersion`, the
+ * action advances it from the freshly-written row on success, and the client
+ * binds it back so a second consecutive save in the same page load isn't
+ * false-409'd. The shared enum stays co-located with its consuming schema.
  */
-const ThemeSchema = z.enum([
-	'modern-minimal',
-	'supabase',
-	'doom-64',
-	'amber-minimal',
-	'soviet-red'
-]);
+const ThemeEnum = z.enum(['modern-minimal', 'supabase', 'doom-64', 'amber-minimal', 'soviet-red']);
+const WrappedLogoModeEnum = z.enum(['always_show', 'always_hide', 'user_choice']);
+
 /**
- * OCC strategy: EXTERNAL. Same shape as `ThemeSchema` — top-level z.enum,
- * validated via `externalOccCheck` against `WRAPPED_LOGO_MODE_SETTINGS_KEYS`
- * before `safeParse` so the conflict response carries the magic
- * `OCC_CONFLICT_CODE` sentinel + the current settingsVersion.
+ * OCC strategy: INLINE `settingsVersion`. Parent schema for the UI theme form.
+ * Same two-stage OCC as privacy (Zod min(1) rejects blank, then `inlineOccCheck`
+ * catches stale submissions against `UI_THEME_SETTINGS_KEYS`).
  */
-const WrappedLogoModeSchema = z.enum(['always_show', 'always_hide', 'user_choice']);
+const UIThemeSchema = z.object({
+	uiTheme: ThemeEnum,
+	settingsVersion: z.string().min(1, 'Missing settings version (reload the page)')
+});
+
+/**
+ * OCC strategy: INLINE `settingsVersion`. Parent schema for the Wrapped theme
+ * form (OCC against `WRAPPED_THEME_SETTINGS_KEYS`).
+ */
+const WrappedThemeSchema = z.object({
+	wrappedTheme: ThemeEnum,
+	settingsVersion: z.string().min(1, 'Missing settings version (reload the page)')
+});
+
+/**
+ * OCC strategy: INLINE `settingsVersion`. Parent schema for the Wrapped logo
+ * visibility form (OCC against `WRAPPED_LOGO_MODE_SETTINGS_KEYS`).
+ */
+const WrappedLogoModeSchema = z.object({
+	logoMode: WrappedLogoModeEnum,
+	settingsVersion: z.string().min(1, 'Missing settings version (reload the page)')
+});
 
 export const load: PageServerLoad = async () => {
 	const [
@@ -63,13 +82,28 @@ export const load: PageServerLoad = async () => {
 		getAppSettingsUpdatedAt(WRAPPED_LOGO_MODE_SETTINGS_KEYS)
 	]);
 
+	const uiThemeForm = await superValidate(
+		{ uiTheme, settingsVersion: settingsVersionISO(uiThemeUpdatedAt) },
+		zod4(UIThemeSchema),
+		{ id: 'uiTheme' }
+	);
+
+	const wrappedThemeForm = await superValidate(
+		{ wrappedTheme, settingsVersion: settingsVersionISO(wrappedThemeUpdatedAt) },
+		zod4(WrappedThemeSchema),
+		{ id: 'wrappedTheme' }
+	);
+
+	const wrappedLogoModeForm = await superValidate(
+		{ logoMode: wrappedLogoMode, settingsVersion: settingsVersionISO(wrappedLogoModeUpdatedAt) },
+		zod4(WrappedLogoModeSchema),
+		{ id: 'wrappedLogoMode' }
+	);
+
 	return {
-		uiTheme,
-		wrappedTheme,
-		wrappedLogoMode,
-		uiThemeVersion: settingsVersionISO(uiThemeUpdatedAt),
-		wrappedThemeVersion: settingsVersionISO(wrappedThemeUpdatedAt),
-		wrappedLogoModeVersion: settingsVersionISO(wrappedLogoModeUpdatedAt),
+		uiThemeForm,
+		wrappedThemeForm,
+		wrappedLogoModeForm,
 		themeOptions: Object.entries(ThemePresets).map(([key, value]) => ({
 			value,
 			label: key
@@ -84,83 +118,93 @@ export const load: PageServerLoad = async () => {
 
 export const actions: Actions = requireAdminActions({
 	updateUITheme: async ({ request }) => {
-		const formData = await request.formData();
-
-		const occ = await externalOccCheck(
-			formData.get('settingsVersion')?.toString() ?? '',
-			UI_THEME_SETTINGS_KEYS
-		);
-		if (occ.status === 'conflict') {
-			return fail(409, {
-				error: OCC_CONFLICT_MESSAGE,
-				code: OCC_CONFLICT_CODE,
-				settingsVersion: occ.current
-			});
+		const form = await superValidate(request, zod4(UIThemeSchema), { id: 'uiTheme' });
+		if (!form.valid) {
+			if (form.errors.settingsVersion?.length) {
+				return fail(409, { form, conflict: true, error: OCC_CONFLICT_MESSAGE });
+			}
+			return fail(400, { form, error: 'Invalid theme selection' });
 		}
 
-		const parsed = ThemeSchema.safeParse(formData.get('theme'));
-		if (!parsed.success) return fail(400, { error: 'Invalid theme selection' });
+		if (
+			(await inlineOccCheck(form.data.settingsVersion, UI_THEME_SETTINGS_KEYS)).status ===
+			'conflict'
+		) {
+			return fail(409, { form, conflict: true, error: OCC_CONFLICT_MESSAGE });
+		}
 
 		try {
-			await setUITheme(parsed.data as ThemePresetType);
-			return { success: true, message: 'UI theme updated' };
+			await setUITheme(form.data.uiTheme as ThemePresetType);
+			// ISSUE-015: advance the returned settingsVersion so a second consecutive
+			// save in the same page load isn't false-409'd. Single-writer admin
+			// setting, so reading the row back post-write is safe.
+			form.data.settingsVersion = settingsVersionISO(
+				await getAppSettingsUpdatedAt(UI_THEME_SETTINGS_KEYS)
+			);
+			return { form, success: true, message: 'UI theme updated' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update UI theme';
-			return fail(500, { error: message });
+			return fail(500, { form, error: message });
 		}
 	},
 
 	updateWrappedTheme: async ({ request }) => {
-		const formData = await request.formData();
-
-		const occ = await externalOccCheck(
-			formData.get('settingsVersion')?.toString() ?? '',
-			WRAPPED_THEME_SETTINGS_KEYS
-		);
-		if (occ.status === 'conflict') {
-			return fail(409, {
-				error: OCC_CONFLICT_MESSAGE,
-				code: OCC_CONFLICT_CODE,
-				settingsVersion: occ.current
-			});
+		const form = await superValidate(request, zod4(WrappedThemeSchema), { id: 'wrappedTheme' });
+		if (!form.valid) {
+			if (form.errors.settingsVersion?.length) {
+				return fail(409, { form, conflict: true, error: OCC_CONFLICT_MESSAGE });
+			}
+			return fail(400, { form, error: 'Invalid theme selection' });
 		}
 
-		const parsed = ThemeSchema.safeParse(formData.get('wrappedTheme') ?? formData.get('theme'));
-		if (!parsed.success) return fail(400, { error: 'Invalid theme selection' });
+		if (
+			(await inlineOccCheck(form.data.settingsVersion, WRAPPED_THEME_SETTINGS_KEYS)).status ===
+			'conflict'
+		) {
+			return fail(409, { form, conflict: true, error: OCC_CONFLICT_MESSAGE });
+		}
 
 		try {
-			await setWrappedTheme(parsed.data as ThemePresetType);
-			return { success: true, message: 'Wrapped theme updated' };
+			await setWrappedTheme(form.data.wrappedTheme as ThemePresetType);
+			// ISSUE-015: advance the returned settingsVersion (see updateUITheme).
+			form.data.settingsVersion = settingsVersionISO(
+				await getAppSettingsUpdatedAt(WRAPPED_THEME_SETTINGS_KEYS)
+			);
+			return { form, success: true, message: 'Wrapped theme updated' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update wrapped theme';
-			return fail(500, { error: message });
+			return fail(500, { form, error: message });
 		}
 	},
 
 	updateWrappedLogoMode: async ({ request }) => {
-		const formData = await request.formData();
-
-		const occ = await externalOccCheck(
-			formData.get('settingsVersion')?.toString() ?? '',
-			WRAPPED_LOGO_MODE_SETTINGS_KEYS
-		);
-		if (occ.status === 'conflict') {
-			return fail(409, {
-				error: OCC_CONFLICT_MESSAGE,
-				code: OCC_CONFLICT_CODE,
-				settingsVersion: occ.current
-			});
+		const form = await superValidate(request, zod4(WrappedLogoModeSchema), {
+			id: 'wrappedLogoMode'
+		});
+		if (!form.valid) {
+			if (form.errors.settingsVersion?.length) {
+				return fail(409, { form, conflict: true, error: OCC_CONFLICT_MESSAGE });
+			}
+			return fail(400, { form, error: 'Invalid logo mode' });
 		}
 
-		const parsed = WrappedLogoModeSchema.safeParse(formData.get('logoMode'));
-		if (!parsed.success) return fail(400, { error: 'Invalid logo mode' });
+		if (
+			(await inlineOccCheck(form.data.settingsVersion, WRAPPED_LOGO_MODE_SETTINGS_KEYS)).status ===
+			'conflict'
+		) {
+			return fail(409, { form, conflict: true, error: OCC_CONFLICT_MESSAGE });
+		}
 
 		try {
-			await setWrappedLogoMode(parsed.data as WrappedLogoModeType);
-			return { success: true, message: 'Logo visibility mode updated' };
+			await setWrappedLogoMode(form.data.logoMode as WrappedLogoModeType);
+			// ISSUE-015: advance the returned settingsVersion (see updateUITheme).
+			form.data.settingsVersion = settingsVersionISO(
+				await getAppSettingsUpdatedAt(WRAPPED_LOGO_MODE_SETTINGS_KEYS)
+			);
+			return { form, success: true, message: 'Logo visibility mode updated' };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update mode';
-			return fail(500, { error: message });
+			return fail(500, { form, error: message });
 		}
 	}
 });

--- a/src/routes/admin/settings/appearance/+page.server.ts
+++ b/src/routes/admin/settings/appearance/+page.server.ts
@@ -159,7 +159,17 @@ export const actions: Actions = requireAdminActions({
 	},
 
 	updateWrappedTheme: async ({ request }) => {
-		const form = await superValidate(request, zod4(WrappedThemeSchema), { id: 'wrappedTheme' });
+		// Read FormData once (consumes the body) so we can detect an absent
+		// `wrappedTheme` field before handing the parsed object to superValidate.
+		// Without this guard a request that omits `wrappedTheme` (e.g. a stale
+		// client) would have the required z.enum silently filled with its first
+		// member ('modern-minimal') and persisted as if intentionally selected.
+		const formData = await request.formData();
+		if (!formData.has('wrappedTheme')) {
+			const form = await superValidate(formData, zod4(WrappedThemeSchema), { id: 'wrappedTheme' });
+			return fail(400, { form, error: 'Invalid theme selection' });
+		}
+		const form = await superValidate(formData, zod4(WrappedThemeSchema), { id: 'wrappedTheme' });
 		if (!form.valid) {
 			if (form.errors.settingsVersion?.length) {
 				return fail(409, { form, conflict: true, error: OCC_CONFLICT_MESSAGE });
@@ -188,7 +198,19 @@ export const actions: Actions = requireAdminActions({
 	},
 
 	updateWrappedLogoMode: async ({ request }) => {
-		const form = await superValidate(request, zod4(WrappedLogoModeSchema), {
+		// Read FormData once (consumes the body) so we can detect an absent
+		// `logoMode` field before handing the parsed object to superValidate.
+		// Without this guard a request that omits `logoMode` (e.g. a stale client)
+		// would have the required z.enum silently filled with its first member
+		// ('always_show') and persisted as if intentionally selected.
+		const formData = await request.formData();
+		if (!formData.has('logoMode')) {
+			const form = await superValidate(formData, zod4(WrappedLogoModeSchema), {
+				id: 'wrappedLogoMode'
+			});
+			return fail(400, { form, error: 'Invalid logo mode' });
+		}
+		const form = await superValidate(formData, zod4(WrappedLogoModeSchema), {
 			id: 'wrappedLogoMode'
 		});
 		if (!form.valid) {

--- a/src/routes/admin/settings/appearance/+page.server.ts
+++ b/src/routes/admin/settings/appearance/+page.server.ts
@@ -118,7 +118,17 @@ export const load: PageServerLoad = async () => {
 
 export const actions: Actions = requireAdminActions({
 	updateUITheme: async ({ request }) => {
-		const form = await superValidate(request, zod4(UIThemeSchema), { id: 'uiTheme' });
+		// Read FormData once (consumes the body) so we can detect an absent
+		// `uiTheme` field before handing the parsed object to superValidate.
+		// Without this guard a request that omits `uiTheme` (e.g. a stale client)
+		// would have the required z.enum silently filled with its first member
+		// ('modern-minimal') and persisted as if intentionally selected.
+		const formData = await request.formData();
+		if (!formData.has('uiTheme')) {
+			const form = await superValidate(formData, zod4(UIThemeSchema), { id: 'uiTheme' });
+			return fail(400, { form, error: 'Invalid theme selection' });
+		}
+		const form = await superValidate(formData, zod4(UIThemeSchema), { id: 'uiTheme' });
 		if (!form.valid) {
 			if (form.errors.settingsVersion?.length) {
 				return fail(409, { form, conflict: true, error: OCC_CONFLICT_MESSAGE });

--- a/src/routes/admin/settings/appearance/+page.svelte
+++ b/src/routes/admin/settings/appearance/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-import { enhance } from '$app/forms';
-import { invalidateAll } from '$app/navigation';
+import { superForm } from 'sveltekit-superforms';
 import { SettingsActionBar, SettingsOptionCard } from '$lib/components/settings/index.js';
 import { Button } from '$lib/components/ui/button/index.js';
 import {
@@ -12,6 +11,7 @@ import {
 } from '$lib/components/ui/card/index.js';
 import { RadioGroup, RadioGroupItem } from '$lib/components/ui/radio-group/index.js';
 import { handleFormToast } from '$lib/utils/form-toast';
+import { surfaceOccConflict } from '$lib/utils/occ-form';
 import type { PageData } from './$types';
 
 interface Props {
@@ -20,18 +20,55 @@ interface Props {
 
 let { data }: Props = $props();
 
-// Initial-value capture is intentional — the radio bindings own UI state
-// from first paint and the server load reseeds via invalidateAll on save.
-/* svelte-ignore state_referenced_locally */
-let selectedUITheme = $state(data.uiTheme);
-/* svelte-ignore state_referenced_locally */
-let selectedWrappedTheme = $state(data.wrappedTheme);
-/* svelte-ignore state_referenced_locally */
-let selectedWrappedLogoMode = $state(data.wrappedLogoMode);
+// svelte-ignore state_referenced_locally
+const uiThemeForm = superForm(data.uiThemeForm, {
+	resetForm: false,
+	onUpdate: surfaceOccConflict,
+	onUpdated({ form: updated }) {
+		if (updated.valid) {
+			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
+		} else {
+			handleFormToast({ error: updated.message ?? 'Validation failed' });
+		}
+	}
+});
+const { form: uiThemeData, enhance: uiThemeEnhance, submitting: uiThemeSubmitting } = uiThemeForm;
 
-let isSavingUITheme = $state(false);
-let isSavingWrappedTheme = $state(false);
-let isSavingWrappedLogoMode = $state(false);
+// svelte-ignore state_referenced_locally
+const wrappedThemeForm = superForm(data.wrappedThemeForm, {
+	resetForm: false,
+	onUpdate: surfaceOccConflict,
+	onUpdated({ form: updated }) {
+		if (updated.valid) {
+			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
+		} else {
+			handleFormToast({ error: updated.message ?? 'Validation failed' });
+		}
+	}
+});
+const {
+	form: wrappedThemeData,
+	enhance: wrappedThemeEnhance,
+	submitting: wrappedThemeSubmitting
+} = wrappedThemeForm;
+
+// svelte-ignore state_referenced_locally
+const wrappedLogoModeForm = superForm(data.wrappedLogoModeForm, {
+	resetForm: false,
+	onUpdate: surfaceOccConflict,
+	onUpdated({ form: updated }) {
+		if (updated.valid) {
+			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
+		} else {
+			handleFormToast({ error: updated.message ?? 'Validation failed' });
+		}
+	}
+});
+const {
+	form: wrappedLogoModeData,
+	enhance: wrappedLogoModeEnhance,
+	submitting: wrappedLogoModeSubmitting
+} = wrappedLogoModeForm;
 
 const themeSwatches: Record<string, string[]> = {
 	'modern-minimal': ['oklch(0.6261 0.1859 259.6)', 'oklch(0.2267 0 0)', 'oklch(0.9389 0 0)'],
@@ -89,34 +126,12 @@ function getThemeDescription(theme: string): string {
 			</CardDescription>
 		</CardHeader>
 		<CardContent>
-			<form
-				method="POST"
-				action="?/updateUITheme"
-				use:enhance={({ cancel }) => {
-					if (isSavingUITheme) {
-						cancel();
-						return;
-					}
-					isSavingUITheme = true;
-					return async ({ result, update }) => {
-						try {
-							if (result.type === 'success' || result.type === 'failure') {
-								handleFormToast(
-									result.data as { success?: boolean; message?: string; error?: string }
-								);
-							}
-							await update({ reset: false });
-							if (result.type === 'success') {
-								await invalidateAll();
-							}
-						} finally {
-							isSavingUITheme = false;
-						}
-					};
-				}}
-				class="space-y-4"
-			>
-				<RadioGroup bind:value={selectedUITheme} name="theme" class="grid sm:grid-cols-2 gap-2">
+			<form method="POST" action="?/updateUITheme" use:uiThemeEnhance class="space-y-4">
+				<RadioGroup
+					bind:value={$uiThemeData.uiTheme}
+					name="uiTheme"
+					class="grid sm:grid-cols-2 gap-2"
+				>
 					{#each data.themeOptions as theme (theme.value)}
 						<SettingsOptionCard
 							title={theme.label}
@@ -130,11 +145,11 @@ function getThemeDescription(theme: string): string {
 					{/each}
 				</RadioGroup>
 
-				<input type="hidden" name="settingsVersion" value={data.uiThemeVersion} />
+				<input type="hidden" name="settingsVersion" bind:value={$uiThemeData.settingsVersion} />
 
 				<SettingsActionBar>
-					<Button type="submit" class="tap-target" disabled={isSavingUITheme}>
-						{isSavingUITheme ? 'Saving…' : 'Save UI theme'}
+					<Button type="submit" class="tap-target" disabled={$uiThemeSubmitting}>
+						{$uiThemeSubmitting ? 'Saving…' : 'Save UI theme'}
 					</Button>
 				</SettingsActionBar>
 			</form>
@@ -149,35 +164,9 @@ function getThemeDescription(theme: string): string {
 			</CardDescription>
 		</CardHeader>
 		<CardContent>
-			<form
-				method="POST"
-				action="?/updateWrappedTheme"
-				use:enhance={({ cancel }) => {
-					if (isSavingWrappedTheme) {
-						cancel();
-						return;
-					}
-					isSavingWrappedTheme = true;
-					return async ({ result, update }) => {
-						try {
-							if (result.type === 'success' || result.type === 'failure') {
-								handleFormToast(
-									result.data as { success?: boolean; message?: string; error?: string }
-								);
-							}
-							await update({ reset: false });
-							if (result.type === 'success') {
-								await invalidateAll();
-							}
-						} finally {
-							isSavingWrappedTheme = false;
-						}
-					};
-				}}
-				class="space-y-4"
-			>
+			<form method="POST" action="?/updateWrappedTheme" use:wrappedThemeEnhance class="space-y-4">
 				<RadioGroup
-					bind:value={selectedWrappedTheme}
+					bind:value={$wrappedThemeData.wrappedTheme}
 					name="wrappedTheme"
 					class="grid sm:grid-cols-2 gap-2"
 				>
@@ -194,11 +183,15 @@ function getThemeDescription(theme: string): string {
 					{/each}
 				</RadioGroup>
 
-				<input type="hidden" name="settingsVersion" value={data.wrappedThemeVersion} />
+				<input
+					type="hidden"
+					name="settingsVersion"
+					bind:value={$wrappedThemeData.settingsVersion}
+				/>
 
 				<SettingsActionBar>
-					<Button type="submit" class="tap-target" disabled={isSavingWrappedTheme}>
-						{isSavingWrappedTheme ? 'Saving…' : 'Save wrapped theme'}
+					<Button type="submit" class="tap-target" disabled={$wrappedThemeSubmitting}>
+						{$wrappedThemeSubmitting ? 'Saving…' : 'Save wrapped theme'}
 					</Button>
 				</SettingsActionBar>
 			</form>
@@ -214,35 +207,10 @@ function getThemeDescription(theme: string): string {
 			<form
 				method="POST"
 				action="?/updateWrappedLogoMode"
-				use:enhance={({ cancel }) => {
-					if (isSavingWrappedLogoMode) {
-						cancel();
-						return;
-					}
-					isSavingWrappedLogoMode = true;
-					return async ({ result, update }) => {
-						try {
-							if (result.type === 'success' || result.type === 'failure') {
-								handleFormToast(
-									result.data as { success?: boolean; message?: string; error?: string }
-								);
-							}
-							await update({ reset: false });
-							if (result.type === 'success') {
-								await invalidateAll();
-							}
-						} finally {
-							isSavingWrappedLogoMode = false;
-						}
-					};
-				}}
+				use:wrappedLogoModeEnhance
 				class="space-y-4"
 			>
-				<RadioGroup
-					bind:value={selectedWrappedLogoMode}
-					name="logoMode"
-					class="grid gap-2"
-				>
+				<RadioGroup bind:value={$wrappedLogoModeData.logoMode} name="logoMode" class="grid gap-2">
 					{#each data.wrappedLogoOptions as option (option.value)}
 						<SettingsOptionCard title={option.label} description={option.description} meta="Logo">
 							{#snippet control()}
@@ -252,11 +220,15 @@ function getThemeDescription(theme: string): string {
 					{/each}
 				</RadioGroup>
 
-				<input type="hidden" name="settingsVersion" value={data.wrappedLogoModeVersion} />
+				<input
+					type="hidden"
+					name="settingsVersion"
+					bind:value={$wrappedLogoModeData.settingsVersion}
+				/>
 
 				<SettingsActionBar>
-					<Button type="submit" class="tap-target" disabled={isSavingWrappedLogoMode}>
-						{isSavingWrappedLogoMode ? 'Saving…' : 'Save logo mode'}
+					<Button type="submit" class="tap-target" disabled={$wrappedLogoModeSubmitting}>
+						{$wrappedLogoModeSubmitting ? 'Saving…' : 'Save logo mode'}
 					</Button>
 				</SettingsActionBar>
 			</form>

--- a/src/routes/admin/settings/connections/+page.server.ts
+++ b/src/routes/admin/settings/connections/+page.server.ts
@@ -17,6 +17,7 @@ import {
 import { optionalTrimmed } from '$lib/server/admin/zod-helpers';
 import { requireAdminActions } from '$lib/server/auth/guards';
 import { testOpenAIConnection } from '$lib/server/funfacts/test-connection';
+import { logger } from '$lib/server/logging';
 import {
 	CredentialedUrlError,
 	envAllowsInsecureLocalPlexHttp,
@@ -176,21 +177,42 @@ export const actions: Actions = requireAdminActions({
 				try {
 					values.openaiBaseUrl = normalizeOpenAIBaseUrl(values.openaiBaseUrl);
 				} catch (err) {
-					return fail(400, {
-						error: err instanceof CredentialedUrlError ? err.message : 'Invalid OpenAI base URL'
-					});
+					const message =
+						err instanceof CredentialedUrlError ? err.message : 'Invalid OpenAI base URL';
+					// Mirror the Zod-level fieldErrors shape (H5) so the normalize-stage
+					// failure (e.g. a credentialed URL) also renders the inline field error,
+					// not just a toast.
+					return fail(400, { error: message, fieldErrors: { openaiBaseUrl: [message] } });
 				}
 			}
 
+			// C2: detect submitted-but-locked fields so we can surface a note.
+			// Only the five lockable fields are checked; plexAllowInsecureLocalHttp
+			// is not ENV-lockable and is excluded from both the locks object and the
+			// submitted-locked scan.
+			const locks = {
+				plexServerUrl: apiConfig.plex.serverUrl.isLocked,
+				plexToken: apiConfig.plex.token.isLocked,
+				openaiApiKey: apiConfig.openai.apiKey.isLocked,
+				openaiBaseUrl: apiConfig.openai.baseUrl.isLocked,
+				openaiModel: apiConfig.openai.model.isLocked
+			};
+			type LockKey = keyof typeof locks;
+			const lockableKeys: LockKey[] = [
+				'plexServerUrl',
+				'plexToken',
+				'openaiApiKey',
+				'openaiBaseUrl',
+				'openaiModel'
+			];
+			// A field counts as "submitted AND locked" when the FormData contained
+			// the key (values[k] !== undefined) AND the field is ENV-locked.
+			const submittedLockedFields = lockableKeys.filter((k) => values[k] !== undefined && locks[k]);
+			const hasLockedFieldSubmission = submittedLockedFields.length > 0;
+
 			const result = await setApiConfigAtomic({
 				values,
-				locks: {
-					plexServerUrl: apiConfig.plex.serverUrl.isLocked,
-					plexToken: apiConfig.plex.token.isLocked,
-					openaiApiKey: apiConfig.openai.apiKey.isLocked,
-					openaiBaseUrl: apiConfig.openai.baseUrl.isLocked,
-					openaiModel: apiConfig.openai.model.isLocked
-				},
+				locks,
 				submittedVersion: parsed.data.apiConfigVersion
 			});
 
@@ -205,7 +227,23 @@ export const actions: Actions = requireAdminActions({
 				await clearCachedServerMachineId();
 			}
 
-			return { success: true, message: 'API configuration updated' };
+			// A2: read the new version immediately after the atomic write so the
+			// client can bind both panels to the fresh token without waiting for
+			// invalidateAll to complete.
+			const newUpdatedAt = await getAppSettingsUpdatedAt(API_CONFIG_KEYS);
+			const newApiConfigVersion = settingsVersionISO(newUpdatedAt);
+
+			// C2: include informational note when a locked field was submitted.
+			let message = 'API configuration updated';
+			if (hasLockedFieldSubmission) {
+				message =
+					'API configuration updated. Some fields are controlled by environment variables and were not changed.';
+				logger.info(
+					`updateApiConfig: submitted values for ENV-locked fields were ignored (${submittedLockedFields.join(', ')})`
+				);
+			}
+
+			return { success: true, message, apiConfigVersion: newApiConfigVersion };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to update settings';
 			return fail(500, { error: message });

--- a/src/routes/admin/settings/connections/+page.svelte
+++ b/src/routes/admin/settings/connections/+page.svelte
@@ -44,6 +44,15 @@ let openaiBaseUrl = $state(settings.openaiBaseUrl.value);
 // svelte-ignore state_referenced_locally
 let openaiModel = $state(settings.openaiModel.value);
 
+// A2: track the current OCC version in $state so both panels immediately use
+// the fresh version returned by a successful save, without waiting for
+// invalidateAll to complete.
+// svelte-ignore state_referenced_locally
+let apiConfigVersion = $state(data.apiConfigVersion);
+
+// H5: inline field-level error for the OpenAI base URL field.
+let openaiBaseUrlError = $state<string | undefined>(undefined);
+
 let isSavingPlex = $state(false);
 let isTestingPlex = $state(false);
 let isSavingOpenai = $state(false);
@@ -94,6 +103,11 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 							}
 							await update({ reset: false });
 							if (result.type === 'success') {
+								// A2: advance local version so the OpenAI panel's next save
+								// uses the fresh token without waiting for invalidateAll.
+								const freshVersion = (result.data as { apiConfigVersion?: string })
+									?.apiConfigVersion;
+								if (freshVersion) apiConfigVersion = freshVersion;
 								plexTokenInput = '';
 								await invalidateAll();
 							}
@@ -168,7 +182,7 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 					value={plexAllowInsecureLocalHttp ? 'true' : 'false'}
 				/>
 
-				<input type="hidden" name="apiConfigVersion" value={data.apiConfigVersion} />
+				<input type="hidden" name="apiConfigVersion" value={apiConfigVersion} />
 			</form>
 
 			<SettingsActionBar>
@@ -241,12 +255,28 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 					return async ({ result, update }) => {
 						try {
 							if (result.type === 'success' || result.type === 'failure') {
-								handleFormToast(
-									result.data as { success?: boolean; message?: string; error?: string }
-								);
+								const data = result.data as {
+									success?: boolean;
+									message?: string;
+									error?: string;
+									fieldErrors?: Record<string, string[] | undefined>;
+									apiConfigVersion?: string;
+								};
+								// H5: capture inline field error for openaiBaseUrl.
+								if (result.type === 'failure') {
+									openaiBaseUrlError = data?.fieldErrors?.openaiBaseUrl?.[0];
+								} else {
+									openaiBaseUrlError = undefined;
+								}
+								handleFormToast(data);
 							}
 							await update({ reset: false });
 							if (result.type === 'success') {
+								// A2: advance local version immediately.
+								const freshVersion = (
+									result.data as { apiConfigVersion?: string }
+								)?.apiConfigVersion;
+								if (freshVersion) apiConfigVersion = freshVersion;
 								openaiApiKeyInput = '';
 								await invalidateAll();
 							}
@@ -295,6 +325,9 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 						bind:value={openaiBaseUrl}
 						disabled={openaiBaseUrlLocked}
 					/>
+					{#if openaiBaseUrlError}
+						<p class="text-xs text-destructive">{openaiBaseUrlError}</p>
+					{/if}
 				</div>
 
 				<div class="space-y-2">
@@ -314,7 +347,7 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 					/>
 				</div>
 
-				<input type="hidden" name="apiConfigVersion" value={data.apiConfigVersion} />
+				<input type="hidden" name="apiConfigVersion" value={apiConfigVersion} />
 			</form>
 
 			<SettingsActionBar>

--- a/src/routes/api/sync/status/stream/+server.ts
+++ b/src/routes/api/sync/status/stream/+server.ts
@@ -1,3 +1,4 @@
+import { requiresOnboarding } from '$lib/server/onboarding';
 import { getSyncProgress, type LiveSyncProgress } from '$lib/server/sync/progress';
 import type { SyncStatusStreamEvent, SyncStatusStreamProgress } from '$lib/sync/types';
 import type { RequestHandler } from './$types';
@@ -5,10 +6,15 @@ import type { RequestHandler } from './$types';
 /**
  * SSE stream of sync status.
  *
- * INTENTIONALLY PUBLIC: polled by the onboarding wizard before any user account
- * exists. `onboardingHandle` in `src/hooks.server.ts` explicitly skips `/api/sync`,
- * and `authorizationHandle` gates `/admin/*` only — this endpoint is reachable
- * pre-login by design.
+ * CONDITIONALLY PUBLIC: anonymous access is allowed only while onboarding is
+ * incomplete (i.e. before any user account exists), so the onboarding wizard
+ * can poll sync progress. Once onboarding is complete, a valid authenticated
+ * session is required; anonymous requests receive 401.
+ *
+ * `onboardingHandle` in `src/hooks.server.ts` skips `/api/sync` from its
+ * onboarding-redirect guard so this endpoint remains reachable during setup.
+ * `authHandle` still runs for every request, so `event.locals.user` is
+ * populated whenever a valid session cookie is present.
  *
  * Exposed fields per frame: event `type` ∈ {'connected','update','completed',
  * 'failed','cancelled','idle'}, boolean `inProgress`, and (for connected/update)
@@ -20,12 +26,27 @@ import type { RequestHandler } from './$types';
  * re-evaluating PII exposure.
  *
  * Rate-limited by the `api` bucket in `rateLimitHandle`.
+ *
+ * In-flight transition (G2): an anonymous stream opened during onboarding that
+ * is still open when onboarding completes is left to drain naturally. The
+ * onboarding wizard navigates away on completion, which drops the client
+ * connection and triggers the `request.signal` abort handler. No additional
+ * close-on-completion logic is needed.
  */
 
 const POLL_INTERVAL_ACTIVE_MS = 500;
 const POLL_INTERVAL_IDLE_MS = 2000;
 
-export const GET: RequestHandler = async ({ request }) => {
+export const GET: RequestHandler = async ({ request, locals }) => {
+	// Gate: allow anonymous access only while onboarding is incomplete.
+	// Once onboarding is done, a valid session is required.
+	const onboardingPending = await requiresOnboarding();
+	if (!onboardingPending && !locals.user) {
+		return new Response(JSON.stringify({ message: 'Unauthorized' }), {
+			status: 401,
+			headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
+		});
+	}
 	const stream = new ReadableStream({
 		async start(controller) {
 			const initialProgress = getSyncProgress();

--- a/src/routes/api/sync/status/stream/+server.ts
+++ b/src/routes/api/sync/status/stream/+server.ts
@@ -27,11 +27,12 @@ import type { RequestHandler } from './$types';
  *
  * Rate-limited by the `api` bucket in `rateLimitHandle`.
  *
- * In-flight transition (G2): an anonymous stream opened during onboarding that
- * is still open when onboarding completes is left to drain naturally. The
- * onboarding wizard navigates away on completion, which drops the client
- * connection and triggers the `request.signal` abort handler. No additional
- * close-on-completion logic is needed.
+ * In-flight transition (G2): the connection-open gate is re-validated on every
+ * poll tick. An anonymous stream that was opened during onboarding is closed as
+ * soon as onboarding completes, so an adversarial client that does NOT navigate
+ * away (e.g. a raw `EventSource`/`curl` left open) cannot keep receiving frames
+ * past the auth gate. Authenticated streams and still-onboarding anonymous
+ * streams are unaffected.
  */
 
 const POLL_INTERVAL_ACTIVE_MS = 500;
@@ -47,6 +48,11 @@ export const GET: RequestHandler = async ({ request, locals }) => {
 			headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' }
 		});
 	}
+	// Capture the auth state at connection open. The poll loop re-validates
+	// against this on every tick so an anonymous stream opened during onboarding
+	// is terminated the moment onboarding completes (see the G2 note above).
+	const capturedUser = locals.user ?? null;
+
 	const stream = new ReadableStream({
 		async start(controller) {
 			const initialProgress = getSyncProgress();
@@ -63,9 +69,33 @@ export const GET: RequestHandler = async ({ request, locals }) => {
 			let currentInterval =
 				initialProgress?.status === 'running' ? POLL_INTERVAL_ACTIVE_MS : POLL_INTERVAL_IDLE_MS;
 			let intervalId: ReturnType<typeof setInterval>;
+			let closed = false;
+			// Guards against overlapping ticks: the auth re-check awaits a DB read,
+			// so a slow read must not let the next interval fire reentrantly.
+			let polling = false;
 
-			const poll = () => {
+			const stop = () => {
+				if (closed) return;
+				closed = true;
+				clearInterval(intervalId);
+				controller.close();
+			};
+
+			const poll = async () => {
+				if (closed || polling) return;
+				polling = true;
 				try {
+					// Re-validate the connection-open gate: once onboarding is
+					// complete, an anonymous (unauthenticated) stream is no longer
+					// permitted and must be closed.
+					if (!capturedUser) {
+						const onboardingStillPending = await requiresOnboarding();
+						if (!onboardingStillPending) {
+							stop();
+							return;
+						}
+					}
+
 					const currentProgress = getSyncProgress();
 					const isActive = currentProgress?.status === 'running';
 					const newInterval = isActive ? POLL_INTERVAL_ACTIVE_MS : POLL_INTERVAL_IDLE_MS;
@@ -123,15 +153,14 @@ export const GET: RequestHandler = async ({ request, locals }) => {
 					}
 				} catch {
 					// Silently ignore errors
+				} finally {
+					polling = false;
 				}
 			};
 
 			intervalId = setInterval(poll, currentInterval);
 
-			request.signal.addEventListener('abort', () => {
-				clearInterval(intervalId);
-				controller.close();
-			});
+			request.signal.addEventListener('abort', stop);
 		}
 	});
 

--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -8,6 +8,7 @@
 import { fail, redirect } from '@sveltejs/kit';
 import {
 	getAnonymizationMode,
+	getApiConfigWithSources,
 	getCachedServerName,
 	getFunFactFrequency,
 	getUITheme,
@@ -59,7 +60,8 @@ export const load: PageServerLoad = async ({ parent, locals, url, cookies }) => 
 		logoMode,
 		shareMode,
 		allowUserControl,
-		funFactFrequency
+		funFactFrequency,
+		apiConfig
 	] = await Promise.all([
 		getCachedServerName(),
 		getUITheme(),
@@ -68,8 +70,14 @@ export const load: PageServerLoad = async ({ parent, locals, url, cookies }) => 
 		getWrappedLogoMode(),
 		getGlobalDefaultShareMode(),
 		getGlobalAllowUserControl(),
-		getFunFactFrequency()
+		getFunFactFrequency(),
+		getApiConfigWithSources()
 	]);
+
+	// Fun facts are only active when an effective OpenAI API key is present.
+	// Without a key the engine falls back to built-in templates only, but the
+	// onboarding "Configure" step treats that as AI fun facts being off.
+	const enableFunFacts = Boolean(apiConfig.openai.apiKey.value.trim());
 
 	return {
 		...parentData,
@@ -79,6 +87,7 @@ export const load: PageServerLoad = async ({ parent, locals, url, cookies }) => 
 			progress: syncProgress,
 			historyCount
 		},
+		enableFunFacts,
 		configSummary: {
 			serverName: serverName || 'Plex Server',
 			uiTheme: formatThemeName(uiTheme),
@@ -87,7 +96,7 @@ export const load: PageServerLoad = async ({ parent, locals, url, cookies }) => 
 			logoMode: formatLogoMode(logoMode),
 			shareMode: formatShareMode(shareMode),
 			allowUserControl: allowUserControl ? 'Allowed' : 'Locked by admin',
-			funFacts: formatFunFactFrequency(funFactFrequency)
+			funFacts: enableFunFacts ? formatFunFactFrequency(funFactFrequency) : 'Disabled'
 		}
 	};
 };

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -1,6 +1,10 @@
 import { fail, redirect } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
-import { getApiConfigWithSources, hasPlexEnvConfig } from '$lib/server/admin/settings.service';
+import {
+	getApiConfigWithSources,
+	hasPlexEnvConfig,
+	toSafeConfigValue
+} from '$lib/server/admin/settings.service';
 import { messageForMembershipFailure, verifyServerMembership } from '$lib/server/auth/membership';
 import { getSessionPlexToken } from '$lib/server/auth/session';
 import type { MembershipResult } from '$lib/server/auth/types';
@@ -30,6 +34,12 @@ export const load: PageServerLoad = async ({ parent }) => {
 	let configuredUrlReachable = true;
 	let configuredUrlErrorReason: string | null = null;
 
+	// Per-field ENV lock info — mirrors how connections/+page.server.ts builds it
+	// so the onboarding Plex step can show ENV badges on locked fields.
+	const apiConfig = await getApiConfigWithSources();
+	const plexServerUrlLocked = apiConfig.plex.serverUrl.isLocked;
+	const plexTokenSafe = toSafeConfigValue(apiConfig.plex.token);
+
 	if (parentData.hasEnvConfig) {
 		// Force a live /identity probe on load so the reachability banner reflects
 		// the current server state, not a possibly-stale cached machineId that
@@ -46,7 +56,10 @@ export const load: PageServerLoad = async ({ parent }) => {
 		isNonAdminUser: parentData.isAuthenticated && !parentData.isAdmin,
 		configuredMachineId,
 		configuredUrlReachable,
-		configuredUrlErrorReason
+		configuredUrlErrorReason,
+		plexServerUrlLocked,
+		plexTokenLocked: plexTokenSafe.isLocked,
+		plexTokenHasValue: plexTokenSafe.hasValue
 	};
 };
 

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -544,25 +544,53 @@ function formatServerUrl(url: string | null): string {
 				<div class="preconfigured-info">
 					<div class="preconfigured-header">
 						<span class="preconfigured-title">Plex Media Server</span>
-						<span class="preconfigured-badge">
-							<svg
-								class="lock-icon"
-								viewBox="0 0 24 24"
-								fill="none"
-								stroke="currentColor"
-								stroke-width="2"
-							>
-								<rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-								<path d="M7 11V7a5 5 0 0 1 10 0v4" />
-							</svg>
-							ENV
-						</span>
 					</div>
 					{#if data.plexServerName}
 						<span class="preconfigured-server-name">{data.plexServerName}</span>
 					{/if}
 					{#if data.plexServerUrl}
-						<span class="preconfigured-url">{formatServerUrl(data.plexServerUrl)}</span>
+						<div class="preconfigured-field-row">
+							<span class="preconfigured-field-label">Server URL</span>
+							<span class="preconfigured-url">{formatServerUrl(data.plexServerUrl)}</span>
+							{#if data.plexServerUrlLocked}
+								<span class="preconfigured-badge" aria-label="Set by environment variable">
+									<svg
+										class="lock-icon"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="2"
+										aria-hidden="true"
+									>
+										<rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+										<path d="M7 11V7a5 5 0 0 1 10 0v4" />
+									</svg>
+									ENV
+								</span>
+							{/if}
+						</div>
+					{/if}
+					{#if data.plexTokenHasValue || data.plexTokenLocked}
+						<div class="preconfigured-field-row">
+							<span class="preconfigured-field-label">Token</span>
+							<span class="preconfigured-url">{data.plexTokenHasValue ? '••••••••' : '(not set)'}</span>
+							{#if data.plexTokenLocked}
+								<span class="preconfigured-badge" aria-label="Set by environment variable">
+									<svg
+										class="lock-icon"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="2"
+										aria-hidden="true"
+									>
+										<rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+										<path d="M7 11V7a5 5 0 0 1 10 0v4" />
+									</svg>
+									ENV
+								</span>
+							{/if}
+						</div>
 					{/if}
 				</div>
 				<div class="preconfigured-check">
@@ -1250,6 +1278,22 @@ function formatServerUrl(url: string | null): string {
 			font-size: 0.875rem;
 			font-weight: 500;
 			color: rgba(255, 255, 255, 0.7);
+		}
+
+		.preconfigured-field-row {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			flex-wrap: wrap;
+		}
+
+		.preconfigured-field-label {
+			font-size: 0.75rem;
+			font-weight: 500;
+			color: rgba(255, 255, 255, 0.45);
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+			flex-shrink: 0;
 		}
 
 		.preconfigured-badge {

--- a/src/routes/onboarding/proxy-trust/+page.svelte
+++ b/src/routes/onboarding/proxy-trust/+page.svelte
@@ -416,7 +416,9 @@ function toggleDetails() {
 
 			<button type="button" class="details-toggle" onclick={toggleDetails} aria-expanded={showDetails}>
 				<span>{showDetails ? 'Hide technical details' : 'Show technical details'}</span>
-				<ChevronDownIcon class="size-4 chevron" data-open={showDetails} aria-hidden="true" />
+				<span class="chevron-wrap" class:open={showDetails} aria-hidden="true">
+					<ChevronDownIcon class="size-4" />
+				</span>
 			</button>
 
 			{#if showDetails}
@@ -740,11 +742,13 @@ function toggleDetails() {
 		outline-offset: 2px;
 	}
 
-	.details-toggle :global(.chevron) {
+	.chevron-wrap {
+		display: inline-flex;
+		align-items: center;
 		transition: transform 0.2s ease;
 	}
 
-	.details-toggle :global(.chevron[data-open='true']) {
+	.chevron-wrap.open {
 		transform: rotate(180deg);
 	}
 

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -169,8 +169,12 @@ export const load: PageServerLoad = async ({ parent }) => {
 		getAppSetting(AppSettingsKey.FUN_FACTS_AI_PERSONA)
 	]);
 
-	// Check if OpenAI is configured (for AI features section)
-	const hasOpenAI = hasOpenAIEnvConfig();
+	// Check if OpenAI is configured (for AI features section). Reflect both an
+	// env-provided key AND a stored DB key: the AI-key-missing warning must not
+	// nag when AI is already operative from a previously saved DB credential
+	// (env still takes precedence, but a DB key alone is enough to drive AI).
+	const apiConfig = await getApiConfigWithSources();
+	const hasOpenAI = hasOpenAIEnvConfig() || Boolean(apiConfig.openai.apiKey.value.trim());
 
 	// Build theme options
 	const themeOptions = Object.entries(ThemePresets).map(([key, value]) => ({

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -55,6 +55,11 @@ let apiKeyError = $state<string | null>(null);
 let baseUrlError = $state<string | null>(null);
 let visibleError = $derived(submitError ?? form?.error ?? null);
 
+// ISSUE-004: warn when AI fun facts are enabled but no OpenAI key will be in
+// effect — neither typed here nor already configured via env/DB (data.hasOpenAI).
+// Non-blocking: onboarding still proceeds and the built-in template generator runs.
+let showAiKeyWarning = $derived(enableFunFacts && !openaiApiKey.trim() && !data.hasOpenAI);
+
 const aiPersonaOptions = [
 	{ value: 'witty', label: 'Witty', description: 'Clever and humorous' },
 	{ value: 'wholesome', label: 'Wholesome', description: 'Warm and kind' },
@@ -248,11 +253,34 @@ function getThemeColors(themeValue: string) {
 				id="onboarding-settings-form"
 				method="POST"
 				action="?/saveSettings"
-				use:enhance={() => {
+				use:enhance={({ formData }) => {
 					isSubmitting = true;
 					submitError = null;
 					apiKeyError = null;
 					baseUrlError = null;
+					// Authoritatively serialize the live runes state into the submitted
+					// FormData. The hidden <input value={…}> mirrors update the value
+					// *attribute*, but FormData reads the *property*; for fields toggled by
+					// <button type="button" onclick> inside a destroyed/recreated {#if}
+					// carousel branch the property can keep its initial (default) value, so
+					// button-driven selections (UI/Wrapped theme, User Control, Public
+					// Landing Lookup) were silently lost. Overwriting formData here makes the
+					// submission reflect the runes state regardless of DOM divergence.
+					formData.set('uiTheme', uiTheme);
+					formData.set('wrappedTheme', wrappedTheme);
+					formData.set('anonymizationMode', anonymizationMode);
+					formData.set('logoMode', wrappedLogoMode);
+					formData.set('defaultShareMode', defaultShareMode);
+					formData.set('allowUserControl', allowUserControl ? 'true' : 'false');
+					formData.set('serverWrappedShareMode', serverWrappedShareMode);
+					formData.set('publicLandingLookup', publicLandingLookup ? 'true' : 'false');
+					formData.set('enabledSlides', enabledSlidesString);
+					formData.set('enableFunFacts', enableFunFacts ? 'true' : 'false');
+					formData.set('funFactFrequency', enableFunFacts ? funFactFrequency : '');
+					formData.set('openaiApiKey', enableFunFacts ? openaiApiKey : '');
+					formData.set('openaiBaseUrl', enableFunFacts ? openaiBaseUrl : '');
+					formData.set('openaiModel', enableFunFacts ? openaiModel : '');
+					formData.set('aiPersona', enableFunFacts ? aiPersona : '');
 					return async ({ result, update }) => {
 						try {
 							if (result.type === 'failure') {
@@ -444,7 +472,7 @@ function getThemeColors(themeValue: string) {
 										<label class="radio-card" class:selected={wrappedLogoMode === option.value}>
 											<input
 												type="radio"
-												name="logoMode"
+												name="logoModeRadio"
 												value={option.value}
 												bind:group={wrappedLogoMode}
 											/>
@@ -470,7 +498,7 @@ function getThemeColors(themeValue: string) {
 										<label class="radio-card" class:selected={defaultShareMode === option.value}>
 											<input
 												type="radio"
-												name="defaultShareMode"
+												name="defaultShareModeRadio"
 												value={option.value}
 												checked={defaultShareMode === option.value}
 												onchange={() => (defaultShareMode = option.value)}
@@ -539,15 +567,6 @@ function getThemeColors(themeValue: string) {
 									>
 										<span class="toggle-knob"></span>
 									</button>
-									<input
-										type="checkbox"
-										name="allowUserControl"
-										value="true"
-										bind:checked={allowUserControl}
-										class="sr-only"
-										tabindex="-1"
-										aria-hidden="true"
-									/>
 								</label>
 							</div>
 
@@ -697,6 +716,12 @@ function getThemeColors(themeValue: string) {
 									{#if apiKeyError}
 										<p id="onboarding-openai-api-key-error" class="field-error" role="alert">
 											{apiKeyError}
+										</p>
+									{/if}
+									{#if showAiKeyWarning}
+										<p class="ai-key-warning" role="status">
+											Enter an OpenAI API key for AI fun facts to work — without it, the
+											built-in template generator is used.
 										</p>
 									{/if}
 								</div>
@@ -1220,6 +1245,18 @@ function getThemeColors(themeValue: string) {
 			font-size: 0.8rem;
 			color: rgba(255, 255, 255, 0.45);
 			margin-bottom: 0.75rem;
+		}
+
+		/* AI-key-missing notice (ISSUE-004): AI enabled but no effective key. */
+		.ai-key-warning {
+			margin: 0.625rem 0 0;
+			padding: 0.625rem 0.75rem;
+			font-size: 0.78rem;
+			line-height: 1.4;
+			color: #fcd34d;
+			background: rgba(245, 158, 11, 0.12);
+			border: 1px solid rgba(245, 158, 11, 0.35);
+			border-radius: 0.625rem;
 		}
 
 		/* Admin contradiction notice: landing lookup on + non-public default. */

--- a/src/routes/wrapped/[year]/+page.server.ts
+++ b/src/routes/wrapped/[year]/+page.server.ts
@@ -19,12 +19,18 @@ import { getServerStatsWithAnonymization } from '$lib/server/stats/engine';
 import { triggerLiveSyncIfNeeded } from '$lib/server/sync/live-sync';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ params, locals, setHeaders }) => {
+export const load: PageServerLoad = async ({ params, locals, parent, setHeaders }) => {
 	setHeaders({ 'cache-control': 'no-store' });
 
 	const year = parseInt(params.year, 10);
 	if (Number.isNaN(year) || year < 2000 || year > 2100) {
 		error(404, 'Invalid year');
+	}
+
+	const currentYear = new Date().getFullYear();
+	const { availableYears } = await parent();
+	if (!availableYears.includes(year) && year !== currentYear) {
+		error(404, 'No data found for this year');
 	}
 
 	try {

--- a/tests/unit/admin/appearance-actions.test.ts
+++ b/tests/unit/admin/appearance-actions.test.ts
@@ -132,6 +132,17 @@ describe('appearance nested route — updateUITheme', () => {
 		);
 		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid theme selection' } });
 	});
+
+	it('rejects an absent uiTheme field as 400 instead of silently persisting the enum default', async () => {
+		// A request that omits uiTheme entirely (e.g. a stale client) must not
+		// have the required z.enum silently filled with its first member
+		// ('modern-minimal') and persisted. Expect a 400, no write.
+		const result = await run(
+			makeRequest('updateUITheme', { settingsVersion: new Date(0).toISOString() })
+		);
+		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid theme selection' } });
+		expect(await getUITheme()).toBe('modern-minimal'); // unchanged DB default, not a persisted write
+	});
 });
 
 describe('appearance nested route — updateWrappedTheme', () => {

--- a/tests/unit/admin/appearance-actions.test.ts
+++ b/tests/unit/admin/appearance-actions.test.ts
@@ -213,6 +213,17 @@ describe('appearance nested route — updateWrappedTheme', () => {
 		);
 		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid theme selection' } });
 	});
+
+	it('rejects an absent wrappedTheme field as 400 instead of silently persisting the enum default', async () => {
+		// A request that omits wrappedTheme entirely (e.g. a stale client) must not
+		// have the required z.enum silently filled with its first member
+		// ('modern-minimal') and persisted. Expect a 400, no write.
+		const result = await run(
+			makeRequest('updateWrappedTheme', { settingsVersion: new Date(0).toISOString() })
+		);
+		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid theme selection' } });
+		expect(await getWrappedTheme()).toBe('modern-minimal'); // unchanged DB default, not a persisted write
+	});
 });
 
 describe('appearance nested route — updateWrappedLogoMode', () => {
@@ -289,6 +300,17 @@ describe('appearance nested route — updateWrappedLogoMode', () => {
 			})
 		);
 		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid logo mode' } });
+	});
+
+	it('rejects an absent logoMode field as 400 instead of silently persisting the enum default', async () => {
+		// A request that omits logoMode entirely (e.g. a stale client) must not
+		// have the required z.enum silently filled with its first member
+		// ('always_show') and persisted. Expect a 400, no write.
+		const result = await run(
+			makeRequest('updateWrappedLogoMode', { settingsVersion: new Date(0).toISOString() })
+		);
+		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid logo mode' } });
+		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.ALWAYS_SHOW); // unchanged DB default
 	});
 });
 

--- a/tests/unit/admin/appearance-actions.test.ts
+++ b/tests/unit/admin/appearance-actions.test.ts
@@ -11,9 +11,12 @@ import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
 import { actions } from '../../../src/routes/admin/settings/appearance/+page.server';
 
-// The actions handler signatures take `{ request, locals }` (and `url` for some).
-// requireAdminActions wraps each handler so the test exercises both the admin
-// guard and the action body.
+// The actions handler signatures take `{ request, locals }`. requireAdminActions
+// wraps each handler so the test exercises both the admin guard and the action
+// body. Post-ISSUE-015 the appearance route uses Superforms with inline OCC:
+// success returns `{ form, success, message }` and an advanced
+// `form.data.settingsVersion`; a stale/blank version returns
+// `fail(409, { form, conflict: true, error })`.
 type UpdateUIThemeAction = NonNullable<typeof actions.updateUITheme>;
 type UpdateWrappedThemeAction = NonNullable<typeof actions.updateWrappedTheme>;
 type UpdateWrappedLogoModeAction = NonNullable<typeof actions.updateWrappedLogoMode>;
@@ -21,6 +24,8 @@ type UpdateWrappedLogoModeAction = NonNullable<typeof actions.updateWrappedLogoM
 const adminLocals = {
 	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
 } as unknown as App.Locals;
+
+const OCC_MESSAGE = 'Settings changed in another tab. Please reload.';
 
 function makeRequest(action: string, fields: Record<string, string>): Request {
 	const formData = new FormData();
@@ -44,7 +49,7 @@ describe('appearance nested route — updateUITheme', () => {
 	it('persists a valid theme with epoch settingsVersion on a fresh DB', async () => {
 		const result = await run(
 			makeRequest('updateUITheme', {
-				theme: 'modern-minimal',
+				uiTheme: 'modern-minimal',
 				settingsVersion: new Date(0).toISOString()
 			})
 		);
@@ -52,24 +57,57 @@ describe('appearance nested route — updateUITheme', () => {
 		expect(await getUITheme()).toBe('modern-minimal');
 	});
 
-	it('rejects blank settingsVersion as 409 __OCC_CONFLICT__', async () => {
+	it('returns an advanced settingsVersion on a clean save (not the submitted epoch)', async () => {
+		const result = (await run(
+			makeRequest('updateUITheme', {
+				uiTheme: 'supabase',
+				settingsVersion: new Date(0).toISOString()
+			})
+		)) as { form: { data: { settingsVersion: string } }; success?: boolean };
+		expect(result).toMatchObject({ success: true });
+		expect(result.form.data.settingsVersion).not.toBe(new Date(0).toISOString());
+	});
+
+	it('advances the returned settingsVersion so two consecutive saves both succeed (ISSUE-015)', async () => {
+		const first = (await run(
+			makeRequest('updateUITheme', {
+				uiTheme: 'supabase',
+				settingsVersion: new Date(0).toISOString()
+			})
+		)) as { form: { data: { settingsVersion: string } }; success?: boolean };
+		expect(first).toMatchObject({ success: true });
+		const returnedVersion = first.form.data.settingsVersion;
+		expect(returnedVersion).not.toBe(new Date(0).toISOString());
+
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+		// Second consecutive save reusing the FIRST save's returned version must
+		// succeed without a reload (no false 409). This is the regression the
+		// pre-migration server (which returned no fresh version) failed.
+		const second = await run(
+			makeRequest('updateUITheme', {
+				uiTheme: 'doom-64',
+				settingsVersion: returnedVersion
+			})
+		);
+		expect(second).toMatchObject({ success: true });
+		expect(await getUITheme()).toBe('doom-64');
+	});
+
+	it('rejects blank settingsVersion as 409 conflict', async () => {
 		const result = await run(
-			makeRequest('updateUITheme', { theme: 'modern-minimal', settingsVersion: '' })
+			makeRequest('updateUITheme', { uiTheme: 'modern-minimal', settingsVersion: '' })
 		);
 		expect(result).toMatchObject({
 			status: 409,
-			data: { error: 'Settings changed in another tab. Please reload.', code: '__OCC_CONFLICT__' }
+			data: { conflict: true, error: OCC_MESSAGE }
 		});
-		// `current` ISO included so the client can refresh
-		expect(typeof (result as { data: { settingsVersion: unknown } }).data.settingsVersion).toBe(
-			'string'
-		);
 	});
 
 	it('rejects stale settingsVersion as 409 without overwriting current value', async () => {
 		await run(
 			makeRequest('updateUITheme', {
-				theme: 'soviet-red',
+				uiTheme: 'soviet-red',
 				settingsVersion: new Date(0).toISOString()
 			})
 		);
@@ -77,21 +115,18 @@ describe('appearance nested route — updateUITheme', () => {
 
 		const result = await run(
 			makeRequest('updateUITheme', {
-				theme: 'doom-64',
+				uiTheme: 'doom-64',
 				settingsVersion: new Date(0).toISOString()
 			})
 		);
-		expect(result).toMatchObject({
-			status: 409,
-			data: { error: 'Settings changed in another tab. Please reload.', code: '__OCC_CONFLICT__' }
-		});
+		expect(result).toMatchObject({ status: 409, data: { conflict: true } });
 		expect(await getUITheme()).toBe('soviet-red');
 	});
 
 	it('rejects unknown theme as 400', async () => {
 		const result = await run(
 			makeRequest('updateUITheme', {
-				theme: 'not-a-theme',
+				uiTheme: 'not-a-theme',
 				settingsVersion: new Date(0).toISOString()
 			})
 		);
@@ -120,32 +155,26 @@ describe('appearance nested route — updateWrappedTheme', () => {
 		expect(await getWrappedTheme()).toBe('amber-minimal');
 	});
 
-	it('falls back to the `theme` field when `wrappedTheme` is missing', async () => {
-		// The action reads `wrappedTheme ?? theme` because the monolith UI used
-		// both names across panels; the nested route preserves the fallback so
-		// stale clients still work.
-		const result = await run(
+	it('advances the returned settingsVersion so two consecutive saves both succeed (ISSUE-015)', async () => {
+		const first = (await run(
 			makeRequest('updateWrappedTheme', {
-				theme: 'supabase',
+				wrappedTheme: 'amber-minimal',
 				settingsVersion: new Date(0).toISOString()
 			})
-		);
-		expect(result).toMatchObject({ success: true });
-		expect(await getWrappedTheme()).toBe('supabase');
-	});
+		)) as { form: { data: { settingsVersion: string } }; success?: boolean };
+		expect(first).toMatchObject({ success: true });
+		const returnedVersion = first.form.data.settingsVersion;
+		expect(returnedVersion).not.toBe(new Date(0).toISOString());
 
-	it('prefers `wrappedTheme` over `theme` when both are present (?? precedence)', async () => {
-		// Pin the documented precedence of `wrappedTheme ?? theme`. If a client
-		// happens to send both (a stale UI from the monolith era + the new
-		// per-tab input both wired up), wrappedTheme wins.
-		const result = await run(
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+		const second = await run(
 			makeRequest('updateWrappedTheme', {
 				wrappedTheme: 'doom-64',
-				theme: 'amber-minimal',
-				settingsVersion: new Date(0).toISOString()
+				settingsVersion: returnedVersion
 			})
 		);
-		expect(result).toMatchObject({ success: true });
+		expect(second).toMatchObject({ success: true });
 		expect(await getWrappedTheme()).toBe('doom-64');
 	});
 
@@ -159,9 +188,19 @@ describe('appearance nested route — updateWrappedTheme', () => {
 		);
 		expect(result).toMatchObject({
 			status: 409,
-			data: { error: 'Settings changed in another tab. Please reload.', code: '__OCC_CONFLICT__' }
+			data: { conflict: true, error: OCC_MESSAGE }
 		});
 		expect(await getWrappedTheme()).toBe('supabase');
+	});
+
+	it('rejects unknown theme as 400', async () => {
+		const result = await run(
+			makeRequest('updateWrappedTheme', {
+				wrappedTheme: 'not-a-theme',
+				settingsVersion: new Date(0).toISOString()
+			})
+		);
+		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid theme selection' } });
 	});
 });
 
@@ -195,7 +234,30 @@ describe('appearance nested route — updateWrappedLogoMode', () => {
 		});
 	}
 
-	it('rejects blank settingsVersion as 409 __OCC_CONFLICT__', async () => {
+	it('advances the returned settingsVersion so two consecutive saves both succeed (ISSUE-015)', async () => {
+		const first = (await run(
+			makeRequest('updateWrappedLogoMode', {
+				logoMode: WrappedLogoMode.ALWAYS_HIDE,
+				settingsVersion: new Date(0).toISOString()
+			})
+		)) as { form: { data: { settingsVersion: string } }; success?: boolean };
+		expect(first).toMatchObject({ success: true });
+		const returnedVersion = first.form.data.settingsVersion;
+		expect(returnedVersion).not.toBe(new Date(0).toISOString());
+
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+		const second = await run(
+			makeRequest('updateWrappedLogoMode', {
+				logoMode: WrappedLogoMode.USER_CHOICE,
+				settingsVersion: returnedVersion
+			})
+		);
+		expect(second).toMatchObject({ success: true });
+		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.USER_CHOICE);
+	});
+
+	it('rejects blank settingsVersion as 409 conflict', async () => {
 		const result = await run(
 			makeRequest('updateWrappedLogoMode', {
 				logoMode: WrappedLogoMode.ALWAYS_HIDE,
@@ -204,7 +266,7 @@ describe('appearance nested route — updateWrappedLogoMode', () => {
 		);
 		expect(result).toMatchObject({
 			status: 409,
-			data: { error: 'Settings changed in another tab. Please reload.', code: '__OCC_CONFLICT__' }
+			data: { conflict: true, error: OCC_MESSAGE }
 		});
 	});
 
@@ -218,3 +280,7 @@ describe('appearance nested route — updateWrappedLogoMode', () => {
 		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid logo mode' } });
 	});
 });
+
+// Touch setAppSetting so the import isn't dropped if a future refactor inlines
+// the priming logic above into a helper.
+void setAppSetting;

--- a/tests/unit/admin/appearance-actions.test.ts
+++ b/tests/unit/admin/appearance-actions.test.ts
@@ -137,10 +137,15 @@ describe('appearance nested route — updateUITheme', () => {
 		// A request that omits uiTheme entirely (e.g. a stale client) must not
 		// have the required z.enum silently filled with its first member
 		// ('modern-minimal') and persisted. Expect a 400, no write.
-		const result = await run(
+		const result = (await run(
 			makeRequest('updateUITheme', { settingsVersion: new Date(0).toISOString() })
-		);
+		)) as { status: number; data: { error: string; form: { valid: boolean; message?: string } } };
 		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid theme selection' } });
+		// setMessage(..., { status: 400 }) makes form.valid honest (the absent enum
+		// is silently coerced, so without this the client would show a false 'Saved'
+		// toast — onUpdated branches on form.valid). Pin valid===false + the message.
+		expect(result.data.form.valid).toBe(false);
+		expect(result.data.form.message).toBe('Invalid theme selection');
 		expect(await getUITheme()).toBe('modern-minimal'); // unchanged DB default, not a persisted write
 	});
 });
@@ -218,10 +223,14 @@ describe('appearance nested route — updateWrappedTheme', () => {
 		// A request that omits wrappedTheme entirely (e.g. a stale client) must not
 		// have the required z.enum silently filled with its first member
 		// ('modern-minimal') and persisted. Expect a 400, no write.
-		const result = await run(
+		const result = (await run(
 			makeRequest('updateWrappedTheme', { settingsVersion: new Date(0).toISOString() })
-		);
+		)) as { status: number; data: { error: string; form: { valid: boolean; message?: string } } };
 		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid theme selection' } });
+		// See updateUITheme: form.valid must be false so the client toast reports a
+		// failure instead of a false 'Saved'.
+		expect(result.data.form.valid).toBe(false);
+		expect(result.data.form.message).toBe('Invalid theme selection');
 		expect(await getWrappedTheme()).toBe('modern-minimal'); // unchanged DB default, not a persisted write
 	});
 });
@@ -306,10 +315,14 @@ describe('appearance nested route — updateWrappedLogoMode', () => {
 		// A request that omits logoMode entirely (e.g. a stale client) must not
 		// have the required z.enum silently filled with its first member
 		// ('always_show') and persisted. Expect a 400, no write.
-		const result = await run(
+		const result = (await run(
 			makeRequest('updateWrappedLogoMode', { settingsVersion: new Date(0).toISOString() })
-		);
+		)) as { status: number; data: { error: string; form: { valid: boolean; message?: string } } };
 		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid logo mode' } });
+		// See updateUITheme: form.valid must be false so the client toast reports a
+		// failure instead of a false 'Saved'.
+		expect(result.data.form.valid).toBe(false);
+		expect(result.data.form.message).toBe('Invalid logo mode');
 		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.ALWAYS_SHOW); // unchanged DB default
 	});
 });

--- a/tests/unit/admin/connections-actions.test.ts
+++ b/tests/unit/admin/connections-actions.test.ts
@@ -234,6 +234,66 @@ describe('connections nested route — updateApiConfig (OCC + schema)', () => {
 		);
 		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid input' } });
 	});
+
+	// H5: bad openaiBaseUrl returns fieldErrors.openaiBaseUrl (not just a generic error)
+	it('returns fieldErrors.openaiBaseUrl for an invalid base URL (H5)', async () => {
+		const result = await run(
+			makeRequest('updateApiConfig', {
+				openaiBaseUrl: 'not-a-url',
+				apiConfigVersion: new Date(Date.now() + 60_000).toISOString()
+			})
+		);
+		expect(result).toMatchObject({
+			status: 400,
+			data: {
+				error: 'Invalid input',
+				fieldErrors: { openaiBaseUrl: ['Invalid URL format'] }
+			}
+		});
+	});
+
+	// A2: successful save returns a fresh apiConfigVersion
+	it('returns a fresh apiConfigVersion on success (A2)', async () => {
+		await withUnlockedPlex(async () => {
+			// Seed a valid Plex URL so the save can succeed.
+			await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'https://plex.local:32400');
+
+			const formData = new FormData();
+			formData.set('openaiModel', 'gpt-4o-mini');
+			formData.set('apiConfigVersion', new Date(Date.now() + 60_000).toISOString());
+			const request = new Request('http://localhost/admin/settings/connections?/updateApiConfig', {
+				method: 'POST',
+				body: formData
+			});
+
+			const result = await run(request);
+			// The result must be a success object (not a failure ActionResult).
+			expect(result).toMatchObject({ success: true });
+			// It must carry a fresh apiConfigVersion string.
+			const version = (result as { apiConfigVersion?: string }).apiConfigVersion;
+			expect(typeof version).toBe('string');
+			expect(version!.length).toBeGreaterThan(0);
+			// The returned version must be parseable as an ISO date.
+			expect(Number.isNaN(Date.parse(version!))).toBe(false);
+		});
+	});
+
+	// C2: submitting a value for a locked field yields the informational note
+	it('includes locked-field note in success message when a locked field is submitted (C2)', async () => {
+		// The test harness has PLEX_SERVER_URL locked via the mock env.
+		// Submit plexServerUrl (the locked field) alongside a valid apiConfigVersion.
+		// The action should succeed (setApiConfigAtomic ignores locked fields) and
+		// include the informational note in the message.
+		const result = await run(
+			makeRequest('updateApiConfig', {
+				plexServerUrl: 'https://plex.local:32400',
+				apiConfigVersion: new Date(Date.now() + 60_000).toISOString()
+			})
+		);
+		expect(result).toMatchObject({ success: true });
+		const message = (result as { message?: string }).message ?? '';
+		expect(message).toContain('Some fields are controlled by environment variables');
+	});
 });
 
 describe('connections nested route — clearOpenaiKey', () => {

--- a/tests/unit/admin/privacy-actions.test.ts
+++ b/tests/unit/admin/privacy-actions.test.ts
@@ -246,6 +246,40 @@ describe('privacy nested route — updateUserDefaults', () => {
 		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid input' } });
 	});
 
+	it('ISSUE-016 regression: stale save 409s with the surfaceOccConflict marker, fresh save advances version', async () => {
+		// Locks in the #125 fix: updateUserDefaults must return the exact conflict
+		// shape `surfaceOccConflict` keys on (`conflict: true` + OCC message) for a
+		// stale settingsVersion, AND a fresh successful save must advance the
+		// returned settingsVersion. Together these prevent the false-success /
+		// sequential-save staleness class of bug on the privacy tab.
+		const fresh = (await run(
+			makeRequest('updateUserDefaults', {
+				defaultShareMode: 'public',
+				allowUserControl: 'true',
+				settingsVersion: new Date(0).toISOString()
+			})
+		)) as { form: { data: { settingsVersion: string } }; success?: boolean };
+		expect(fresh).toMatchObject({ success: true });
+		const advanced = fresh.form.data.settingsVersion;
+		expect(advanced).not.toBe(new Date(0).toISOString());
+
+		// A subsequent submission with the now-stale epoch must 409 with the
+		// marker, not false-succeed.
+		const stale = await run(
+			makeRequest('updateUserDefaults', {
+				defaultShareMode: 'private-oauth',
+				allowUserControl: 'false',
+				settingsVersion: new Date(0).toISOString()
+			})
+		);
+		expect(stale).toMatchObject({
+			status: 409,
+			data: { conflict: true, error: 'Settings changed in another tab. Please reload.' }
+		});
+		// Stale save did not overwrite the fresh value.
+		expect(await getGlobalDefaultShareMode()).toBe('public');
+	});
+
 	it('rejects unknown defaultShareMode as 400', async () => {
 		const result = await run(
 			makeRequest('updateUserDefaults', {

--- a/tests/unit/admin/settings-actions.test.ts
+++ b/tests/unit/admin/settings-actions.test.ts
@@ -540,12 +540,16 @@ describe('admin updateWrappedLogoMode action', () => {
 		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.ALWAYS_HIDE);
 	});
 
-	it('rejects missing logo mode without persisting a change', async () => {
+	it('rejects an unknown logo mode value without persisting a change', async () => {
+		// Post-ISSUE-015 the route uses Superforms: a *present-but-invalid* enum
+		// value fails validation → 400 'Invalid logo mode'. (A wholly *missing*
+		// field would instead default to the first enum value per Superforms
+		// semantics, so this test asserts the invalid-value branch explicitly.)
 		await setAppSetting(AppSettingsKey.WRAPPED_LOGO_MODE, WrappedLogoMode.ALWAYS_HIDE);
 
 		const futureVersion = new Date(Date.now() + 60_000).toISOString();
 		const result = await runUpdateWrappedLogoMode(
-			createWrappedLogoModeRequest(undefined, futureVersion)
+			createWrappedLogoModeRequest('not-a-mode', futureVersion)
 		);
 
 		expect(result).toMatchObject({
@@ -557,9 +561,11 @@ describe('admin updateWrappedLogoMode action', () => {
 		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.ALWAYS_HIDE);
 	});
 
-	it('rejects updateWrappedLogoMode with blank settingsVersion as 409 (__OCC_CONFLICT__)', async () => {
+	it('rejects updateWrappedLogoMode with blank settingsVersion as 409 conflict', async () => {
 		// Pre-seed to ALWAYS_HIDE so the assertion below distinguishes "OCC blocked
-		// the write" from "default value happens to match".
+		// the write" from "default value happens to match". Post-migration the
+		// conflict shape is the inline-OCC `{ conflict: true, error }` that
+		// `surfaceOccConflict` keys on (was external-OCC `code: __OCC_CONFLICT__`).
 		await setAppSetting(AppSettingsKey.WRAPPED_LOGO_MODE, WrappedLogoMode.ALWAYS_HIDE);
 
 		const result = await runUpdateWrappedLogoMode(
@@ -568,14 +574,10 @@ describe('admin updateWrappedLogoMode action', () => {
 		expect(result).toMatchObject({
 			status: 409,
 			data: {
-				error: 'Settings changed in another tab. Please reload.',
-				code: '__OCC_CONFLICT__'
+				conflict: true,
+				error: 'Settings changed in another tab. Please reload.'
 			}
 		});
-		// Conflict response includes the current version so the client can refresh.
-		expect(typeof (result as { data: { settingsVersion: unknown } }).data.settingsVersion).toBe(
-			'string'
-		);
 		// Row left intact — OCC blocked the write before any service call.
 		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.ALWAYS_HIDE);
 	});
@@ -591,7 +593,7 @@ describe('admin updateWrappedLogoMode action', () => {
 		);
 		expect(result).toMatchObject({
 			status: 409,
-			data: { error: 'Settings changed in another tab. Please reload.', code: '__OCC_CONFLICT__' }
+			data: { conflict: true, error: 'Settings changed in another tab. Please reload.' }
 		});
 		// First write's value still in place.
 		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.ALWAYS_SHOW);

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -355,17 +355,20 @@ describe('admin UI source regressions', () => {
 	});
 
 	// US-022 / monolith deletion — wrapped logo mode is now an Appearance tab
-	// RadioGroup driven by use:enhance (commit a46279c). The monolith's
-	// selectedWrappedLogoMode + syncedWrappedLogoMode state machine doesn't
-	// exist anymore; the equivalent UX is handled by the RadioGroup
-	// primitive's controlled value. Source assertion re-points to the nested
-	// Appearance route:
+	// RadioGroup. Post-ISSUE-015 the Appearance route was migrated from raw
+	// use:enhance to Superforms (parity with Privacy): the RadioGroup binds to
+	// the Superform store field and the hidden settingsVersion input binds
+	// two-way so a fresh version round-trips without invalidateAll. The
+	// monolith's selectedWrappedLogoMode + syncedWrappedLogoMode state machine
+	// doesn't exist anymore.
 	it('binds the wrapped logo mode RadioGroup in the Appearance route', async () => {
 		const source = await readSource('src/routes/admin/settings/appearance/+page.svelte');
 
 		expect(source).toContain('action="?/updateWrappedLogoMode"');
-		expect(source).toContain('bind:value={selectedWrappedLogoMode}');
+		expect(source).toContain('bind:value={$wrappedLogoModeData.logoMode}');
 		expect(source).toContain('name="logoMode"');
+		// Two-way settingsVersion binding is the core of the ISSUE-015 fix.
+		expect(source).toContain('bind:value={$wrappedLogoModeData.settingsVersion}');
 	});
 
 	it('uses real onboarding privacy field names for submitted controls', async () => {
@@ -376,6 +379,57 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('name="allowUserControl"');
 		expect(source).not.toContain('name="wrappedLogoModeRadio"');
 		expect(source).not.toContain('name="shareModeRadio"');
+	});
+
+	// ISSUE-005/006: button-driven onboarding selections (UI/Wrapped theme, User
+	// Control, Public Landing Lookup) were lost on Save & Continue. Their values
+	// rode on always-rendered hidden <input value={…}> mirrors, but FormData reads
+	// the DOM .value *property* while value={…} only updates the *attribute*; when
+	// the interactive control lives in a destroyed/recreated {#if} carousel branch
+	// the property kept its default. Fix authoritatively writes live runes state
+	// onto the submitted FormData inside use:enhance, bypassing DOM divergence.
+	it('serializes onboarding settings from live state in the enhance submit callback', async () => {
+		const source = await readSource('src/routes/onboarding/settings/+page.svelte');
+
+		// enhance destructures formData so it can overwrite the submitted values.
+		expect(source).toContain('use:enhance={({ formData }) => {');
+		// Every server-consumed field is written from live runes state.
+		expect(source).toContain("formData.set('uiTheme', uiTheme);");
+		expect(source).toContain("formData.set('wrappedTheme', wrappedTheme);");
+		expect(source).toContain("formData.set('anonymizationMode', anonymizationMode);");
+		expect(source).toContain("formData.set('logoMode', wrappedLogoMode);");
+		expect(source).toContain("formData.set('defaultShareMode', defaultShareMode);");
+		expect(source).toContain(
+			"formData.set('allowUserControl', allowUserControl ? 'true' : 'false');"
+		);
+		expect(source).toContain("formData.set('serverWrappedShareMode', serverWrappedShareMode);");
+		expect(source).toContain(
+			"formData.set('publicLandingLookup', publicLandingLookup ? 'true' : 'false');"
+		);
+		expect(source).toContain("formData.set('enabledSlides', enabledSlidesString);");
+		expect(source).toContain("formData.set('enableFunFacts', enableFunFacts ? 'true' : 'false');");
+
+		// Duplicate submitting-name collisions are removed: the in-branch radios use
+		// the non-submitting …Radio convention, and the redundant sr-only
+		// allowUserControl checkbox is gone (the hidden input is the sole submitter).
+		expect(source).toContain('name="logoModeRadio"');
+		expect(source).toContain('name="defaultShareModeRadio"');
+		expect(source).not.toContain('bind:checked={allowUserControl}');
+		// Exactly one submitting allowUserControl input (the always-rendered hidden one).
+		expect(source.match(/name="allowUserControl"/g)).toHaveLength(1);
+	});
+
+	// ISSUE-004: AI enabled + no effective OpenAI key (typed, env, or DB) shows a
+	// non-blocking inline warning that the built-in template generator is used.
+	it('warns when onboarding AI fun facts are enabled without an OpenAI key', async () => {
+		const source = await readSource('src/routes/onboarding/settings/+page.svelte');
+
+		expect(source).toContain(
+			'let showAiKeyWarning = $derived(enableFunFacts && !openaiApiKey.trim() && !data.hasOpenAI);'
+		);
+		expect(source).toContain('{#if showAiKeyWarning}');
+		expect(source).toContain('class="ai-key-warning"');
+		expect(source).toContain('built-in template generator is used');
 	});
 
 	it('keeps share modal radios checked from local state while updating', async () => {

--- a/tests/unit/auth/login-completion.test.ts
+++ b/tests/unit/auth/login-completion.test.ts
@@ -221,6 +221,113 @@ describe('createSessionFromPlexToken', () => {
 		expect(await db.select().from(sessions)).toHaveLength(1);
 	});
 
+	// ISSUE-010 regression lock — account-identity mapping.
+	//
+	// `play_history.accountId` is stamped by the Plex Media Server's
+	// `/status/sessions/history/all` endpoint with the *local* SystemAccount ID,
+	// where the server owner/admin is always `1` (verified against Plex docs and
+	// python-plexapi: history `accountID` == SystemAccount ID, owner == 1). This
+	// is a DIFFERENT id space from the plex.tv global id returned by
+	// `getPlexUserInfo()` (`plexUser.id`, e.g. 677042263).
+	//
+	// Personal-Wrapped resolution is `statsAccountId = user.accountId ?? user.plexId`,
+	// which filters `play_history.accountId == statsAccountId`. Therefore the OWNER
+	// must store `accountId = 1` (matches their own history rows); a NON-OWNER member
+	// must store their real plex.tv id (their history rows carry that id). Storing the
+	// owner's real plex.tv id would make their Wrapped permanently empty — do NOT swap.
+	it('stores accountId = 1 (local owner id) for the server owner during normal login, not the plex.tv id', async () => {
+		spies.push(
+			spyOn(membership, 'requireServerMembership').mockResolvedValue({
+				isMember: true,
+				isOwner: true,
+				serverName: 'Test Plex'
+			})
+		);
+
+		const { createSessionFromPlexToken } = await import('$lib/server/auth/login-completion');
+		await createSessionFromPlexToken('secret-auth-token', createCookies());
+
+		const stored = await db.select().from(users);
+		expect(stored).toHaveLength(1);
+		// Owner is the local SystemAccount 1 in play_history, NOT plexUser.id (12345).
+		expect(stored[0]?.accountId).toBe(1);
+		expect(stored[0]?.plexId).toBe(12345);
+		expect(stored[0]?.isAdmin).toBe(true);
+	});
+
+	it('stores the real plex.tv id as accountId for a non-owner member during normal login', async () => {
+		// Default beforeEach mock has requireServerMembership -> isOwner: false.
+		const { createSessionFromPlexToken } = await import('$lib/server/auth/login-completion');
+		await createSessionFromPlexToken('secret-auth-token', createCookies());
+
+		const stored = await db.select().from(users);
+		expect(stored).toHaveLength(1);
+		// Members' history rows carry their real account id, so account_id == plexId.
+		expect(stored[0]?.accountId).toBe(12345);
+		expect(stored[0]?.plexId).toBe(12345);
+		expect(stored[0]?.isAdmin).toBe(false);
+	});
+
+	it('stores accountId = 1 for the owner via the bootstrap-claim onboarding path (configured Plex)', async () => {
+		spies.push(
+			spyOn(onboarding, 'requiresOnboarding').mockResolvedValue(true),
+			spyOn(membership, 'requireServerMembership').mockResolvedValue({
+				isMember: true,
+				isOwner: true,
+				serverName: 'Test Plex'
+			})
+		);
+
+		const cookies = createCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies, token)).toBe('claimed');
+
+		const { createSessionFromPlexToken } = await import('$lib/server/auth/login-completion');
+		await createSessionFromPlexToken('secret-auth-token', cookies);
+
+		const stored = await db.select().from(users);
+		expect(stored).toHaveLength(1);
+		// Bootstrap-claim owner must use the SAME convention as the OAuth owner branch:
+		// local SystemAccount id 1, never the plex.tv id 12345 (ISSUE-010 trap).
+		expect(stored[0]?.accountId).toBe(1);
+		expect(stored[0]?.plexId).toBe(12345);
+		expect(stored[0]?.isAdmin).toBe(true);
+	});
+
+	it('stores accountId = 1 for the owner via the bootstrap-claim onboarding path (fresh, unconfigured Plex)', async () => {
+		spies.push(
+			spyOn(onboarding, 'requiresOnboarding').mockResolvedValue(true),
+			spyOn(settingsService, 'getApiConfigWithSources').mockResolvedValue({
+				plex: {
+					serverUrl: { value: '', source: 'default', isLocked: false },
+					token: { value: '', source: 'default', isLocked: false }
+				},
+				openai: {
+					apiKey: { value: '', source: 'default', isLocked: false },
+					baseUrl: { value: 'https://api.openai.com/v1', source: 'default', isLocked: false },
+					model: { value: 'gpt-5-mini', source: 'default', isLocked: false }
+				}
+			}),
+			spyOn(membership, 'verifyServerOwnership').mockResolvedValue({
+				isOwner: true,
+				serverName: 'Owned Plex'
+			})
+		);
+
+		const cookies = createCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies, token)).toBe('claimed');
+
+		const { createSessionFromPlexToken } = await import('$lib/server/auth/login-completion');
+		await createSessionFromPlexToken('secret-auth-token', cookies);
+
+		const stored = await db.select().from(users);
+		expect(stored).toHaveLength(1);
+		expect(stored[0]?.accountId).toBe(1);
+		expect(stored[0]?.plexId).toBe(12345);
+		expect(stored[0]?.isAdmin).toBe(true);
+	});
+
 	it('propagates unexpected setup claim renewal errors during fresh onboarding', async () => {
 		const unexpectedError = new Error('claim storage failed');
 

--- a/tests/unit/cron/validation.test.ts
+++ b/tests/unit/cron/validation.test.ts
@@ -113,5 +113,22 @@ describe('validateCronExpression', () => {
 		it('rejects out-of-range upper bound in a range: 0-60 * * * *', () => {
 			expect(validateCronExpression('0-60 * * * *')).toBe(CRON_RANGE_MESSAGE);
 		});
+
+		// Malformed step/range tokens — empty segments must not coerce to 0
+		it('rejects step with empty base: /5 * * * *', () => {
+			expect(validateCronExpression('/5 * * * *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects range with empty lower bound: -1 * * * *', () => {
+			expect(validateCronExpression('-1 * * * *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects range with empty upper bound: 1- * * * *', () => {
+			expect(validateCronExpression('1- * * * *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects range with extra segments: 1-5-2 * * * *', () => {
+			expect(validateCronExpression('1-5-2 * * * *')).toBe(CRON_RANGE_MESSAGE);
+		});
 	});
 });

--- a/tests/unit/cron/validation.test.ts
+++ b/tests/unit/cron/validation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test';
-import { CRON_ALLOWED_CHARS_MESSAGE, validateCronExpression } from '$lib/cron/validation';
+import {
+	CRON_ALLOWED_CHARS_MESSAGE,
+	CRON_RANGE_MESSAGE,
+	validateCronExpression
+} from '$lib/cron/validation';
 
 describe('validateCronExpression', () => {
 	it('accepts ordinary space-separated cron expressions', () => {
@@ -10,5 +14,104 @@ describe('validateCronExpression', () => {
 		for (const expression of ['0\t0 * * *', '0 0\n* * *', '0 0\r\n* * *']) {
 			expect(validateCronExpression(expression)).toBe(CRON_ALLOWED_CHARS_MESSAGE);
 		}
+	});
+
+	// ── Per-field range validation (E2) ──────────────────────────────────────
+
+	describe('per-field range validation', () => {
+		// Valid boundary values
+		it('accepts minute 0 and 59', () => {
+			expect(validateCronExpression('0 0 * * *')).toBe('');
+			expect(validateCronExpression('59 0 * * *')).toBe('');
+		});
+
+		it('accepts hour 0 and 23', () => {
+			expect(validateCronExpression('0 23 * * *')).toBe('');
+		});
+
+		it('accepts day-of-month 1 and 31', () => {
+			expect(validateCronExpression('0 0 1 * *')).toBe('');
+			expect(validateCronExpression('0 0 31 * *')).toBe('');
+		});
+
+		it('accepts month 1 and 12', () => {
+			expect(validateCronExpression('0 0 * 1 *')).toBe('');
+			expect(validateCronExpression('0 0 * 12 *')).toBe('');
+		});
+
+		it('accepts day-of-week 0 through 7 (0 and 7 are both Sunday)', () => {
+			expect(validateCronExpression('0 0 * * 0')).toBe('');
+			expect(validateCronExpression('0 0 * * 7')).toBe('');
+		});
+
+		it('accepts all-wildcard expression', () => {
+			expect(validateCronExpression('* * * * *')).toBe('');
+		});
+
+		it('accepts a complete boundary expression: 0 0 31 12 7', () => {
+			expect(validateCronExpression('0 0 31 12 7')).toBe('');
+		});
+
+		// Step syntax
+		it('accepts step syntax: */5 * * * *', () => {
+			expect(validateCronExpression('*/5 * * * *')).toBe('');
+		});
+
+		it('accepts step with base: 0/15 * * * *', () => {
+			expect(validateCronExpression('0/15 * * * *')).toBe('');
+		});
+
+		it('accepts range syntax: 1-5 * * * *', () => {
+			expect(validateCronExpression('1-5 * * * *')).toBe('');
+		});
+
+		it('accepts list syntax: 0,15,30,45 * * * *', () => {
+			expect(validateCronExpression('0,15,30,45 * * * *')).toBe('');
+		});
+
+		it('accepts range-based step syntax: 1-5/2 * * * *', () => {
+			expect(validateCronExpression('1-5/2 * * * *')).toBe('');
+		});
+
+		// Invalid cases — these must now be rejected client-side
+		it('rejects minute 60 (99 99 * * *)', () => {
+			expect(validateCronExpression('99 99 * * *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects minute 60', () => {
+			expect(validateCronExpression('60 * * * *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects hour 24', () => {
+			expect(validateCronExpression('0 24 * * *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects day-of-month 0', () => {
+			expect(validateCronExpression('0 0 0 * *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects day-of-month 32', () => {
+			expect(validateCronExpression('0 0 32 * *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects month 0', () => {
+			expect(validateCronExpression('0 0 * 0 *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects month 13', () => {
+			expect(validateCronExpression('0 0 * 13 *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects day-of-week 8', () => {
+			expect(validateCronExpression('0 0 * * 8')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects out-of-range value in a list: 0,60 * * * *', () => {
+			expect(validateCronExpression('0,60 * * * *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects out-of-range upper bound in a range: 0-60 * * * *', () => {
+			expect(validateCronExpression('0-60 * * * *')).toBe(CRON_RANGE_MESSAGE);
+		});
 	});
 });

--- a/tests/unit/cron/validation.test.ts
+++ b/tests/unit/cron/validation.test.ts
@@ -130,5 +130,17 @@ describe('validateCronExpression', () => {
 		it('rejects range with extra segments: 1-5-2 * * * *', () => {
 			expect(validateCronExpression('1-5-2 * * * *')).toBe(CRON_RANGE_MESSAGE);
 		});
+
+		it('rejects list with trailing empty segment: 1, * * * *', () => {
+			expect(validateCronExpression('1, * * * *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects list with leading empty segment: ,5 * * * *', () => {
+			expect(validateCronExpression(',5 * * * *')).toBe(CRON_RANGE_MESSAGE);
+		});
+
+		it('rejects list with interior empty segment: 1,,2 * * * *', () => {
+			expect(validateCronExpression('1,,2 * * * *')).toBe(CRON_RANGE_MESSAGE);
+		});
 	});
 });

--- a/tests/unit/onboarding/complete-summary.test.ts
+++ b/tests/unit/onboarding/complete-summary.test.ts
@@ -141,9 +141,10 @@ describe('onboarding completion summary', () => {
 		expect(result.notice).toBeNull();
 	});
 
-	it('shows the configured fun fact frequency when OpenAI key is missing', async () => {
+	it('shows Disabled for fun facts when no OpenAI key is configured', async () => {
 		await setFunFactFrequency(FunFactFrequency.MANY);
 		await setAppSetting(AppSettingsKey.OPENAI_BASE_URL, 'https://api.example.com/v1');
+		// No OPENAI_API_KEY set — fun facts should display as Disabled
 
 		const result = (await load({
 			parent: async () => ({}),
@@ -152,8 +153,28 @@ describe('onboarding completion summary', () => {
 			cookies: await createClaimedCookies()
 		} as Parameters<typeof load>[0])) as {
 			configSummary: Record<string, string>;
+			enableFunFacts: boolean;
 		};
 
+		expect(result.enableFunFacts).toBe(false);
+		expect(result.configSummary.funFacts).toBe('Disabled');
+	});
+
+	it('shows the configured fun fact frequency when OpenAI key is present', async () => {
+		await setFunFactFrequency(FunFactFrequency.MANY);
+		await setAppSetting(AppSettingsKey.OPENAI_API_KEY, 'sk-test-key');
+
+		const result = (await load({
+			parent: async () => ({}),
+			locals: adminLocals,
+			url: new URL('http://localhost/onboarding/complete'),
+			cookies: await createClaimedCookies()
+		} as Parameters<typeof load>[0])) as {
+			configSummary: Record<string, string>;
+			enableFunFacts: boolean;
+		};
+
+		expect(result.enableFunFacts).toBe(true);
 		expect(result.configSummary.funFacts).toBe('Many (8)');
 	});
 });

--- a/tests/unit/onboarding/plex-load-env-lock.test.ts
+++ b/tests/unit/onboarding/plex-load-env-lock.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import * as serverIdentityModule from '$lib/server/plex/server-identity.service';
+import { load } from '../../../src/routes/onboarding/plex/+page.server';
+
+/**
+ * Tests that the onboarding/plex/+page.server.ts load function exposes
+ * per-field ENV lock information (plexServerUrlLocked, plexTokenLocked,
+ * plexTokenHasValue) so the Svelte page can render individual ENV badges.
+ *
+ * ISSUE-002: ENV badge + lock on the onboarding Plex step.
+ *
+ * Note: The test environment mocks $env/dynamic/private with non-placeholder
+ * PLEX_SERVER_URL and PLEX_TOKEN values, so both fields always appear ENV-locked
+ * in this test suite. The tests verify the load correctly threads those lock
+ * flags through from getApiConfigWithSources().
+ */
+
+describe('onboarding plex load — per-field ENV lock info (C1)', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+	});
+
+	it('exposes plexServerUrlLocked and plexTokenLocked reflecting the env configuration', async () => {
+		// The test setup mock sets PLEX_SERVER_URL + PLEX_TOKEN as non-placeholder
+		// env values — both should be reported as locked.
+		const result = (await load({
+			parent: async () => ({
+				hasEnvConfig: false,
+				isAuthenticated: false,
+				isAdmin: false,
+				username: null,
+				plexConfigured: false,
+				plexServerUrl: '',
+				plexConfigSource: 'default' as const,
+				plexServerName: null,
+				uiTheme: 'default'
+			})
+		} as unknown as Parameters<typeof load>[0])) as {
+			plexServerUrlLocked: boolean;
+			plexTokenLocked: boolean;
+			plexTokenHasValue: boolean;
+		};
+
+		// Both fields are locked because the test env mock provides real-looking values
+		expect(result.plexServerUrlLocked).toBe(true);
+		expect(result.plexTokenLocked).toBe(true);
+		expect(result.plexTokenHasValue).toBe(true);
+	});
+
+	it('exposes plexTokenHasValue=true and keeps lock flags when token is in env', async () => {
+		// Calling load with hasEnvConfig=false (no server probe needed) still reads
+		// the config lock state from getApiConfigWithSources() — lock flags come
+		// from env, not from hasEnvConfig.
+		const result = (await load({
+			parent: async () => ({
+				hasEnvConfig: false,
+				isAuthenticated: true,
+				isAdmin: true,
+				username: 'admin',
+				plexConfigured: true,
+				plexServerUrl: 'https://test-plex-server:32400',
+				plexConfigSource: 'env' as const,
+				plexServerName: null,
+				uiTheme: 'default'
+			})
+		} as unknown as Parameters<typeof load>[0])) as {
+			plexServerUrlLocked: boolean;
+			plexTokenLocked: boolean;
+			plexTokenHasValue: boolean;
+		};
+
+		expect(result.plexServerUrlLocked).toBe(true);
+		expect(result.plexTokenLocked).toBe(true);
+		expect(result.plexTokenHasValue).toBe(true);
+	});
+
+	it('calls refreshConfiguredServerMachineId and threads configuredMachineId when hasEnvConfig=true', async () => {
+		const spy = spyOn(serverIdentityModule, 'refreshConfiguredServerMachineId').mockResolvedValue({
+			machineId: 'mock-machine-id',
+			source: 'fresh' as const,
+			errorReason: null
+		});
+
+		try {
+			const result = (await load({
+				parent: async () => ({
+					hasEnvConfig: true,
+					isAuthenticated: true,
+					isAdmin: true,
+					username: 'admin',
+					plexConfigured: true,
+					plexServerUrl: 'https://test-plex-server:32400',
+					plexConfigSource: 'env' as const,
+					plexServerName: 'My Plex',
+					uiTheme: 'default'
+				})
+			} as unknown as Parameters<typeof load>[0])) as {
+				plexServerUrlLocked: boolean;
+				plexTokenLocked: boolean;
+				plexTokenHasValue: boolean;
+				configuredMachineId: string | null;
+				configuredUrlReachable: boolean;
+			};
+
+			// Identity probe is called when hasEnvConfig=true
+			expect(spy).toHaveBeenCalledTimes(1);
+			expect(result.configuredMachineId).toBe('mock-machine-id');
+			expect(result.configuredUrlReachable).toBe(true);
+			// Lock flags are still threaded through
+			expect(result.plexServerUrlLocked).toBe(true);
+			expect(result.plexTokenLocked).toBe(true);
+			expect(result.plexTokenHasValue).toBe(true);
+		} finally {
+			spy.mockRestore();
+		}
+	});
+});

--- a/tests/unit/onboarding/settings-actions.test.ts
+++ b/tests/unit/onboarding/settings-actions.test.ts
@@ -208,6 +208,26 @@ describe('onboarding settings actions', () => {
 		expect(await getAppSetting(AppSettingsKey.PUBLIC_LANDING_LOOKUP)).toBe('true');
 	});
 
+	it('persists the full dogfood combo (themes + user control + landing lookup all non-default)', async () => {
+		// Locks in the server contract for ISSUE-005/006: the exact field set that
+		// was lost in the wizard (button-driven UI/Wrapped theme + User Control ON +
+		// Public Landing Lookup ON) persists when correct FormData reaches the action.
+		// The defect was purely client-side serialization; this guards the server.
+		const request = createSettingsRequest({
+			uiTheme: ThemePresets.SUPABASE,
+			wrappedTheme: ThemePresets.DOOM_64,
+			allowUserControl: 'true',
+			publicLandingLookup: 'true'
+		});
+
+		await expectRedirect(() => runSaveSettings(request), '/onboarding/complete');
+
+		expect(await getUITheme()).toBe(ThemePresets.SUPABASE);
+		expect(await getWrappedTheme()).toBe(ThemePresets.DOOM_64);
+		expect(await getGlobalAllowUserControl()).toBe(true);
+		expect(await getPublicLandingLookupEnabled()).toBe(true);
+	});
+
 	it('persists enabled fun fact frequency when AI credentials are supplied', async () => {
 		const request = createSettingsRequest({
 			enableFunFacts: 'true',

--- a/tests/unit/sharing/server-wrapped-route.test.ts
+++ b/tests/unit/sharing/server-wrapped-route.test.ts
@@ -15,6 +15,16 @@ type UpdateServerWrappedSettingsAction = NonNullable<
 	typeof adminSettingsActions.updateServerWrappedSettings
 >;
 
+/** Helper: build a minimal parent() that satisfies the year guard. */
+function makeParent(availableYears: number[]) {
+	return async () => ({
+		availableYears,
+		wrappedTheme: 'default',
+		syncStatus: null,
+		lookupSyncTriggered: false
+	});
+}
+
 describe('server wrapped route access', () => {
 	beforeEach(async () => {
 		await db.delete(appSettings);
@@ -27,6 +37,7 @@ describe('server wrapped route access', () => {
 			await load({
 				params: { year: '2024' },
 				locals: {},
+				parent: makeParent([2024]),
 				url: new URL('http://localhost/wrapped/2024'),
 				setHeaders: () => {}
 			} as unknown as Parameters<ServerWrappedLoad>[0]);
@@ -47,6 +58,7 @@ describe('server wrapped route access', () => {
 			await load({
 				params: { year: '2024' },
 				locals: {},
+				parent: makeParent([2024]),
 				url: new URL('http://localhost/wrapped/2024'),
 				setHeaders: (values: Record<string, string>) => Object.assign(headers, values)
 			} as unknown as Parameters<ServerWrappedLoad>[0]);
@@ -82,6 +94,7 @@ describe('server wrapped route access', () => {
 			await load({
 				params: { year: '2024' },
 				locals: {},
+				parent: makeParent([2024]),
 				url: new URL('http://localhost/wrapped/2024'),
 				setHeaders: () => {}
 			} as unknown as Parameters<ServerWrappedLoad>[0]);
@@ -90,6 +103,91 @@ describe('server wrapped route access', () => {
 			expect(isHttpError(error)).toBe(true);
 			if (!isHttpError(error)) throw error;
 			expect(error.status).toBe(403);
+		}
+	});
+});
+
+describe('server wrapped route year guard (ISSUE-009, ISSUE-018)', () => {
+	beforeEach(async () => {
+		await db.delete(appSettings);
+	});
+
+	it('returns 404 for a future year not in availableYears (ISSUE-018)', async () => {
+		try {
+			await load({
+				params: { year: '2099' },
+				locals: {},
+				parent: makeParent([2026]),
+				url: new URL('http://localhost/wrapped/2099'),
+				setHeaders: () => {}
+			} as unknown as Parameters<ServerWrappedLoad>[0]);
+			expect.unreachable('Expected 404 for future year');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			expect(err.status).toBe(404);
+		}
+	});
+
+	it('returns 404 for an empty past year not in availableYears (ISSUE-009)', async () => {
+		// availableYears = [2026], year 2025 has no data → must 404
+		const currentYear = new Date().getFullYear();
+		const emptyPastYear = currentYear - 1;
+		try {
+			await load({
+				params: { year: String(emptyPastYear) },
+				locals: {},
+				parent: makeParent([currentYear]),
+				url: new URL(`http://localhost/wrapped/${emptyPastYear}`),
+				setHeaders: () => {}
+			} as unknown as Parameters<ServerWrappedLoad>[0]);
+			expect.unreachable('Expected 404 for empty past year');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			expect(err.status).toBe(404);
+		}
+	});
+
+	it('does not 404 for the current year even when not yet in availableYears (pre-first-sync)', async () => {
+		// Current year with no data yet should reach the access-control check,
+		// not be blocked by the year guard. Since no access restriction is set,
+		// the load will proceed past the guard (and may throw for other reasons
+		// such as missing stats, but NOT a 404 from the year guard).
+		const currentYear = new Date().getFullYear();
+		try {
+			await load({
+				params: { year: String(currentYear) },
+				locals: {},
+				parent: makeParent([]), // empty — no data synced yet
+				url: new URL(`http://localhost/wrapped/${currentYear}`),
+				setHeaders: () => {}
+			} as unknown as Parameters<ServerWrappedLoad>[0]);
+			// If load somehow succeeds, that's also fine for this guard test
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			// Must NOT be blocked by the year guard (404 "No data found for this year")
+			expect(err.body.message).not.toBe('No data found for this year');
+		}
+	});
+
+	it('does not 404 for a year present in availableYears', async () => {
+		// A year with actual data should pass the guard and reach access-control.
+		// Expect either success or a non-year-guard error (e.g. 403 from access control).
+		try {
+			await load({
+				params: { year: '2026' },
+				locals: {},
+				parent: makeParent([2026]),
+				url: new URL('http://localhost/wrapped/2026'),
+				setHeaders: () => {}
+			} as unknown as Parameters<ServerWrappedLoad>[0]);
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			// Must NOT be a year-guard 404
+			expect(err.body.message).not.toBe('No data found for this year');
 		}
 	});
 });

--- a/tests/unit/slides/messaging-context.test.ts
+++ b/tests/unit/slides/messaging-context.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for slide messaging-context helpers
+ *
+ * Covers verb-agreement helpers: getHaveVerb, getAreVerb, getWatchVerb,
+ * as well as getSubject, getPossessive, and the context factory functions.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+	createPersonalContext,
+	createServerContext,
+	getAreVerb,
+	getHaveVerb,
+	getPossessive,
+	getSubject,
+	getWatchVerb
+} from '$lib/components/slides/messaging-context';
+
+describe('createPersonalContext', () => {
+	it('creates a non-server-wrapped context', () => {
+		const ctx = createPersonalContext();
+		expect(ctx.isServerWrapped).toBe(false);
+		expect(ctx.serverName).toBeNull();
+	});
+});
+
+describe('createServerContext', () => {
+	it('creates a server-wrapped context with a name', () => {
+		const ctx = createServerContext('PARENTI');
+		expect(ctx.isServerWrapped).toBe(true);
+		expect(ctx.serverName).toBe('PARENTI');
+	});
+
+	it('creates a server-wrapped context with null name', () => {
+		const ctx = createServerContext(null);
+		expect(ctx.isServerWrapped).toBe(true);
+		expect(ctx.serverName).toBeNull();
+	});
+});
+
+describe('getSubject', () => {
+	it('returns "You" for personal context', () => {
+		expect(getSubject(createPersonalContext())).toBe('You');
+	});
+
+	it('returns server name for named server context', () => {
+		expect(getSubject(createServerContext('PARENTI'))).toBe('PARENTI');
+	});
+
+	it('returns "We" for unnamed server context', () => {
+		expect(getSubject(createServerContext(null))).toBe('We');
+	});
+});
+
+describe('getPossessive', () => {
+	it('returns "Your" for personal context', () => {
+		expect(getPossessive(createPersonalContext())).toBe('Your');
+	});
+
+	it('returns possessive of server name for named server context', () => {
+		expect(getPossessive(createServerContext('PARENTI'))).toBe("PARENTI's");
+	});
+
+	it('returns "Our" for unnamed server context', () => {
+		expect(getPossessive(createServerContext(null))).toBe('Our');
+	});
+});
+
+describe('getHaveVerb', () => {
+	it('returns "have" for personal context', () => {
+		expect(getHaveVerb(createPersonalContext())).toBe('have');
+	});
+
+	it('returns "has" for named server context (singular proper noun)', () => {
+		expect(getHaveVerb(createServerContext('PARENTI'))).toBe('has');
+	});
+
+	it('returns "have" for unnamed server context (plural fallback)', () => {
+		expect(getHaveVerb(createServerContext(null))).toBe('have');
+	});
+});
+
+describe('getAreVerb', () => {
+	it('returns "are" for personal context', () => {
+		expect(getAreVerb(createPersonalContext())).toBe('are');
+	});
+
+	it('returns "is" for named server context (singular proper noun)', () => {
+		expect(getAreVerb(createServerContext('PARENTI'))).toBe('is');
+	});
+
+	it('returns "are" for unnamed server context (plural fallback)', () => {
+		expect(getAreVerb(createServerContext(null))).toBe('are');
+	});
+});
+
+describe('getWatchVerb', () => {
+	it('returns "watch" for personal context', () => {
+		expect(getWatchVerb(createPersonalContext())).toBe('watch');
+	});
+
+	it('returns "watches" for named server context (singular proper noun)', () => {
+		expect(getWatchVerb(createServerContext('PARENTI'))).toBe('watches');
+	});
+
+	it('returns "watch" for unnamed server context (plural fallback)', () => {
+		expect(getWatchVerb(createServerContext(null))).toBe('watch');
+	});
+
+	it('produces grammatically correct heading for server name', () => {
+		const ctx = createServerContext('PARENTI');
+		const heading = `When ${getSubject(ctx)} ${getWatchVerb(ctx)}`;
+		expect(heading).toBe('When PARENTI watches');
+	});
+
+	it('produces grammatically correct heading for personal context', () => {
+		const ctx = createPersonalContext();
+		const heading = `When ${getSubject(ctx)} ${getWatchVerb(ctx)}`;
+		expect(heading).toBe('When You watch');
+	});
+});

--- a/tests/unit/sync/scheduler.test.ts
+++ b/tests/unit/sync/scheduler.test.ts
@@ -4,7 +4,8 @@ import {
 	pauseSyncScheduler,
 	resumeSyncScheduler,
 	setupSyncScheduler,
-	stopSyncScheduler
+	stopSyncScheduler,
+	updateSchedulerCron
 } from '$lib/server/sync/scheduler';
 
 describe('getSchedulerStatus pause/resume', () => {
@@ -49,5 +50,52 @@ describe('getSchedulerStatus pause/resume', () => {
 		const restartedStatus = getSchedulerStatus();
 		expect(restartedStatus.isRunning).toBe(true);
 		expect(restartedStatus.isPaused).toBe(false);
+	});
+});
+
+describe('updateSchedulerCron preserves run-state — ISSUE-012 regression guard', () => {
+	afterEach(() => {
+		stopSyncScheduler();
+	});
+
+	it('does NOT activate an INACTIVE scheduler when only the cron is updated', () => {
+		// Scheduler is inactive (never set up)
+		const before = getSchedulerStatus();
+		expect(before.isRunning).toBe(false);
+		expect(before.isPaused).toBe(false);
+		expect(before.cronExpression).toBeNull();
+
+		// Updating the cron must not flip it to active
+		updateSchedulerCron('0 6 * * *');
+
+		const after = getSchedulerStatus();
+		expect(after.isRunning).toBe(false);
+		expect(after.isPaused).toBe(false);
+	});
+
+	it('keeps a PAUSED scheduler paused after a cron update', () => {
+		setupSyncScheduler({ cronExpression: '0 0 * * *', startImmediately: true });
+		pauseSyncScheduler();
+		expect(getSchedulerStatus().isPaused).toBe(true);
+
+		updateSchedulerCron('0 3 * * *');
+
+		const after = getSchedulerStatus();
+		expect(after.isPaused).toBe(true);
+		expect(after.isRunning).toBe(false);
+		// The new expression should be applied
+		expect(after.cronExpression).toBe('0 3 * * *');
+	});
+
+	it('keeps an ACTIVE scheduler active after a cron update', () => {
+		setupSyncScheduler({ cronExpression: '0 0 * * *', startImmediately: true });
+		expect(getSchedulerStatus().isRunning).toBe(true);
+
+		updateSchedulerCron('0 12 * * *');
+
+		const after = getSchedulerStatus();
+		expect(after.isRunning).toBe(true);
+		expect(after.isPaused).toBe(false);
+		expect(after.cronExpression).toBe('0 12 * * *');
 	});
 });

--- a/tests/unit/sync/status-stream-auth.test.ts
+++ b/tests/unit/sync/status-stream-auth.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { appSettings } from '$lib/server/db/schema';
+import { GET } from '../../../src/routes/api/sync/status/stream/+server';
+
+type HandlerArgs = Parameters<typeof GET>[0];
+
+const anonLocals = {} as HandlerArgs['locals'];
+
+const authedLocals = {
+	user: { id: 1, plexId: 100, username: 'admin', isAdmin: true }
+} as HandlerArgs['locals'];
+
+function runGet(locals: HandlerArgs['locals'] = anonLocals): ReturnType<typeof GET> {
+	const request = new Request('http://localhost/api/sync/status/stream');
+	return GET({
+		request,
+		locals,
+		url: new URL('http://localhost/api/sync/status/stream'),
+		getClientAddress: () => '127.0.0.1'
+	} as unknown as HandlerArgs);
+}
+
+/**
+ * ISSUE-017 — Gate /api/sync/status/stream
+ *
+ * The endpoint must be conditionally public:
+ *   - anonymous access is ALLOWED while onboarding is incomplete (pre-account)
+ *   - anonymous access is DENIED (401) once onboarding is complete
+ *   - authenticated access is ALLOWED once onboarding is complete
+ */
+describe('GET /api/sync/status/stream — auth gate (ISSUE-017)', () => {
+	beforeEach(async () => {
+		// Start each test with a clean app_settings table so onboarding state
+		// is unambiguous (no ONBOARDING_COMPLETED row = onboarding pending).
+		await db.delete(appSettings);
+	});
+
+	afterEach(async () => {
+		await db.delete(appSettings);
+	});
+
+	it('(a) denies anonymous GET with 401 once onboarding is complete', async () => {
+		// Mark onboarding complete — simulates a fully-provisioned install.
+		await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+
+		const response = await runGet(anonLocals);
+
+		expect(response.status).toBe(401);
+		expect(response.headers.get('Cache-Control')).toBe('no-store');
+		const body = await response.json();
+		expect(body).toMatchObject({ message: 'Unauthorized' });
+	});
+
+	it('(b) allows anonymous GET while onboarding is incomplete (pre-account)', async () => {
+		// No ONBOARDING_COMPLETED row — fresh install, onboarding in progress.
+		// The onboarding wizard must be able to poll before any user account exists.
+		const response = await runGet(anonLocals);
+
+		// Should receive the SSE stream (200 text/event-stream), not a denial.
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Content-Type')).toBe('text/event-stream');
+
+		// Abort the stream so the interval timer does not leak into subsequent tests.
+		response.body?.cancel();
+	});
+
+	it('(c) allows authenticated GET once onboarding is complete', async () => {
+		await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+
+		const response = await runGet(authedLocals);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Content-Type')).toBe('text/event-stream');
+
+		response.body?.cancel();
+	});
+});

--- a/tests/unit/sync/status-stream-auth.test.ts
+++ b/tests/unit/sync/status-stream-auth.test.ts
@@ -76,4 +76,74 @@ describe('GET /api/sync/status/stream — auth gate (ISSUE-017)', () => {
 
 		response.body?.cancel();
 	});
+
+	it('(d) closes an anonymous stream once onboarding completes mid-stream', async () => {
+		// Open an anonymous stream while onboarding is still pending — allowed.
+		const response = await runGet(anonLocals);
+		expect(response.status).toBe(200);
+
+		const reader = response.body?.getReader();
+		expect(reader).toBeDefined();
+		if (!reader) return;
+
+		// SSE frames are enqueued as strings by formatSSE; decode defensively in
+		// case the runtime delivers them as bytes.
+		const asText = (value: unknown): string =>
+			typeof value === 'string' ? value : new TextDecoder().decode(value as Uint8Array);
+
+		// First read drains the initial `connected` frame enqueued synchronously
+		// in start(). The stream is still open at this point.
+		const first = await reader.read();
+		expect(first.done).toBe(false);
+		expect(asText(first.value)).toContain('"type":"connected"');
+
+		// Onboarding completes — the anonymous connection is no longer permitted.
+		await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+
+		// The next poll tick re-checks the gate and closes the stream. The poll
+		// interval is the idle interval (no sync running), so read with a bounded
+		// timeout and assert the reader reports the stream as done.
+		const closed = await Promise.race([
+			(async () => {
+				// Keep reading until the controller closes; any further frames before
+				// closure are tolerated, but closure must occur.
+				while (true) {
+					const { done } = await reader.read();
+					if (done) return true;
+				}
+			})(),
+			new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 5000))
+		]);
+
+		expect(closed).toBe(true);
+	});
+
+	it('(e) keeps an authenticated stream open after onboarding completes', async () => {
+		// Authenticated client opened during onboarding must NOT be closed by the
+		// mid-stream gate when onboarding completes.
+		const response = await runGet(authedLocals);
+		expect(response.status).toBe(200);
+
+		const reader = response.body?.getReader();
+		expect(reader).toBeDefined();
+		if (!reader) return;
+
+		const first = await reader.read();
+		expect(first.done).toBe(false);
+
+		await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+
+		// Wait beyond a poll tick; the stream must remain open (no `done`).
+		const stayedOpen = await Promise.race([
+			(async () => {
+				const { done } = await reader.read();
+				return !done;
+			})(),
+			new Promise<boolean>((resolve) => setTimeout(() => resolve(true), 3000))
+		]);
+
+		expect(stayedOpen).toBe(true);
+
+		await reader.cancel();
+	});
 });


### PR DESCRIPTION
## Summary

Resolves all 18 findings from the 2026-05-31 dogfood report. Every finding was diagnosed before any code changed. Twelve findings were genuine residual gaps and are fixed; three are closed as not-a-bug, backed by evidence and regression tests rather than altered blindly.

## Findings addressed

### Settings-save OCC integrity (ISSUE-015, ISSUE-016)
- The appearance page used raw `use:enhance` with a one-way `value={data.*Version}` hidden input and returned no fresh version on success, so a second consecutive save in the same page load submitted a stale `settingsVersion` and was silently dropped behind a success toast.
- Migrated appearance to the canonical privacy pattern: `superForm` + `onUpdate: surfaceOccConflict`, each action advances the `settingsVersion` from the freshly written row, and the client binds it back. Sequential saves now persist and a real 409 is surfaced as a conflict.
- Converged the connections page onto the same approach (success returns a fresh `apiConfigVersion` bound to both panels).
- The privacy page was already correct (fixed in #125) and is left unchanged apart from a regression test asserting the 409 conflict marker.

### Account identity mapping (ISSUE-010) - not a bug
- `account_id = 1` is the correct Plex Media Server SystemAccount id for the server owner; the sync writes `play_history.accountId` straight from the PMS history API, which stamps the owner's own watches as `1`. The report's prescription to store the plex.tv global id would make `calculateUserStats` filter on a value that never appears in `play_history`, permanently emptying the owner's Wrapped.
- Hardened the load-bearing comment and locked the convention with tests (owner maps to `1`, member to the real id, across both onboarding-claim and normal-login paths).

### Unauthenticated sync status stream (ISSUE-017) - security
- `/api/sync/status/stream` was unconditionally public, streaming live sync state to anonymous clients on a completed install.
- It is now conditionally public: anonymous access is allowed only while `requiresOnboarding()` is live-true (so the onboarding wizard can still poll before any account exists); once onboarding is complete an authenticated session is required and anonymous requests receive 401. In-flight anonymous streams drain on client disconnect.

### ENV config transparency (ISSUE-002, ISSUE-013)
- The onboarding Plex step now surfaces a per-field ENV badge and disables the locked input when `PLEX_SERVER_URL` / `PLEX_TOKEN` come from the environment (the admin connections page already did this, so ISSUE-013 is closed as not-a-bug).
- A locked (env-sourced) field write now returns an explicit "controlled by environment" note instead of a silent success.

### Onboarding configure persistence (ISSUE-005, ISSUE-006)
- Root cause: in Svelte 5, `value={expr}` updates an input's content attribute while `FormData` reads the `.value` IDL property. For fields driven by `<button type="button">` inside a recreated `{#if}` carousel branch, the submitted property kept its default, so theme and privacy-toggle selections were lost.
- Fixed by authoritatively setting every server-consumed field from live runes state inside the `use:enhance` callback and removing duplicate input `name` collisions. UI theme, Wrapped theme, user control, and landing lookup now persist.

### Scheduler and cron validation (ISSUE-011, ISSUE-012)
- `validateCronExpression` now enforces per-field ranges (minute 0-59, hour 0-23, day-of-month 1-31, month 1-12, day-of-week 0-7, honoring `*` `/` `-` `,`), so out-of-range values such as `99 99 * * *` are rejected on both client and server.
- `updateSchedulerCron` preserves the prior run-state: updating the cron while INACTIVE leaves it inactive (the expression is still persisted to `app_settings`), while paused and active schedulers keep their state.

### Wrapped year guard (ISSUE-009, ISSUE-018)
- The `[year]` route reuses `availableYears` from the layout and returns 404 for future years and empty past years. The current year pre-sync keeps its empty-state page and populated years are unchanged.

### Copy, validation, and a11y polish (ISSUE-001, ISSUE-003, ISSUE-004, ISSUE-007, ISSUE-008, ISSUE-014)
- ISSUE-003: `gpt-5-mini` is a valid 2026 model (GPT-5 family); closed as not-a-bug.
- ISSUE-004: inline warning when AI Fun Facts is enabled without an OpenAI key (now considering a stored DB key as well as env).
- ISSUE-007: the Done step shows the Fun Facts row as "Disabled" when AI is off.
- ISSUE-008: the server-name slide heading now conjugates correctly ("When PARENTI watches") via a verb helper, keeping the server name.
- ISSUE-014: the OpenAI base-URL validation error renders inline, not only as a toast.
- ISSUE-001: the proxy-trust "Show technical details" chevron now rotates and `aria-expanded` is confirmed bound.

## Verification

- `bun run check`: 0 errors, 0 warnings (3129 files)
- `bun run lint`: clean (632 files)
- `bun run test`: 2034 pass, 0 fail (115 files)

Every residual-gap fix ships a test that fails before and passes after. An architect review (read-only) approved the change set with no must-fix items.

## Notes for reviewers

- Three findings are intentionally closed as not-a-bug (ISSUE-010, ISSUE-013, ISSUE-003); see the per-finding rationale above and the accompanying regression tests.
- The privacy and system settings pages are deliberately not refactored beyond added tests.
