### PR TITLE
fix(security): close wrapped enumeration oracle and raw /auth/plex JSON, plus dogfood UX fixes

### DIFF
--- a/src/routes/admin/settings/connections/+page.svelte
+++ b/src/routes/admin/settings/connections/+page.svelte
@@ -341,7 +341,7 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 						id="openaiModel"
 						name="openaiModel"
 						type="text"
-						placeholder="gpt-4o-mini"
+						placeholder="gpt-5-mini"
 						bind:value={openaiModel}
 						disabled={openaiModelLocked}
 					/>

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -255,32 +255,46 @@ function handleDragEnd() {
 	dragOverIndex = null;
 }
 
+type SlideOrderEntry = { type: 'builtin'; id: string } | { type: 'custom'; id: number };
+
+// Submit a reordered list through the existing hidden reorder form.
+function submitReorder(newOrder: SlideOrderEntry[]) {
+	const form = document.getElementById('reorder-form') as HTMLFormElement | null;
+	const orderInput = form?.querySelector('input[name="order"]') as HTMLInputElement | null;
+	if (!form || !orderInput) return;
+	orderInput.value = JSON.stringify(newOrder);
+	form.requestSubmit();
+}
+
+// Move a slide from one index to another. Shared by drag-and-drop and the
+// keyboard move-up/down buttons (ISSUE-010 a11y: drag-and-drop alone is not
+// keyboard operable).
+function moveSlide(fromIndex: number, toIndex: number) {
+	if (toIndex < 0 || toIndex >= unifiedSlides.length || fromIndex === toIndex) return;
+	const newOrder: SlideOrderEntry[] = unifiedSlides.map((item) =>
+		item.kind === 'builtin'
+			? { type: 'builtin' as const, id: item.slideType }
+			: { type: 'custom' as const, id: item.id }
+	);
+	const [moved] = newOrder.splice(fromIndex, 1);
+	if (!moved) return;
+	newOrder.splice(toIndex, 0, moved);
+	submitReorder(newOrder);
+}
+
+// Accessible name for the per-slide reorder controls.
+function reorderItemLabel(item: UnifiedSlideItem): string {
+	if (item.kind === 'builtin') {
+		return SLIDE_NAMES[item.slideType as SlideType] ?? item.slideType;
+	}
+	return item.title.trim().length > 0 ? item.title : 'Untitled custom slide';
+}
+
 // Handle drop - reorder unified slides
 function handleDrop(event: DragEvent, dropIndex: number) {
 	event.preventDefault();
 	if (draggedIndex === null || draggedIndex === dropIndex) return;
-
-	// Create new order from unified slides
-	const newOrder = unifiedSlides.map((item) => {
-		if (item.kind === 'builtin') {
-			return { type: 'builtin' as const, id: item.slideType };
-		} else {
-			return { type: 'custom' as const, id: item.id };
-		}
-	});
-
-	// Move the dragged item to the new position
-	const [moved] = newOrder.splice(draggedIndex, 1);
-	if (moved) {
-		newOrder.splice(dropIndex, 0, moved);
-	}
-
-	// Submit the reorder form
-	const form = document.getElementById('reorder-form') as HTMLFormElement;
-	const orderInput = form.querySelector('input[name="order"]') as HTMLInputElement;
-	orderInput.value = JSON.stringify(newOrder);
-	form.requestSubmit();
-
+	moveSlide(draggedIndex, dropIndex);
 	handleDragEnd();
 }
 
@@ -308,7 +322,8 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			<div class="section-title-content">
 				<h2>Slide Order</h2>
 				<p class="section-description">
-					Drag and drop to reorder. Toggle to enable or disable slides.
+					Drag and drop, or use the move up/down buttons, to reorder. Toggle to enable or
+					disable slides.
 				</p>
 			</div>
 			<Button type="button" class="add-button tap-target" onclick={openNewEditor}>
@@ -336,7 +351,27 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 					ondrop={(e) => handleDrop(e, index)}
 					role="listitem"
 				>
-					<span class="drag-handle" aria-hidden="true">⋮⋮</span>
+					<div class="reorder-controls">
+						<button
+							type="button"
+							class="move-button tap-target"
+							onclick={() => moveSlide(index, index - 1)}
+							disabled={index === 0}
+							aria-label={`Move ${reorderItemLabel(item)} up`}
+						>
+							<span aria-hidden="true">▲</span>
+						</button>
+						<span class="drag-handle" aria-hidden="true">⋮⋮</span>
+						<button
+							type="button"
+							class="move-button tap-target"
+							onclick={() => moveSlide(index, index + 1)}
+							disabled={index === unifiedSlides.length - 1}
+							aria-label={`Move ${reorderItemLabel(item)} down`}
+						>
+							<span aria-hidden="true">▼</span>
+						</button>
+					</div>
 
 					{#if item.kind === 'builtin'}
 						<span class="slide-name">
@@ -857,6 +892,51 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			cursor: grab;
 			user-select: none;
 			flex-shrink: 0;
+		}
+
+		.reorder-controls {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 0.125rem;
+			flex-shrink: 0;
+		}
+
+		.move-button {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			width: 1.5rem;
+			height: 1.25rem;
+			padding: 0;
+			background: transparent;
+			border: 1px solid transparent;
+			border-radius: 6px;
+			color: oklch(var(--muted-foreground));
+			font-size: 0.625rem;
+			line-height: 1;
+			cursor: pointer;
+			transition:
+				color 0.15s ease,
+				background 0.15s ease,
+				border-color 0.15s ease;
+		}
+
+		.move-button:hover:not(:disabled) {
+			color: oklch(var(--foreground));
+			background: oklch(var(--muted));
+			border-color: oklch(var(--border));
+		}
+
+		.move-button:focus-visible {
+			outline: none;
+			border-color: oklch(var(--ring));
+			box-shadow: 0 0 0 2px oklch(var(--ring) / 0.4);
+		}
+
+		.move-button:disabled {
+			opacity: 0.35;
+			cursor: not-allowed;
 		}
 
 		.slide-name {

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -326,6 +326,22 @@ async function goToPage(page: number) {
 			{#if syncActive || progress}
 				<!-- Active Sync Display -->
 				<div class="sync-active-display">
+					{#if syncActive}
+						<!-- ISSUE-009: persistent, AT-announced affordance that a sync is
+						     already in progress, so an attempt to start another is not met
+						     with silence (the start action only surfaced a transient toast). -->
+						<div class="sync-running-banner" role="status" aria-live="polite">
+							<svg viewBox="0 0 24 24" fill="currentColor" class="banner-icon" aria-hidden="true">
+								<path
+									d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm-1-7v2h2v-2h-2zm0-8v6h2V7h-2z"
+								/>
+							</svg>
+							<span
+								>A sync is already running. Watch its progress below, or cancel it to start a new
+								one.</span
+							>
+						</div>
+					{/if}
 					<div class="sync-status-ring" class:running={progress?.status === 'running'}>
 						<div class="ring-outer">
 							<div class="ring-inner">
@@ -1219,6 +1235,26 @@ async function goToPage(page: number) {
 			width: 18px;
 			height: 18px;
 			flex-shrink: 0;
+		}
+
+		.sync-running-banner {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			padding: 0.75rem 1rem;
+			background: oklch(var(--primary) / 0.12);
+			border: 1px solid oklch(var(--primary) / 0.3);
+			border-radius: 8px;
+			font-size: 0.8125rem;
+			color: oklch(var(--foreground));
+			width: 100%;
+		}
+
+		.banner-icon {
+			width: 18px;
+			height: 18px;
+			flex-shrink: 0;
+			color: oklch(var(--primary));
 		}
 
 		/* `.cancel-btn` is the cancel-sync CTA. Hoisted to :global so

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -96,7 +96,7 @@ function markAvatarFailed(userId: number): void {
 	<section class="section">
 		<div class="section-header">
 			<h2>Server Users</h2>
-			<span class="user-count">{data.users.length} users</span>
+			<span class="user-count">{data.users.length} {data.users.length === 1 ? 'user' : 'users'}</span>
 		</div>
 
 		{#if data.users.length === 0}

--- a/src/routes/auth/plex/+server.ts
+++ b/src/routes/auth/plex/+server.ts
@@ -16,13 +16,21 @@ const PollRequestSchema = z.object({
 	pinId: z.number().int().positive()
 });
 
-export const GET: RequestHandler = async ({ cookies, url, request }) => {
+// The PIN JSON / OAuth URL carry short-lived credentials; keep them out of any
+// browser or proxy cache. Mirrors the NO_STORE_HEADERS pattern used by other
+// sensitive endpoints (see api/security/reverse-proxy-diagnostic/+server.ts).
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' };
+
+export const GET: RequestHandler = async ({ cookies, url, request, setHeaders }) => {
 	// Fetch-metadata content negotiation (ISSUE-002). The homepage keeps a no-JS
 	// `<a href="/auth/plex">` sign-in fallback. A real top-level navigation must
 	// NOT dump the raw PIN JSON to the page — it should start the OAuth flow and
 	// redirect to Plex. A `fetch()`/XHR caller (the JS sign-in button) still gets
-	// the JSON PIN payload unchanged. Detection is via Sec-Fetch-Dest, which is
-	// browser-set and cannot be spoofed by the client.
+	// the JSON PIN payload unchanged. Detection is via Sec-Fetch-Dest, a
+	// browser-set fetch-metadata hint. This is a UX convenience, not a security
+	// boundary: a non-browser client can set the header freely, but both branches
+	// mint the same PIN/cookie and the redirect only targets the (non-sensitive)
+	// Plex OAuth URL, so spoofing it grants no elevated access.
 	const fetchDest = request.headers.get('sec-fetch-dest');
 	const isDocumentNavigation = fetchDest === 'document';
 	const isPrefetch = (request.headers.get('sec-purpose') ?? '').toLowerCase().includes('prefetch');
@@ -30,8 +38,12 @@ export const GET: RequestHandler = async ({ cookies, url, request }) => {
 	// Link prefetch of the no-JS sign-in anchor must not burn a PIN: short-circuit
 	// before any stateful work. The real navigation (non-prefetch) mints normally.
 	if (isPrefetch) {
-		return new Response(null, { status: 204 });
+		return new Response(null, { status: 204, headers: NO_STORE_HEADERS });
 	}
+
+	// Applies to the eventual response regardless of whether this handler returns
+	// JSON or throws the redirect() below, keeping minted PIN credentials uncached.
+	setHeaders(NO_STORE_HEADERS);
 
 	try {
 		const redirectUrl = url.searchParams.get('redirectUrl') ?? `${url.origin}/auth/plex/redirect`;

--- a/src/routes/auth/plex/+server.ts
+++ b/src/routes/auth/plex/+server.ts
@@ -1,4 +1,4 @@
-import { error, json } from '@sveltejs/kit';
+import { error, isRedirect, json, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 import { completePlexPinLogin } from '$lib/server/auth/login-completion';
 import {
@@ -16,7 +16,23 @@ const PollRequestSchema = z.object({
 	pinId: z.number().int().positive()
 });
 
-export const GET: RequestHandler = async ({ cookies, url }) => {
+export const GET: RequestHandler = async ({ cookies, url, request }) => {
+	// Fetch-metadata content negotiation (ISSUE-002). The homepage keeps a no-JS
+	// `<a href="/auth/plex">` sign-in fallback. A real top-level navigation must
+	// NOT dump the raw PIN JSON to the page — it should start the OAuth flow and
+	// redirect to Plex. A `fetch()`/XHR caller (the JS sign-in button) still gets
+	// the JSON PIN payload unchanged. Detection is via Sec-Fetch-Dest, which is
+	// browser-set and cannot be spoofed by the client.
+	const fetchDest = request.headers.get('sec-fetch-dest');
+	const isDocumentNavigation = fetchDest === 'document';
+	const isPrefetch = (request.headers.get('sec-purpose') ?? '').toLowerCase().includes('prefetch');
+
+	// Link prefetch of the no-JS sign-in anchor must not burn a PIN: short-circuit
+	// before any stateful work. The real navigation (non-prefetch) mints normally.
+	if (isPrefetch) {
+		return new Response(null, { status: 204 });
+	}
+
 	try {
 		const redirectUrl = url.searchParams.get('redirectUrl') ?? `${url.origin}/auth/plex/redirect`;
 		parsePinForwardUrl(redirectUrl, url);
@@ -31,8 +47,20 @@ export const GET: RequestHandler = async ({ cookies, url }) => {
 			expiresAt: pin.expiresAt ?? new Date(Date.now() + 15 * 60 * 1000).toISOString()
 		};
 
+		// Document navigation (no-JS / hard link click): the PIN + cookie are now
+		// minted, so send the browser straight to the Plex OAuth URL instead of
+		// rendering JSON. SvelteKit's redirect() throws; it is rethrown past the
+		// catch below via isRedirect() so it is not mistaken for a 500.
+		if (isDocumentNavigation) {
+			redirect(303, pinInfo.authUrl);
+		}
+
 		return json(pinInfo);
 	} catch (err) {
+		if (isRedirect(err)) {
+			throw err;
+		}
+
 		if (
 			err instanceof TypeError ||
 			(err instanceof Error && err.message.includes('redirect URL'))

--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -96,7 +96,7 @@ export const load: PageServerLoad = async ({ parent, locals, url, cookies }) => 
 			logoMode: formatLogoMode(logoMode),
 			shareMode: formatShareMode(shareMode),
 			allowUserControl: allowUserControl ? 'Allowed' : 'Locked by admin',
-			funFacts: enableFunFacts ? formatFunFactFrequency(funFactFrequency) : 'Disabled'
+			funFacts: deriveFunFactsSummary(enableFunFacts, notice === 'ai-key-missing', funFactFrequency)
 		}
 	};
 };
@@ -147,6 +147,31 @@ function formatLogoMode(mode: string): string {
 function formatFunFactFrequency(config: { mode: string; count: number }): string {
 	if (config.mode === 'custom') return `Custom (${config.count})`;
 	return `${formatThemeName(config.mode)} (${config.count})`;
+}
+
+/**
+ * Derive the "Fun Facts" summary label for the onboarding Done step.
+ *
+ * The summary must distinguish three states the old `enableFunFacts ? ... :
+ * 'Disabled'` copy collapsed into two:
+ *  - an effective OpenAI key is present  -> AI fun facts on, show the frequency;
+ *  - no key but the user enabled AI fun facts during Configure (signalled by the
+ *    `ai-key-missing` notice) -> built-in templates are used, so it is "template
+ *    mode", not disabled;
+ *  - no key and fun facts were left off  -> genuinely "Disabled".
+ */
+function deriveFunFactsSummary(
+	hasOpenAiKey: boolean,
+	aiKeyMissing: boolean,
+	frequency: { mode: string; count: number }
+): string {
+	if (hasOpenAiKey) {
+		return formatFunFactFrequency(frequency);
+	}
+	if (aiKeyMissing) {
+		return 'Template mode — add an OpenAI key to enable AI';
+	}
+	return 'Disabled';
 }
 
 async function requireOnboardingCompleteClaim(

--- a/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year]/u/[identifier]/+page.server.ts
@@ -39,6 +39,13 @@ import { triggerLiveSyncIfNeeded } from '$lib/server/sync/live-sync';
 import { hasWatchHistory } from '$lib/stats/types';
 import type { Actions, PageServerLoad } from './$types';
 
+// Single source of truth for the anti-enumeration 404 body on the numeric
+// identifier path. Every anonymous "cannot view" outcome (non-existent id,
+// existing-but-private-oauth, existing-but-private-link-without-token) returns
+// this exact status+body so an anonymous caller can't tell them apart (F-015 /
+// ISSUE-001 uniform-404 contract).
+const WRAPPED_NOT_FOUND_MESSAGE = "We couldn't find a Wrapped page for that link.";
+
 async function resolveUserIdFromIdentifier(
 	identifier: string,
 	year: number,
@@ -116,11 +123,11 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 		}
 	} else {
 		if (!isPureNumericId(identifier)) {
-			error(404, "We couldn't find a Wrapped page for that link.");
+			error(404, WRAPPED_NOT_FOUND_MESSAGE);
 		}
 		const parsedId = Number(identifier);
 		if (!Number.isSafeInteger(parsedId) || parsedId <= 0) {
-			error(404, "We couldn't find a Wrapped page for that link.");
+			error(404, WRAPPED_NOT_FOUND_MESSAGE);
 		}
 		userId = parsedId;
 
@@ -128,14 +135,15 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 		// share_settings rows for them (checkWrappedAccess -> getOrCreateShareSettings).
 		// Preserves the F-015 anti-enumeration story (unknown id -> 404) and blocks
 		// the route by which a stray numeric id (e.g. a Plex id) became a
-		// share_settings.user_id orphan.
+		// share_settings.user_id orphan. This is a read-only existence check, so no
+		// orphan share_settings row is created for a non-existent id.
 		const userExists = await db
 			.select({ id: users.id })
 			.from(users)
 			.where(eq(users.id, userId))
 			.limit(1);
 		if (!userExists[0]) {
-			error(404, "We couldn't find a Wrapped page for that link.");
+			error(404, WRAPPED_NOT_FOUND_MESSAGE);
 		}
 
 		try {
@@ -145,11 +153,28 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 				currentUser: locals.user
 			});
 		} catch (err) {
+			// F-015 / ISSUE-001 uniform-404 anti-enumeration contract: an anonymous
+			// caller on a numeric id must not be able to tell "exists but private"
+			// from "does not exist". For anonymous callers every "cannot view"
+			// outcome collapses to one byte-identical 404 + body (matching the
+			// non-existent-id 404 above and the canonical landing `lookupUser`
+			// pattern). Authenticated callers keep the existing 403/404 split — a
+			// signed-in viewer already proves server membership, so existence is
+			// not a secret we are protecting from them.
+			const isAnonymous = !locals.user;
 			if (err instanceof ShareAccessDeniedError) {
+				if (isAnonymous) {
+					error(404, WRAPPED_NOT_FOUND_MESSAGE);
+				}
 				error(403, err.message);
 			}
 			if (err instanceof InvalidShareTokenError) {
-				error(404, 'This share link is invalid, expired, or has been revoked.');
+				error(
+					404,
+					isAnonymous
+						? WRAPPED_NOT_FOUND_MESSAGE
+						: 'This share link is invalid, expired, or has been revoked.'
+				);
 			}
 			throw err;
 		}

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -696,4 +696,60 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('token === transitionToken');
 		expect(source).toContain('function startNavigation');
 	});
+
+	it('disables the log-settings submit during submit and clamps retention server-side (ISSUE-006 double-click)', async () => {
+		// ISSUE-006 (double-click corrupted retention 8 -> 78). The double-submit
+		// vector is closed by disabling the submit button while a request is in
+		// flight AND when the form is out of range; the server schema independently
+		// clamps retentionDays to [1, 365]. Lock both so the fix can't regress.
+		const clientSource = await readSource('src/routes/admin/settings/system/+page.svelte');
+		expect(clientSource).toContain('disabled={$submitting || isLoggingFormInvalid}');
+
+		const serverSource = await readSource('src/routes/admin/settings/system/+page.server.ts');
+		expect(serverSource).toContain('.min(1');
+		expect(serverSource).toContain('.max(365');
+	});
+
+	it('keeps the admin slide reorder keyboard-operable with labeled move controls (ISSUE-010 a11y)', async () => {
+		// ISSUE-010: drag-and-drop is not keyboard operable. Lock the move up/down
+		// buttons + their accessible labels so the keyboard path can't regress.
+		const source = await readSource('src/routes/admin/slides/+page.svelte');
+
+		expect(source).toContain('function moveSlide(fromIndex: number, toIndex: number)');
+		expect(source).toContain('onclick={() => moveSlide(index, index - 1)}');
+		expect(source).toContain('onclick={() => moveSlide(index, index + 1)}');
+		// Asserted in fragments to avoid embedding a literal template placeholder
+		// in this plain test string (biome noTemplateCurlyInString).
+		expect(source).toContain('aria-label={`Move ');
+		expect(source).toContain('reorderItemLabel(item)} up`}');
+		expect(source).toContain('reorderItemLabel(item)} down`}');
+		expect(source).toContain('disabled={index === 0}');
+		expect(source).toContain('disabled={index === unifiedSlides.length - 1}');
+	});
+
+	it('shows a persistent AT-announced banner while a sync is already running (ISSUE-009)', async () => {
+		// ISSUE-009: starting a sync while one runs only surfaced a transient toast.
+		// Lock the persistent, polite-live status banner in the active-sync block.
+		const source = await readSource('src/routes/admin/sync/+page.svelte');
+
+		expect(source).toContain('class="sync-running-banner" role="status" aria-live="polite"');
+		expect(source).toContain('A sync is already running.');
+	});
+
+	it('pluralizes the admin users count (ISSUE-007: "1 user" not "1 users")', async () => {
+		const source = await readSource('src/routes/admin/users/+page.svelte');
+
+		expect(source).toContain("{data.users.length === 1 ? 'user' : 'users'}");
+		expect(source).not.toContain('{data.users.length} users</span>');
+	});
+
+	it('uses the actual default model as the admin OpenAI placeholder (ISSUE-005 consistency)', async () => {
+		// ISSUE-005: the admin connections placeholder said gpt-4o-mini while the
+		// real default (settings.service + funfacts) and the onboarding placeholder
+		// are gpt-5-mini. Align the lone inconsistent placeholder.
+		const source = await readSource('src/routes/admin/settings/connections/+page.svelte');
+
+		expect(source).toContain('placeholder="gpt-5-mini"');
+		expect(source).not.toContain('placeholder="gpt-4o-mini"');
+	});
 });

--- a/tests/unit/auth/plex-content-negotiation.test.ts
+++ b/tests/unit/auth/plex-content-negotiation.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import * as pinTransactions from '$lib/server/auth/pin-transactions';
+import * as plexOAuth from '$lib/server/auth/plex-oauth';
+import { GET } from '../../../src/routes/auth/plex/+server';
+
+/**
+ * ISSUE-002 regression: GET /auth/plex content-negotiates on Sec-Fetch-Dest.
+ *
+ * The homepage keeps a no-JS `<a href="/auth/plex">` sign-in fallback. A real
+ * top-level navigation (Sec-Fetch-Dest: document) must NOT render the raw PIN
+ * JSON to the page — it must mint a PIN and 303-redirect to the Plex OAuth URL,
+ * so the no-JS path works end-to-end. A `fetch()`/XHR caller (the JS button,
+ * Sec-Fetch-Dest: empty) still receives the JSON PIN payload unchanged. A link
+ * prefetch (Sec-Purpose: prefetch) must NOT burn a PIN.
+ */
+
+const FAKE_PIN = { id: 999001, code: 'WXYZ', expiresAt: '2026-06-01T00:15:00.000Z' };
+const FAKE_OAUTH_URL = 'https://app.plex.tv/auth#?clientID=test&code=WXYZ&forwardUrl=fwd';
+
+type Spy = ReturnType<typeof spyOn>;
+
+function cookieStub() {
+	return {
+		get: () => undefined,
+		getAll: () => [],
+		set: () => {},
+		delete: () => {},
+		serialize: () => ''
+	} as unknown as Parameters<typeof GET>[0]['cookies'];
+}
+
+function invokeGet(headers: Record<string, string>) {
+	const url = new URL('http://localhost/auth/plex');
+	const request = new Request(url, { headers });
+	return GET({
+		cookies: cookieStub(),
+		url,
+		request
+	} as unknown as Parameters<typeof GET>[0]);
+}
+
+describe('GET /auth/plex: Sec-Fetch-Dest content negotiation (ISSUE-002)', () => {
+	let requestPinSpy: Spy;
+	let buildOAuthSpy: Spy;
+	let createTxSpy: Spy;
+	let parseForwardSpy: Spy;
+	let appendForwardSpy: Spy;
+
+	beforeEach(() => {
+		requestPinSpy = spyOn(plexOAuth, 'requestPin').mockResolvedValue(FAKE_PIN);
+		buildOAuthSpy = spyOn(plexOAuth, 'buildPlexOAuthUrl').mockReturnValue(FAKE_OAUTH_URL);
+		createTxSpy = spyOn(pinTransactions, 'createPinTransaction').mockResolvedValue('state-token');
+		// parsePinForwardUrl validates and returns the parsed URL; the handler calls
+		// it only for its throw-on-invalid side effect, so any valid URL works here.
+		parseForwardSpy = spyOn(pinTransactions, 'parsePinForwardUrl').mockReturnValue(
+			new URL('http://localhost/auth/plex/redirect')
+		);
+		appendForwardSpy = spyOn(pinTransactions, 'appendPinStateToForwardUrl').mockReturnValue('fwd');
+	});
+
+	afterEach(() => {
+		requestPinSpy.mockRestore();
+		buildOAuthSpy.mockRestore();
+		createTxSpy.mockRestore();
+		parseForwardSpy.mockRestore();
+		appendForwardSpy.mockRestore();
+	});
+
+	it('303-redirects a document navigation straight to the Plex OAuth URL', async () => {
+		try {
+			await invokeGet({ 'sec-fetch-dest': 'document' });
+			expect.unreachable('Expected a redirect to be thrown');
+		} catch (err) {
+			const redirectErr = err as { status?: number; location?: string };
+			expect(redirectErr.status).toBe(303);
+			expect(redirectErr.location).toBe(FAKE_OAUTH_URL);
+		}
+		// A document nav still mints a PIN (so the redirect target is live).
+		expect(requestPinSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('mints NO PIN for a link prefetch (Sec-Purpose: prefetch) and returns 204', async () => {
+		const response = (await invokeGet({
+			'sec-fetch-dest': 'document',
+			'sec-purpose': 'prefetch'
+		})) as Response;
+
+		expect(response.status).toBe(204);
+		expect(requestPinSpy).not.toHaveBeenCalled();
+		expect(createTxSpy).not.toHaveBeenCalled();
+	});
+
+	it('returns the JSON PIN payload for a fetch/XHR caller (Sec-Fetch-Dest: empty)', async () => {
+		const response = (await invokeGet({ 'sec-fetch-dest': 'empty' })) as Response;
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { pinId: number; code: string; authUrl: string };
+		expect(body.pinId).toBe(FAKE_PIN.id);
+		expect(body.code).toBe(FAKE_PIN.code);
+		expect(body.authUrl).toBe(FAKE_OAUTH_URL);
+		expect(requestPinSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('falls back to JSON when Sec-Fetch-Dest is absent (very old browsers)', async () => {
+		const response = (await invokeGet({})) as Response;
+
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { pinId: number };
+		expect(body.pinId).toBe(FAKE_PIN.id);
+	});
+});

--- a/tests/unit/auth/plex-content-negotiation.test.ts
+++ b/tests/unit/auth/plex-content-negotiation.test.ts
@@ -29,13 +29,19 @@ function cookieStub() {
 	} as unknown as Parameters<typeof GET>[0]['cookies'];
 }
 
-function invokeGet(headers: Record<string, string>) {
+function invokeGet(headers: Record<string, string>, recordedHeaders?: Record<string, string>) {
 	const url = new URL('http://localhost/auth/plex');
 	const request = new Request(url, { headers });
 	return GET({
 		cookies: cookieStub(),
 		url,
-		request
+		request,
+		// Real SvelteKit RequestEvent always supplies setHeaders; the handler calls
+		// it to set Cache-Control: no-store on the minted-PIN responses. Record into
+		// the caller-supplied object when provided so tests can assert on it.
+		setHeaders: (newHeaders: Record<string, string>) => {
+			if (recordedHeaders) Object.assign(recordedHeaders, newHeaders);
+		}
 	} as unknown as Parameters<typeof GET>[0]);
 }
 
@@ -91,7 +97,8 @@ describe('GET /auth/plex: Sec-Fetch-Dest content negotiation (ISSUE-002)', () =>
 	});
 
 	it('returns the JSON PIN payload for a fetch/XHR caller (Sec-Fetch-Dest: empty)', async () => {
-		const response = (await invokeGet({ 'sec-fetch-dest': 'empty' })) as Response;
+		const recordedHeaders: Record<string, string> = {};
+		const response = (await invokeGet({ 'sec-fetch-dest': 'empty' }, recordedHeaders)) as Response;
 
 		expect(response.status).toBe(200);
 		const body = (await response.json()) as { pinId: number; code: string; authUrl: string };
@@ -99,6 +106,8 @@ describe('GET /auth/plex: Sec-Fetch-Dest content negotiation (ISSUE-002)', () =>
 		expect(body.code).toBe(FAKE_PIN.code);
 		expect(body.authUrl).toBe(FAKE_OAUTH_URL);
 		expect(requestPinSpy).toHaveBeenCalledTimes(1);
+		// Minted PIN credentials must not be cached by browsers/proxies.
+		expect(recordedHeaders['Cache-Control']).toBe('no-store');
 	});
 
 	it('falls back to JSON when Sec-Fetch-Dest is absent (very old browsers)', async () => {

--- a/tests/unit/onboarding/complete-summary.test.ts
+++ b/tests/unit/onboarding/complete-summary.test.ts
@@ -160,6 +160,27 @@ describe('onboarding completion summary', () => {
 		expect(result.configSummary.funFacts).toBe('Disabled');
 	});
 
+	it('distinguishes template mode (AI enabled, no key) from Disabled (ISSUE-004)', async () => {
+		await setFunFactFrequency(FunFactFrequency.MANY);
+		await setAppSetting(AppSettingsKey.OPENAI_BASE_URL, 'https://api.example.com/v1');
+		// No OPENAI_API_KEY, but the user enabled AI fun facts during Configure —
+		// signalled by the ai-key-missing notice. Built-in templates are used, so
+		// the summary must read "template mode", NOT the same "Disabled" as opt-out.
+
+		const result = (await load({
+			parent: async () => ({}),
+			locals: adminLocals,
+			url: new URL('http://localhost/onboarding/complete?notice=ai-key-missing'),
+			cookies: await createClaimedCookies()
+		} as Parameters<typeof load>[0])) as {
+			configSummary: Record<string, string>;
+			enableFunFacts: boolean;
+		};
+
+		expect(result.enableFunFacts).toBe(false);
+		expect(result.configSummary.funFacts).toBe('Template mode — add an OpenAI key to enable AI');
+	});
+
 	it('shows the configured fun fact frequency when OpenAI key is present', async () => {
 		await setFunFactFrequency(FunFactFrequency.MANY);
 		await setAppSetting(AppSettingsKey.OPENAI_API_KEY, 'sk-test-key');

--- a/tests/unit/sharing/wrapped-identifier-loader.test.ts
+++ b/tests/unit/sharing/wrapped-identifier-loader.test.ts
@@ -309,18 +309,20 @@ describe('wrapped/[year]/u/[identifier] loader: identifier validation (F-303)', 
 		await expectStatus('550e8400-e29b-41d4-a716-446655449999', 404);
 	});
 
-	it('returns 403 for an anonymous viewer on a valid numeric id in private-oauth mode (ISSUE-002)', async () => {
-		// F-015/ISSUE-002 regression: a logged-out viewer hitting a valid user's
-		// numeric wrapped URL while the effective mode is private-oauth must get
-		// ShareAccessDeniedError -> error(403) ("sign in"), NOT a 404. The 404
-		// anti-enumeration path is reserved for stale/unknown tokens (covered
-		// above); a known user in an auth-gated mode is correctly a 403.
+	it('returns 404 for an anonymous viewer on a valid numeric id in private-oauth mode (ISSUE-001 uniform-404)', async () => {
+		// F-015/ISSUE-001 uniform-404 contract: a logged-out viewer hitting a valid
+		// user's numeric wrapped URL while the effective mode is private-oauth must
+		// get a 404 that is byte-identical to the non-existent-id 404, so existence
+		// cannot be enumerated. (Reversed from the previous 403 "sign in" contract,
+		// which leaked existence: private-oauth -> 403 but non-existent -> 404 told
+		// an attacker which numeric ids were real.) Authenticated callers keep the
+		// 403/404 split — see the contract block below.
 		await setGlobalShareDefaults({
 			defaultShareMode: ShareMode.PRIVATE_OAUTH,
 			allowUserControl: false
 		});
 
-		await expectStatus(String(USER_ID), 403);
+		await expectStatus(String(USER_ID), 404);
 	});
 
 	it('resolves a valid numeric identifier to the matching user', async () => {
@@ -872,5 +874,125 @@ describe('wrapped/[year]/u/[identifier] loader: ISSUE-004 private-oauth contract
 			.where(and(eq(shareSettings.userId, OWNER_ID), eq(shareSettings.year, YEAR)));
 		const linkHref = await getOwnerWrappedHref(OWNER_ID, YEAR);
 		expect(linkHref).toBe(`/wrapped/${YEAR}/u/${LINK_TOKEN}`);
+	});
+});
+
+/**
+ * ISSUE-001 uniform-404 anti-enumeration contract.
+ *
+ * For an ANONYMOUS caller on the numeric identifier path, all three "cannot
+ * view" outcomes — existing-private-oauth, existing-private-link-without-token,
+ * and non-existent id — must be byte-identical (same status AND body) so the
+ * numeric id space cannot be enumerated. A PUBLIC personal wrapped still loads
+ * for anon, and a valid share-link token still resolves. See the F-015 note in
+ * wrapped/[year]/u/[identifier]/+page.server.ts.
+ */
+describe('wrapped/[year]/u/[identifier] loader: ISSUE-001 uniform-404 anti-enumeration contract', () => {
+	const EXISTING_ID = 2;
+	const NON_EXISTENT_ID = 4242;
+	const YEAR = 2024;
+	// Reuse the module-level fixture UUIDs rather than minting new literals.
+	const PRIVATE_LINK_TOKEN = CURRENT_YEAR_TOKEN;
+	const VALID_LINK_TOKEN = OTHER_YEAR_TOKEN_FOR_PRESEED;
+
+	beforeEach(async () => {
+		await db.delete(shareSettings);
+		await db.delete(appSettings);
+		await db.delete(users);
+		await db.delete(cachedStats);
+		await db.delete(playHistory);
+		await db.delete(slideConfig);
+		await seedUser(EXISTING_ID, 100002, 200002);
+	});
+
+	async function captureAnonFailure(
+		identifier: string
+	): Promise<{ status?: number; message?: string }> {
+		try {
+			await invokeLoad({ year: YEAR, identifier, availableYears: [YEAR] });
+			expect.unreachable(`Expected anon load to fail for "${identifier}"`);
+			return {};
+		} catch (err) {
+			const e = err as { status?: number; body?: { message?: string } };
+			return { status: e.status, message: e.body?.message };
+		}
+	}
+
+	it('returns a byte-identical 404 for anon private-oauth, anon private-link-no-token, and non-existent id', async () => {
+		// Case A: existing user, private-oauth (was 403 before the uniform-404 fix).
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_OAUTH,
+			allowUserControl: false
+		});
+		const privateOauth = await captureAnonFailure(String(EXISTING_ID));
+
+		// Case B: existing user, private-link without a token in the URL.
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		await seedShareSettings({
+			userId: EXISTING_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: PRIVATE_LINK_TOKEN
+		});
+		const privateLinkNoToken = await captureAnonFailure(String(EXISTING_ID));
+
+		// Case C: non-existent numeric id.
+		const nonExistent = await captureAnonFailure(String(NON_EXISTENT_ID));
+
+		expect(privateOauth.status).toBe(404);
+		expect(privateLinkNoToken.status).toBe(404);
+		expect(nonExistent.status).toBe(404);
+		// Byte-identical body across all three so existence cannot be inferred.
+		expect(privateOauth.message).toBe(nonExistent.message);
+		expect(privateLinkNoToken.message).toBe(nonExistent.message);
+		expect(nonExistent.message).toBe("We couldn't find a Wrapped page for that link.");
+	});
+
+	it('does NOT create a share_settings row for a non-existent id (no orphan)', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_OAUTH,
+			allowUserControl: false
+		});
+		await captureAnonFailure(String(NON_EXISTENT_ID));
+		const rows = await db
+			.select()
+			.from(shareSettings)
+			.where(eq(shareSettings.userId, NON_EXISTENT_ID));
+		expect(rows.length).toBe(0);
+	});
+
+	it('still loads a PUBLIC personal wrapped for an anonymous viewer (200)', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PUBLIC,
+			allowUserControl: false
+		});
+		const data = await invokeLoad({
+			year: YEAR,
+			identifier: String(EXISTING_ID),
+			availableYears: [YEAR]
+		});
+		expect(data.userId).toBe(EXISTING_ID);
+	});
+
+	it('still resolves a valid share-link token for an anonymous viewer (200)', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		await seedShareSettings({
+			userId: EXISTING_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			token: VALID_LINK_TOKEN
+		});
+		const data = await invokeLoad({
+			year: YEAR,
+			identifier: VALID_LINK_TOKEN,
+			availableYears: [YEAR]
+		});
+		expect(data.userId).toBe(EXISTING_ID);
 	});
 });


### PR DESCRIPTION
## Summary

Resolves the confirmed findings from the 2026-06-01 dogfood run. Each finding was first re-baselined against current `main`, because a prior commit (#126) had already resolved an unrelated finding set. The two security items were untouched by #126 and are the core of this PR; the remaining diagnose-first items were verified already-fixed and closed with regression locks.

## Security

### ISSUE-001 — Personal-Wrapped enumeration oracle
The numeric-id loader (`src/routes/wrapped/[year]/u/[identifier]/+page.server.ts`) leaked user existence: an existing private-oauth user returned `403` while a non-existent id returned `404`, letting an anonymous visitor enumerate valid user ids.

Anonymous callers now receive a **byte-identical `404`** (same status and body, "We couldn't find a Wrapped page for that link.") for all three "cannot view" cases:
- existing private-oauth
- existing private-link without a token
- non-existent id

This matches the canonical landing-page `lookupUser` pattern. The change is scoped to anonymous callers via a read-only existence check, so:
- no orphan `share_settings` rows are created for non-existent ids;
- authenticated owner / server-member / admin paths are unchanged (still `200` / `403` / `404` as before);
- public personal wrappeds and valid share-link tokens still load.

In this loader, `ShareAccessDeniedError` (the `403`) only ever fires for anonymous callers, because `checkWrappedAccess` treats any authenticated user as a server member, so the conversion is surgical and does not affect signed-in viewers.

### ISSUE-002 — Homepage no-JS link dumped raw `/auth/plex` JSON
`GET /auth/plex` now content-negotiates on `Sec-Fetch-Dest`:
- a real document navigation (the no-JS `<a>` sign-in fallback) mints a PIN and `303`-redirects to the Plex OAuth URL, so the no-JS path works end-to-end and never renders JSON;
- a link prefetch (`Sec-Purpose: prefetch`) returns `204` and mints no PIN;
- a `fetch`/XHR caller (`Sec-Fetch-Dest: empty`, the JS button) still receives the JSON PIN payload unchanged.

The SvelteKit `redirect()` is rethrown ahead of the handler's `try/catch` via `isRedirect()` so it is not mistaken for a `500`. No new route is added (the existing `POST /auth/plex` PIN-poll endpoint is untouched) and there is no CSRF coupling, since the change is GET-only.

## Functional / UX

- **ISSUE-009** — A persistent, assistive-tech-announced banner (`role="status"`, `aria-live="polite"`) is shown in the active-sync block, so attempting to start a sync while one is running is no longer met with only a transient toast.
- **ISSUE-010** — Slide reordering gains keyboard-operable move up/down controls (aria-labelled, disabled at list boundaries) that submit the existing reorder form. Drag-and-drop now delegates to the same code path; the order-array shape sent to the server is unchanged.
- **ISSUE-004** — The onboarding "Done" summary distinguishes fun facts being **disabled** from **template mode** (enabled without an OpenAI key, using built-in templates).
- **ISSUE-007** — The admin users count pluralizes correctly ("1 user" instead of "1 users").
- **ISSUE-005** — The admin OpenAI model placeholder is aligned to `gpt-5-mini`, matching the actual default used elsewhere.

## Verify / decision batch

ISSUE-003, 006, 008, 011, 012, and 013 were re-baselined and found already-fixed on `main`, or are product/browser-repro items. They are closed with regression locks where useful or documented closure, with no speculative edits:

- **006** (double-click log retention): already fixed — submit disabled during in-flight submit and out-of-range, server schema clamps `[1, 365]`. Regression-locked.
- **003** (onboarding theme persistence): already covered by an existing passing integration test.
- **008** (Plex URL ENV lock): already correct (locked pill, disabled input, lock text).
- **013** ("undefined" is not valid JSON): not reproducible from source; the only unguarded `JSON.parse` is server-side behind a content guard and a caller-level try/catch.
- **011** (possessive server-name labels): correct in code; a product/content call.
- **012** ("Go to Dashboard" first-click): no code guard found; needs a browser repro before any change.

## Tests

- Flips the `wrapped-identifier-loader` contract test from `403` to `404` and adds a byte-identical anti-enumeration contract block (three anon cases identical, no orphan row, public-200, valid-token-200).
- New `tests/unit/auth/plex-content-negotiation.test.ts` covering all three negotiation branches plus the absent-header fallback.
- New fun-facts template-mode case in the onboarding completion summary tests.
- Source-regression locks for ISSUE-005 / 006 / 009 / 010.

## Verification

- `bun run check:biome` — clean
- `bun run check` (svelte-check) — 0 errors, 0 warnings
- `bun run test` — 2082 pass / 0 fail
