### PR TITLE
feat(privacy): add preset-based privacy configuration to onboarding and admin

### DIFF
--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -119,7 +119,9 @@ export const wrappedLogoOptions: OptionCopy<WrappedLogoOptionValue>[] = [
  * Copy for the public-landing-lookup toggle (the new dedicated admin setting).
  * `contradictionWarning` is surfaced in both settings and onboarding when the
  * toggle is on while the default share mode is non-public — visitors would see
- * the lookup form but every lookup would 404 until at least one Wrapped is set to public sharing.
+ * the lookup form but every lookup would 404 until the default share mode is set to public.
+ * (A non-public default is a privacy floor: per-user public rows are blocked at write
+ * time and promoted back to the floor at read time, so only raising the default unblocks lookups.)
  */
 export const publicLandingLookupCopy = {
 	label: 'Allow public Wrapped lookup on the landing page',
@@ -130,7 +132,7 @@ export const publicLandingLookupCopy = {
 	disabledDescription:
 		'The landing page hides the lookup field and shows a "Sign in with Plex" button instead.',
 	contradictionWarning:
-		'Public lookup is on, but your default share mode is non-public — visitors will not find any Wrapped until at least one Wrapped is set to public sharing.'
+		'Public lookup is on, but your default share mode is non-public — every lookup will return "not found" until the default share mode is set to Public.'
 } as const;
 
 // ============================================================================

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -119,7 +119,7 @@ export const wrappedLogoOptions: OptionCopy<WrappedLogoOptionValue>[] = [
  * Copy for the public-landing-lookup toggle (the new dedicated admin setting).
  * `contradictionWarning` is surfaced in both settings and onboarding when the
  * toggle is on while the default share mode is non-public — visitors would see
- * the lookup form but every lookup would 404 until users opt into public sharing.
+ * the lookup form but every lookup would 404 until at least one Wrapped is set to public sharing.
  */
 export const publicLandingLookupCopy = {
 	label: 'Allow public Wrapped lookup on the landing page',
@@ -130,7 +130,7 @@ export const publicLandingLookupCopy = {
 	disabledDescription:
 		'The landing page hides the lookup field and shows a "Sign in with Plex" button instead.',
 	contradictionWarning:
-		'Public lookup is on, but your default share mode is non-public — visitors will not find any Wrapped until users opt into public sharing.'
+		'Public lookup is on, but your default share mode is non-public — visitors will not find any Wrapped until at least one Wrapped is set to public sharing.'
 } as const;
 
 // ============================================================================

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -214,7 +214,7 @@ export const PRIVACY_PRESETS: PrivacyPreset[] = [
 		id: 'internal-community',
 		label: 'Internal Community',
 		description: 'Real names for your members, but nothing exposed to the public web.',
-		exposureSummary: 'Real names, server-members-only, users control their own sharing.',
+		exposureSummary: 'Real names, server-members-only access, nothing public.',
 		values: {
 			anonymizationMode: 'real',
 			defaultShareMode: ShareMode.PRIVATE_OAUTH,
@@ -228,7 +228,7 @@ export const PRIVACY_PRESETS: PrivacyPreset[] = [
 		id: 'balanced',
 		label: 'Balanced',
 		description: 'Recommended default. Members see their own name; nothing is public by default.',
-		exposureSummary: 'Hybrid names, members-only recap, users control their own sharing.',
+		exposureSummary: 'Hybrid names, members-only recap, nothing public.',
 		values: {
 			anonymizationMode: 'hybrid',
 			defaultShareMode: ShareMode.PRIVATE_OAUTH,

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -1,14 +1,19 @@
 /**
- * Shared, client-safe option COPY for privacy / sharing controls.
+ * Shared, client-safe option COPY + preset value-maps for privacy / sharing controls.
  *
  * This is the single source of truth for the user-visible *strings* (label +
  * description) shown in BOTH the onboarding privacy step and the admin settings
- * pages, so the two flows can never drift apart again.
+ * pages, so the two flows can never drift apart again. It also holds the
+ * client-safe privacy *preset* value-maps ({@link PRIVACY_PRESETS}) consumed by
+ * both flows; the pure preset logic (match + preview) lives in the sibling
+ * `src/lib/sharing/preset-logic.ts`.
  *
- * Scope is COPY ONLY — deliberately NOT Zod schemas. Each route keeps its own
+ * Scope is copy + client-safe preset value-maps — deliberately NOT Zod schemas.
+ * A preset is a client-only control surface: it selects existing fields, it is
+ * never a persisted DB key nor a submitted form field. Each route keeps its own
  * schema and submission model co-located (Superforms vs `use:enhance`, `z.object`
  * vs `z.enum`, inline vs external OCC), as documented in
- * `src/routes/admin/settings/privacy/+page.server.ts`. We only share text.
+ * `src/routes/admin/settings/privacy/+page.server.ts`. We only share text + presets.
  *
  * Client boundary: this module imports nothing from `$lib/server/**`. It pulls
  * `ShareMode` from `$lib/sharing/types` (a pure constant map, no server imports)
@@ -127,3 +132,137 @@ export const publicLandingLookupCopy = {
 	contradictionWarning:
 		'Public lookup is on, but your default share mode is non-public — visitors will not find any Wrapped until users opt into public sharing.'
 } as const;
+
+// ============================================================================
+// Privacy presets (client-only control surface)
+// ============================================================================
+
+/**
+ * Privacy preset identifiers. A preset bundles a recommended combination of the
+ * existing privacy/sharing fields behind one visual card. Presets are NEVER a
+ * persisted field — selecting one just mutates the existing form state; the
+ * active preset is recomputed from field values on load (see `preset-logic.ts`).
+ */
+export type PrivacyPresetId =
+	| 'maximum-privacy'
+	| 'internal-community'
+	| 'balanced'
+	| 'public-showcase'
+	| 'anonymous-public';
+
+/**
+ * The exact set of fields a preset configures. EXACTLY six keys, mirroring the
+ * six privacy/sharing fields the onboarding privacy step owns. Each value type
+ * is the shared client-safe option value-type so the maps stay type-checked
+ * against the server enums (a drift test enforces enum membership at CI time).
+ */
+export interface PrivacyPresetValues {
+	anonymizationMode: AnonymizationOptionValue;
+	defaultShareMode: ShareModeType;
+	serverWrappedShareMode: ServerWrappedShareModeValue;
+	publicLandingLookup: boolean;
+	allowUserControl: boolean;
+	logoMode: WrappedLogoOptionValue;
+}
+
+/**
+ * The five preset keys the ADMIN privacy route owns — every field except
+ * `logoMode`, which lives on the separate Appearance route / OCC group. Admin
+ * matching ({@link matchPresetPrivacy} in `preset-logic.ts`) compares only these
+ * so a perfect 5-field match isn't dragged to "Custom" by a differing persisted
+ * logoMode (commonly `user_choice`).
+ */
+export type PrivacyPresetPrivacyKey = Exclude<keyof PrivacyPresetValues, 'logoMode'>;
+
+export interface PrivacyPreset {
+	id: PrivacyPresetId;
+	label: string;
+	description: string;
+	/** One-line plain-language summary of what this preset exposes. */
+	exposureSummary: string;
+	values: PrivacyPresetValues;
+}
+
+/**
+ * The shipped privacy presets. Field order in each `values` map mirrors the
+ * documented order: anonymizationMode / defaultShareMode / serverWrappedShareMode
+ * / publicLandingLookup / allowUserControl / logoMode.
+ *
+ * Note: "Balanced" ships with `publicLandingLookup: false` (a clean first-run,
+ * members-only default that exposes nothing to anonymous visitors), so no shipped
+ * preset trips the landing-lookup contradiction warning — that path is still
+ * reachable (and tested) via a custom combination.
+ */
+export const PRIVACY_PRESETS: PrivacyPreset[] = [
+	{
+		id: 'maximum-privacy',
+		label: 'Maximum Privacy',
+		description: 'Everything locked down. Usernames hidden, nothing public, no landing lookup.',
+		exposureSummary: 'Anonymous stats, server-members-only recap, no public exposure.',
+		values: {
+			anonymizationMode: 'anonymous',
+			defaultShareMode: ShareMode.PRIVATE_OAUTH,
+			serverWrappedShareMode: 'private-oauth',
+			publicLandingLookup: false,
+			allowUserControl: false,
+			logoMode: 'always_hide'
+		}
+	},
+	{
+		id: 'internal-community',
+		label: 'Internal Community',
+		description: 'Real names for your members, but nothing exposed to the public web.',
+		exposureSummary: 'Real names, server-members-only, users control their own sharing.',
+		values: {
+			anonymizationMode: 'real',
+			defaultShareMode: ShareMode.PRIVATE_OAUTH,
+			serverWrappedShareMode: 'private-oauth',
+			publicLandingLookup: false,
+			allowUserControl: true,
+			logoMode: 'user_choice'
+		}
+	},
+	{
+		id: 'balanced',
+		label: 'Balanced',
+		description: 'Recommended default. Members see their own name; nothing is public by default.',
+		exposureSummary: 'Hybrid names, members-only default, users opt in to public sharing.',
+		values: {
+			anonymizationMode: 'hybrid',
+			defaultShareMode: ShareMode.PRIVATE_OAUTH,
+			serverWrappedShareMode: 'private-oauth',
+			publicLandingLookup: false,
+			allowUserControl: true,
+			logoMode: 'user_choice'
+		}
+	},
+	{
+		id: 'public-showcase',
+		label: 'Public Showcase',
+		description: 'Share everything publicly with real names and a public landing lookup.',
+		exposureSummary: 'Real names, public recap + landing lookup, users control their sharing.',
+		values: {
+			anonymizationMode: 'real',
+			defaultShareMode: ShareMode.PUBLIC,
+			serverWrappedShareMode: 'public',
+			publicLandingLookup: true,
+			allowUserControl: true,
+			logoMode: 'always_show'
+		}
+	},
+	{
+		id: 'anonymous-public',
+		label: 'Anonymous Public',
+		description: 'Public stats, but every username stays anonymous and locked.',
+		exposureSummary: 'Anonymous names (forced), public recap + landing lookup.',
+		values: {
+			anonymizationMode: 'anonymous',
+			defaultShareMode: ShareMode.PUBLIC,
+			serverWrappedShareMode: 'public',
+			publicLandingLookup: true,
+			// Deliberate: "forced anonymization" only holds if users cannot reveal themselves.
+			allowUserControl: false,
+			logoMode: 'always_hide'
+		}
+	}
+];

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -226,7 +226,7 @@ export const PRIVACY_PRESETS: PrivacyPreset[] = [
 		id: 'balanced',
 		label: 'Balanced',
 		description: 'Recommended default. Members see their own name; nothing is public by default.',
-		exposureSummary: 'Hybrid names, members-only default, users opt in to public sharing.',
+		exposureSummary: 'Hybrid names, members-only recap, users control their own sharing.',
 		values: {
 			anonymizationMode: 'hybrid',
 			defaultShareMode: ShareMode.PRIVATE_OAUTH,

--- a/src/lib/sharing/preset-logic.ts
+++ b/src/lib/sharing/preset-logic.ts
@@ -1,0 +1,205 @@
+/**
+ * Pure, client-safe privacy-preset logic — the match + preview functions shared
+ * by the onboarding privacy step and the admin privacy page.
+ *
+ * Companion to `src/lib/sharing/options.ts` (which holds the preset *data* +
+ * types). Like that module, this file imports nothing from `$lib/server/**`; it
+ * is pure logic over the client-safe option value-types. Each page binds these
+ * functions to its own state source (onboarding `$state` runes vs. admin
+ * Superform stores) and renders the result in its own idiom.
+ *
+ * Privacy trust is the top constraint: `derivePreview` deliberately separates
+ * admin-controlled *form/recap visibility* from *per-user effective
+ * reachability* (the server-side `getEffectiveShareMode` floor, which admin
+ * defaults do NOT override), so the preview can never overstate exposure.
+ */
+import {
+	PRIVACY_PRESETS,
+	type PrivacyPresetId,
+	type PrivacyPresetPrivacyKey,
+	type PrivacyPresetValues,
+	publicLandingLookupCopy,
+	type WrappedLogoOptionValue
+} from '$lib/sharing/options';
+
+/** Result of a preset match: a known preset id, or `'custom'` for any off-map combination. */
+export type PrivacyPresetMatch = PrivacyPresetId | 'custom';
+
+/**
+ * Match the full six-field value set against the shipped presets. Used by
+ * ONBOARDING, which owns all six fields (including `logoMode`) in one atomic
+ * form. Returns the matching preset id, or `'custom'` if no preset matches.
+ * Field order is irrelevant — comparison is key-by-key.
+ */
+export function matchPresetFull(values: PrivacyPresetValues): PrivacyPresetMatch {
+	for (const preset of PRIVACY_PRESETS) {
+		const p = preset.values;
+		if (
+			p.anonymizationMode === values.anonymizationMode &&
+			p.defaultShareMode === values.defaultShareMode &&
+			p.serverWrappedShareMode === values.serverWrappedShareMode &&
+			p.publicLandingLookup === values.publicLandingLookup &&
+			p.allowUserControl === values.allowUserControl &&
+			p.logoMode === values.logoMode
+		) {
+			return preset.id;
+		}
+	}
+	return 'custom';
+}
+
+/**
+ * Match only the five admin-owned fields (everything except `logoMode`) against
+ * the shipped presets. Used by ADMIN, whose privacy route does NOT own
+ * `logoMode` (it lives on the Appearance route / a separate OCC group).
+ *
+ * Excluding `logoMode` fixes the trap where a perfect five-field match would
+ * otherwise read `'custom'` because the persisted logoMode (commonly
+ * `user_choice`) differs from a preset's logo value.
+ */
+export function matchPresetPrivacy(
+	values: Pick<PrivacyPresetValues, PrivacyPresetPrivacyKey>
+): PrivacyPresetMatch {
+	for (const preset of PRIVACY_PRESETS) {
+		const p = preset.values;
+		if (
+			p.anonymizationMode === values.anonymizationMode &&
+			p.defaultShareMode === values.defaultShareMode &&
+			p.serverWrappedShareMode === values.serverWrappedShareMode &&
+			p.publicLandingLookup === values.publicLandingLookup &&
+			p.allowUserControl === values.allowUserControl
+		) {
+			return preset.id;
+		}
+	}
+	return 'custom';
+}
+
+/**
+ * Skin-agnostic preview of what a privacy configuration exposes. Rendered
+ * per-page in each flow's own markup. Each field is scoped precisely so the
+ * preview never overstates exposure or privacy:
+ *
+ * - `landingLookupForm` — whether the landing page shows the username lookup
+ *   FORM. Admin-controlled (the `publicLandingLookup` toggle). Showing the form
+ *   never makes a non-public Wrapped reachable — the server still 404s those.
+ * - `serverRecapVisibility` — who can view the server-wide `/wrapped` recap.
+ *   Admin-controlled (`serverWrappedShareMode`).
+ * - `perUserDefaultForNewUsers` — the default share mode applied to NEW users.
+ *   Explicitly labeled "for new users": it does NOT change existing/private
+ *   users, and the model never claims an existing private user becomes reachable.
+ * - `nameDisplay` — how usernames appear, mirroring anonymization (including the
+ *   hybrid "self sees own name" nuance).
+ * - `logoVisibility` — OPTIONAL. Present only when `logoMode` is supplied
+ *   (onboarding). Admin omits it (logoMode is managed on a different route).
+ * - `warnings` — surfaced contradiction copy, e.g. landing lookup on while the
+ *   default is non-public.
+ */
+export interface PrivacyPreviewModel {
+	landingLookupForm: 'visible' | 'hidden';
+	serverRecapVisibility: 'public' | 'members-only';
+	perUserDefaultForNewUsers: 'public' | 'members-only' | 'private-link';
+	nameDisplay: 'real' | 'anonymous' | 'hybrid-self-sees-own';
+	logoVisibility?: 'always-show' | 'always-hide' | 'user-choice';
+	warnings: string[];
+}
+
+const SHARE_MODE_TO_PER_USER: Record<
+	PrivacyPresetValues['defaultShareMode'],
+	PrivacyPreviewModel['perUserDefaultForNewUsers']
+> = {
+	public: 'public',
+	'private-oauth': 'members-only',
+	'private-link': 'private-link'
+};
+
+const ANONYMIZATION_TO_NAME_DISPLAY: Record<
+	PrivacyPresetValues['anonymizationMode'],
+	PrivacyPreviewModel['nameDisplay']
+> = {
+	real: 'real',
+	anonymous: 'anonymous',
+	hybrid: 'hybrid-self-sees-own'
+};
+
+const LOGO_MODE_TO_VISIBILITY: Record<
+	WrappedLogoOptionValue,
+	NonNullable<PrivacyPreviewModel['logoVisibility']>
+> = {
+	always_show: 'always-show',
+	always_hide: 'always-hide',
+	user_choice: 'user-choice'
+};
+
+/**
+ * Derive a {@link PrivacyPreviewModel} from a privacy configuration.
+ *
+ * `logoMode` is OPTIONAL: when supplied (onboarding) `logoVisibility` is
+ * populated and the consumer renders a logo line; when omitted (admin)
+ * `logoVisibility` stays `undefined` and the consumer renders no logo line —
+ * which is why the admin privacy page needs no logoMode wiring at all.
+ */
+export function derivePreview(
+	values: Omit<PrivacyPresetValues, 'logoMode'> & { logoMode?: WrappedLogoOptionValue }
+): PrivacyPreviewModel {
+	const warnings: string[] = [];
+
+	// Landing lookup on while the default is non-public: the form shows but every
+	// lookup 404s until users opt into public sharing. Mirrors the live warning
+	// both flows already surface; sourced from the shared copy module.
+	if (values.publicLandingLookup && values.defaultShareMode !== 'public') {
+		warnings.push(publicLandingLookupCopy.contradictionWarning);
+	}
+
+	const model: PrivacyPreviewModel = {
+		landingLookupForm: values.publicLandingLookup ? 'visible' : 'hidden',
+		serverRecapVisibility: values.serverWrappedShareMode === 'public' ? 'public' : 'members-only',
+		perUserDefaultForNewUsers: SHARE_MODE_TO_PER_USER[values.defaultShareMode],
+		nameDisplay: ANONYMIZATION_TO_NAME_DISPLAY[values.anonymizationMode],
+		warnings
+	};
+
+	if (values.logoMode !== undefined) {
+		model.logoVisibility = LOGO_MODE_TO_VISIBILITY[values.logoMode];
+	}
+
+	return model;
+}
+
+/**
+ * Human-readable labels for {@link PrivacyPreviewModel} fields, shared by both
+ * the onboarding and admin preview UIs so the wording can't drift between flows
+ * (the same reason option copy lives in `options.ts`). Keyed by the model's own
+ * union types, so a new model value fails to compile until a label is added.
+ */
+export const PREVIEW_NAME_DISPLAY_LABELS: Record<PrivacyPreviewModel['nameDisplay'], string> = {
+	real: 'Real usernames',
+	anonymous: 'Anonymous (hidden)',
+	'hybrid-self-sees-own': 'Hybrid — each sees their own name'
+};
+
+export const PREVIEW_RECAP_VISIBILITY_LABELS: Record<
+	PrivacyPreviewModel['serverRecapVisibility'],
+	string
+> = {
+	public: 'Anyone can view',
+	'members-only': 'Server members only'
+};
+
+export const PREVIEW_PER_USER_DEFAULT_LABELS: Record<
+	PrivacyPreviewModel['perUserDefaultForNewUsers'],
+	string
+> = {
+	public: 'Public',
+	'members-only': 'Server members only',
+	'private-link': 'Private link'
+};
+
+export const PREVIEW_LOGO_VISIBILITY_LABELS: Record<
+	NonNullable<PrivacyPreviewModel['logoVisibility']>,
+	string
+> = {
+	'always-show': 'Always shown',
+	'always-hide': 'Always hidden',
+	'user-choice': 'Each user chooses'
+};

--- a/src/lib/sharing/preset-logic.ts
+++ b/src/lib/sharing/preset-logic.ts
@@ -145,7 +145,7 @@ export function derivePreview(
 	const warnings: string[] = [];
 
 	// Landing lookup on while the default is non-public: the form shows but every
-	// lookup 404s until users opt into public sharing. Mirrors the live warning
+	// lookup 404s until at least one Wrapped is set to public sharing. Mirrors the live warning
 	// both flows already surface; sourced from the shared copy module.
 	if (values.publicLandingLookup && values.defaultShareMode !== 'public') {
 		warnings.push(publicLandingLookupCopy.contradictionWarning);

--- a/src/lib/sharing/preset-logic.ts
+++ b/src/lib/sharing/preset-logic.ts
@@ -145,7 +145,7 @@ export function derivePreview(
 	const warnings: string[] = [];
 
 	// Landing lookup on while the default is non-public: the form shows but every
-	// lookup 404s until at least one Wrapped is set to public sharing. Mirrors the live warning
+	// lookup 404s until the default share mode is set to public. Mirrors the live warning
 	// both flows already surface; sourced from the shared copy module.
 	if (values.publicLandingLookup && values.defaultShareMode !== 'public') {
 		warnings.push(publicLandingLookupCopy.contradictionWarning);

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -165,7 +165,16 @@ let showContradictionWarning = $derived(
 // ---------------------------------------------------------------------------
 // Privacy presets (client-only control surface)
 // ---------------------------------------------------------------------------
-let advancedOpen = $state(false);
+// Auto-open Advanced options at mount ONLY when the saved config is already
+// contradictory (public landing lookup on, but the per-user default isn't
+// public), so the contradiction Alert inside Collapsible.Content isn't hidden
+// on page load. This is a one-time init snapshot of showContradictionWarning,
+// not a $effect — the project rule forbids state updates in effects, and an
+// effect would intrusively re-open the section while the admin is editing.
+// After mount the admin can freely collapse/expand. The suppressor matches the
+// other one-time $state-from-reactive declarations above.
+// svelte-ignore state_referenced_locally
+let advancedOpen = $state(showContradictionWarning);
 
 // The active preset is matched over the FIVE admin-owned fields only — logoMode
 // is excluded (it lives on the Appearance route), so a perfect five-field match
@@ -363,7 +372,15 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 		<Collapsible.Trigger
 			class="flex w-full items-center justify-between rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm font-medium transition-colors hover:bg-muted/50"
 		>
-			Advanced options
+			<span class="flex items-center gap-2">
+				Advanced options
+				{#if showContradictionWarning}
+					<!-- At-a-glance flag for the collapsed case: if the admin closes Advanced
+					     while the saved config is still contradictory, this keeps the broken
+					     public-lookup state visible without duplicating the Alert's full text. -->
+					<TriangleAlertIcon class="size-4 text-destructive" />
+				{/if}
+			</span>
 			<ChevronDownIcon class={advancedOpen ? 'size-4 rotate-180 transition-transform' : 'size-4 transition-transform'} />
 		</Collapsible.Trigger>
 		<Collapsible.Content class="space-y-6 pt-6">

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -257,9 +257,11 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 				<dd class="text-right font-medium">{model.landingLookupForm === 'visible' ? 'Shown' : 'Hidden'}</dd>
 			</div>
 		</dl>
-		{#each model.warnings as warning}
-			<p class="text-xs text-amber-500">{warning}</p>
-		{/each}
+		<!-- The only preview warning is the landing-lookup contradiction, which the
+		     inline Alert in the "Public landing lookup" card already surfaces (with
+		     icon, where the admin edits). Rendering it here too duplicated the same
+		     sentence across both preview panels + the Alert, so the warnings line is
+		     intentionally not shown in the preview. -->
 	{/snippet}
 
 	<Card>

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
+import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
 import EyeOffIcon from '@lucide/svelte/icons/eye-off';
 import GlobeIcon from '@lucide/svelte/icons/globe';
+import ImageIcon from '@lucide/svelte/icons/image';
 import LinkIcon from '@lucide/svelte/icons/link';
 import LockIcon from '@lucide/svelte/icons/lock';
+import ScaleIcon from '@lucide/svelte/icons/scale';
+import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
 import ShieldUserIcon from '@lucide/svelte/icons/shield-user';
 import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 import UserCogIcon from '@lucide/svelte/icons/user-cog';
 import UsersIcon from '@lucide/svelte/icons/users';
+import UsersRoundIcon from '@lucide/svelte/icons/users-round';
+import VenetianMaskIcon from '@lucide/svelte/icons/venetian-mask';
+import type { Component } from 'svelte';
 import { superForm } from 'sveltekit-superforms';
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
@@ -25,9 +33,23 @@ import {
 	CardHeader,
 	CardTitle
 } from '$lib/components/ui/card/index.js';
+import * as Collapsible from '$lib/components/ui/collapsible/index.js';
 import * as Form from '$lib/components/ui/form/index.js';
 import { RadioGroup, RadioGroupItem } from '$lib/components/ui/radio-group/index.js';
-import { publicLandingLookupCopy } from '$lib/sharing/options';
+import {
+	PRIVACY_PRESETS,
+	type PrivacyPreset,
+	type PrivacyPresetId,
+	publicLandingLookupCopy
+} from '$lib/sharing/options';
+import {
+	derivePreview,
+	matchPresetPrivacy,
+	PREVIEW_NAME_DISPLAY_LABELS,
+	PREVIEW_PER_USER_DEFAULT_LABELS,
+	PREVIEW_RECAP_VISIBILITY_LABELS,
+	type PrivacyPreviewModel
+} from '$lib/sharing/preset-logic';
 import { handleFormToast } from '$lib/utils/form-toast';
 import { surfaceOccConflict } from '$lib/utils/occ-form';
 import type { PageData } from './$types';
@@ -38,12 +60,36 @@ interface Props {
 
 let { data }: Props = $props();
 
+// Per-section "last saved" baselines. Each advances ONLY after its own section
+// saves successfully (in that form's onUpdated). The unsaved-sections banner and
+// the "Current (saved)" preview read these — never the original load snapshot —
+// so a save in one OCC group correctly clears just that section's pending state.
+// svelte-ignore state_referenced_locally
+let savedServerWrapped = $state({
+	anonymizationMode: data.serverWrappedForm.data.anonymizationMode,
+	serverWrappedShareMode: data.serverWrappedForm.data.serverWrappedShareMode
+});
+// svelte-ignore state_referenced_locally
+let savedUserDefaults = $state({
+	defaultShareMode: data.userDefaultsForm.data.defaultShareMode,
+	allowUserControl: data.userDefaultsForm.data.allowUserControl
+});
+// svelte-ignore state_referenced_locally
+let savedPublicLandingLookup = $state({
+	publicLandingLookup: data.publicLandingLookupForm.data.publicLandingLookup
+});
+
 // svelte-ignore state_referenced_locally
 const serverWrappedForm = superForm(data.serverWrappedForm, {
 	resetForm: false,
 	onUpdate: surfaceOccConflict,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
+			// Advance this section's saved baseline to what was just persisted.
+			savedServerWrapped = {
+				anonymizationMode: updated.data.anonymizationMode,
+				serverWrappedShareMode: updated.data.serverWrappedShareMode
+			};
 			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
 		} else {
 			handleFormToast({ error: updated.message ?? 'Validation failed' });
@@ -62,6 +108,10 @@ const userDefaultsForm = superForm(data.userDefaultsForm, {
 	onUpdate: surfaceOccConflict,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
+			savedUserDefaults = {
+				defaultShareMode: updated.data.defaultShareMode,
+				allowUserControl: updated.data.allowUserControl
+			};
 			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
 		} else {
 			handleFormToast({ error: updated.message ?? 'Validation failed' });
@@ -80,6 +130,9 @@ const publicLandingLookupForm = superForm(data.publicLandingLookupForm, {
 	onUpdate: surfaceOccConflict,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
+			savedPublicLandingLookup = {
+				publicLandingLookup: updated.data.publicLandingLookup
+			};
 			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
 		} else {
 			handleFormToast({ error: updated.message ?? 'Validation failed' });
@@ -102,6 +155,82 @@ let isBulkApplying = $state(false);
 let showContradictionWarning = $derived(
 	$publicLandingLookupData.publicLandingLookup && $userDefaultsData.defaultShareMode !== 'public'
 );
+
+// ---------------------------------------------------------------------------
+// Privacy presets (client-only control surface)
+// ---------------------------------------------------------------------------
+let advancedOpen = $state(false);
+
+// The active preset is matched over the FIVE admin-owned fields only — logoMode
+// is excluded (it lives on the Appearance route), so a perfect five-field match
+// never reads "Custom" because of a differing persisted logoMode.
+let selectedPreset = $derived(
+	matchPresetPrivacy({
+		anonymizationMode: $serverWrappedData.anonymizationMode,
+		defaultShareMode: $userDefaultsData.defaultShareMode,
+		serverWrappedShareMode: $serverWrappedData.serverWrappedShareMode,
+		publicLandingLookup: $publicLandingLookupData.publicLandingLookup,
+		allowUserControl: $userDefaultsData.allowUserControl
+	})
+);
+
+// Dual preview, both WITHOUT logoMode (so neither renders a logo line — admin
+// does not manage logoMode here). "After you save" reflects the staged store
+// values; "Current (saved)" reflects each section's last-saved baseline.
+let stagedPreview: PrivacyPreviewModel = $derived(
+	derivePreview({
+		anonymizationMode: $serverWrappedData.anonymizationMode,
+		defaultShareMode: $userDefaultsData.defaultShareMode,
+		serverWrappedShareMode: $serverWrappedData.serverWrappedShareMode,
+		publicLandingLookup: $publicLandingLookupData.publicLandingLookup,
+		allowUserControl: $userDefaultsData.allowUserControl
+	})
+);
+let savedPreview: PrivacyPreviewModel = $derived(
+	derivePreview({
+		anonymizationMode: savedServerWrapped.anonymizationMode,
+		defaultShareMode: savedUserDefaults.defaultShareMode,
+		serverWrappedShareMode: savedServerWrapped.serverWrappedShareMode,
+		publicLandingLookup: savedPublicLandingLookup.publicLandingLookup,
+		allowUserControl: savedUserDefaults.allowUserControl
+	})
+);
+
+// Per-section divergence: staged store value vs. that section's own last-saved
+// baseline. The banner counts how many sections still need their Save button.
+let serverWrappedUnsaved = $derived(
+	$serverWrappedData.anonymizationMode !== savedServerWrapped.anonymizationMode ||
+		$serverWrappedData.serverWrappedShareMode !== savedServerWrapped.serverWrappedShareMode
+);
+let userDefaultsUnsaved = $derived(
+	$userDefaultsData.defaultShareMode !== savedUserDefaults.defaultShareMode ||
+		$userDefaultsData.allowUserControl !== savedUserDefaults.allowUserControl
+);
+let publicLandingUnsaved = $derived(
+	$publicLandingLookupData.publicLandingLookup !== savedPublicLandingLookup.publicLandingLookup
+);
+let unsavedSectionCount = $derived(
+	(serverWrappedUnsaved ? 1 : 0) + (userDefaultsUnsaved ? 1 : 0) + (publicLandingUnsaved ? 1 : 0)
+);
+
+// Applying a preset is pure client-side state mutation across the three stores.
+// It writes the FIVE admin-owned fields and NEVER touches logoMode. Persistence
+// still flows through each section's existing Save button + OCC group.
+function applyPrivacyPreset(preset: PrivacyPreset) {
+	$serverWrappedData.anonymizationMode = preset.values.anonymizationMode;
+	$serverWrappedData.serverWrappedShareMode = preset.values.serverWrappedShareMode;
+	$userDefaultsData.defaultShareMode = preset.values.defaultShareMode;
+	$userDefaultsData.allowUserControl = preset.values.allowUserControl;
+	$publicLandingLookupData.publicLandingLookup = preset.values.publicLandingLookup;
+}
+
+const presetIcons: Record<PrivacyPresetId, Component> = {
+	'maximum-privacy': ShieldCheckIcon,
+	'internal-community': UsersRoundIcon,
+	balanced: ScaleIcon,
+	'public-showcase': GlobeIcon,
+	'anonymous-public': VenetianMaskIcon
+};
 </script>
 
 <svelte:head>
@@ -109,6 +238,127 @@ let showContradictionWarning = $derived(
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">
+	{#snippet previewRows(model: PrivacyPreviewModel)}
+		<dl class="space-y-1.5 text-sm">
+			<div class="flex justify-between gap-3">
+				<dt class="text-muted-foreground">Names in stats</dt>
+				<dd class="text-right font-medium">{PREVIEW_NAME_DISPLAY_LABELS[model.nameDisplay]}</dd>
+			</div>
+			<div class="flex justify-between gap-3">
+				<dt class="text-muted-foreground">New-user default</dt>
+				<dd class="text-right font-medium">{PREVIEW_PER_USER_DEFAULT_LABELS[model.perUserDefaultForNewUsers]}</dd>
+			</div>
+			<div class="flex justify-between gap-3">
+				<dt class="text-muted-foreground">Server-wide recap</dt>
+				<dd class="text-right font-medium">{PREVIEW_RECAP_VISIBILITY_LABELS[model.serverRecapVisibility]}</dd>
+			</div>
+			<div class="flex justify-between gap-3">
+				<dt class="text-muted-foreground">Landing lookup form</dt>
+				<dd class="text-right font-medium">{model.landingLookupForm === 'visible' ? 'Shown' : 'Hidden'}</dd>
+			</div>
+		</dl>
+		{#each model.warnings as warning}
+			<p class="text-xs text-amber-500">{warning}</p>
+		{/each}
+	{/snippet}
+
+	<Card>
+		<CardHeader>
+			<CardTitle>Privacy presets</CardTitle>
+			<CardDescription>
+				Pick a preset to set anonymization, sharing and landing-lookup in one step — then save each
+				section below. Logo behavior is configured separately on Appearance.
+			</CardDescription>
+		</CardHeader>
+		<CardContent class="space-y-4">
+			<div
+				class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
+				role="radiogroup"
+				aria-label="Privacy preset"
+			>
+				{#each PRIVACY_PRESETS as preset (preset.id)}
+					{@const PresetIcon = presetIcons[preset.id]}
+					<button
+						type="button"
+						role="radio"
+						aria-checked={selectedPreset === preset.id}
+						onclick={() => applyPrivacyPreset(preset)}
+						class={selectedPreset === preset.id
+							? 'flex flex-col items-start gap-2 rounded-lg border border-primary bg-primary/5 p-4 text-left ring-1 ring-primary transition-colors'
+							: 'flex flex-col items-start gap-2 rounded-lg border border-border p-4 text-left transition-colors hover:bg-muted/50'}
+					>
+						<span class="flex items-center gap-2 text-sm font-medium">
+							<PresetIcon class="size-4 text-primary" />
+							{preset.label}
+						</span>
+						<span class="text-xs text-muted-foreground">{preset.description}</span>
+						<span class="text-xs font-medium text-primary/80">{preset.exposureSummary}</span>
+					</button>
+				{/each}
+			</div>
+			{#if selectedPreset === 'custom'}
+				<p class="text-sm italic text-muted-foreground">
+					Custom configuration — your settings don’t match a preset.
+				</p>
+			{/if}
+			<div class="flex items-start gap-2 rounded-lg border border-border bg-muted/30 p-3 text-sm">
+				<ImageIcon class="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+				<div class="space-y-1">
+					<p class="font-medium">Wrapped logo</p>
+					<p class="text-muted-foreground">
+						Logo behavior is configured on
+						<a
+							href="/admin/settings/appearance"
+							class="inline-flex items-center gap-1 underline"
+						>Appearance<ExternalLinkIcon class="size-3" /></a>. Presets don’t change it.
+					</p>
+				</div>
+			</div>
+		</CardContent>
+	</Card>
+
+	<Card>
+		<CardHeader>
+			<CardTitle>Preview</CardTitle>
+			<CardDescription>
+				What your saved and staged settings expose. Logo is managed on Appearance and is not shown here.
+			</CardDescription>
+		</CardHeader>
+		<CardContent class="space-y-4">
+			{#if unsavedSectionCount > 0}
+				<Alert>
+					<TriangleAlertIcon />
+					<AlertDescription>
+						{unsavedSectionCount} unsaved section{unsavedSectionCount === 1 ? '' : 's'} — staged changes
+						aren't live until you save each section below.
+					</AlertDescription>
+				</Alert>
+			{/if}
+			<div class="grid gap-4 sm:grid-cols-2">
+				<div class="space-y-2 rounded-lg border border-border p-4">
+					<p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Current (saved)</p>
+					{@render previewRows(savedPreview)}
+				</div>
+				<div
+					class={unsavedSectionCount > 0
+						? 'space-y-2 rounded-lg border border-primary bg-primary/5 p-4'
+						: 'space-y-2 rounded-lg border border-border p-4'}
+				>
+					<p class="text-xs font-semibold uppercase tracking-wide text-primary/80">After you save</p>
+					{@render previewRows(stagedPreview)}
+				</div>
+			</div>
+		</CardContent>
+	</Card>
+
+	<Collapsible.Root bind:open={advancedOpen} class="space-y-6">
+		<Collapsible.Trigger
+			class="flex w-full items-center justify-between rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm font-medium transition-colors hover:bg-muted/50"
+		>
+			Advanced options
+			<ChevronDownIcon class={advancedOpen ? 'size-4 rotate-180 transition-transform' : 'size-4 transition-transform'} />
+		</Collapsible.Trigger>
+		<Collapsible.Content class="space-y-6 pt-6">
 	<Card>
 		<CardHeader>
 			<CardTitle>Server-wide wrapped sharing</CardTitle>
@@ -336,6 +586,8 @@ let showContradictionWarning = $derived(
 			</form>
 		</CardContent>
 	</Card>
+		</Collapsible.Content>
+	</Collapsible.Root>
 
 	<Card>
 		<CardHeader>

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -64,6 +64,12 @@ let { data }: Props = $props();
 // saves successfully (in that form's onUpdated). The unsaved-sections banner and
 // the "Current (saved)" preview read these — never the original load snapshot —
 // so a save in one OCC group correctly clears just that section's pending state.
+// These are deliberate $state snapshots, NOT $derived from `data`: $derived would
+// re-track every load and zero out unsavedSectionCount after navigation, defeating
+// the per-section unsaved tracking. The state_referenced_locally suppressors are
+// intentional — we want the one-time mount snapshot. (A re-load from a concurrent
+// external write can leave "Current (saved)" one version behind until the next
+// save/navigation; that's cosmetic and OCC catches any real overwrite conflict.)
 // svelte-ignore state_referenced_locally
 let savedServerWrapped = $state({
 	anonymizationMode: data.serverWrappedForm.data.anonymizationMode,

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -14,6 +14,7 @@ import UserCogIcon from '@lucide/svelte/icons/user-cog';
 import UsersIcon from '@lucide/svelte/icons/users';
 import UsersRoundIcon from '@lucide/svelte/icons/users-round';
 import VenetianMaskIcon from '@lucide/svelte/icons/venetian-mask';
+import type { ActionResult } from '@sveltejs/kit';
 import type { Component } from 'svelte';
 import { superForm } from 'sveltekit-superforms';
 import { enhance } from '$app/forms';
@@ -60,6 +61,26 @@ interface Props {
 
 let { data }: Props = $props();
 
+// superForm `onUpdate` guard for the three settings forms. Runs the shared OCC
+// stale-write guard first (cancels on fail(409,{conflict:true}) — ISSUE-006),
+// then also cancels on a *server-side* failure whose form is still schema-valid:
+// the actions return `fail(500, { form, error })` from their catch blocks AFTER
+// validation, so `onUpdated`'s `form.valid` stays true and would otherwise fire a
+// false "Saved" toast + advance the saved baseline even though nothing persisted.
+// fail(400) validation failures have `form.valid === false` and are left alone so
+// they still reach `onUpdated`'s else branch to render field errors. (Locally
+// scoped — the shared occ-form helper is intentionally not generalised here.)
+function guardSettingsUpdate(event: { result: ActionResult; cancel: () => void }): void {
+	surfaceOccConflict(event);
+	const { result } = event;
+	if (result.type === 'failure' && result.status >= 500) {
+		const message =
+			(result.data as { error?: string } | undefined)?.error ?? 'Failed to save. Please try again.';
+		handleFormToast({ error: message });
+		event.cancel();
+	}
+}
+
 // Per-section "last saved" baselines. Each advances ONLY after its own section
 // saves successfully (in that form's onUpdated). The unsaved-sections banner and
 // the "Current (saved)" preview read these — never the original load snapshot —
@@ -88,7 +109,7 @@ let savedPublicLandingLookup = $state({
 // svelte-ignore state_referenced_locally
 const serverWrappedForm = superForm(data.serverWrappedForm, {
 	resetForm: false,
-	onUpdate: surfaceOccConflict,
+	onUpdate: guardSettingsUpdate,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
 			// Advance this section's saved baseline to what was just persisted.
@@ -111,7 +132,7 @@ const {
 // svelte-ignore state_referenced_locally
 const userDefaultsForm = superForm(data.userDefaultsForm, {
 	resetForm: false,
-	onUpdate: surfaceOccConflict,
+	onUpdate: guardSettingsUpdate,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
 			savedUserDefaults = {
@@ -133,7 +154,7 @@ const {
 // svelte-ignore state_referenced_locally
 const publicLandingLookupForm = superForm(data.publicLandingLookupForm, {
 	resetForm: false,
-	onUpdate: surfaceOccConflict,
+	onUpdate: guardSettingsUpdate,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
 			savedPublicLandingLookup = {
@@ -239,6 +260,41 @@ function applyPrivacyPreset(preset: PrivacyPreset) {
 	$publicLandingLookupData.publicLandingLookup = preset.values.publicLandingLookup;
 }
 
+// WAI-ARIA APG radio-group keyboard support for the preset selector. Each preset
+// button is a `role="radio"` in a `role="radiogroup"`; native buttons already
+// handle Space/Enter, so we add roving tabindex (one tab stop) + arrow/Home/End
+// navigation here. Refs are indexed by preset position so a keyboard move can both
+// select (APG: moving in a radio group selects) and shift DOM focus.
+let presetButtons = $state<(HTMLButtonElement | null)[]>([]);
+
+function handlePresetKeydown(event: KeyboardEvent, index: number) {
+	const last = PRIVACY_PRESETS.length - 1;
+	let target: number;
+	switch (event.key) {
+		case 'ArrowRight':
+		case 'ArrowDown':
+			target = index === last ? 0 : index + 1;
+			break;
+		case 'ArrowLeft':
+		case 'ArrowUp':
+			target = index === 0 ? last : index - 1;
+			break;
+		case 'Home':
+			target = 0;
+			break;
+		case 'End':
+			target = last;
+			break;
+		default:
+			return;
+	}
+	const targetPreset = PRIVACY_PRESETS[target];
+	if (!targetPreset) return;
+	event.preventDefault();
+	applyPrivacyPreset(targetPreset);
+	presetButtons[target]?.focus();
+}
+
 const presetIcons: Record<PrivacyPresetId, Component> = {
 	'maximum-privacy': ShieldCheckIcon,
 	'internal-community': UsersRoundIcon,
@@ -293,13 +349,18 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 				role="radiogroup"
 				aria-label="Privacy preset"
 			>
-				{#each PRIVACY_PRESETS as preset (preset.id)}
+				{#each PRIVACY_PRESETS as preset, i (preset.id)}
 					{@const PresetIcon = presetIcons[preset.id]}
 					<button
+						bind:this={presetButtons[i]}
 						type="button"
 						role="radio"
 						aria-checked={selectedPreset === preset.id}
+						tabindex={selectedPreset === preset.id || (selectedPreset === 'custom' && i === 0)
+							? 0
+							: -1}
 						onclick={() => applyPrivacyPreset(preset)}
+						onkeydown={(event) => handlePresetKeydown(event, i)}
 						class={selectedPreset === preset.id
 							? 'flex flex-col items-start gap-2 rounded-lg border border-primary bg-primary/5 p-4 text-left ring-1 ring-primary transition-colors'
 							: 'flex flex-col items-start gap-2 rounded-lg border border-border p-4 text-left transition-colors hover:bg-muted/50'}

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -1,13 +1,34 @@
 <script lang="ts">
 import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
+import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+import GlobeIcon from '@lucide/svelte/icons/globe';
+import ScaleIcon from '@lucide/svelte/icons/scale';
+import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
+import UsersRoundIcon from '@lucide/svelte/icons/users-round';
+import VenetianMaskIcon from '@lucide/svelte/icons/venetian-mask';
 import { animate } from 'motion';
+import type { Component } from 'svelte';
 import { tick, untrack } from 'svelte';
 import { enhance } from '$app/forms';
 import SubmitButton from '$lib/components/forms/SubmitButton.svelte';
 import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
 import { Button } from '$lib/components/ui/button';
-import { publicLandingLookupCopy } from '$lib/sharing/options';
+import {
+	PRIVACY_PRESETS,
+	type PrivacyPreset,
+	type PrivacyPresetId,
+	publicLandingLookupCopy,
+	type ServerWrappedShareModeValue
+} from '$lib/sharing/options';
+import {
+	derivePreview,
+	matchPresetFull,
+	PREVIEW_LOGO_VISIBILITY_LABELS,
+	PREVIEW_NAME_DISPLAY_LABELS,
+	PREVIEW_PER_USER_DEFAULT_LABELS,
+	PREVIEW_RECAP_VISIBILITY_LABELS
+} from '$lib/sharing/preset-logic';
 import { handleFormToast } from '$lib/utils/form-toast';
 import { submitAction } from '$lib/utils/submit-action';
 import { loadThemeFonts } from '$lib/utils/theme-fonts';
@@ -28,14 +49,60 @@ let anonymizationMode = $state(untrack(() => data.settings.anonymizationMode));
 let wrappedLogoMode = $state(untrack(() => data.settings.wrappedLogoMode));
 let defaultShareMode = $state(untrack(() => data.settings.defaultShareMode));
 let allowUserControl = $state(untrack(() => data.settings.allowUserControl));
-let serverWrappedShareMode = $state(untrack(() => data.settings.serverWrappedShareMode));
+// Narrow to the server-wide union ('public' | 'private-oauth') the preset
+// helpers expect; the load already maps any wider value down to these two.
+let serverWrappedShareMode = $state<ServerWrappedShareModeValue>(
+	untrack(() => (data.settings.serverWrappedShareMode === 'public' ? 'public' : 'private-oauth'))
+);
 let publicLandingLookup = $state(untrack(() => data.settings.publicLandingLookup));
 let enableFunFacts = $state(false);
 
-// Live contradiction warning (parity with the settings Privacy page): the landing
-// toggle is the sole gate, so a non-public default means the form shows but every
-// lookup 404s. Surface it to the admin instead of silently hiding the form.
-let showLandingContradiction = $derived(publicLandingLookup && defaultShareMode !== 'public');
+// Privacy presets: a card selects a recommended combination of the six privacy
+// fields below. The active preset is recomputed from the live runes (so manual
+// edits in Advanced Options flip it to "Custom"), never persisted as a field.
+let advancedPrivacyOpen = $state(false);
+
+let selectedPreset = $derived(
+	matchPresetFull({
+		anonymizationMode,
+		defaultShareMode,
+		serverWrappedShareMode,
+		publicLandingLookup,
+		allowUserControl,
+		logoMode: wrappedLogoMode
+	})
+);
+
+// Single live preview (onboarding owns logoMode, so the logo line is included).
+// Its `warnings` is the sole source of the landing-lookup contradiction notice.
+let privacyPreview = $derived(
+	derivePreview({
+		anonymizationMode,
+		defaultShareMode,
+		serverWrappedShareMode,
+		publicLandingLookup,
+		allowUserControl,
+		logoMode: wrappedLogoMode
+	})
+);
+
+function applyPrivacyPreset(preset: PrivacyPreset) {
+	anonymizationMode = preset.values.anonymizationMode;
+	defaultShareMode = preset.values.defaultShareMode;
+	serverWrappedShareMode = preset.values.serverWrappedShareMode;
+	publicLandingLookup = preset.values.publicLandingLookup;
+	allowUserControl = preset.values.allowUserControl;
+	wrappedLogoMode = preset.values.logoMode;
+}
+
+const presetIcons: Record<PrivacyPresetId, Component> = {
+	'maximum-privacy': ShieldCheckIcon,
+	'internal-community': UsersRoundIcon,
+	balanced: ScaleIcon,
+	'public-showcase': GlobeIcon,
+	'anonymous-public': VenetianMaskIcon
+};
+
 let funFactFrequency = $state(untrack(() => data.funFactConfig.mode || 'normal'));
 let openaiApiKey = $state('');
 let openaiBaseUrl = $state(
@@ -438,6 +505,87 @@ function getThemeColors(themeValue: string) {
 						</div>
 
 						<div class="step-fields">
+							<!-- Preset selector: one card sets all six privacy fields below -->
+							<div class="setting-group preset-section">
+								<span class="setting-label">Privacy Preset</span>
+								<p class="setting-description">
+									Pick a starting point — then fine-tune anything in Advanced Options.
+								</p>
+								<div class="preset-grid" role="radiogroup" aria-label="Privacy preset">
+									{#each PRIVACY_PRESETS as preset (preset.id)}
+										{@const PresetIcon = presetIcons[preset.id]}
+										<button
+											type="button"
+											class="preset-card"
+											class:selected={selectedPreset === preset.id}
+											role="radio"
+											aria-checked={selectedPreset === preset.id}
+											onclick={() => applyPrivacyPreset(preset)}
+										>
+											<span class="preset-card-icon">
+												<PresetIcon />
+											</span>
+											<span class="preset-card-body">
+												<span class="preset-card-label">{preset.label}</span>
+												<span class="preset-card-desc">{preset.description}</span>
+												<span class="preset-card-summary">{preset.exposureSummary}</span>
+											</span>
+										</button>
+									{/each}
+								</div>
+								{#if selectedPreset === 'custom'}
+									<p class="preset-custom-note" role="status">
+										Custom configuration — your choices don’t match a preset.
+									</p>
+								{/if}
+							</div>
+
+							<!-- Live preview of what this configuration exposes -->
+							<div class="privacy-preview" aria-live="polite">
+								<span class="preview-title">What this exposes</span>
+								<dl class="preview-rows">
+									<div class="preview-row">
+										<dt>Names in stats</dt>
+										<dd>{PREVIEW_NAME_DISPLAY_LABELS[privacyPreview.nameDisplay]}</dd>
+									</div>
+									<div class="preview-row">
+										<dt>New-user default</dt>
+										<dd>{PREVIEW_PER_USER_DEFAULT_LABELS[privacyPreview.perUserDefaultForNewUsers]}</dd>
+									</div>
+									<div class="preview-row">
+										<dt>Server-wide recap</dt>
+										<dd>{PREVIEW_RECAP_VISIBILITY_LABELS[privacyPreview.serverRecapVisibility]}</dd>
+									</div>
+									<div class="preview-row">
+										<dt>Landing lookup form</dt>
+										<dd>{privacyPreview.landingLookupForm === 'visible' ? 'Shown' : 'Hidden'}</dd>
+									</div>
+									{#if privacyPreview.logoVisibility}
+										<div class="preview-row">
+											<dt>Wrapped logo</dt>
+											<dd>{PREVIEW_LOGO_VISIBILITY_LABELS[privacyPreview.logoVisibility]}</dd>
+										</div>
+									{/if}
+								</dl>
+								{#each privacyPreview.warnings as warning}
+									<p class="landing-warning" role="status">{warning}</p>
+								{/each}
+							</div>
+
+							<!-- Advanced Options: the six granular controls, collapsed by default -->
+							<div class="advanced-options">
+								<button
+									type="button"
+									class="advanced-toggle"
+									class:open={advancedPrivacyOpen}
+									aria-expanded={advancedPrivacyOpen}
+									onclick={() => (advancedPrivacyOpen = !advancedPrivacyOpen)}
+								>
+									<span>Advanced Options</span>
+									<ChevronDownIcon class="advanced-chevron" />
+								</button>
+								{#if advancedPrivacyOpen}
+									<div class="advanced-content">
 							<div class="setting-group">
 								<span class="setting-label">User Identity in Stats</span>
 								<p class="setting-description">How usernames appear in server-wide statistics</p>
@@ -587,10 +735,8 @@ function getThemeColors(themeValue: string) {
 										<span class="toggle-knob"></span>
 									</button>
 								</label>
-								{#if showLandingContradiction}
-									<p class="landing-warning" role="status">
-										{publicLandingLookupCopy.contradictionWarning}
-									</p>
+							</div>
+									</div>
 								{/if}
 							</div>
 						</div>
@@ -1269,6 +1415,196 @@ function getThemeColors(themeValue: string) {
 			background: rgba(245, 158, 11, 0.12);
 			border: 1px solid rgba(245, 158, 11, 0.35);
 			border-radius: 0.625rem;
+		}
+
+		/* ==========================================================================
+		   Privacy Presets
+		   ========================================================================== */
+		.preset-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+			gap: 0.625rem;
+		}
+
+		.preset-card {
+			display: flex;
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.625rem;
+			padding: 0.875rem;
+			text-align: left;
+			background: rgba(0, 0, 0, 0.2);
+			border: 1.5px solid rgba(255, 255, 255, 0.08);
+			border-radius: 0.875rem;
+			cursor: pointer;
+			transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+		}
+
+		.preset-card:hover {
+			background: rgba(0, 0, 0, 0.3);
+			border-color: rgba(255, 255, 255, 0.16);
+			transform: translateY(-2px);
+		}
+
+		.preset-card.selected {
+			border-color: oklch(var(--primary));
+			background: oklch(var(--primary) / 0.1);
+			box-shadow: 0 0 18px oklch(var(--primary) / 0.25);
+		}
+
+		.preset-card-icon {
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			width: 2.25rem;
+			height: 2.25rem;
+			border-radius: 0.625rem;
+			background: oklch(var(--primary) / 0.12);
+			color: oklch(var(--primary));
+			transition: all 0.25s ease;
+		}
+
+		.preset-card-icon :global(svg) {
+			width: 1.25rem;
+			height: 1.25rem;
+		}
+
+		.preset-card.selected .preset-card-icon {
+			background: linear-gradient(135deg, oklch(var(--primary)), oklch(var(--accent)));
+			color: oklch(var(--primary-foreground));
+		}
+
+		.preset-card-body {
+			display: flex;
+			flex-direction: column;
+			gap: 0.25rem;
+		}
+
+		.preset-card-label {
+			font-size: 0.875rem;
+			font-weight: 600;
+			color: rgba(255, 255, 255, 0.92);
+		}
+
+		.preset-card-desc {
+			font-size: 0.75rem;
+			line-height: 1.4;
+			color: rgba(255, 255, 255, 0.5);
+		}
+
+		.preset-card-summary {
+			font-size: 0.7rem;
+			line-height: 1.35;
+			color: oklch(var(--primary) / 0.85);
+			font-variant: small-caps;
+			letter-spacing: 0.02em;
+		}
+
+		.preset-custom-note {
+			margin: 0.75rem 0 0;
+			font-size: 0.78rem;
+			color: rgba(255, 255, 255, 0.6);
+			font-style: italic;
+		}
+
+		/* Live preview panel */
+		.privacy-preview {
+			margin-top: 1.25rem;
+			padding: 1rem;
+			background: rgba(0, 0, 0, 0.22);
+			border: 1px solid oklch(var(--primary) / 0.18);
+			border-radius: 0.875rem;
+		}
+
+		.preview-title {
+			display: block;
+			font-size: 0.7rem;
+			font-weight: 600;
+			text-transform: uppercase;
+			letter-spacing: 0.08em;
+			color: oklch(var(--primary) / 0.9);
+			margin-bottom: 0.75rem;
+		}
+
+		.preview-rows {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+			margin: 0;
+		}
+
+		.preview-row {
+			display: flex;
+			align-items: baseline;
+			justify-content: space-between;
+			gap: 1rem;
+			padding-bottom: 0.5rem;
+			border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+		}
+
+		.preview-row:last-child {
+			padding-bottom: 0;
+			border-bottom: none;
+		}
+
+		.preview-row dt {
+			font-size: 0.78rem;
+			color: rgba(255, 255, 255, 0.5);
+		}
+
+		.preview-row dd {
+			margin: 0;
+			font-size: 0.8rem;
+			font-weight: 500;
+			color: rgba(255, 255, 255, 0.9);
+			text-align: right;
+		}
+
+		/* Advanced Options disclosure */
+		.advanced-options {
+			margin-top: 1.25rem;
+			border-top: 1px solid rgba(255, 255, 255, 0.08);
+			padding-top: 1rem;
+		}
+
+		.advanced-toggle {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			gap: 0.5rem;
+			width: 100%;
+			padding: 0.625rem 0.875rem;
+			background: rgba(0, 0, 0, 0.18);
+			border: 1px solid rgba(255, 255, 255, 0.1);
+			border-radius: 0.75rem;
+			color: rgba(255, 255, 255, 0.78);
+			font-size: 0.82rem;
+			font-weight: 500;
+			cursor: pointer;
+			transition: all 0.2s ease;
+		}
+
+		.advanced-toggle:hover {
+			background: rgba(0, 0, 0, 0.28);
+			color: rgba(255, 255, 255, 0.95);
+		}
+
+		.advanced-toggle :global(.advanced-chevron) {
+			width: 1rem;
+			height: 1rem;
+			transition: transform 0.25s ease;
+		}
+
+		.advanced-toggle.open :global(.advanced-chevron) {
+			transform: rotate(180deg);
+		}
+
+		.advanced-content {
+			display: flex;
+			flex-direction: column;
+			gap: 1.25rem;
+			margin-top: 1rem;
+			animation: fadeSlide 0.25s ease;
 		}
 
 		/* Theme Swatches */

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -95,6 +95,50 @@ function applyPrivacyPreset(preset: PrivacyPreset) {
 	wrappedLogoMode = preset.values.logoMode;
 }
 
+// WAI-ARIA radiogroup keyboard support for the preset selector. The cards are
+// native <button role="radio"> (Space/Enter already activate them); this adds
+// roving tabindex + arrow/Home/End navigation so the group behaves like a real
+// radio group for assistive tech. `presetButtons` is populated by bind:this on
+// each card, indexed by position in PRIVACY_PRESETS.
+let presetButtons = $state<(HTMLButtonElement | undefined)[]>([]);
+
+// Index of the card that holds tabindex=0. When a preset is selected, that card
+// is the tab stop; when the config matches no preset ('custom'), the first card
+// keeps the group reachable.
+let presetTabIndex = $derived.by(() => {
+	const i = PRIVACY_PRESETS.findIndex((p) => p.id === selectedPreset);
+	return i === -1 ? 0 : i;
+});
+
+function handlePresetKeydown(event: KeyboardEvent, index: number) {
+	const last = PRIVACY_PRESETS.length - 1;
+	let target: number;
+	switch (event.key) {
+		case 'ArrowRight':
+		case 'ArrowDown':
+			target = index === last ? 0 : index + 1;
+			break;
+		case 'ArrowLeft':
+		case 'ArrowUp':
+			target = index === 0 ? last : index - 1;
+			break;
+		case 'Home':
+			target = 0;
+			break;
+		case 'End':
+			target = last;
+			break;
+		default:
+			return;
+	}
+	event.preventDefault();
+	const preset = PRIVACY_PRESETS[target];
+	if (!preset) return;
+	// APG: moving within a radio group selects the focused radio.
+	applyPrivacyPreset(preset);
+	presetButtons[target]?.focus();
+}
+
 const presetIcons: Record<PrivacyPresetId, Component> = {
 	'maximum-privacy': ShieldCheckIcon,
 	'internal-community': UsersRoundIcon,
@@ -512,7 +556,7 @@ function getThemeColors(themeValue: string) {
 									Pick a starting point — then fine-tune anything in Advanced Options.
 								</p>
 								<div class="preset-grid" role="radiogroup" aria-label="Privacy preset">
-									{#each PRIVACY_PRESETS as preset (preset.id)}
+									{#each PRIVACY_PRESETS as preset, i (preset.id)}
 										{@const PresetIcon = presetIcons[preset.id]}
 										<button
 											type="button"
@@ -520,7 +564,10 @@ function getThemeColors(themeValue: string) {
 											class:selected={selectedPreset === preset.id}
 											role="radio"
 											aria-checked={selectedPreset === preset.id}
+											tabindex={i === presetTabIndex ? 0 : -1}
+											bind:this={presetButtons[i]}
 											onclick={() => applyPrivacyPreset(preset)}
+											onkeydown={(e) => handlePresetKeydown(e, i)}
 										>
 											<span class="preset-card-icon">
 												<PresetIcon />

--- a/tests/unit/admin/public-landing-lookup.test.ts
+++ b/tests/unit/admin/public-landing-lookup.test.ts
@@ -14,6 +14,7 @@ import { appSettings } from '$lib/server/db/schema';
 import {
 	anonymizationOptions,
 	type OptionCopy,
+	PRIVACY_PRESETS,
 	serverWrappedShareModeOptions,
 	shareModeOptions,
 	wrappedLogoOptions
@@ -122,5 +123,69 @@ describe('shared sharing-option copy module', () => {
 			'private-oauth',
 			'public'
 		]);
+	});
+
+	describe('privacy presets', () => {
+		const anonymizationValues = new Set(anonymizationOptions.map((o) => o.value));
+		const shareModeValues = new Set(shareModeOptions.map((o) => o.value));
+		const serverWrappedValues = new Set(serverWrappedShareModeOptions.map((o) => o.value));
+		const logoValues = new Set(wrappedLogoOptions.map((o) => o.value));
+		const serverAnonymization = new Set(Object.values(AnonymizationMode));
+		const serverShareModes = new Set(Object.values(ShareMode));
+		const serverLogoModes = new Set(Object.values(WrappedLogoMode));
+
+		const expectedKeys = [
+			'anonymizationMode',
+			'defaultShareMode',
+			'serverWrappedShareMode',
+			'publicLandingLookup',
+			'allowUserControl',
+			'logoMode'
+		].sort();
+
+		it('every preset has a unique id', () => {
+			const ids = PRIVACY_PRESETS.map((p) => p.id);
+			expect(new Set(ids).size).toBe(ids.length);
+		});
+
+		it('every preset has non-empty label, description and exposureSummary', () => {
+			for (const preset of PRIVACY_PRESETS) {
+				expect(preset.label.trim().length).toBeGreaterThan(0);
+				expect(preset.description.trim().length).toBeGreaterThan(0);
+				expect(preset.exposureSummary.trim().length).toBeGreaterThan(0);
+			}
+		});
+
+		it('every preset has exactly the six value keys', () => {
+			for (const preset of PRIVACY_PRESETS) {
+				expect(Object.keys(preset.values).sort()).toEqual(expectedKeys);
+			}
+		});
+
+		it('every preset value is a member of its option value-set AND the server enum', () => {
+			for (const preset of PRIVACY_PRESETS) {
+				const v = preset.values;
+
+				// anonymizationMode
+				expect(anonymizationValues.has(v.anonymizationMode)).toBe(true);
+				expect(serverAnonymization.has(v.anonymizationMode)).toBe(true);
+
+				// defaultShareMode (per-user, all three modes)
+				expect(shareModeValues.has(v.defaultShareMode)).toBe(true);
+				expect(serverShareModes.has(v.defaultShareMode)).toBe(true);
+
+				// serverWrappedShareMode (public | private-oauth only)
+				expect(serverWrappedValues.has(v.serverWrappedShareMode)).toBe(true);
+				expect(serverShareModes.has(v.serverWrappedShareMode)).toBe(true);
+
+				// logoMode
+				expect(logoValues.has(v.logoMode)).toBe(true);
+				expect(serverLogoModes.has(v.logoMode)).toBe(true);
+
+				// booleans
+				expect(typeof v.publicLandingLookup).toBe('boolean');
+				expect(typeof v.allowUserControl).toBe('boolean');
+			}
+		});
 	});
 });

--- a/tests/unit/sharing/presets.test.ts
+++ b/tests/unit/sharing/presets.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'bun:test';
+import { PRIVACY_PRESETS, type PrivacyPresetValues } from '$lib/sharing/options';
+import { derivePreview, matchPresetFull, matchPresetPrivacy } from '$lib/sharing/preset-logic';
+
+const byId = (id: string) => {
+	const preset = PRIVACY_PRESETS.find((p) => p.id === id);
+	if (!preset) throw new Error(`preset ${id} not found`);
+	return preset;
+};
+
+describe('matchPresetFull (onboarding, 6 fields)', () => {
+	it('returns the matching id for each preset’s exact six values', () => {
+		for (const preset of PRIVACY_PRESETS) {
+			expect(matchPresetFull(preset.values)).toBe(preset.id);
+		}
+	});
+
+	it('is stable under key reordering', () => {
+		const balanced = byId('balanced').values;
+		// Rebuild the object with keys in a different insertion order.
+		const reordered: PrivacyPresetValues = {
+			logoMode: balanced.logoMode,
+			allowUserControl: balanced.allowUserControl,
+			publicLandingLookup: balanced.publicLandingLookup,
+			serverWrappedShareMode: balanced.serverWrappedShareMode,
+			defaultShareMode: balanced.defaultShareMode,
+			anonymizationMode: balanced.anonymizationMode
+		};
+		expect(matchPresetFull(reordered)).toBe('balanced');
+	});
+
+	it('returns "custom" for an off-map combination', () => {
+		const balanced = byId('balanced').values;
+		// Flip one field so no preset matches.
+		const offMap: PrivacyPresetValues = { ...balanced, logoMode: 'always_show' };
+		expect(matchPresetFull(offMap)).toBe('custom');
+	});
+});
+
+describe('matchPresetPrivacy (admin, 5 fields, logoMode excluded)', () => {
+	it('returns the matching id for the five admin-owned fields', () => {
+		for (const preset of PRIVACY_PRESETS) {
+			const { logoMode: _logoMode, ...fiveFields } = preset.values;
+			expect(matchPresetPrivacy(fiveFields)).toBe(preset.id);
+		}
+	});
+
+	it('matches regardless of logoMode: Balanced 5 fields + logoMode always_hide => "balanced"', () => {
+		const balanced = byId('balanced').values;
+		const { logoMode: _logoMode, ...fiveFields } = balanced;
+		// logoMode is NOT part of the admin match, so passing only the five fields
+		// (whatever the persisted logoMode is) still resolves to balanced.
+		expect(balanced.logoMode).not.toBe('always_hide'); // sanity: balanced is user_choice
+		expect(matchPresetPrivacy(fiveFields)).toBe('balanced');
+	});
+
+	it('returns "custom" when a five-field combination matches no preset', () => {
+		const balanced = byId('balanced').values;
+		const { logoMode: _logoMode, ...fiveFields } = balanced;
+		expect(matchPresetPrivacy({ ...fiveFields, publicLandingLookup: true })).toBe('custom');
+	});
+});
+
+describe('derivePreview', () => {
+	it('populates logoVisibility when logoMode is provided (onboarding)', () => {
+		const preview = derivePreview(byId('public-showcase').values);
+		expect(preview.logoVisibility).toBe('always-show');
+	});
+
+	it('leaves logoVisibility undefined when logoMode is omitted (admin)', () => {
+		const { logoMode: _logoMode, ...fiveFields } = byId('public-showcase').values;
+		const preview = derivePreview(fiveFields);
+		expect(preview.logoVisibility).toBeUndefined();
+	});
+
+	it('separates form/recap visibility from per-user reachability for a public showcase', () => {
+		const preview = derivePreview(byId('public-showcase').values);
+		expect(preview.landingLookupForm).toBe('visible');
+		expect(preview.serverRecapVisibility).toBe('public');
+		expect(preview.perUserDefaultForNewUsers).toBe('public');
+		// No field on the model claims an existing/private user is reachable.
+		expect(preview.warnings).toHaveLength(0);
+	});
+
+	it('admin default public + a sampled private user makes no reachable claim', () => {
+		// Admin default is public, but the model only ever reports the NEW-user
+		// default — it never asserts that a specific existing private user is reachable.
+		const preview = derivePreview({
+			anonymizationMode: 'real',
+			defaultShareMode: 'public',
+			serverWrappedShareMode: 'public',
+			publicLandingLookup: true,
+			allowUserControl: true
+		});
+		expect(preview.perUserDefaultForNewUsers).toBe('public');
+		// The model has no 'reachable'/per-user field at all — exposure is scoped to
+		// the new-user default and admin-controlled form/recap visibility only.
+		expect(Object.keys(preview)).not.toContain('perUserReachable');
+	});
+
+	it('maps hybrid anonymization to hybrid-self-sees-own', () => {
+		const preview = derivePreview(byId('balanced').values);
+		expect(preview.nameDisplay).toBe('hybrid-self-sees-own');
+	});
+
+	it('maps anonymous and real name displays', () => {
+		expect(derivePreview(byId('maximum-privacy').values).nameDisplay).toBe('anonymous');
+		expect(derivePreview(byId('internal-community').values).nameDisplay).toBe('real');
+	});
+
+	it('emits the contradiction warning for a custom combo (public lookup on + non-public default)', () => {
+		const preview = derivePreview({
+			anonymizationMode: 'hybrid',
+			defaultShareMode: 'private-oauth',
+			serverWrappedShareMode: 'private-oauth',
+			publicLandingLookup: true,
+			allowUserControl: true
+		});
+		expect(preview.warnings.length).toBeGreaterThan(0);
+		expect(preview.warnings.some((w) => /public lookup is on/i.test(w))).toBe(true);
+	});
+
+	it('no shipped preset trips the contradiction warning', () => {
+		for (const preset of PRIVACY_PRESETS) {
+			expect(derivePreview(preset.values).warnings).toHaveLength(0);
+		}
+	});
+});
+
+describe('negative guard: preset is never a persisted or submitted field', () => {
+	const read = async (path: string) => await Bun.file(path).text();
+
+	it('onboarding +page.svelte never submits a "preset" form field', async () => {
+		const src = await read('src/routes/onboarding/settings/+page.svelte');
+		expect(/name=["']preset["']/.test(src)).toBe(false);
+		expect(/formData\.set\(\s*["']preset["']/.test(src)).toBe(false);
+	});
+
+	it('onboarding SettingsSchema has no "preset" key and the action never reads one', async () => {
+		const src = await read('src/routes/onboarding/settings/+page.server.ts');
+		expect(/^\s*preset\s*:/m.test(src)).toBe(false);
+		expect(/formData\.get\(\s*["']preset["']/.test(src)).toBe(false);
+	});
+
+	it('admin privacy +page.svelte never submits a "preset" form field', async () => {
+		const src = await read('src/routes/admin/settings/privacy/+page.svelte');
+		expect(/name=["']preset["']/.test(src)).toBe(false);
+		expect(/formData\.set\(\s*["']preset["']/.test(src)).toBe(false);
+	});
+
+	it('admin privacy schemas have no "preset" key and actions never read one', async () => {
+		const src = await read('src/routes/admin/settings/privacy/+page.server.ts');
+		expect(/^\s*preset\s*:/m.test(src)).toBe(false);
+		expect(/formData\.get\(\s*["']preset["']/.test(src)).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Introduces a preset-based privacy configuration model with strict parity between the onboarding "Configure Your Experience" step and the admin Privacy settings page. Each surface gains a visual preset card selector, a live exposure preview, and keeps the existing granular controls in a collapsed "Advanced Options" disclosure.

A preset is a **client-only control surface**: it selects existing fields and is never a persisted DB key, Zod field, or submitted form field. Persistence continues to flow through the existing setters, actions, and OCC groups, which are unchanged. The admin privacy `+page.server.ts` is untouched.

## Changes

### Shared logic (client-safe, no `$lib/server` imports)

- `src/lib/sharing/options.ts`
  - Adds `PrivacyPresetId`, `PrivacyPresetValues` (exactly 6 keys), `PrivacyPresetPrivacyKey` (the 5 admin-owned keys, `logoMode` excluded), and `PRIVACY_PRESETS`.
  - Ships five presets: Maximum Privacy, Internal Community, Balanced (default), Public Showcase, Anonymous Public. Balanced ships with `publicLandingLookup: false`, so no shipped preset trips the landing-lookup contradiction warning.
  - Header widened from "copy only" to "copy + client-safe preset value-maps".
- `src/lib/sharing/preset-logic.ts` (new)
  - `matchPresetFull` (6 fields) for onboarding, `matchPresetPrivacy` (5 fields, `logoMode` excluded) for admin.
  - `derivePreview` (with optional `logoMode`), the `PrivacyPreviewModel` type, and shared preview-label maps.
  - `derivePreview` deliberately separates admin-controlled landing-form / recap visibility from per-user effective reachability, so the preview can never overstate exposure or privacy.

### Onboarding (`src/routes/onboarding/settings/+page.svelte`)

- Preset card grid (dark custom-CSS idiom) sets all six existing `$state` runes.
- Single live preview that includes the logo line; the contradiction warning is sourced from `derivePreview().warnings`.
- The six granular controls move into a collapsed-by-default Advanced Options disclosure.
- The `enhance` submit logic and hidden inputs are unchanged (the preset reuses the existing `wrappedLogoMode` to `logoMode` mapping; no second field name is introduced).

### Admin (`src/routes/admin/settings/privacy/+page.svelte` only)

- shadcn `Card` preset selector that writes only the five admin-owned fields across the three Superform stores and never touches `logoMode`.
- `logoMode` is shown read-only with a link to the Appearance route and is excluded from the preset match.
- Dual preview ("Current (saved)" vs "After you save", both without the logo line) plus an "N unsaved section(s)" banner computed against each section's advancing last-saved baseline, making the multi-save lifecycle legible.
- The three OCC-isolated forms, per-section Save buttons, and hidden `settingsVersion` inputs are kept exactly as-is. `+page.server.ts` is unchanged.

### Tests

- Extends the shared-copy drift test (`tests/unit/admin/public-landing-lookup.test.ts`) to protect presets: every preset value is a member of its option value-set and the server enum, each preset has exactly the six keys, ids are unique, and copy is non-empty.
- Adds `tests/unit/sharing/presets.test.ts` covering both match functions, the `logoMode` false-Custom trap, preview honesty (no per-user reachability claim), and a negative guard that no `preset` field is ever persisted or submitted.

## Verification

- `bun run check` (svelte-kit sync + svelte-check): 0 errors, 0 warnings.
- `bun run check:biome`: clean.
- `bun run test`: 2068 pass, 0 fail; coverage thresholds met.
- Admin privacy `+page.server.ts` confirmed byte-for-byte unchanged.

## Notes

- No database schema, migration, Zod schema, or write-path changes.
- The three admin OCC groups remain isolated; saves work in any order without false 409s.
