### PR TITLE
feat(privacy): add per-value tooltips to "What this exposes" preview

### DIFF
--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -210,6 +210,70 @@ export const PRIVACY_PREVIEW_ROW_TOOLTIPS: Record<
 };
 
 // ============================================================================
+// "What this exposes" preview-VALUE tooltips
+// ============================================================================
+
+/**
+ * Value literals each preview row can display, mirroring the matching
+ * `PrivacyPreviewModel` field unions in `src/lib/sharing/preset-logic.ts`. They
+ * are redeclared here (rather than imported) on purpose: `preset-logic.ts`
+ * imports from this module, so importing its types back would create a circular
+ * dependency. Keeping them local follows the same pattern as the anonymization /
+ * logo value literals above, which mirror the server enums without importing
+ * them. `wrappedLogo` covers the onboarding-only logo row (admin omits it).
+ */
+export interface PrivacyPreviewValueTooltips {
+	namesInStats: Record<'real' | 'anonymous' | 'hybrid-self-sees-own', string>;
+	newUserDefault: Record<'public' | 'members-only' | 'private-link', string>;
+	serverWideRecap: Record<'public' | 'members-only', string>;
+	landingLookupForm: Record<'visible' | 'hidden', string>;
+	wrappedLogo: Record<'always-show' | 'always-hide' | 'user-choice', string>;
+}
+
+/**
+ * Tooltip copy explaining the *specific effect* of the currently-selected value
+ * in each "What this exposes" preview row — the complement to
+ * {@link PRIVACY_PREVIEW_ROW_TOOLTIPS}, which describes the setting in general.
+ * Where the row tooltip answers "what is this control?", these answer "what does
+ * *this* choice actually do?". Centralized next to the row copy so the onboarding
+ * and admin previews stay in lockstep. Each string is a single, plain-language
+ * sentence rendered under a small info trigger on the `<dd>` value.
+ */
+export const PRIVACY_PREVIEW_VALUE_TOOLTIPS: PrivacyPreviewValueTooltips = {
+	namesInStats: {
+		real: "Public, server-wide stats and leaderboards show each person's actual Plex username.",
+		anonymous:
+			'Usernames are replaced with neutral placeholders like “User #1” everywhere except the admin dashboard — no one is identifiable in public stats.',
+		'hybrid-self-sees-own':
+			'A signed-in member sees their own real name, while everyone else stays anonymized as “User #1”.'
+	},
+	newUserDefault: {
+		public: "New users' Wrapped pages are reachable by anyone with the link — no sign-in required.",
+		'members-only':
+			"New users' Wrapped pages require signing in with a Plex account on this server.",
+		'private-link':
+			"New users' Wrapped pages are reachable only through a unique, unguessable share link."
+	},
+	serverWideRecap: {
+		public:
+			"The server-wide /wrapped recap is open to anyone, including anonymous visitors who aren't signed in.",
+		'members-only':
+			'The server-wide /wrapped recap requires signing in with a Plex account on this server.'
+	},
+	landingLookupForm: {
+		visible:
+			'The landing page shows a username lookup field so visitors can open any Public Wrapped without signing in.',
+		hidden:
+			'The landing page hides the lookup field and shows a “Sign in with Plex” button instead.'
+	},
+	wrappedLogo: {
+		'always-show': "The Obzorarr logo is shown on every Wrapped page and users can't hide it.",
+		'always-hide': "The Obzorarr logo is hidden on every Wrapped page and users can't reveal it.",
+		'user-choice': 'Each user decides whether the Obzorarr logo appears on their own Wrapped pages.'
+	}
+};
+
+// ============================================================================
 // Privacy presets (client-only control surface)
 // ============================================================================
 

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -42,6 +42,7 @@ import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 import {
 	PRIVACY_PRESETS,
 	PRIVACY_PREVIEW_ROW_TOOLTIPS,
+	PRIVACY_PREVIEW_VALUE_TOOLTIPS,
 	type PrivacyPreset,
 	type PrivacyPresetId,
 	type PrivacyPreviewRowKey,
@@ -339,23 +340,58 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 		</dt>
 	{/snippet}
 
+	<!-- Value tooltip: explains the specific effect of the selected value, mirroring
+	     the tipDt label-trigger styling but right-aligned + emphasized like the value. -->
+	{#snippet previewDd(tip: string, label: string)}
+		<dd class="text-right font-medium">
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					class="inline-flex items-center gap-1 rounded text-right font-medium underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+				>
+					{label}
+					<InfoIcon class="size-3 shrink-0 opacity-70" aria-hidden="true" />
+				</Tooltip.Trigger>
+				<Tooltip.Content
+					side="top"
+					sideOffset={6}
+					collisionPadding={16}
+					portalProps={{ to: 'body' }}
+				>
+					<p class="text-left">{tip}</p>
+				</Tooltip.Content>
+			</Tooltip.Root>
+		</dd>
+	{/snippet}
+
 	{#snippet previewRows(model: PrivacyPreviewModel)}
 		<dl class="space-y-1.5 text-sm">
 			<div class="flex justify-between gap-3">
 				{@render tipDt('namesInStats', 'Names in stats')}
-				<dd class="text-right font-medium">{PREVIEW_NAME_DISPLAY_LABELS[model.nameDisplay]}</dd>
+				{@render previewDd(
+					PRIVACY_PREVIEW_VALUE_TOOLTIPS.namesInStats[model.nameDisplay],
+					PREVIEW_NAME_DISPLAY_LABELS[model.nameDisplay]
+				)}
 			</div>
 			<div class="flex justify-between gap-3">
 				{@render tipDt('newUserDefault', 'New-user default')}
-				<dd class="text-right font-medium">{PREVIEW_PER_USER_DEFAULT_LABELS[model.perUserDefaultForNewUsers]}</dd>
+				{@render previewDd(
+					PRIVACY_PREVIEW_VALUE_TOOLTIPS.newUserDefault[model.perUserDefaultForNewUsers],
+					PREVIEW_PER_USER_DEFAULT_LABELS[model.perUserDefaultForNewUsers]
+				)}
 			</div>
 			<div class="flex justify-between gap-3">
 				{@render tipDt('serverWideRecap', 'Server-wide recap')}
-				<dd class="text-right font-medium">{PREVIEW_RECAP_VISIBILITY_LABELS[model.serverRecapVisibility]}</dd>
+				{@render previewDd(
+					PRIVACY_PREVIEW_VALUE_TOOLTIPS.serverWideRecap[model.serverRecapVisibility],
+					PREVIEW_RECAP_VISIBILITY_LABELS[model.serverRecapVisibility]
+				)}
 			</div>
 			<div class="flex justify-between gap-3">
 				{@render tipDt('landingLookupForm', 'Landing lookup form')}
-				<dd class="text-right font-medium">{model.landingLookupForm === 'visible' ? 'Shown' : 'Hidden'}</dd>
+				{@render previewDd(
+					PRIVACY_PREVIEW_VALUE_TOOLTIPS.landingLookupForm[model.landingLookupForm],
+					model.landingLookupForm === 'visible' ? 'Shown' : 'Hidden'
+				)}
 			</div>
 		</dl>
 		<!-- The only preview warning is the landing-lookup contradiction, which the

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -19,6 +19,7 @@ import * as Tooltip from '$lib/components/ui/tooltip';
 import {
 	PRIVACY_PRESETS,
 	PRIVACY_PREVIEW_ROW_TOOLTIPS,
+	PRIVACY_PREVIEW_VALUE_TOOLTIPS,
 	type PrivacyPreset,
 	type PrivacyPresetId,
 	type PrivacyPreviewRowKey,
@@ -615,30 +616,70 @@ function getThemeColors(themeValue: string) {
 									</Tooltip.Root>
 								</dt>
 							{/snippet}
+							<!-- Value tooltip: explains the specific effect of the selected value -->
+							{#snippet previewDd(tip: string, label: string)}
+								<dd>
+									<Tooltip.Root>
+										<Tooltip.Trigger class="preview-dd-trigger">
+											{label}
+											<InfoIcon class="preview-info-icon" aria-hidden="true" />
+										</Tooltip.Trigger>
+										<Tooltip.Content
+											side="top"
+											sideOffset={6}
+											collisionPadding={16}
+											portalProps={{ to: 'body' }}
+										>
+											<p class="text-left">{tip}</p>
+										</Tooltip.Content>
+									</Tooltip.Root>
+								</dd>
+							{/snippet}
 							<div class="privacy-preview" aria-live="polite">
 								<span class="preview-title">What this exposes</span>
 								<Tooltip.Provider delayDuration={150}>
 									<dl class="preview-rows">
 										<div class="preview-row">
 											{@render previewDt('namesInStats', 'Names in stats')}
-											<dd>{PREVIEW_NAME_DISPLAY_LABELS[privacyPreview.nameDisplay]}</dd>
+											{@render previewDd(
+												PRIVACY_PREVIEW_VALUE_TOOLTIPS.namesInStats[privacyPreview.nameDisplay],
+												PREVIEW_NAME_DISPLAY_LABELS[privacyPreview.nameDisplay]
+											)}
 										</div>
 										<div class="preview-row">
 											{@render previewDt('newUserDefault', 'New-user default')}
-											<dd>{PREVIEW_PER_USER_DEFAULT_LABELS[privacyPreview.perUserDefaultForNewUsers]}</dd>
+											{@render previewDd(
+												PRIVACY_PREVIEW_VALUE_TOOLTIPS.newUserDefault[
+													privacyPreview.perUserDefaultForNewUsers
+												],
+												PREVIEW_PER_USER_DEFAULT_LABELS[privacyPreview.perUserDefaultForNewUsers]
+											)}
 										</div>
 										<div class="preview-row">
 											{@render previewDt('serverWideRecap', 'Server-wide recap')}
-											<dd>{PREVIEW_RECAP_VISIBILITY_LABELS[privacyPreview.serverRecapVisibility]}</dd>
+											{@render previewDd(
+												PRIVACY_PREVIEW_VALUE_TOOLTIPS.serverWideRecap[
+													privacyPreview.serverRecapVisibility
+												],
+												PREVIEW_RECAP_VISIBILITY_LABELS[privacyPreview.serverRecapVisibility]
+											)}
 										</div>
 										<div class="preview-row">
 											{@render previewDt('landingLookupForm', 'Landing lookup form')}
-											<dd>{privacyPreview.landingLookupForm === 'visible' ? 'Shown' : 'Hidden'}</dd>
+											{@render previewDd(
+												PRIVACY_PREVIEW_VALUE_TOOLTIPS.landingLookupForm[
+													privacyPreview.landingLookupForm
+												],
+												privacyPreview.landingLookupForm === 'visible' ? 'Shown' : 'Hidden'
+											)}
 										</div>
 										{#if privacyPreview.logoVisibility}
 											<div class="preview-row">
 												<dt>Wrapped logo</dt>
-												<dd>{PREVIEW_LOGO_VISIBILITY_LABELS[privacyPreview.logoVisibility]}</dd>
+												{@render previewDd(
+													PRIVACY_PREVIEW_VALUE_TOOLTIPS.wrappedLogo[privacyPreview.logoVisibility],
+													PREVIEW_LOGO_VISIBILITY_LABELS[privacyPreview.logoVisibility]
+												)}
 											</div>
 										{/if}
 									</dl>
@@ -1668,6 +1709,32 @@ function getThemeColors(themeValue: string) {
 			font-weight: 500;
 			color: rgba(255, 255, 255, 0.9);
 			text-align: right;
+		}
+
+		/* Tooltip trigger on each preview VALUE: mirrors .preview-dt-trigger so the
+		   value + info icon read as one help target. Inherits the dd's font weight +
+		   color so the selected value still reads as the emphasized right column. */
+		.preview-row :global(.preview-dd-trigger) {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.3rem;
+			padding: 0;
+			background: none;
+			border: none;
+			font: inherit;
+			color: inherit;
+			cursor: help;
+			text-align: right;
+			border-radius: 0.25rem;
+		}
+
+		.preview-row :global(.preview-dd-trigger:hover) {
+			color: #fff;
+		}
+
+		.preview-row :global(.preview-dd-trigger:focus-visible) {
+			outline: 2px solid oklch(var(--primary) / 0.6);
+			outline-offset: 2px;
 		}
 
 		/* Advanced Options disclosure */


### PR DESCRIPTION
## Summary

Adds tooltips to the selected option **values** (the `<dd>` elements) in the "What this exposes" privacy preview, complementing the existing per-perspective tooltips on the **labels** (`<dt>` elements). This applies to both the onboarding privacy step and the admin privacy settings page.

Where a label tooltip describes the setting in general ("what is this control?"), the new value tooltip explains the specific effect of the currently-selected value ("what does *this* choice actually do?"). For example, hovering the **Anonymous (hidden)** value under *Names in stats* now explains that usernames are replaced with neutral placeholders everywhere except the admin dashboard.

## Changes

### `src/lib/sharing/options.ts`
- New `PRIVACY_PREVIEW_VALUE_TOOLTIPS` mapping and `PrivacyPreviewValueTooltips` interface.
- Keyed by preview row, then by the preview model's value literal, so each possible value has its own explanation. Covers all four shared rows (`namesInStats`, `newUserDefault`, `serverWideRecap`, `landingLookupForm`) plus the onboarding-only `wrappedLogo` row.
- The value literals are redeclared locally rather than imported from `preset-logic.ts`. This is deliberate: `preset-logic.ts` already imports from `options.ts`, so importing its types back would create a circular dependency. This mirrors the existing pattern in the same module, where the anonymization and logo value literals are redeclared to mirror the server enums.

### `src/routes/onboarding/settings/+page.svelte`
- New `previewDd` snippet wrapping each value in `Tooltip.Root` / `Tooltip.Trigger`, applied to all five rows (including the previously plain Wrapped logo row).
- Scoped `.preview-dd-trigger` CSS mirroring the existing `.preview-dt-trigger` styling (inline-flex trigger, info icon, `cursor: help`, hover and focus-visible states), inheriting the value's emphasized weight and color.

### `src/routes/admin/settings/privacy/+page.svelte`
- New `previewDd` snippet using Tailwind classes that match the existing `tipDt` label-trigger styling (right-aligned, `font-medium`, underline-on-hover, focus ring).
- Wired into all four `previewRows` entries, so both the "Current (saved)" and "After you save" preview panels show value tooltips.

## Consistency

Both the label and value tooltips share the same trigger pattern (inline-flex, info icon, help cursor, hover/focus-visible states) and the same `Tooltip.Content` placement (`side="top"`, offset, collision padding, portal to body), so the two read as a consistent help affordance. Copy continues to live in `options.ts` next to `PRIVACY_PREVIEW_ROW_TOOLTIPS`, keeping the onboarding and admin previews from drifting apart.

## Verification

- `bun run check` — 0 errors, 0 warnings
- `bun run check:biome` — clean
- `bun test` (sharing presets + public-landing-lookup) — 34 pass / 0 fail; `options.ts` and `preset-logic.ts` at 100% coverage
