### PR TITLE
feat(privacy): add per-perspective tooltips to "What this exposes" preview

### DIFF
--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -187,13 +187,13 @@ export const PRIVACY_PREVIEW_ROW_TOOLTIPS: Record<
 		admin:
 			'Sets the share mode applied to each newly-created user. Existing users keep their current setting until you apply defaults to all users.',
 		visitor:
-			"A visitor can only open a user's Wrapped when this default is Public. Members-only and private-link pages stay unreachable without signing in.",
+			"A visitor can open a user's Wrapped without signing in when this default is Public, or Private Link if they have the share link. Server-members-only pages require signing in.",
 		member:
 			'Signed-in members can open members-only Wrapped pages. If user control is allowed, each member can still override their own share mode.'
 	},
 	serverWideRecap: {
 		admin:
-			"Controls who can open the server-wide /wrapped recap that aggregates every user's stats.",
+			"Controls who can open the server-wide Wrapped recap that aggregates every user's stats.",
 		visitor:
 			'A visitor sees the server-wide recap only when it is set to Public; otherwise they are prompted to sign in.',
 		member:

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -136,6 +136,80 @@ export const publicLandingLookupCopy = {
 } as const;
 
 // ============================================================================
+// "What this exposes" preview-row tooltips
+// ============================================================================
+
+/**
+ * Stable identifiers for the four shared "What this exposes" preview rows. They
+ * map onto the corresponding {@link PrivacyPreviewModel} fields but are keyed by
+ * the row concept (not the model union) because the tooltip copy describes the
+ * *setting*, not its current value.
+ */
+export type PrivacyPreviewRowKey =
+	| 'namesInStats'
+	| 'newUserDefault'
+	| 'serverWideRecap'
+	| 'landingLookupForm';
+
+/**
+ * Real-world implications of a privacy preview row from the three viewpoints the
+ * app distinguishes: the admin managing the server, an anonymous visitor on the
+ * public landing page / shared links, and a signed-in server member.
+ */
+export interface PrivacyPreviewPerspectives {
+	/** How the setting affects server-wide data and management. */
+	admin: string;
+	/** What an anonymous (non-member) visitor sees on public surfaces. */
+	visitor: string;
+	/** What a signed-in server member sees vs. their own and others' data. */
+	member: string;
+}
+
+/**
+ * Tooltip copy for each "What this exposes" preview row. Centralized here — next
+ * to the option copy that drives the same controls — so the onboarding and admin
+ * privacy previews can never drift apart. Both flows render these strings under a
+ * small info trigger on each `<dt>` label.
+ */
+export const PRIVACY_PREVIEW_ROW_TOOLTIPS: Record<
+	PrivacyPreviewRowKey,
+	PrivacyPreviewPerspectives
+> = {
+	namesInStats: {
+		admin:
+			'Admins always see real usernames in the dashboard and Users page. This setting only changes how names appear in public-facing, server-wide stats and leaderboards.',
+		visitor:
+			'Anonymous visitors see real names, an anonymous placeholder, or no name at all — whichever anonymization mode you choose here.',
+		member:
+			'With Hybrid, a signed-in member sees their own real name while everyone else stays anonymized. Real shows all names; Anonymous hides them for everyone.'
+	},
+	newUserDefault: {
+		admin:
+			'Sets the share mode applied to each newly-created user. Existing users keep their current setting until you apply defaults to all users.',
+		visitor:
+			"A visitor can only open a user's Wrapped when this default is Public. Members-only and private-link pages stay unreachable without signing in.",
+		member:
+			'Signed-in members can open members-only Wrapped pages. If user control is allowed, each member can still override their own share mode.'
+	},
+	serverWideRecap: {
+		admin:
+			"Controls who can open the server-wide /wrapped recap that aggregates every user's stats.",
+		visitor:
+			'A visitor sees the server-wide recap only when it is set to Public; otherwise they are prompted to sign in.',
+		member:
+			'Signed-in server members can open the server-wide recap whether it is set to members-only or public.'
+	},
+	landingLookupForm: {
+		admin:
+			'Shows or hides the username lookup field on the public landing page. Only Wrapped pages set to Public are reachable through it.',
+		visitor:
+			"When shown, a visitor can type a username to find that person's public Wrapped without signing in.",
+		member:
+			'Members normally reach Wrapped pages from the dashboard, so this form mainly affects anonymous visitors on the landing page.'
+	}
+};
+
+// ============================================================================
 // Privacy presets (client-only control surface)
 // ============================================================================
 

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -4,6 +4,7 @@ import ExternalLinkIcon from '@lucide/svelte/icons/external-link';
 import EyeOffIcon from '@lucide/svelte/icons/eye-off';
 import GlobeIcon from '@lucide/svelte/icons/globe';
 import ImageIcon from '@lucide/svelte/icons/image';
+import InfoIcon from '@lucide/svelte/icons/info';
 import LinkIcon from '@lucide/svelte/icons/link';
 import LockIcon from '@lucide/svelte/icons/lock';
 import ScaleIcon from '@lucide/svelte/icons/scale';
@@ -37,10 +38,13 @@ import {
 import * as Collapsible from '$lib/components/ui/collapsible/index.js';
 import * as Form from '$lib/components/ui/form/index.js';
 import { RadioGroup, RadioGroupItem } from '$lib/components/ui/radio-group/index.js';
+import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 import {
 	PRIVACY_PRESETS,
+	PRIVACY_PREVIEW_ROW_TOOLTIPS,
 	type PrivacyPreset,
 	type PrivacyPresetId,
+	type PrivacyPreviewRowKey,
 	publicLandingLookupCopy
 } from '$lib/sharing/options';
 import {
@@ -309,22 +313,48 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">
+	{#snippet tipDt(key: PrivacyPreviewRowKey, label: string)}
+		{@const tip = PRIVACY_PREVIEW_ROW_TOOLTIPS[key]}
+		<dt class="text-muted-foreground">
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					class="inline-flex items-center gap-1 rounded text-left underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+				>
+					{label}
+					<InfoIcon class="size-3 shrink-0 opacity-70" aria-hidden="true" />
+				</Tooltip.Trigger>
+				<Tooltip.Content
+					side="top"
+					sideOffset={6}
+					collisionPadding={16}
+					portalProps={{ to: 'body' }}
+				>
+					<div class="flex flex-col gap-1.5 text-left">
+						<p><span class="font-semibold">Admin:</span> {tip.admin}</p>
+						<p><span class="font-semibold">Visitor:</span> {tip.visitor}</p>
+						<p><span class="font-semibold">Member:</span> {tip.member}</p>
+					</div>
+				</Tooltip.Content>
+			</Tooltip.Root>
+		</dt>
+	{/snippet}
+
 	{#snippet previewRows(model: PrivacyPreviewModel)}
 		<dl class="space-y-1.5 text-sm">
 			<div class="flex justify-between gap-3">
-				<dt class="text-muted-foreground">Names in stats</dt>
+				{@render tipDt('namesInStats', 'Names in stats')}
 				<dd class="text-right font-medium">{PREVIEW_NAME_DISPLAY_LABELS[model.nameDisplay]}</dd>
 			</div>
 			<div class="flex justify-between gap-3">
-				<dt class="text-muted-foreground">New-user default</dt>
+				{@render tipDt('newUserDefault', 'New-user default')}
 				<dd class="text-right font-medium">{PREVIEW_PER_USER_DEFAULT_LABELS[model.perUserDefaultForNewUsers]}</dd>
 			</div>
 			<div class="flex justify-between gap-3">
-				<dt class="text-muted-foreground">Server-wide recap</dt>
+				{@render tipDt('serverWideRecap', 'Server-wide recap')}
 				<dd class="text-right font-medium">{PREVIEW_RECAP_VISIBILITY_LABELS[model.serverRecapVisibility]}</dd>
 			</div>
 			<div class="flex justify-between gap-3">
-				<dt class="text-muted-foreground">Landing lookup form</dt>
+				{@render tipDt('landingLookupForm', 'Landing lookup form')}
 				<dd class="text-right font-medium">{model.landingLookupForm === 'visible' ? 'Shown' : 'Hidden'}</dd>
 			</div>
 		</dl>
@@ -412,20 +442,22 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 					</AlertDescription>
 				</Alert>
 			{/if}
-			<div class="grid gap-4 sm:grid-cols-2">
-				<div class="space-y-2 rounded-lg border border-border p-4">
-					<p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Current (saved)</p>
-					{@render previewRows(savedPreview)}
+			<Tooltip.Provider delayDuration={150}>
+				<div class="grid gap-4 sm:grid-cols-2">
+					<div class="space-y-2 rounded-lg border border-border p-4">
+						<p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Current (saved)</p>
+						{@render previewRows(savedPreview)}
+					</div>
+					<div
+						class={unsavedSectionCount > 0
+							? 'space-y-2 rounded-lg border border-primary bg-primary/5 p-4'
+							: 'space-y-2 rounded-lg border border-border p-4'}
+					>
+						<p class="text-xs font-semibold uppercase tracking-wide text-primary/80">After you save</p>
+						{@render previewRows(stagedPreview)}
+					</div>
 				</div>
-				<div
-					class={unsavedSectionCount > 0
-						? 'space-y-2 rounded-lg border border-primary bg-primary/5 p-4'
-						: 'space-y-2 rounded-lg border border-border p-4'}
-				>
-					<p class="text-xs font-semibold uppercase tracking-wide text-primary/80">After you save</p>
-					{@render previewRows(stagedPreview)}
-				</div>
-			</div>
+			</Tooltip.Provider>
 		</CardContent>
 	</Card>
 

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -3,6 +3,7 @@ import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
 import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 import GlobeIcon from '@lucide/svelte/icons/globe';
+import InfoIcon from '@lucide/svelte/icons/info';
 import ScaleIcon from '@lucide/svelte/icons/scale';
 import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
 import UsersRoundIcon from '@lucide/svelte/icons/users-round';
@@ -14,10 +15,13 @@ import { enhance } from '$app/forms';
 import SubmitButton from '$lib/components/forms/SubmitButton.svelte';
 import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
 import { Button } from '$lib/components/ui/button';
+import * as Tooltip from '$lib/components/ui/tooltip';
 import {
 	PRIVACY_PRESETS,
+	PRIVACY_PREVIEW_ROW_TOOLTIPS,
 	type PrivacyPreset,
 	type PrivacyPresetId,
+	type PrivacyPreviewRowKey,
 	publicLandingLookupCopy,
 	type ServerWrappedShareModeValue
 } from '$lib/sharing/options';
@@ -588,32 +592,57 @@ function getThemeColors(themeValue: string) {
 							</div>
 
 							<!-- Live preview of what this configuration exposes -->
+							{#snippet previewDt(key: PrivacyPreviewRowKey, label: string)}
+								{@const tip = PRIVACY_PREVIEW_ROW_TOOLTIPS[key]}
+								<dt>
+									<Tooltip.Root>
+										<Tooltip.Trigger class="preview-dt-trigger">
+											{label}
+											<InfoIcon class="preview-info-icon" aria-hidden="true" />
+										</Tooltip.Trigger>
+										<Tooltip.Content
+											side="top"
+											sideOffset={6}
+											collisionPadding={16}
+											portalProps={{ to: 'body' }}
+										>
+											<div class="flex flex-col gap-1.5 text-left">
+												<p><span class="font-semibold">Admin:</span> {tip.admin}</p>
+												<p><span class="font-semibold">Visitor:</span> {tip.visitor}</p>
+												<p><span class="font-semibold">Member:</span> {tip.member}</p>
+											</div>
+										</Tooltip.Content>
+									</Tooltip.Root>
+								</dt>
+							{/snippet}
 							<div class="privacy-preview" aria-live="polite">
 								<span class="preview-title">What this exposes</span>
-								<dl class="preview-rows">
-									<div class="preview-row">
-										<dt>Names in stats</dt>
-										<dd>{PREVIEW_NAME_DISPLAY_LABELS[privacyPreview.nameDisplay]}</dd>
-									</div>
-									<div class="preview-row">
-										<dt>New-user default</dt>
-										<dd>{PREVIEW_PER_USER_DEFAULT_LABELS[privacyPreview.perUserDefaultForNewUsers]}</dd>
-									</div>
-									<div class="preview-row">
-										<dt>Server-wide recap</dt>
-										<dd>{PREVIEW_RECAP_VISIBILITY_LABELS[privacyPreview.serverRecapVisibility]}</dd>
-									</div>
-									<div class="preview-row">
-										<dt>Landing lookup form</dt>
-										<dd>{privacyPreview.landingLookupForm === 'visible' ? 'Shown' : 'Hidden'}</dd>
-									</div>
-									{#if privacyPreview.logoVisibility}
+								<Tooltip.Provider delayDuration={150}>
+									<dl class="preview-rows">
 										<div class="preview-row">
-											<dt>Wrapped logo</dt>
-											<dd>{PREVIEW_LOGO_VISIBILITY_LABELS[privacyPreview.logoVisibility]}</dd>
+											{@render previewDt('namesInStats', 'Names in stats')}
+											<dd>{PREVIEW_NAME_DISPLAY_LABELS[privacyPreview.nameDisplay]}</dd>
 										</div>
-									{/if}
-								</dl>
+										<div class="preview-row">
+											{@render previewDt('newUserDefault', 'New-user default')}
+											<dd>{PREVIEW_PER_USER_DEFAULT_LABELS[privacyPreview.perUserDefaultForNewUsers]}</dd>
+										</div>
+										<div class="preview-row">
+											{@render previewDt('serverWideRecap', 'Server-wide recap')}
+											<dd>{PREVIEW_RECAP_VISIBILITY_LABELS[privacyPreview.serverRecapVisibility]}</dd>
+										</div>
+										<div class="preview-row">
+											{@render previewDt('landingLookupForm', 'Landing lookup form')}
+											<dd>{privacyPreview.landingLookupForm === 'visible' ? 'Shown' : 'Hidden'}</dd>
+										</div>
+										{#if privacyPreview.logoVisibility}
+											<div class="preview-row">
+												<dt>Wrapped logo</dt>
+												<dd>{PREVIEW_LOGO_VISIBILITY_LABELS[privacyPreview.logoVisibility]}</dd>
+											</div>
+										{/if}
+									</dl>
+								</Tooltip.Provider>
 								{#each privacyPreview.warnings as warning}
 									<p class="landing-warning" role="status">{warning}</p>
 								{/each}
@@ -1597,6 +1626,40 @@ function getThemeColors(themeValue: string) {
 		.preview-row dt {
 			font-size: 0.78rem;
 			color: rgba(255, 255, 255, 0.5);
+		}
+
+		/* Tooltip trigger on each preview label: a borderless inline button so the
+		   label + info icon read as one help target (hover or keyboard focus). The
+		   class lands on the bits-ui Trigger's rendered <button>, so it must be
+		   :global — scoped under .preview-row to stay effectively local. */
+		.preview-row :global(.preview-dt-trigger) {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.3rem;
+			padding: 0;
+			background: none;
+			border: none;
+			font: inherit;
+			color: inherit;
+			cursor: help;
+			text-align: left;
+			border-radius: 0.25rem;
+		}
+
+		.preview-row :global(.preview-dt-trigger:hover) {
+			color: rgba(255, 255, 255, 0.8);
+		}
+
+		.preview-row :global(.preview-dt-trigger:focus-visible) {
+			outline: 2px solid oklch(var(--primary) / 0.6);
+			outline-offset: 2px;
+		}
+
+		.preview-row :global(.preview-info-icon) {
+			width: 0.85rem;
+			height: 0.85rem;
+			flex-shrink: 0;
+			opacity: 0.65;
 		}
 
 		.preview-row dd {


### PR DESCRIPTION
## Summary

Enhances the "What this exposes" privacy preview in both the onboarding flow and the admin privacy settings by adding informative tooltips to each preview row. The goal is to clarify the real-world implications of each privacy setting for the three kinds of people who interact with the app.

For each of the four preview rows — **Names in stats**, **New-user default**, **Server-wide recap**, and **Landing lookup form** — a hoverable tooltip now explains the setting from three perspectives:

- **Admin** — how the setting affects server-wide data and management.
- **Visitor (non-member)** — what an anonymous visitor sees on the public landing page and shared links.
- **Member** — what a signed-in server member sees compared to their own data and other users' data.

## Changes

- **`src/lib/sharing/options.ts`** — New `PRIVACY_PREVIEW_ROW_TOOLTIPS` map (keyed by the new `PrivacyPreviewRowKey` type, typed by the new `PrivacyPreviewPerspectives` interface) holding all tooltip copy. Centralized here next to the existing shared option copy so the onboarding and admin previews cannot drift apart.
- **`src/routes/onboarding/settings/+page.svelte`** — Adds a `previewDt` snippet that wraps each `<dt>` label in a Tooltip with an info-icon trigger. The preview list is wrapped in a `Tooltip.Provider`. Scoped styles added for the trigger button and info icon.
- **`src/routes/admin/settings/privacy/+page.svelte`** — Adds a `tipDt` snippet used by the shared `previewRows` snippet, so the tooltips appear in both the "Current (saved)" and "After you save" preview panels. The preview grid is wrapped in a `Tooltip.Provider`.

## Accessibility

Each tooltip trigger is a focusable `<button>` whose accessible name includes the row label, so tooltips open on both hover and keyboard focus, with a visible focus ring.

## Verification

- `bun run check` — 0 errors, 0 warnings
- `bun run lint` and `bun run check:biome` — clean
- `bun test` — 262 pass / 0 fail; `options.ts` and `preset-logic.ts` remain at 100% coverage

No behavioral or data changes; this is presentation-only copy plus the tooltip wiring.
