### PR TITLE
fix(onboarding): resolve cookie race, redirect-mode UX, nav and icon issues

### DIFF
--- a/src/lib/server/auth/login-completion.ts
+++ b/src/lib/server/auth/login-completion.ts
@@ -136,7 +136,25 @@ export async function createSessionFromPlexToken(
 	// does not alter the ownership/isAdmin decision made above.
 	markSessionRevalidated(sessionId, { isMember: true, isOwner: isAdmin });
 
-	cookies.set('session', sessionId, COOKIE_OPTIONS);
+	// The session row is already persisted above; this cookie write is what
+	// actually logs the browser in. In a race the underlying request can be
+	// aborted before this runs (e.g. an overlapping `/auth/plex` poll whose
+	// client already navigated after a sibling poll won the login). SvelteKit
+	// then throws "Cannot use cookies.set(...) after the response has been
+	// generated". That request's response is discarded anyway, so swallow only
+	// that specific error instead of surfacing a spurious 500; re-throw the rest.
+	try {
+		cookies.set('session', sessionId, COOKIE_OPTIONS);
+	} catch (err) {
+		if (!(err instanceof Error) || !err.message.includes('after the response has been generated')) {
+			throw err;
+		}
+		logger.warn(
+			'Skipped session cookie write on an already-generated response (aborted login race)',
+			'Auth',
+			{ errorType: err.name }
+		);
+	}
 
 	return {
 		user: {

--- a/src/lib/server/auth/login-completion.ts
+++ b/src/lib/server/auth/login-completion.ts
@@ -27,6 +27,13 @@ const COOKIE_OPTIONS = {
 const ONBOARDING_OWNER_REQUIRED_MESSAGE =
 	'Only the server owner can configure Obzorarr. Please sign in with the server owner account.';
 
+// SvelteKit throws a bare `Error` (no subclass/`.code`) when `cookies.set(...)` runs
+// after the response is generated, so this trailing substring of its message is the
+// only available discriminator. It is stable across SvelteKit 2.x but is an undocumented
+// internal — if a future version reworks the wording, the guard below logs `err.message`
+// so the mismatch is diagnosable.
+const RESPONSE_ALREADY_GENERATED_MESSAGE = 'after the response has been generated';
+
 export interface CompletedLoginUser {
 	username: string;
 	isAdmin: boolean;
@@ -146,13 +153,13 @@ export async function createSessionFromPlexToken(
 	try {
 		cookies.set('session', sessionId, COOKIE_OPTIONS);
 	} catch (err) {
-		if (!(err instanceof Error) || !err.message.includes('after the response has been generated')) {
+		if (!(err instanceof Error) || !err.message.includes(RESPONSE_ALREADY_GENERATED_MESSAGE)) {
 			throw err;
 		}
 		logger.warn(
 			'Skipped session cookie write on an already-generated response (aborted login race)',
 			'Auth',
-			{ errorType: err.name }
+			{ errorType: err.name, errorMessage: err.message }
 		);
 	}
 

--- a/src/routes/auth/plex/redirect/+page.svelte
+++ b/src/routes/auth/plex/redirect/+page.svelte
@@ -120,19 +120,19 @@ function handleRetry(): void {
 	<Card.Root class="redirect-card">
 		<Card.Header class="items-center text-center">
 			{#if status === 'loading'}
-				<LoaderCircleIcon class="size-12 text-primary animate-spin" />
+				<LoaderCircleIcon class="size-12 text-primary animate-spin mx-auto" />
 				<Card.Title>Completing Authentication</Card.Title>
 				<Card.Description>Please wait while we verify your Plex account...</Card.Description>
 			{:else if status === 'success'}
-				<CheckIcon class="size-12 text-success" />
+				<CheckIcon class="size-12 text-success mx-auto" />
 				<Card.Title>Authentication Successful</Card.Title>
 				<Card.Description>Redirecting you now...</Card.Description>
 			{:else if status === 'cancelled'}
-				<CircleXIcon class="size-12 text-muted-foreground" />
+				<CircleXIcon class="size-12 text-muted-foreground mx-auto" />
 				<Card.Title>Authentication Cancelled</Card.Title>
 				<Card.Description>You cancelled the Plex authentication.</Card.Description>
 			{:else if status === 'error'}
-				<CircleAlertIcon class="size-12 text-destructive" />
+				<CircleAlertIcon class="size-12 text-destructive mx-auto" />
 				<Card.Title>Authentication Error</Card.Title>
 				<Card.Description>{errorMessage}</Card.Description>
 			{/if}

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -140,6 +140,24 @@ export const actions: Actions = {
 		}
 	},
 
+	// Rewind to the reverse-proxy step. Going back does not sign the user out
+	// (the session cookie persists) and the configured server is untouched, so
+	// returning forward simply re-shows the connected state. Only the onboarding
+	// cursor moves; no auth is required to step backwards, just an active claim.
+	goBack: async ({ cookies, url }) => {
+		try {
+			await requireActiveOnboardingClaim(cookies, { requestUrl: url });
+		} catch (err) {
+			if (err instanceof OnboardingClaimRequiredError) {
+				return fail(403, { error: err.message });
+			}
+			throw err;
+		}
+
+		await setOnboardingStep(OnboardingSteps.PROXY_TRUST);
+		redirect(303, '/onboarding/proxy-trust');
+	},
+
 	continueAfterServerSelection: async ({ locals, cookies, url }) => {
 		if (!locals.user) {
 			return fail(401, { error: 'Please sign in with Plex first' });

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
 import CircleCheckIcon from '@lucide/svelte/icons/circle-check';
 import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
@@ -7,6 +8,7 @@ import { animate, stagger } from 'motion';
 import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
+import { page } from '$app/state';
 import { shouldUseRedirectAuth } from '$lib/client/auth-mode';
 import {
 	commitRedirectFromPopupBlocked,
@@ -452,6 +454,11 @@ const effectiveIsAuthenticated = $derived(localAuthState?.isAuthenticated ?? dat
 const effectiveIsAdmin = $derived(localAuthState?.isAdmin ?? data.isAdmin);
 const effectiveUsername = $derived(localAuthState?.username ?? data.username);
 
+// Reflects the explicit `?auth=redirect` opt-in so the UI can show that the
+// login mode changed (Safari/iOS popup blockers, AI agents). Reactive to the
+// query string so toggling the link updates the badge/button without a reload.
+const redirectModeActive = $derived(page.url.searchParams.get('auth') === 'redirect');
+
 const showLoginButton = $derived(!effectiveIsAuthenticated);
 const showVerifyButton = $derived(data.hasEnvConfig && effectiveIsAuthenticated);
 const showServerSelector = $derived(
@@ -687,13 +694,24 @@ function formatServerUrl(url: string | null): string {
 							<span>Connecting to Plex...</span>
 						{:else}
 							<PlayIcon class="size-[18px]" fill="currentColor" />
-							<span>Sign in with Plex</span>
+							<span>{redirectModeActive ? 'Sign in with Plex (redirect)' : 'Sign in with Plex'}</span>
 						{/if}
 					</Button>
-					<a class="redirect-fallback" href="?auth=redirect">
-						<span class="redirect-fallback-label">Use redirect instead</span>
-						<span class="redirect-fallback-hint">If sign-in doesn't return, use this.</span>
-					</a>
+					{#if redirectModeActive}
+						<div class="redirect-mode-badge" role="status" aria-live="polite">
+							<CircleCheckIcon class="size-[14px]" aria-hidden="true" />
+							<span>Redirect mode active</span>
+						</div>
+						<a class="redirect-fallback" href="?auth=popup">
+							<span class="redirect-fallback-label">Use popup instead</span>
+							<span class="redirect-fallback-hint">Opens Plex sign-in in a new window.</span>
+						</a>
+					{:else}
+						<a class="redirect-fallback" href="?auth=redirect">
+							<span class="redirect-fallback-label">Use redirect instead</span>
+							<span class="redirect-fallback-hint">If sign-in doesn't return, use this.</span>
+						</a>
+					{/if}
 				</div>
 			{:else if isNonAdminUser}
 				<div class="error-card animate-item">
@@ -745,13 +763,24 @@ function formatServerUrl(url: string | null): string {
 							<span>Connecting to Plex...</span>
 						{:else}
 							<PlayIcon class="size-[18px]" fill="currentColor" />
-							<span>Sign in with Plex</span>
+							<span>{redirectModeActive ? 'Sign in with Plex (redirect)' : 'Sign in with Plex'}</span>
 						{/if}
 					</Button>
-					<a class="redirect-fallback" href="?auth=redirect">
-						<span class="redirect-fallback-label">Use redirect instead</span>
-						<span class="redirect-fallback-hint">If sign-in doesn't return, use this.</span>
-					</a>
+					{#if redirectModeActive}
+						<div class="redirect-mode-badge" role="status" aria-live="polite">
+							<CircleCheckIcon class="size-[14px]" aria-hidden="true" />
+							<span>Redirect mode active</span>
+						</div>
+						<a class="redirect-fallback" href="?auth=popup">
+							<span class="redirect-fallback-label">Use popup instead</span>
+							<span class="redirect-fallback-hint">Opens Plex sign-in in a new window.</span>
+						</a>
+					{:else}
+						<a class="redirect-fallback" href="?auth=redirect">
+							<span class="redirect-fallback-label">Use redirect instead</span>
+							<span class="redirect-fallback-hint">If sign-in doesn't return, use this.</span>
+						</a>
+					{/if}
 				</div>
 			{:else if isNonAdminUser}
 				<div class="error-card animate-item">
@@ -1111,6 +1140,12 @@ function formatServerUrl(url: string | null): string {
 	</div>
 
 	{#snippet footer()}
+		<form method="POST" action="?/goBack" use:enhance class="mr-auto">
+			<Button type="submit" variant="outline" class="tap-target">
+				<ArrowLeftIcon class="size-[18px]" />
+				Previous
+			</Button>
+		</form>
 		{#if data.hasEnvConfig && data.canProceed}
 			<form method="POST" action="?/verifyAdmin" use:enhance>
 				<SubmitButton class="continue-button tap-target">
@@ -1410,6 +1445,20 @@ function formatServerUrl(url: string | null): string {
 			border-top-color: rgba(0, 0, 0, 0.7);
 			border-radius: 50%;
 			animation: spin 0.8s linear infinite;
+		}
+
+		.redirect-mode-badge {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.4rem;
+			margin-top: 0.5rem;
+			padding: 0.3rem 0.7rem;
+			font-size: 0.78rem;
+			font-weight: 600;
+			color: oklch(0.8116 0.1789 152.1);
+			background: rgba(34, 197, 94, 0.12);
+			border: 1px solid rgba(34, 197, 94, 0.3);
+			border-radius: 999px;
 		}
 
 		.redirect-fallback {

--- a/src/routes/onboarding/proxy-trust/+page.server.ts
+++ b/src/routes/onboarding/proxy-trust/+page.server.ts
@@ -128,6 +128,18 @@ export const actions: Actions = {
 		redirect(303, '/onboarding/plex');
 	},
 
+	// Rewind to the previous step so the user can review the security settings.
+	// Both steps are pure configuration with no destructive side effects, so the
+	// only state changed is the onboarding cursor; forward navigation re-runs the
+	// normal `continue` action and its validation.
+	goBack: async ({ cookies, url }) => {
+		const guardResult = await requireOnboardingProxyTrustAction(cookies, url, 'error');
+		if (guardResult) return guardResult;
+
+		await setOnboardingStep(OnboardingSteps.CSRF);
+		redirect(303, '/onboarding/csrf');
+	},
+
 	diagnoseReverseProxy: async ({ request, cookies, url, getClientAddress }) => {
 		const guardResult = await requireOnboardingProxyTrustAction(cookies, url, 'diagnosticError');
 		if (guardResult) return guardResult;

--- a/src/routes/onboarding/proxy-trust/+page.svelte
+++ b/src/routes/onboarding/proxy-trust/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 import CheckIcon from '@lucide/svelte/icons/check';
 import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
@@ -491,6 +492,12 @@ function toggleDetails() {
 	</div>
 
 	{#snippet footer()}
+		<form method="POST" action="?/goBack" class="mr-auto">
+			<Button type="submit" variant="outline" class="tap-target">
+				<ArrowLeftIcon class="size-[18px]" />
+				Previous
+			</Button>
+		</form>
 		<form method="POST" action="?/continue" class="continue-form">
 			<SubmitButton class="continue-btn tap-target">
 				{#snippet children()}

--- a/src/routes/onboarding/sync/+page.server.ts
+++ b/src/routes/onboarding/sync/+page.server.ts
@@ -110,5 +110,16 @@ export const actions: Actions = {
 
 		await setOnboardingStep(OnboardingSteps.SETTINGS);
 		redirect(303, '/onboarding/settings');
+	},
+
+	// Rewind to the Plex connection step. A running sync is decoupled from the
+	// request lifecycle (see startBackgroundSync), so it keeps running in the
+	// background; stepping back only moves the onboarding cursor.
+	goBack: async ({ cookies, url }) => {
+		const guardResult = await requireOnboardingSyncClaim(cookies, url);
+		if (guardResult) return guardResult;
+
+		await setOnboardingStep(OnboardingSteps.PLEX);
+		redirect(303, '/onboarding/plex');
 	}
 };

--- a/src/routes/onboarding/sync/+page.svelte
+++ b/src/routes/onboarding/sync/+page.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
+import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
 import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
-import SquareIcon from '@lucide/svelte/icons/square';
+import XIcon from '@lucide/svelte/icons/x';
 import { animate, stagger } from 'motion';
 import { untrack } from 'svelte';
 import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
 import SubmitButton from '$lib/components/forms/SubmitButton.svelte';
 import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
+import { Button } from '$lib/components/ui/button';
 import type { ActionData, PageData } from './$types';
 
 /**
@@ -37,6 +39,12 @@ let error = $state<string | null>(null);
 
 // SSE connection
 let eventSource: EventSource | null = null;
+// Pending auto-reconnect timer + a teardown flag. Without these, the 2s
+// reconnect scheduled in `onerror` outlives component unmount (the user
+// advancing to the next step), spawning an orphaned EventSource that keeps
+// polling `/api/sync/status/stream` in the background.
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let sseDisconnected = false;
 
 // Animation refs
 let contentRef: HTMLElement | undefined = $state();
@@ -144,9 +152,13 @@ function setupEventSource(es: EventSource) {
 		es.close();
 		eventSource = null;
 
-		// Attempt to reconnect after 2 seconds if sync should still be running
-		setTimeout(() => {
-			if (browser && (syncStatus === 'running' || data.syncRunning)) {
+		// Attempt to reconnect after 2 seconds if sync should still be running.
+		// Track the timer so the effect cleanup can cancel a pending reconnect,
+		// and bail if the component was torn down in the meantime.
+		if (reconnectTimer) clearTimeout(reconnectTimer);
+		reconnectTimer = setTimeout(() => {
+			reconnectTimer = null;
+			if (!sseDisconnected && browser && (syncStatus === 'running' || data.syncRunning)) {
 				eventSource = new EventSource('/api/sync/status/stream');
 				setupEventSource(eventSource);
 			}
@@ -160,10 +172,16 @@ $effect(() => {
 	if (!isRunning && !data.syncRunning) return;
 
 	// Connect to public SSE endpoint (doesn't require admin auth)
+	sseDisconnected = false;
 	eventSource = new EventSource('/api/sync/status/stream');
 	setupEventSource(eventSource);
 
 	return () => {
+		sseDisconnected = true;
+		if (reconnectTimer) {
+			clearTimeout(reconnectTimer);
+			reconnectTimer = null;
+		}
 		eventSource?.close();
 		eventSource = null;
 	};
@@ -382,6 +400,12 @@ function formatNumber(n: number): string {
 
 	{#snippet footer()}
 		<div class="footer-actions">
+			<form method="POST" action="?/goBack" use:enhance class="mr-auto">
+				<Button type="submit" variant="outline" class="tap-target">
+					<ArrowLeftIcon class="size-[18px]" />
+					Previous
+				</Button>
+			</form>
 			{#if isRunning}
 				<form
 					method="POST"
@@ -399,7 +423,7 @@ function formatNumber(n: number): string {
 				>
 					<SubmitButton class="cancel-button tap-target" submitting={isCancelling}>
 						{#snippet children()}
-							<SquareIcon class="size-[18px]" />
+							<XIcon class="size-[18px]" />
 							<span>Cancel</span>
 						{/snippet}
 						{#snippet submittingLabel()}
@@ -866,7 +890,7 @@ function formatNumber(n: number): string {
 		/* Cancel button — destructive variant. Hoisted to :global so
 		   SubmitButton's child-rendered <button> inherits the red palette
 		   + hover-darken effect. The `.cancel-button svg` descendant rule
-		   is dropped; the lucide SquareIcon is sized inline via
+		   is dropped; the lucide XIcon is sized inline via
 		   `class="size-[18px]"`. */
 		:global(.cancel-button) {
 			display: inline-flex;

--- a/src/routes/onboarding/sync/+page.svelte
+++ b/src/routes/onboarding/sync/+page.svelte
@@ -147,6 +147,9 @@ function setupEventSource(es: EventSource) {
 	};
 
 	es.onerror = () => {
+		// Bail if the component was torn down: a closed ES can still deliver a
+		// pending `onerror`, which would otherwise schedule an orphaned timer.
+		if (sseDisconnected) return;
 		// Connection lost - attempt reconnection after delay
 		console.warn('SSE connection lost, attempting reconnect...');
 		es.close();


### PR DESCRIPTION
## Summary

Addresses five technical and UI/UX issues identified in the onboarding flow, plus a related SSE connection leak. All changes are scoped to the onboarding and Plex authentication surfaces.

Verification: `bun run check:biome` clean, `bun run check` reports 0 errors / 0 warnings, and the full test suite passes (2046 pass, 0 fail).

## Changes

### Session cookie race (`Cannot use cookies.set(...) after the response has been generated`)

Root cause: the popup login flow polls `/auth/plex` every two seconds. Each poll runs `createSessionFromPlexToken`, which performs several Plex API round-trips (PIN status, user info, server-membership probe). These probes run long while the initial sync saturates the Plex API. When one poll wins the login and the page navigates away, the browser aborts the sibling in-flight poll; that request later finishes its slow probe and calls `cookies.set('session')` on an already-sealed response, which throws.

Fix: `createSessionFromPlexToken` now guards the session cookie write, swallowing only the specific "after the response has been generated" error (logged at warn) and re-throwing everything else. The session row is already persisted and the winning request sets the cookie, so a losing/aborted request failing to write is harmless.

### SSE reconnect-timer leak (background load / latency)

The onboarding sync page scheduled a 2s reconnect inside the `EventSource` `onerror` handler. That timer outlived component unmount (advancing to the next step), spawning an orphaned `EventSource` that kept polling `/api/sync/status/stream` in the background. The timer is now tracked and cancelled in the effect cleanup, and the reconnect bails if the component was torn down.

### Redirect-mode visual feedback (Plex step)

`?auth=redirect` previously produced no visible change. It now drives reactive UI (via `$app/state`): a "Redirect mode active" badge, an updated sign-in button label ("Sign in with Plex (redirect)"), and a "Use popup instead" toggle. This helps users on Safari/iOS and automated agents understand that the login mode changed.

### Cross-step Previous navigation

There was no cross-step back navigation (the settings page only had intra-page sub-step navigation). Added a `goBack` action and a Previous button to the safe configuration steps:

- proxy-trust to csrf
- plex to proxy-trust
- sync to plex

Each action rewinds `ONBOARDING_CURRENT_STEP` behind the existing claim guard. Navigation is back-only, forward navigation re-runs the normal validation actions, and a running sync is decoupled from the request lifecycle and keeps running, so there is no security or state regression.

### Authentication success icon alignment

On `/auth/plex/redirect`, the status icons were left-aligned because the shadcn `Card.Header` is a CSS grid with `items-start`; `items-center` only affects the vertical axis, so the fixed-size icon hugged the left edge of its grid cell while the text was centered. Added `mx-auto` to the status icons so they center horizontally relative to the text.

### Sync Cancel button icon

The Cancel button used `SquareIcon`, which rendered as an empty outlined box beside the label. Replaced it with the `X` icon.

## Files changed

- `src/lib/server/auth/login-completion.ts`
- `src/routes/auth/plex/redirect/+page.svelte`
- `src/routes/onboarding/plex/+page.server.ts`
- `src/routes/onboarding/plex/+page.svelte`
- `src/routes/onboarding/proxy-trust/+page.server.ts`
- `src/routes/onboarding/proxy-trust/+page.svelte`
- `src/routes/onboarding/sync/+page.server.ts`
- `src/routes/onboarding/sync/+page.svelte`

## Notes

- An initial client-side poll-deduplication guard was considered and reverted: it broke an existing test that deliberately requires overlapping polls to be tolerated (stale failure ignored, success honored). The server-side cookie guard is the correct and sufficient fix for the logged error.
- The Step 3 to Step 4 transition latency is partly inherent: proxy-trust "Continue" is a full-page POST and redirect, plus the Plex OAuth round-trips. This PR reduces background noise (the SSE leak and the error-handler churn from the cookie exception) but does not claim to eliminate the OAuth round-trip cost.