### PR TITLE
fix: resolve dogfood UX findings and clarify privacy copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ docs/
 # Build analysis
 bundle-stats.html
 .omx/
+dogfood-output/

--- a/src/lib/server/admin/users.service.ts
+++ b/src/lib/server/admin/users.service.ts
@@ -47,6 +47,20 @@ export async function getUserCount(): Promise<number> {
 	return result[0]?.count ?? 0;
 }
 
+/**
+ * Count distinct synced viewers — the Plex accounts that appear in play history.
+ * This is distinct from {@link getUserCount} (login/app accounts in `users`): a
+ * fresh server commonly has one login user but many synced viewers, so the
+ * dashboard surfaces both to reconcile "1 user / N plays". Single cheap
+ * COUNT(DISTINCT) query, no per-row work.
+ */
+export async function getSyncedViewerCount(): Promise<number> {
+	const result = await db
+		.select({ count: sql<number>`count(distinct ${playHistory.accountId})` })
+		.from(playHistory);
+	return result[0]?.count ?? 0;
+}
+
 export async function getAllUsersWithStats(year: number): Promise<UserWithStats[]> {
 	const yearStart = Math.floor(new Date(Date.UTC(year, 0, 1, 0, 0, 0)).getTime() / 1000);
 	const yearEnd = Math.floor(new Date(Date.UTC(year, 11, 31, 23, 59, 59)).getTime() / 1000);

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -53,7 +53,8 @@ export const shareModeOptions: OptionCopy<ShareModeType>[] = [
 	{
 		value: ShareMode.PRIVATE_OAUTH,
 		label: 'Server Members Only',
-		description: 'Only authenticated Plex server members can view'
+		description:
+			'Any signed-in Plex server member can view — including this person’s real name and full viewing history'
 	},
 	{
 		value: ShareMode.PRIVATE_LINK,

--- a/src/lib/sharing/preset-logic.ts
+++ b/src/lib/sharing/preset-logic.ts
@@ -26,6 +26,25 @@ import {
 export type PrivacyPresetMatch = PrivacyPresetId | 'custom';
 
 /**
+ * Whether the onboarding privacy step should show the "Custom configuration —
+ * your choices don't match a preset" note.
+ *
+ * On a fresh install the seeded values can incidentally resolve to `'custom'`
+ * (the raw defaults match no shipped preset) before the admin touches anything.
+ * Showing the "your choices don't match a preset" note in that untouched state
+ * is misleading — the admin hasn't made any choices yet (ISSUE-001). The note is
+ * therefore gated on interaction: it appears only once the admin has picked a
+ * preset card or edited an Advanced Option AND the live values still match no
+ * preset.
+ */
+export function shouldShowCustomPresetNote(
+	selectedPreset: PrivacyPresetMatch,
+	hasInteracted: boolean
+): boolean {
+	return selectedPreset === 'custom' && hasInteracted;
+}
+
+/**
  * Match the full six-field value set against the shipped presets. Used by
  * ONBOARDING, which owns all six fields (including `logoMode`) in one atomic
  * form. Returns the matching preset id, or `'custom'` if no preset matches.

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -1,4 +1,4 @@
-import { getUserCount } from '$lib/server/admin/users.service';
+import { getSyncedViewerCount, getUserCount } from '$lib/server/admin/users.service';
 import { calculateServerStats } from '$lib/server/stats/engine';
 import { getSchedulerStatus } from '$lib/server/sync/scheduler';
 import {
@@ -12,19 +12,28 @@ export const load: PageServerLoad = async () => {
 	const year = new Date().getFullYear();
 
 	// Load all dashboard data in parallel
-	const [userCount, historyCount, lastSync, schedulerStatus, serverStats, isRunning] =
-		await Promise.all([
-			getUserCount(),
-			getPlayHistoryCount(),
-			getLastSuccessfulSync(),
-			getSchedulerStatus(),
-			calculateServerStats(year, { cacheTtlSeconds: 3600 }).catch(() => null),
-			isSyncRunning()
-		]);
+	const [
+		userCount,
+		syncedViewerCount,
+		historyCount,
+		lastSync,
+		schedulerStatus,
+		serverStats,
+		isRunning
+	] = await Promise.all([
+		getUserCount(),
+		getSyncedViewerCount(),
+		getPlayHistoryCount(),
+		getLastSuccessfulSync(),
+		getSchedulerStatus(),
+		calculateServerStats(year, { cacheTtlSeconds: 3600 }).catch(() => null),
+		isSyncRunning()
+	]);
 
 	return {
 		year,
 		userCount,
+		syncedViewerCount,
 		historyCount,
 		lastSync: lastSync
 			? {

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -92,6 +92,7 @@ const statsConfig = $derived([
 	{
 		value: data.userCount,
 		label: 'Total Users',
+		sub: `${data.syncedViewerCount.toLocaleString()} synced viewers`,
 		icon: Users,
 		color: 'blue',
 		gradient: 'from-blue-500/20 to-blue-600/5'
@@ -264,7 +265,12 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 				{#if data.schedulerStatus?.nextRun}
 					<div class="sync-row">
 						<span class="sync-label">Next Sync</span>
-						<span class="sync-value">{formatDate(data.schedulerStatus.nextRun)}</span>
+						<span class="sync-value">
+							{formatDate(data.schedulerStatus.nextRun)}
+							{#if data.schedulerStatus.cronExpression}
+								<span class="sync-cron">(cron {data.schedulerStatus.cronExpression} UTC)</span>
+							{/if}
+						</span>
 					</div>
 				{/if}
 			</div>
@@ -655,6 +661,12 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 		.sync-value.highlight {
 			color: oklch(var(--primary));
 			font-weight: 600;
+		}
+
+		.sync-cron {
+			font-weight: 400;
+			color: oklch(var(--muted-foreground));
+			font-variant-numeric: tabular-nums;
 		}
 
 		.status-badge {

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -517,7 +517,9 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 		<CardHeader>
 			<CardTitle>Server-wide wrapped sharing</CardTitle>
 			<CardDescription>
-				Controls anonymization and the share mode used by the server-wide /wrapped pages.
+				Controls anonymization and the share mode for the aggregate server-wide /wrapped recap
+				only. It does NOT change who can view individual users' personal Wrapped pages — that
+				is governed by the per-user default share mode below.
 			</CardDescription>
 		</CardHeader>
 		<CardContent>
@@ -656,7 +658,9 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 			<CardTitle>User sharing defaults</CardTitle>
 			<CardDescription>
 				Default share mode for newly-created users, and whether users can change their own
-				share settings.
+				share settings. This default is also the privacy floor for every user's personal
+				Wrapped page — raise or lower it here (not via the server-wide recap control above) to
+				change who can view personal Wrapped pages.
 			</CardDescription>
 		</CardHeader>
 		<CardContent>

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -602,17 +602,13 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 					action={editingSlide ? '?/updateCustom' : '?/createCustom'}
 					use:enhance={() => {
 						return async ({ result, update }) => {
+							// Refresh the list first so a newly created/updated slide appears
+							// immediately; keep the user's entered content on failure
+							// (reset: false) so a validation error never blanks the open modal.
+							await update({ reset: false });
 							if (result.type === 'success') {
 								closeEditor();
-							} else if (
-								result.type === 'failure' &&
-								typeof result.data?.error === 'string' &&
-								result.data.error.toLowerCase().includes('unsafe html')
-							) {
-								editorTitle = '';
-								editorContent = '';
 							}
-							await update();
 						};
 					}}
 				>
@@ -649,7 +645,14 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 							required
 							rows="10"
 							placeholder="Write your slide content in Markdown..."
+							aria-invalid={slideFieldErrors?.content?.[0] ? 'true' : undefined}
+							aria-describedby={slideFieldErrors?.content?.[0] ? 'content-error' : undefined}
 						></textarea>
+						{#if slideFieldErrors?.content?.[0]}
+							<span id="content-error" class="field-error" role="alert">
+								{slideFieldErrors.content[0]}
+							</span>
+						{/if}
 					</div>
 
 					<div class="form-row form-row-aligned">

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -552,7 +552,11 @@ async function goToPage(page: number) {
 						{#if data.schedulerStatus.nextRun}
 							<div class="time-row">
 								<span class="time-label">Next sync</span>
-								<span class="time-value">{formatDate(data.schedulerStatus.nextRun)}</span>
+								<span class="time-value"
+										>{formatDate(data.schedulerStatus.nextRun)}{#if data.schedulerStatus.cronExpression}
+											<span class="time-cron">(cron {data.schedulerStatus.cronExpression} UTC)</span>
+										{/if}</span
+									>
 							</div>
 						{/if}
 						{#if data.schedulerStatus.previousRun}
@@ -1468,6 +1472,12 @@ async function goToPage(page: number) {
 			font-size: 0.8125rem;
 			font-weight: 500;
 			color: oklch(var(--foreground));
+		}
+
+		.time-cron {
+			font-weight: 400;
+			color: oklch(var(--muted-foreground));
+			font-variant-numeric: tabular-nums;
 		}
 
 		.scheduler-controls {

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -32,7 +32,8 @@ import {
 	PREVIEW_LOGO_VISIBILITY_LABELS,
 	PREVIEW_NAME_DISPLAY_LABELS,
 	PREVIEW_PER_USER_DEFAULT_LABELS,
-	PREVIEW_RECAP_VISIBILITY_LABELS
+	PREVIEW_RECAP_VISIBILITY_LABELS,
+	shouldShowCustomPresetNote
 } from '$lib/sharing/preset-logic';
 import { handleFormToast } from '$lib/utils/form-toast';
 import { submitAction } from '$lib/utils/submit-action';
@@ -67,6 +68,13 @@ let enableFunFacts = $state(false);
 // edits in Advanced Options flip it to "Custom"), never persisted as a field.
 let advancedPrivacyOpen = $state(false);
 
+// Tracks whether the admin has actively touched the privacy controls (picked a
+// preset card or edited an Advanced Option). On a fresh install the seeded
+// values can resolve to 'custom' before any interaction; the "Custom
+// configuration" note is gated on this flag so it never accuses the admin of
+// off-preset choices they haven't made yet (ISSUE-001).
+let privacyTouched = $state(false);
+
 let selectedPreset = $derived(
 	matchPresetFull({
 		anonymizationMode,
@@ -92,6 +100,7 @@ let privacyPreview = $derived(
 );
 
 function applyPrivacyPreset(preset: PrivacyPreset) {
+	privacyTouched = true;
 	anonymizationMode = preset.values.anonymizationMode;
 	defaultShareMode = preset.values.defaultShareMode;
 	serverWrappedShareMode = preset.values.serverWrappedShareMode;
@@ -585,9 +594,13 @@ function getThemeColors(themeValue: string) {
 										</button>
 									{/each}
 								</div>
-								{#if selectedPreset === 'custom'}
+								{#if shouldShowCustomPresetNote(selectedPreset, privacyTouched)}
 									<p class="preset-custom-note" role="status">
 										Custom configuration — your choices don’t match a preset.
+									</p>
+								{:else if selectedPreset === 'custom'}
+									<p class="preset-custom-note preset-custom-note-neutral" role="status">
+										No preset selected yet — pick one above to get started.
 									</p>
 								{/if}
 							</div>
@@ -702,7 +715,9 @@ function getThemeColors(themeValue: string) {
 									<ChevronDownIcon class="advanced-chevron" />
 								</button>
 								{#if advancedPrivacyOpen}
-									<div class="advanced-content">
+									<!-- change events from the descendant radios bubble here, so editing
+									     any granular control counts as interaction (see privacyTouched). -->
+									<div class="advanced-content" onchange={() => (privacyTouched = true)}>
 							<div class="setting-group">
 								<span class="setting-label">User Identity in Stats</span>
 								<p class="setting-description">How usernames appear in server-wide statistics</p>
@@ -826,7 +841,10 @@ function getThemeColors(themeValue: string) {
 										type="button"
 										class="toggle-switch"
 										class:active={allowUserControl}
-										onclick={() => (allowUserControl = !allowUserControl)}
+										onclick={() => {
+											privacyTouched = true;
+											allowUserControl = !allowUserControl;
+										}}
 										aria-pressed={allowUserControl}
 										aria-label="Allow User Control"
 									>
@@ -845,7 +863,10 @@ function getThemeColors(themeValue: string) {
 										type="button"
 										class="toggle-switch"
 										class:active={publicLandingLookup}
-										onclick={() => (publicLandingLookup = !publicLandingLookup)}
+										onclick={() => {
+											privacyTouched = true;
+											publicLandingLookup = !publicLandingLookup;
+										}}
 										aria-pressed={publicLandingLookup}
 										aria-label={publicLandingLookupCopy.label}
 									>
@@ -1622,6 +1643,11 @@ function getThemeColors(themeValue: string) {
 			font-size: 0.78rem;
 			color: rgba(255, 255, 255, 0.6);
 			font-style: italic;
+		}
+
+		.preset-custom-note-neutral {
+			font-style: normal;
+			color: rgba(255, 255, 255, 0.45);
 		}
 
 		/* Live preview panel */

--- a/src/routes/wrapped/[year]/+error.svelte
+++ b/src/routes/wrapped/[year]/+error.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+import { goto } from '$app/navigation';
+import { page } from '$app/stores';
+
+const status = $derived($page.status);
+const message = $derived($page.error?.message ?? '');
+const year = $derived($page.params.year ?? '');
+
+// The recap loader throws this exact 404 message when a year has no synced data
+// yet (src/routes/wrapped/[year]/+page.server.ts). Detect that one case so we can
+// show a friendly, role-agnostic empty-state instead of the bare "not found"
+// card. Every other error (403 access denied, generic 404, 5xx) falls through to
+// the generic copy below — no internal paths or admin-only affordances leaked.
+const isNoDataForYear = $derived(status === 404 && message === 'No data found for this year');
+
+const title = $derived.by(() => {
+	if (isNoDataForYear) return `No Wrapped for ${year} yet`;
+	if (status === 404) return 'Page not found';
+	if (status === 403) return 'Access denied';
+	if (status === 429) return 'Too many requests';
+	if (status >= 500) return 'Something went wrong';
+	return 'Error';
+});
+
+const description = $derived.by(() => {
+	if (isNoDataForYear) {
+		return `There's no Wrapped data for ${year} yet. It appears here once a sync has imported viewing history for that year.`;
+	}
+	if (message) return message;
+	if (status === 404) return "We couldn't find the page you were looking for.";
+	if (status === 403) return "You don't have permission to view this page.";
+	if (status === 429) return 'Please slow down and try again in a moment.';
+	if (status >= 500) return 'An unexpected error occurred on the server.';
+	return 'An unexpected error occurred.';
+});
+
+function goBack(): void {
+	if (typeof window !== 'undefined' && window.history.length > 1) {
+		window.history.back();
+	} else {
+		goto('/');
+	}
+}
+</script>
+
+<svelte:head>
+	<title>{title} - Obzorarr</title>
+</svelte:head>
+
+<div class="error-page">
+	<div class="error-card">
+		<div class="status-code">{status}</div>
+		<h1>{title}</h1>
+		<p>{description}</p>
+		<div class="actions">
+			<button type="button" class="btn secondary" onclick={goBack}>Go back</button>
+			<a href="/" class="btn primary">Home</a>
+		</div>
+	</div>
+</div>
+
+<style>
+	.error-page {
+		min-height: 100vh;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 2rem;
+		background: oklch(var(--background));
+	}
+
+	.error-card {
+		max-width: 480px;
+		width: 100%;
+		text-align: center;
+		background: oklch(var(--card));
+		border: 1px solid oklch(var(--border));
+		border-radius: var(--radius);
+		padding: 2.5rem 2rem;
+	}
+
+	.status-code {
+		font-size: 4rem;
+		font-weight: 800;
+		color: oklch(var(--primary));
+		line-height: 1;
+		margin-bottom: 0.5rem;
+	}
+
+	h1 {
+		font-size: 1.5rem;
+		font-weight: 600;
+		margin: 0 0 0.75rem;
+		color: oklch(var(--foreground));
+	}
+
+	p {
+		color: oklch(var(--muted-foreground));
+		margin: 0 0 2rem;
+		line-height: 1.5;
+	}
+
+	.actions {
+		display: flex;
+		gap: 0.75rem;
+		justify-content: center;
+		flex-wrap: wrap;
+	}
+
+	.btn {
+		padding: 0.625rem 1.25rem;
+		border-radius: var(--radius);
+		font-size: 0.875rem;
+		font-weight: 500;
+		cursor: pointer;
+		border: 1px solid oklch(var(--border));
+		transition: opacity 0.15s ease;
+		text-decoration: none;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		line-height: 1;
+	}
+
+	.btn:hover {
+		opacity: 0.85;
+	}
+
+	.btn.primary {
+		background: oklch(var(--primary));
+		color: oklch(var(--primary-foreground));
+		border-color: oklch(var(--primary));
+	}
+
+	.btn.secondary {
+		background: oklch(var(--muted));
+		color: oklch(var(--foreground));
+	}
+</style>

--- a/tests/unit/admin/slides-actions.test.ts
+++ b/tests/unit/admin/slides-actions.test.ts
@@ -183,6 +183,54 @@ describe('admin slides actions', () => {
 		});
 	}
 
+	describe('createCustom success contract (FIX-5 / ISSUE-007)', () => {
+		it('returns { success: true, slide } on a valid create so the modal can close only on success', async () => {
+			const result = await runCreateCustom(
+				buildCreateCustomRequest({
+					title: 'My recap slide',
+					content: 'Some safe **markdown** content',
+					enabled: 'true'
+				})
+			);
+
+			// The enhance callback closes the editor ONLY when result.type === 'success';
+			// the persisted slide must come back so the refreshed list shows it immediately.
+			expect(result).toMatchObject({ success: true, slide: { title: 'My recap slide' } });
+
+			const rows = await db.select().from(customSlides);
+			expect(rows).toHaveLength(1);
+			expect(rows[0]?.content).toBe('Some safe **markdown** content');
+		});
+	});
+
+	describe('createCustom enhance ordering (FIX-5 / ISSUE-007 source guard)', () => {
+		const readSource = async () => await Bun.file('src/routes/admin/slides/+page.svelte').text();
+
+		it('awaits update() before closing the editor and only closes on success', async () => {
+			const src = await readSource();
+			const updateIdx = src.indexOf('await update(');
+			const closeIdx = src.indexOf('closeEditor();', updateIdx);
+			expect(updateIdx).toBeGreaterThan(-1);
+			expect(closeIdx).toBeGreaterThan(updateIdx);
+			// closeEditor in the enhance flow is guarded by a success check.
+			expect(/result\.type === 'success'\)\s*\{\s*closeEditor\(\);/s.test(src)).toBe(true);
+		});
+
+		it('no longer blanks editorTitle/editorContent inside the enhance callback (content preserved on failure)', async () => {
+			const src = await readSource();
+			// Scope the assertion to the create/update editor form so we don't trip
+			// over openCreate()'s legitimate field reset elsewhere. Anchor on the
+			// editor form's action attribute, then take its enhance callback body.
+			const formStart = src.indexOf("'?/updateCustom' : '?/createCustom'");
+			expect(formStart).toBeGreaterThan(-1);
+			const region = src.slice(formStart, src.indexOf('</form>', formStart));
+			// FIX-5: the old unsafe-html branch that blanked the fields on failure is gone…
+			expect(region.includes('editorContent = ')).toBe(false);
+			// …and the list is refreshed without resetting the still-open form.
+			expect(region.includes('update({ reset: false })')).toBe(true);
+		});
+	});
+
 	describe('createCustom error mapping', () => {
 		it('returns 400 with fieldErrors.content when content has unsafe HTML', async () => {
 			const result = await runCreateCustom(

--- a/tests/unit/admin/users.service.test.ts
+++ b/tests/unit/admin/users.service.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import { getAllUsersWithStats } from '$lib/server/admin/users.service';
+import { getAllUsersWithStats, getSyncedViewerCount } from '$lib/server/admin/users.service';
 import { db } from '$lib/server/db/client';
 import { playHistory, shareSettings, users } from '$lib/server/db/schema';
 import { createTimestamp } from '../../helpers/factories';
@@ -73,6 +73,51 @@ describe('admin users service', () => {
 			totalWatchTimeMinutes: 0,
 			totalPlays: 0,
 			hasWatchHistory: false
+		});
+	});
+
+	describe('getSyncedViewerCount (FIX-3 / ISSUE-004)', () => {
+		it('returns 0 when there is no play history', async () => {
+			expect(await getSyncedViewerCount()).toBe(0);
+		});
+
+		it('counts distinct play-history accounts, not raw rows', async () => {
+			// Three rows across two distinct accountIds (2001 appears twice) → 2 viewers,
+			// reconciling the "1 login user / many synced viewers" dashboard gap.
+			await db.insert(playHistory).values([
+				{
+					historyKey: 'h-1',
+					ratingKey: 'r-1',
+					title: 'Movie 1',
+					type: 'movie',
+					viewedAt: createTimestamp(2025, 1, 15),
+					accountId: 2001,
+					librarySectionId: 1,
+					duration: 1800
+				},
+				{
+					historyKey: 'h-2',
+					ratingKey: 'r-2',
+					title: 'Movie 2',
+					type: 'movie',
+					viewedAt: createTimestamp(2025, 2, 15),
+					accountId: 2001,
+					librarySectionId: 1,
+					duration: 1800
+				},
+				{
+					historyKey: 'h-3',
+					ratingKey: 'r-3',
+					title: 'Movie 3',
+					type: 'movie',
+					viewedAt: createTimestamp(2025, 3, 15),
+					accountId: 2002,
+					librarySectionId: 1,
+					duration: 1800
+				}
+			]);
+
+			expect(await getSyncedViewerCount()).toBe(2);
 		});
 	});
 });

--- a/tests/unit/sharing/presets.test.ts
+++ b/tests/unit/sharing/presets.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 import { PRIVACY_PRESETS, type PrivacyPresetValues } from '$lib/sharing/options';
-import { derivePreview, matchPresetFull, matchPresetPrivacy } from '$lib/sharing/preset-logic';
+import {
+	derivePreview,
+	matchPresetFull,
+	matchPresetPrivacy,
+	shouldShowCustomPresetNote
+} from '$lib/sharing/preset-logic';
 
 const byId = (id: string) => {
 	const preset = PRIVACY_PRESETS.find((p) => p.id === id);
@@ -123,6 +128,26 @@ describe('derivePreview', () => {
 	it('no shipped preset trips the contradiction warning', () => {
 		for (const preset of PRIVACY_PRESETS) {
 			expect(derivePreview(preset.values).warnings).toHaveLength(0);
+		}
+	});
+});
+
+describe('shouldShowCustomPresetNote (ISSUE-001: gate the "Custom configuration" note on interaction)', () => {
+	it('does NOT show the note for a fresh-install custom state before any interaction', () => {
+		// The defect: seeded values resolve to 'custom' on first load. With no
+		// interaction the misleading "your choices don't match a preset" note must
+		// stay hidden.
+		expect(shouldShowCustomPresetNote('custom', false)).toBe(false);
+	});
+
+	it('shows the note once the user has interacted and the values still match no preset', () => {
+		expect(shouldShowCustomPresetNote('custom', true)).toBe(true);
+	});
+
+	it('never shows the note when a named preset is selected, regardless of interaction', () => {
+		for (const preset of PRIVACY_PRESETS) {
+			expect(shouldShowCustomPresetNote(preset.id, false)).toBe(false);
+			expect(shouldShowCustomPresetNote(preset.id, true)).toBe(false);
 		}
 	});
 });

--- a/tests/unit/sharing/server-wrapped-route.test.ts
+++ b/tests/unit/sharing/server-wrapped-route.test.ts
@@ -149,6 +149,29 @@ describe('server wrapped route year guard (ISSUE-009, ISSUE-018)', () => {
 		}
 	});
 
+	it('throws the exact "No data found for this year" 404 message (FIX-2 +error.svelte contract)', async () => {
+		// The route-scoped wrapped/[year]/+error.svelte detects this exact message
+		// to render its friendly empty-state. Lock the string so the boundary copy
+		// and the thrown error can never silently drift apart.
+		const currentYear = new Date().getFullYear();
+		const emptyPastYear = currentYear - 1;
+		try {
+			await load({
+				params: { year: String(emptyPastYear) },
+				locals: {},
+				parent: makeParent([currentYear]),
+				url: new URL(`http://localhost/wrapped/${emptyPastYear}`),
+				setHeaders: () => {}
+			} as unknown as Parameters<ServerWrappedLoad>[0]);
+			expect.unreachable('Expected 404 for empty past year');
+		} catch (err) {
+			expect(isHttpError(err)).toBe(true);
+			if (!isHttpError(err)) throw err;
+			expect(err.status).toBe(404);
+			expect(err.body.message).toBe('No data found for this year');
+		}
+	});
+
 	it('does not 404 for the current year even when not yet in availableYears (pre-first-sync)', async () => {
 		// Current year with no data yet should reach the access-control check,
 		// not be blocked by the year guard. Since no access restriction is set,


### PR DESCRIPTION
## Summary

Resolves the actionable findings from the latest dogfood pass. Every change is copy, UI gating, a read-only query, an error boundary, or a dashboard count. No access-control, share-mode semantics, anti-enumeration behavior, or the public share-page thumbnail contract is changed.

## Fixes

| Issue | Area | Change |
| --- | --- | --- |
| ISSUE-001 | Onboarding privacy | The "Custom configuration — your choices don't match a preset" note is now gated behind real interaction (a new pure helper `shouldShowCustomPresetNote`). A fresh install shows a neutral "pick a preset" prompt instead of accusing the admin of off-preset choices they have not made. UI-only; nothing saved changes. |
| ISSUE-003 | Wrapped | New route-scoped `wrapped/[year]/+error.svelte` renders a friendly, role-agnostic empty-state for the exact "No data found for this year" 404. Access-denied (403) and other errors still render the generic card. No admin-only link or internal path is leaked. |
| ISSUE-004 | Admin dashboard | New `getSyncedViewerCount()` (single `COUNT(DISTINCT account_id)` over play history) is surfaced as a sub-label on the Total Users card so "1 user / N plays" reconciles at a glance. |
| ISSUE-005 | Admin dashboard + sync | "Next sync" now echoes the stored cron expression labeled UTC next to the localized time, removing the "entered 3, saw 5:00 AM" offset surprise. Presentational only; no scheduler logic changed. |
| ISSUE-007 | Admin slides | The create/update modal now awaits `update({ reset: false })` before closing, closes only on success, preserves the entered content on failure, and surfaces an inline content error. A created slide appears in the list immediately. |
| ISSUE-010 (10a) | Sharing | The "Server Members Only" (`private-oauth`) description is now honest: any signed-in server member can view the person's full Wrapped, including their real name and viewing history. No access-control change. |
| ISSUE-008 | Admin privacy | Copy clarification distinguishing the two controls: the server-wide card now states it affects only the aggregate `/wrapped` recap, and the user-defaults card states it is the privacy floor that governs personal Wrapped pages. |

## ISSUE-008 investigation (verdict: two-control label confusion)

The report's symptom was "setting server-wide Public did not lower the personal-Wrapped floor." Code-grounded analysis confirms this is label confusion, not a precedence bug:

- The personal-Wrapped floor is `default_share_mode`, applied by `getEffectiveShareMode()` via `getMoreRestrictiveMode(rowMode, globalDefault)`. Lowering `default_share_mode` to public does lower the floor for default-sourced rows (an explicit per-user members-only choice still correctly wins).
- `server_wrapped_share_mode` is a separate setting that gates only the aggregate `/wrapped/[year]` recap, never personal Wrapped.
- There is no ENV companion for any share-mode key, so the report's "ENV-level floor" wording was itself mistaken; the floor was DB-set from onboarding's Balanced preset.

The fix is the copy clarification above.

## Decisions (kept by design)

- ISSUE-010: "Server Members Only" stays as designed (the household/family use case wants member-to-member sharing). The honesty copy ships now; a member-level opt-out (allow `private-link` below a `private-oauth` floor) is deferred as a separately-scoped follow-up since it touches the highest-blast-radius access-control code (`ShareModePrivacyLevel` / `getMoreRestrictiveMode` / enumeration handling). Corrected premise: anonymization applies only to the server-wide recap, not personal Wrapped.
- ISSUE-009: token-only `/plex/thumb` access is closed as designed (required for public share-page thumbnails).
- ISSUE-002: third-party Plex/Google SDK console warnings, won't-fix.
- ISSUE-011: "Logo preference updated" copy is accurate, no change.
- ISSUE-006 (new-tab admin redirect to `/`): code review shows no path that redirects a valid admin session (`hooks.server.ts` only redirects unauthenticated/non-admin; the session cookie is `SameSite=lax`). Could not be reproduced via code analysis and needs a manual second-tab check before final close.

## Tests

Extended the existing suites:

- `tests/unit/sharing/presets.test.ts` — `shouldShowCustomPresetNote` gating
- `tests/unit/sharing/server-wrapped-route.test.ts` — locks the exact "No data found for this year" 404 message the new boundary keys off
- `tests/unit/admin/users.service.test.ts` — `getSyncedViewerCount` (zero + distinct-count)
- `tests/unit/admin/slides-actions.test.ts` — create success contract + enhance-ordering source guard

## Verification

- `bun run check` (svelte-check): 0 errors, 0 warnings
- `bun run check:biome`: clean
- `bun run test`: 2091 pass, 0 fail

## Notes

- No change to anti-enumeration behavior, share-mode semantics, or the public share-page thumbnail contract.
- Decision records (ADR + the deferred 10b backlog item) were authored locally but `docs/` is gitignored in this repo, so the full dispositions live in this PR description instead.