### PR TITLE
fix: remediate dogfood findings (sync race, CSRF lockout, logout, sharing, a11y)

### DIFF
--- a/src/lib/components/slides/TotalTimeSlide.svelte
+++ b/src/lib/components/slides/TotalTimeSlide.svelte
@@ -55,7 +55,10 @@ const comparisonText = $derived.by(() => {
 	if (days >= 1) {
 		return `That's ${days} days of content!`;
 	}
-	return `That's ${hours} hours of entertainment!`;
+	if (totalWatchTimeMinutes < 60) {
+		return `That's ${minutes} ${minutes === 1 ? 'minute' : 'minutes'} of entertainment!`;
+	}
+	return `That's ${hours} ${hours === 1 ? 'hour' : 'hours'} of entertainment!`;
 });
 
 // Element references for animation

--- a/src/lib/components/slides/TotalTimeSlide.svelte
+++ b/src/lib/components/slides/TotalTimeSlide.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { animate } from 'motion';
 import { prefersReducedMotion } from 'svelte/motion';
+import { formatWatchHours } from '$lib/stats/format';
 import {
 	animateNumber,
 	DELAY_PRESETS,
@@ -29,7 +30,7 @@ let {
 const subject = $derived(getSubject(messagingContext));
 
 // Derived computed values
-const hours = $derived(Math.floor(totalWatchTimeMinutes / 60));
+const hours = $derived(formatWatchHours(totalWatchTimeMinutes));
 const minutes = $derived(Math.round(totalWatchTimeMinutes % 60));
 const days = $derived(Number((totalWatchTimeMinutes / 60 / 24).toFixed(1)));
 const weeks = $derived(Number((totalWatchTimeMinutes / 60 / 24 / 7).toFixed(1)));

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -88,6 +88,13 @@ const canRegenerateToken = $derived(
 	canControlShare && displayMode === 'private-link' && !isBelowFloor(displayMode)
 );
 
+// ISSUE-019: an owner whose `canUserControl` is off (and who isn't an admin)
+// gets no visibility controls at all. Surface why, plus a path to their own
+// settings, instead of silently hiding the section.
+const showNoControlNotice = $derived(
+	isOwner && !isAdmin && !isServerWrapped && !(shareSettings?.canUserControl ?? false)
+);
+
 // Available modes based on permissions
 const availableModes = $derived.by(() => {
 	if (isAdmin) return ['public', 'private-link', 'private-oauth'] as const;
@@ -438,8 +445,12 @@ $effect(() => {
 									<span class="mode-desc">{modeLabels[mode as ShareModeType].description}</span>
 									{#if globalFloor && isBelowFloor(mode as ShareModeType)}
 										<span class="floor-note">
-											Global floor is <strong>{modeLabels[globalFloor].label}</strong>. Effective
-											mode at access time will be <strong>{modeLabels[globalFloor].label}</strong>.
+											Disabled by server policy: visibility can't be more public than
+											<strong>{modeLabels[globalFloor].label}</strong>. Effective mode at access
+											time will be <strong>{modeLabels[globalFloor].label}</strong>.
+											{#if !isAdmin}
+												Contact your admin to change the server floor.
+											{/if}
 										</span>
 									{/if}
 								</div>
@@ -509,10 +520,24 @@ $effect(() => {
 			</div>
 		{/if}
 
-		<!-- Advanced Options Link (admin only) -->
-		{#if isAdmin}
-			<div class="advanced-section">
-				<a href="/admin/settings?tab=privacy" class="advanced-link">
+		<!-- ISSUE-019: explain why visibility controls are unavailable + a path to act -->
+		{#if showNoControlNotice}
+			<div class="control-notice">
+				<p class="control-notice-text">
+					Your admin hasn't enabled per-user visibility control, so this Wrapped uses the
+					server default. Manage your account from
+					<a href="/dashboard/settings" class="control-notice-link">your settings</a>, or contact
+					your admin to request control.
+				</p>
+			</div>
+		{/if}
+
+		<!-- Advanced Options Link: admin-scoped vs user-scoped (ISSUE-020) -->
+		<div class="advanced-section">
+			<a
+				href={isAdmin ? '/admin/settings?tab=privacy' : '/dashboard/settings'}
+				class="advanced-link"
+			>
 					<svg
 						xmlns="http://www.w3.org/2000/svg"
 						width="14"
@@ -532,7 +557,6 @@ $effect(() => {
 					Advanced sharing options
 				</a>
 			</div>
-		{/if}
 
 		<AlertDialog.Footer>
 			<AlertDialog.Cancel>Close</AlertDialog.Cancel>
@@ -762,6 +786,30 @@ $effect(() => {
 		.btn-link:disabled {
 			opacity: 0.5;
 			cursor: not-allowed;
+		}
+
+		.control-notice {
+			padding: 0.75rem 0.875rem;
+			margin-bottom: 1.25rem;
+			border: 1px solid oklch(var(--border));
+			border-radius: 8px;
+			background-color: oklch(var(--muted) / 0.4);
+		}
+
+		.control-notice-text {
+			margin: 0;
+			font-size: 0.8125rem;
+			line-height: 1.45;
+			color: oklch(var(--muted-foreground));
+		}
+
+		.control-notice-link {
+			color: oklch(var(--primary));
+			text-decoration: none;
+		}
+
+		.control-notice-link:hover {
+			text-decoration: underline;
 		}
 
 		.advanced-section {

--- a/src/lib/server/admin/users.service.ts
+++ b/src/lib/server/admin/users.service.ts
@@ -3,6 +3,7 @@ import { db } from '$lib/server/db/client';
 import { playHistory, shareSettings, users } from '$lib/server/db/schema';
 import { generateShareToken, getGlobalDefaultShareMode } from '$lib/server/sharing/service';
 import {
+	getMoreRestrictiveMode,
 	ShareMode,
 	ShareModeSource,
 	type ShareModeSourceType,
@@ -23,6 +24,52 @@ export interface UserWithStats {
 	shareMode: ShareModeType | null;
 	shareModeSource: ShareModeSourceType | null;
 	canUserControl: boolean;
+	/**
+	 * Effective access mode after clamping the stored mode by the global floor
+	 * (ISSUE-007). Never more permissive than what a viewer actually gets, so the
+	 * admin Users badge can't read "Public"/"Link" while access is private-oauth.
+	 */
+	effectiveShareMode: ShareModeType;
+	/** Badge label derived from {@link effectiveShareMode} (or "Default" for default-sourced rows). */
+	effectiveLabel: string;
+	/** Badge CSS class derived from {@link effectiveShareMode} ('' for default-sourced rows). */
+	effectiveClass: '' | 'public' | 'oauth' | 'link';
+}
+
+/**
+ * Derive the badge label + CSS class for a user's share mode, clamped by the
+ * global floor. Pure so it can be unit-tested without a DB or DOM. The badge
+ * LABEL and CSS class both come from `effective` so they can never desync, and
+ * a "Default" tag is shown ONLY for rows with no explicit per-user override.
+ */
+export function deriveEffectiveShareBadge(
+	storedMode: ShareModeType | null,
+	source: ShareModeSourceType | null,
+	globalFloor: ShareModeType
+): {
+	effectiveShareMode: ShareModeType;
+	effectiveLabel: string;
+	effectiveClass: '' | 'public' | 'oauth' | 'link';
+} {
+	const baseMode = storedMode ?? globalFloor;
+	const effectiveShareMode = getMoreRestrictiveMode(baseMode, globalFloor);
+
+	// A default-sourced row (no explicit override) is shown as "Default" with no
+	// color class — it tracks whatever the global default is.
+	if (source === ShareModeSource.DEFAULT || source === null) {
+		return { effectiveShareMode, effectiveLabel: 'Default', effectiveClass: '' };
+	}
+
+	switch (effectiveShareMode) {
+		case ShareMode.PUBLIC:
+			return { effectiveShareMode, effectiveLabel: 'Public', effectiveClass: 'public' };
+		case ShareMode.PRIVATE_OAUTH:
+			return { effectiveShareMode, effectiveLabel: 'OAuth', effectiveClass: 'oauth' };
+		case ShareMode.PRIVATE_LINK:
+			return { effectiveShareMode, effectiveLabel: 'Link', effectiveClass: 'link' };
+		default:
+			return { effectiveShareMode, effectiveLabel: 'Default', effectiveClass: '' };
+	}
 }
 
 export interface UserBasicInfo {
@@ -66,6 +113,7 @@ export async function getAllUsersWithStats(year: number): Promise<UserWithStats[
 	const yearEnd = Math.floor(new Date(Date.UTC(year, 11, 31, 23, 59, 59)).getTime() / 1000);
 
 	const allUsers = await db.select().from(users);
+	const globalFloor = await getGlobalDefaultShareMode();
 
 	const watchTimeByUser = await db
 		.select({
@@ -108,6 +156,9 @@ export async function getAllUsersWithStats(year: number): Promise<UserWithStats[
 		const stats = (user.accountId !== null ? watchTimeMap.get(user.accountId) : undefined) ??
 			watchTimeMap.get(user.plexId) ?? { totalDuration: 0, totalPlays: 0 };
 		const settings = shareSettingsMap.get(user.id);
+		const shareMode = settings?.mode ?? null;
+		const shareModeSource = settings?.modeSource ?? null;
+		const badge = deriveEffectiveShareBadge(shareMode, shareModeSource, globalFloor);
 
 		return {
 			id: user.id,
@@ -120,9 +171,12 @@ export async function getAllUsersWithStats(year: number): Promise<UserWithStats[
 			totalWatchTimeMinutes: Math.round(stats.totalDuration / 60),
 			totalPlays: stats.totalPlays,
 			hasWatchHistory: stats.totalPlays > 0,
-			shareMode: settings?.mode ?? null,
-			shareModeSource: settings?.modeSource ?? null,
-			canUserControl: settings?.canUserControl ?? false
+			shareMode,
+			shareModeSource,
+			canUserControl: settings?.canUserControl ?? false,
+			effectiveShareMode: badge.effectiveShareMode,
+			effectiveLabel: badge.effectiveLabel,
+			effectiveClass: badge.effectiveClass
 		};
 	});
 }

--- a/src/lib/server/db/client.ts
+++ b/src/lib/server/db/client.ts
@@ -44,6 +44,15 @@ export const db = drizzle(sqlite, { schema });
 
 if (databasePath !== ':memory:') {
 	migrate(db, { migrationsFolder: './drizzle' });
+
+	// Reconcile sync rows orphaned in the `running` state by a crash/restart,
+	// exactly once at process start — before any request can begin a sync
+	// (ISSUE-001 restart deadlock). Dynamic import of the LIGHT reconcile module
+	// (no Plex/`$env` graph) avoids a static import cycle — `sync/reconcile.ts`
+	// imports `db` from this module, which is already assigned above — and is
+	// skipped entirely for in-memory test databases.
+	const { reconcileInterruptedSyncs } = await import('$lib/server/sync/reconcile');
+	await reconcileInterruptedSyncs();
 }
 
 export { sqlite };

--- a/src/lib/server/security/csrf-handle.ts
+++ b/src/lib/server/security/csrf-handle.ts
@@ -11,7 +11,36 @@ import { applySecurityHeaders } from './security-headers';
 
 const STATE_CHANGING_METHODS = ['POST', 'PUT', 'PATCH', 'DELETE'];
 
+// CSRF self-lockout recovery carve-out (ISSUE-002). The ONLY in-app path to
+// repair a misconfigured CSRF origin is POSTing the `updateCsrfOrigin` action on
+// the security settings page. Once a bad origin is stored, csrfHandle would 403
+// that very repair POST, wedging the admin out with no in-app recovery.
+const CSRF_REPAIR_ROUTE_ID = '/admin/settings/security';
+const CSRF_REPAIR_ACTION = 'updateCsrfOrigin';
+
 let startupLogged = false;
+
+/**
+ * Returns true iff this request is the CSRF-origin repair POST on the security
+ * settings page. Keyed PURELY on `event.route.id` + the resolved SvelteKit form
+ * action — NO same-origin derivation. `event.url.origin` is rewritten from
+ * `x-forwarded-*` by proxyHandle (ordered before csrfHandle) under TRUST_PROXY
+ * and is spoofable, so a forged forwarded header must not be able to widen this
+ * carve-out. The form action is encoded by SvelteKit as a search-param key
+ * beginning with `/` (e.g. `?/updateCsrfOrigin` → key `/updateCsrfOrigin`),
+ * which is independent of the proxy-influenced origin.
+ */
+function isCsrfOriginRepairRequest(event: Parameters<Handle>[0]['event']): boolean {
+	if (event.route.id !== CSRF_REPAIR_ROUTE_ID) return false;
+
+	for (const key of event.url.searchParams.keys()) {
+		if (key.startsWith('/')) {
+			return key.slice(1) === CSRF_REPAIR_ACTION;
+		}
+	}
+
+	return false;
+}
 
 // Exported so admin actions (e.g. updateCsrfOrigin) can predict the same
 // origin csrfHandle compares against, rather than rederiving from
@@ -37,6 +66,19 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 
 	// Skip non-state-changing methods
 	if (!STATE_CHANGING_METHODS.includes(method)) {
+		return resolve(event);
+	}
+
+	// CSRF self-lockout recovery (ISSUE-002): exempt EXACTLY the security-route
+	// `updateCsrfOrigin` repair POST from the hook-level origin check and let the
+	// action's own confirm-mismatch gate govern the write. This is the one
+	// setting whose misconfiguration this check exists to repair; every other
+	// state-changing route keeps strict origin matching below. No same-origin
+	// derivation happens here, so a forged `x-forwarded-*` cannot widen it.
+	if (isCsrfOriginRepairRequest(event)) {
+		logger.warn('CSRF self-repair: allowing updateCsrfOrigin POST to reach its action', 'CSRF', {
+			route: event.route.id ?? '<unmatched>'
+		});
 		return resolve(event);
 	}
 

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull, ne } from 'drizzle-orm';
 import { db } from '$lib/server/db/client';
 import { appSettings, shareSettings } from '$lib/server/db/schema';
 import {
@@ -134,7 +134,21 @@ export async function setGlobalShareDefaults(defaults: GlobalShareDefaults): Pro
 	});
 }
 
-export async function bulkApplyShareDefaults(): Promise<number> {
+export interface BulkApplyShareDefaultsResult {
+	/** Rows whose mode was (re)set to the current default. */
+	updated: number;
+	/** Rows left untouched because they carry an explicit per-user override. */
+	skipped: number;
+}
+
+/**
+ * Apply the current global defaults to existing share rows WITHOUT clobbering
+ * explicit per-user overrides (ISSUE-006). Only rows whose `modeSource` is NOT
+ * `explicit` (i.e. default-sourced rows) are rewritten; rows a user/admin
+ * explicitly set are skipped and counted separately. Token rotation for a
+ * PRIVATE_LINK default only touches the updated (default-sourced) rows.
+ */
+export async function bulkApplyShareDefaults(): Promise<BulkApplyShareDefaultsResult> {
 	return db.transaction(async (tx) => {
 		const defaultsResult = await tx
 			.select({ key: appSettings.key, value: appSettings.value })
@@ -154,6 +168,14 @@ export async function bulkApplyShareDefaults(): Promise<number> {
 			: ShareMode.PUBLIC;
 		const allowUserControl = allowResult[0]?.value === 'true';
 
+		// Count explicit rows up front so the caller can report how many were
+		// deliberately left untouched.
+		const explicitRows = await tx
+			.select({ id: shareSettings.id })
+			.from(shareSettings)
+			.where(eq(shareSettings.modeSource, ShareModeSource.EXPLICIT));
+		const skipped = explicitRows.length;
+
 		const baseUpdate: Record<string, unknown> = {
 			mode: defaultMode,
 			modeSource: ShareModeSource.DEFAULT,
@@ -164,12 +186,18 @@ export async function bulkApplyShareDefaults(): Promise<number> {
 			baseUpdate.shareToken = null;
 		}
 
-		const updated = await tx.update(shareSettings).set(baseUpdate).returning({
-			id: shareSettings.id,
-			userId: shareSettings.userId,
-			year: shareSettings.year,
-			shareToken: shareSettings.shareToken
-		});
+		// Scope the bulk update to default-sourced rows ONLY. Explicit overrides
+		// (modeSource = 'explicit') are preserved verbatim.
+		const updated = await tx
+			.update(shareSettings)
+			.set(baseUpdate)
+			.where(ne(shareSettings.modeSource, ShareModeSource.EXPLICIT))
+			.returning({
+				id: shareSettings.id,
+				userId: shareSettings.userId,
+				year: shareSettings.year,
+				shareToken: shareSettings.shareToken
+			});
 
 		if (defaultMode === ShareMode.PRIVATE_LINK) {
 			for (const row of updated) {
@@ -188,7 +216,7 @@ export async function bulkApplyShareDefaults(): Promise<number> {
 			}
 		}
 
-		return updated.length;
+		return { updated: updated.length, skipped };
 	});
 }
 

--- a/src/lib/server/stats/calculators/ranking.ts
+++ b/src/lib/server/stats/calculators/ranking.ts
@@ -96,11 +96,16 @@ export function calculateTopGenres(
 	const genreCounts = new Map<string, number>();
 
 	for (const record of records) {
-		if (!record.genres) continue;
+		// Only attempt to parse non-empty JSON strings. Plex enrichment can
+		// persist the literal strings "undefined"/"null" (or an empty value)
+		// into the nullable `genres` column; feeding those to JSON.parse is the
+		// source of the "Unable to parse JSON: undefined" warning (ISSUE-010).
+		const raw = typeof record.genres === 'string' ? record.genres.trim() : '';
+		if (raw.length === 0 || raw === 'undefined' || raw === 'null') continue;
 
 		let genres: unknown;
 		try {
-			genres = JSON.parse(record.genres);
+			genres = JSON.parse(raw);
 			if (!Array.isArray(genres)) continue;
 		} catch {
 			continue;

--- a/src/lib/server/sync/reconcile.ts
+++ b/src/lib/server/sync/reconcile.ts
@@ -1,0 +1,45 @@
+import { eq } from 'drizzle-orm';
+import { db } from '$lib/server/db/client';
+import { syncStatus } from '$lib/server/db/schema';
+import { logger } from '$lib/server/logging';
+
+/**
+ * Marks any pre-existing `running` sync rows as failed. A crash or restart
+ * mid-sync leaves `status='running'` forever, which would otherwise permanently
+ * block every future sync via the atomic single-flight claim in
+ * `createSyncRecord` (ISSUE-001, restart deadlock). Runs exactly once at process
+ * start (from `db/client.ts`, right after migrations) — before any request can
+ * begin a sync — so it can never clobber a sync started by this process.
+ *
+ * Kept in its own lightweight module (importing only `db`, the schema, and the
+ * logger — no Plex/`$env` graph) so `db/client.ts` can call it at boot without
+ * pulling SvelteKit virtual modules into raw-bun import contexts.
+ *
+ * Returns the number of interrupted rows reconciled.
+ */
+export async function reconcileInterruptedSyncs(): Promise<number> {
+	const running = await db
+		.select({ id: syncStatus.id })
+		.from(syncStatus)
+		.where(eq(syncStatus.status, 'running'));
+
+	if (running.length === 0) {
+		return 0;
+	}
+
+	await db
+		.update(syncStatus)
+		.set({
+			status: 'failed',
+			completedAt: new Date(),
+			error: 'Interrupted by restart'
+		})
+		.where(eq(syncStatus.status, 'running'));
+
+	logger.warn(
+		`Reconciled ${running.length} interrupted sync(s) left running by a previous restart`,
+		'Sync'
+	);
+
+	return running.length;
+}

--- a/src/lib/server/sync/service.ts
+++ b/src/lib/server/sync/service.ts
@@ -1,4 +1,4 @@
-import { count, desc, eq, inArray, isNull, or } from 'drizzle-orm';
+import { count, desc, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 import { db } from '$lib/server/db/client';
 import { metadataCache, playHistory, syncStatus } from '$lib/server/db/schema';
 import { logger } from '$lib/server/logging';
@@ -101,22 +101,39 @@ export async function isSyncRunning(): Promise<boolean> {
 	return running !== null;
 }
 
-async function createSyncRecord(): Promise<number> {
-	const result = await db
-		.insert(syncStatus)
-		.values({
-			startedAt: new Date(),
-			status: 'running',
-			recordsProcessed: 0
-		})
-		.returning({ id: syncStatus.id });
+/**
+ * Atomically claim the single "running" sync slot.
+ *
+ * This is the ONLY correctness boundary for sync single-flight (ISSUE-001).
+ * Every entry path (manual startBackgroundSync, triggerImmediateSync, the Cron
+ * callback, live-sync) funnels through here, so the claim must be race-free.
+ *
+ * `INSERT ... SELECT ... WHERE NOT EXISTS (running) RETURNING id` is atomic
+ * under SQLite WAL (single writer), so two concurrent callers can never both
+ * insert a `running` row. The Drizzle query builder cannot express
+ * `INSERT ... WHERE NOT EXISTS`, so a raw `sql` statement is required (M-1).
+ *
+ * Returns the new sync id, or `null` when a sync is already running (zero rows
+ * inserted) — callers treat `null` as "already in progress".
+ */
+async function createSyncRecord(): Promise<number | null> {
+	// `started_at` is a Drizzle `timestamp` column → stored as Unix seconds.
+	const nowSeconds = Math.floor(Date.now() / 1000);
 
-	const record = result[0];
-	if (!record) {
-		throw new SyncError('Failed to create sync status record');
-	}
-	return record.id;
+	const rows = db.all<{ id: number }>(sql`
+		INSERT INTO sync_status (started_at, status, records_processed)
+		SELECT ${nowSeconds}, 'running', 0
+		WHERE NOT EXISTS (SELECT 1 FROM sync_status WHERE status = 'running')
+		RETURNING id
+	`);
+
+	const record = rows[0];
+	return record ? record.id : null;
 }
+
+// Re-exported from the lightweight `reconcile` module so it can also be invoked
+// at boot from `db/client.ts` without pulling this module's Plex/`$env` graph.
+export { reconcileInterruptedSyncs } from './reconcile';
 
 async function completeSyncRecord(
 	syncId: number,
@@ -189,11 +206,14 @@ export async function startSync(options: StartSyncOptions = {}): Promise<SyncRes
 	const { backfillYear, signal, onProgress } = options;
 	const startTime = Date.now();
 
-	if (await isSyncRunning()) {
+	// Atomically claim the single running slot. This is the authoritative
+	// single-flight boundary (ISSUE-001): a zero-row result means another sync
+	// already holds the slot, so we reject without arming any progress state.
+	const syncId = await createSyncRecord();
+	if (syncId === null) {
+		logger.info('Rejected duplicate sync start: a sync is already in progress', 'Sync');
 		throw new SyncError('A sync operation is already in progress');
 	}
-
-	const syncId = await createSyncRecord();
 
 	let recordsProcessed = 0;
 	let recordsInserted = 0;

--- a/src/lib/stats/format.ts
+++ b/src/lib/stats/format.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared watch-time formatting helpers.
+ *
+ * Both the admin dashboard ("Hours Watched" stat) and the Wrapped
+ * "Total Time" slide derive an hours figure from the same source field
+ * (`totalWatchTimeMinutes`, in minutes). They previously disagreed because
+ * the dashboard rounded (`Math.round`) while the slide floored
+ * (`Math.floor`), so the same user/year could show e.g. 100h vs 99h
+ * (ISSUE-011). This is the single rounding authority for that conversion.
+ */
+
+/**
+ * Convert a watch-time duration in minutes to whole hours.
+ *
+ * Rounds to the nearest hour so both surfaces report an identical figure
+ * for the same input.
+ */
+export function formatWatchHours(minutes: number): number {
+	if (!Number.isFinite(minutes) || minutes <= 0) return 0;
+	return Math.round(minutes / 60);
+}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -16,6 +16,7 @@ import SlidersHorizontal from '@lucide/svelte/icons/sliders-horizontal';
 import Star from '@lucide/svelte/icons/star';
 import Users from '@lucide/svelte/icons/users';
 import { goto } from '$app/navigation';
+import { formatWatchHours } from '$lib/stats/format';
 import { formatDuration } from '$lib/utils/format';
 import type { PageData } from './$types';
 
@@ -33,7 +34,7 @@ let { data }: { data: PageData } = $props();
 // Format watch time as human-readable
 const formatWatchTime = $derived.by(() => {
 	if (!data.stats) return { hours: 0, days: '0' };
-	const hours = Math.round(data.stats.totalWatchTimeMinutes / 60);
+	const hours = formatWatchHours(data.stats.totalWatchTimeMinutes);
 	const days = (data.stats.totalWatchTimeMinutes / 60 / 24).toFixed(1);
 	return { hours, days };
 });
@@ -261,6 +262,18 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 						</span>
 					</div>
 				</div>
+
+				{#if syncStatus === 'inactive'}
+					<div class="scheduler-cta">
+						<p class="scheduler-cta-text">
+							No automatic sync is scheduled. Set one up so your viewing history stays up to date.
+						</p>
+						<a href="/admin/sync" class="scheduler-cta-link" onclick={handleAdminNavigation}>
+							<span>Configure schedule</span>
+							<ArrowRight class="h-4 w-4" />
+						</a>
+					</div>
+				{/if}
 
 				{#if data.schedulerStatus?.nextRun}
 					<div class="sync-row">
@@ -661,6 +674,39 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 		.sync-value.highlight {
 			color: oklch(var(--primary));
 			font-weight: 600;
+		}
+
+		.scheduler-cta {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+			margin-top: 0.75rem;
+			padding: 0.75rem;
+			background: oklch(var(--primary) / 0.06);
+			border: 1px solid oklch(var(--primary) / 0.2);
+			border-radius: 0.5rem;
+		}
+
+		.scheduler-cta-text {
+			margin: 0;
+			font-size: 0.75rem;
+			color: oklch(var(--muted-foreground));
+		}
+
+		.scheduler-cta-link {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.25rem;
+			align-self: flex-start;
+			font-size: 0.8125rem;
+			font-weight: 600;
+			color: oklch(var(--primary));
+			text-decoration: none;
+			transition: gap 0.2s ease;
+		}
+
+		.scheduler-cta-link:hover {
+			gap: 0.5rem;
 		}
 
 		.sync-cron {

--- a/src/routes/admin/settings/appearance/+page.svelte
+++ b/src/routes/admin/settings/appearance/+page.svelte
@@ -114,7 +114,7 @@ function getThemeDescription(theme: string): string {
 </script>
 
 <svelte:head>
-	<title>Appearance — Settings</title>
+	<title>Appearance — Settings — Obzorarr</title>
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">

--- a/src/routes/admin/settings/connections/+page.server.ts
+++ b/src/routes/admin/settings/connections/+page.server.ts
@@ -85,6 +85,15 @@ export const load: PageServerLoad = async () => {
 		getAppSettingsUpdatedAt(API_CONFIG_KEYS)
 	]);
 
+	// ISSUE-016: whether an OpenAI key is in effect from EITHER an authoritative
+	// env var OR a stored DB row. `apiConfig.openai.apiKey.value` already merges
+	// both sources (env-over-DB via resolveConfigValue), so a non-empty trimmed
+	// value means AI fun facts will actually run; an empty one means the OpenAI
+	// card is configured (base URL / model) but will silently fall back to the
+	// template generator. The connections page surfaces a visible warning in the
+	// latter case instead of only the subtle "falls back" copy.
+	const hasEffectiveOpenAIKey = Boolean(apiConfig.openai.apiKey.value.trim());
+
 	return {
 		settings: {
 			plexServerUrl: apiConfig.plex.serverUrl as SettingValue,
@@ -94,6 +103,7 @@ export const load: PageServerLoad = async () => {
 			openaiBaseUrl: apiConfig.openai.baseUrl as SettingValue,
 			openaiModel: apiConfig.openai.model as SettingValue
 		},
+		hasEffectiveOpenAIKey,
 		apiConfigVersion: settingsVersionISO(apiConfigUpdatedAt)
 	};
 };

--- a/src/routes/admin/settings/connections/+page.svelte
+++ b/src/routes/admin/settings/connections/+page.svelte
@@ -68,10 +68,16 @@ const openaiModelLocked = $derived(settings.openaiModel.isLocked);
 
 const plexAnyLocked = $derived(plexServerUrlLocked || plexTokenLocked);
 const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || openaiModelLocked);
+
+// ISSUE-016: AI fun facts run only with an effective OpenAI key. `hasEffectiveOpenAIKey`
+// (server load) reflects an authoritative env var OR a stored DB row. Surface a visible,
+// non-blocking warning when no key is in effect AND none is being entered now — the
+// generator silently falls back to templates otherwise, which the subtle card copy hides.
+const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiKeyInput.trim());
 </script>
 
 <svelte:head>
-	<title>Connections — Settings</title>
+	<title>Connections — Settings — Obzorarr</title>
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">
@@ -79,8 +85,12 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 		<CardHeader>
 			<CardTitle>Plex server</CardTitle>
 			<CardDescription>
-				URL + auth token for the Plex Media Server obzorarr syncs from. Locked fields are set
-				via environment variables.
+				URL + auth token for the Plex Media Server obzorarr syncs from.
+				{#if plexAnyLocked}
+					Locked fields are set via environment variables and can only be changed there.
+					Placeholder env values (e.g. the shipped <code>.env.example</code> defaults) are
+					ignored and leave the field editable here.
+				{/if}
 			</CardDescription>
 		</CardHeader>
 		<CardContent class="space-y-4">
@@ -308,6 +318,13 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 						bind:value={openaiApiKeyInput}
 						disabled={openaiApiKeyLocked}
 					/>
+					{#if showOpenaiKeyWarning}
+						<p class="ai-key-warning" role="status">
+							No OpenAI API key is in effect, so AI fun facts will not run — the built-in
+							template generator is used instead. Enter a key above (or set
+							<code>OPENAI_API_KEY</code>) to enable AI-generated fun facts.
+						</p>
+					{/if}
 				</div>
 
 				<div class="space-y-2">
@@ -462,3 +479,23 @@ const openaiAnyLocked = $derived(openaiApiKeyLocked || openaiBaseUrlLocked || op
 		</CardContent>
 	</Card>
 </div>
+
+<style>
+	/* ISSUE-016: visible AI-key-missing notice. Uses the same warning palette as
+	   the security tab's `.status-card.warning` (theme OKLCH tokens) so it reads
+	   as a real alert rather than muted helper copy. */
+	.ai-key-warning {
+		margin: 0.5rem 0 0;
+		padding: 0.625rem 0.75rem;
+		font-size: 0.8rem;
+		line-height: 1.5;
+		border-radius: 8px;
+		color: oklch(var(--foreground));
+		background: oklch(0.79 0.1606 79.6 / 0.1);
+		border: 1px solid oklch(0.79 0.1606 79.6 / 0.3);
+	}
+
+	.ai-key-warning code {
+		font-size: 0.75rem;
+	}
+</style>

--- a/src/routes/admin/settings/data/+page.svelte
+++ b/src/routes/admin/settings/data/+page.svelte
@@ -58,7 +58,7 @@ const historyYearLabel = $derived(
 </script>
 
 <svelte:head>
-	<title>Data — Settings</title>
+	<title>Data — Settings — Obzorarr</title>
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">

--- a/src/routes/admin/settings/privacy/+page.server.ts
+++ b/src/routes/admin/settings/privacy/+page.server.ts
@@ -354,11 +354,14 @@ export const actions: Actions = requireAdminActions({
 
 	bulkApplyShareDefaults: async () => {
 		try {
-			const count = await bulkApplyShareDefaults();
+			const { updated, skipped } = await bulkApplyShareDefaults();
+			const updatedPart = `Updated ${updated} user share record${updated === 1 ? '' : 's'}`;
+			const skippedPart =
+				skipped > 0 ? `; skipped ${skipped} with an explicit per-user override` : '';
 			const message =
-				count === 0
+				updated === 0 && skipped === 0
 					? 'No users needed to be updated'
-					: `Updated ${count} user share record${count === 1 ? '' : 's'}`;
+					: `${updatedPart}${skippedPart}`;
 			return { form: null, success: true, message };
 		} catch (error) {
 			const message =

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -310,7 +310,7 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 </script>
 
 <svelte:head>
-	<title>Privacy — Settings</title>
+	<title>Privacy — Settings — Obzorarr</title>
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -752,7 +752,7 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 			<CardTitle>Apply defaults to existing users</CardTitle>
 			<CardDescription>
 				Reset every existing user's share mode + "can control" flag to match the current
-				defaults above. Per-user customizations will be lost.
+				defaults above. Users with an explicit per-user override are skipped, not reset.
 			</CardDescription>
 		</CardHeader>
 		<CardContent>
@@ -777,7 +777,7 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 			<AlertDialog.Title>Apply current defaults to all users?</AlertDialog.Title>
 			<AlertDialog.Description>
 				This resets every existing user's share mode and "can control" setting back to the
-				current server defaults. Per-user customizations will be lost. Future users continue to
+				current server defaults. Users with an explicit per-user override are skipped, not reset. Future users continue to
 				receive the current defaults.
 			</AlertDialog.Description>
 		</AlertDialog.Header>

--- a/src/routes/admin/settings/security/+page.server.ts
+++ b/src/routes/admin/settings/security/+page.server.ts
@@ -193,7 +193,7 @@ export const actions: Actions = requireAdminActions({
 					requireConfirmation: true,
 					attemptedOrigin: normalizedOrigin,
 					requestOrigin,
-					csrfMismatchMessage: `Saving "${normalizedOrigin}" while loaded from "${requestOrigin}" will lock this browser out of all admin POST operations. Recovery would require restarting the server with ORIGIN=<correct> env or editing the app_settings table directly. Confirm to proceed anyway.`
+					csrfMismatchMessage: `Saving "${normalizedOrigin}" while loaded from "${requestOrigin}" will lock THIS browser out of admin POST operations until you reload the admin from "${normalizedOrigin}". To recover, open the admin at "${normalizedOrigin}" and update the CSRF origin again from this same page — no server restart or database edit is required. Confirm to proceed anyway.`
 				});
 			}
 

--- a/src/routes/admin/settings/security/+page.svelte
+++ b/src/routes/admin/settings/security/+page.svelte
@@ -200,7 +200,7 @@ function getForwardedPairLabel(status: string): string {
 </script>
 
 <svelte:head>
-	<title>Security — Settings</title>
+	<title>Security — Settings — Obzorarr</title>
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">

--- a/src/routes/admin/settings/system/+page.svelte
+++ b/src/routes/admin/settings/system/+page.svelte
@@ -56,12 +56,26 @@ const { form: formData, enhance, submitting } = form;
 // Block submit when the visible inputs are out of the server-validated range.
 // The HTML5 min/max attributes only clamp some browsers' UI, so a user can
 // still paste -1 / 999999 and trigger a silent no-op save without this check.
-const isLoggingFormInvalid = $derived(
-	$formData.retentionDays < 1 ||
-		$formData.retentionDays > 365 ||
-		$formData.maxCount < 1000 ||
-		$formData.maxCount > 1_000_000
+//
+// ISSUE-017: the disabled-submit guard alone left users with no feedback — the
+// server-side `Form.FieldErrors` never render because the disabled button stops
+// the submit that would populate them. Surface the range violation inline as the
+// user types, mirroring the zod schema's range + messages.
+const retentionDaysError = $derived(
+	$formData.retentionDays < 1
+		? 'Retention days must be at least 1'
+		: $formData.retentionDays > 365
+			? 'Retention days cannot exceed 365'
+			: undefined
 );
+const maxCountError = $derived(
+	$formData.maxCount < 1000
+		? 'Max log count must be at least 1000'
+		: $formData.maxCount > 1_000_000
+			? 'Max log count cannot exceed 1,000,000'
+			: undefined
+);
+const isLoggingFormInvalid = $derived(Boolean(retentionDaysError) || Boolean(maxCountError));
 
 function formatUptime(seconds: number): string {
 	const days = Math.floor(seconds / 86400);
@@ -76,7 +90,7 @@ function formatUptime(seconds: number): string {
 </script>
 
 <svelte:head>
-	<title>System — Settings</title>
+	<title>System — Settings — Obzorarr</title>
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">
@@ -104,6 +118,9 @@ function formatUptime(seconds: number): string {
 					</Form.Control>
 					<Form.Description>Auto-delete logs older than this. Range 1–365.</Form.Description>
 					<Form.FieldErrors />
+					{#if retentionDaysError}
+						<p class="text-sm text-destructive">{retentionDaysError}</p>
+					{/if}
 				</Form.Field>
 
 				<Form.Field {form} name="maxCount">
@@ -122,6 +139,9 @@ function formatUptime(seconds: number): string {
 					</Form.Control>
 					<Form.Description>Older entries dropped once this ceiling is reached.</Form.Description>
 					<Form.FieldErrors />
+					{#if maxCountError}
+						<p class="text-sm text-destructive">{maxCountError}</p>
+					{/if}
 				</Form.Field>
 
 				<Form.Field {form} name="debugEnabled">

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -382,7 +382,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 							<input type="hidden" name="slideType" value={item.slideType} />
 							<SubmitButton
 								class={`toggle-button tap-target ${item.enabled ? 'enabled' : ''}`}
-								aria-label={item.enabled ? 'Disable slide' : 'Enable slide'}
+								aria-label={`${item.enabled ? 'Disable' : 'Enable'} ${SLIDE_NAMES[item.slideType as SlideType] ?? item.slideType} slide`}
 							>
 								{#snippet children()}
 									{item.enabled ? 'Enabled' : 'Disabled'}
@@ -419,7 +419,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 								<input type="hidden" name="id" value={item.id} />
 								<SubmitButton
 									class={`toggle-button tap-target ${item.enabled ? 'enabled' : ''}`}
-									aria-label={item.enabled ? 'Disable slide' : 'Enable slide'}
+									aria-label={`${item.enabled ? 'Disable' : 'Enable'} ${item.title.trim().length > 0 ? item.title : 'Untitled custom slide'}`}
 								>
 									{#snippet children()}
 										{item.enabled ? 'Enabled' : 'Disabled'}

--- a/src/routes/admin/users/+page.server.ts
+++ b/src/routes/admin/users/+page.server.ts
@@ -42,6 +42,8 @@ export const load: PageServerLoad = async ({ url }) => {
 			shareMode: u.shareMode,
 			shareModeSource: u.shareModeSource,
 			canUserControl: u.canUserControl,
+			effectiveLabel: u.effectiveLabel,
+			effectiveClass: u.effectiveClass,
 			wrappedHref: await getOwnerWrappedHref(u.id, year)
 		}))
 	);

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -35,22 +35,6 @@ function formatWatchTime(minutes: number): string {
 	return `${hours}h`;
 }
 
-// Get share mode display label
-function getShareModeLabel(mode: string | null, source: string | null): string {
-	if (source === 'default') return 'Default';
-
-	switch (mode) {
-		case 'public':
-			return 'Public';
-		case 'private-oauth':
-			return 'OAuth';
-		case 'private-link':
-			return 'Link';
-		default:
-			return 'Default';
-	}
-}
-
 function hasVisibleAvatar(user: (typeof data.users)[number]): boolean {
 	return !!user.thumb && !failedAvatarUserIds.has(user.id);
 }
@@ -155,18 +139,22 @@ function markAvatarFailed(userId: number): void {
 									</div>
 								</td>
 								<td>
-									<span class="watch-time">{formatWatchTime(user.totalWatchTimeMinutes)}</span>
+										{#if user.hasWatchHistory}
+											<span class="watch-time">{formatWatchTime(user.totalWatchTimeMinutes)}</span>
+										{:else}
+											<span class="watch-time watch-time-empty" title="This user has no personal play history yet">
+												0h <span class="watch-time-note">(no personal plays)</span>
+											</span>
+										{/if}
 								</td>
 								<td>
 									<span
 										class="share-mode"
-										class:public={user.shareModeSource !== 'default' && user.shareMode === 'public'}
-										class:oauth={user.shareModeSource !== 'default' &&
-											user.shareMode === 'private-oauth'}
-										class:link={user.shareModeSource !== 'default' &&
-											user.shareMode === 'private-link'}
+										class:public={user.effectiveClass === 'public'}
+										class:oauth={user.effectiveClass === 'oauth'}
+										class:link={user.effectiveClass === 'link'}
 									>
-										{getShareModeLabel(user.shareMode, user.shareModeSource)}
+										{user.effectiveLabel}
 									</span>
 								</td>
 								<td>
@@ -255,19 +243,23 @@ function markAvatarFailed(userId: number): void {
 						<div class="mobile-user-meta">
 							<div class="mobile-meta-item">
 								<span class="mobile-meta-label">Watch Time</span>
-								<span class="watch-time">{formatWatchTime(user.totalWatchTimeMinutes)}</span>
+								{#if user.hasWatchHistory}
+									<span class="watch-time">{formatWatchTime(user.totalWatchTimeMinutes)}</span>
+								{:else}
+									<span class="watch-time watch-time-empty" title="This user has no personal play history yet">
+										0h <span class="watch-time-note">(no personal plays)</span>
+									</span>
+								{/if}
 							</div>
 							<div class="mobile-meta-item">
 								<span class="mobile-meta-label">Share Mode</span>
 								<span
 									class="share-mode"
-									class:public={user.shareModeSource !== 'default' && user.shareMode === 'public'}
-									class:oauth={user.shareModeSource !== 'default' &&
-										user.shareMode === 'private-oauth'}
-									class:link={user.shareModeSource !== 'default' &&
-										user.shareMode === 'private-link'}
+									class:public={user.effectiveClass === 'public'}
+									class:oauth={user.effectiveClass === 'oauth'}
+									class:link={user.effectiveClass === 'link'}
 								>
-									{getShareModeLabel(user.shareMode, user.shareModeSource)}
+									{user.effectiveLabel}
 								</span>
 							</div>
 							<div class="mobile-meta-item">
@@ -544,6 +536,17 @@ function markAvatarFailed(userId: number): void {
 		.watch-time {
 			font-weight: 600;
 			color: oklch(var(--foreground));
+		}
+
+		.watch-time-empty {
+			color: oklch(var(--muted-foreground));
+			font-weight: 500;
+		}
+
+		.watch-time-note {
+			font-weight: 400;
+			font-size: 0.75rem;
+			color: oklch(var(--muted-foreground) / 0.8);
 		}
 
 		.share-mode {

--- a/src/routes/auth/logout/+page.server.ts
+++ b/src/routes/auth/logout/+page.server.ts
@@ -2,8 +2,13 @@ import { redirect } from '@sveltejs/kit';
 import { logout } from '$lib/server/auth/logout';
 import type { Actions, PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ cookies }) => {
-	await logout(cookies);
+// ISSUE-024: logout must be POST-only. A GET `load` side-effect made
+// `<img src="/auth/logout">`/prefetch/navigation clear the session with no CSRF
+// check (SvelteKit's built-in origin check is disabled via
+// `csrf.trustedOrigins:['*']`, and `csrfHandle` skips GET). The `load` therefore
+// MUST NOT mutate — it only redirects. Session clearing happens exclusively in
+// the POST action, which is covered by `csrfHandle` + `SameSite=Lax` cookies.
+export const load: PageServerLoad = async () => {
 	throw redirect(303, '/');
 };
 

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import LogOut from '@lucide/svelte/icons/log-out';
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
 import { page } from '$app/stores';
@@ -454,17 +455,22 @@ function getLogoModeDescription(): string {
 						}}
 						class="logo-form"
 					>
-						<div class="privacy-card-grid two-col">
+						<div
+							class="privacy-card-grid two-col"
+							role="radiogroup"
+							aria-label="Logo visibility on your wrapped page"
+						>
 							<label class="privacy-card" class:selected={selectedLogoPreference === 'show'}>
 								<input
 									type="radio"
 									name="logoPreference"
 									value="show"
+									aria-label="Show logo"
 									bind:group={selectedLogoPreference}
 									disabled={isUpdating}
 								/>
-								<span class="card-icon">✅</span>
-								<span class="card-title">Show Logo</span>
+								<span class="card-icon" aria-hidden="true">✅</span>
+								<span class="card-title">Show logo</span>
 								<span class="card-desc">Display the Obzorarr logo on your wrapped page</span>
 							</label>
 
@@ -473,11 +479,12 @@ function getLogoModeDescription(): string {
 									type="radio"
 									name="logoPreference"
 									value="hide"
+									aria-label="Hide logo"
 									bind:group={selectedLogoPreference}
 									disabled={isUpdating}
 								/>
-								<span class="card-icon">🚫</span>
-								<span class="card-title">Hide Logo</span>
+								<span class="card-icon" aria-hidden="true">🚫</span>
+								<span class="card-title">Hide logo</span>
 								<span class="card-desc">Hide the logo for a cleaner presentation</span>
 							</label>
 						</div>
@@ -558,6 +565,17 @@ function getLogoModeDescription(): string {
 						View My {data.currentYear} Wrapped →
 					</a>
 				</div>
+			</section>
+
+			<section class="section">
+				<h2>Sign Out</h2>
+				<p class="section-description">End your session on this device.</p>
+				<form method="POST" action="/auth/logout" use:enhance class="logout-form">
+					<button type="submit" class="logout-button">
+						<LogOut class="logout-icon" aria-hidden="true" />
+						<span>Log out</span>
+					</button>
+				</form>
 			</section>
 		</Tabs.Content>
 	</Tabs.Root>
@@ -1074,6 +1092,34 @@ function getLogoModeDescription(): string {
 
 		.view-wrapped-link:hover {
 			opacity: 0.9;
+		}
+
+		.logout-form {
+			margin: 0;
+		}
+
+		.logout-button {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.5rem;
+			padding: 0.75rem 1.25rem;
+			background: oklch(var(--destructive) / 0.1);
+			color: oklch(var(--destructive));
+			border: 1px solid oklch(var(--destructive) / 0.3);
+			border-radius: var(--radius);
+			font-weight: 500;
+			font-size: 0.875rem;
+			cursor: pointer;
+			transition: background 0.15s ease;
+		}
+
+		.logout-button:hover {
+			background: oklch(var(--destructive) / 0.18);
+		}
+
+		.logout-button :global(.logout-icon) {
+			width: 1rem;
+			height: 1rem;
 		}
 
 		/* Responsive */

--- a/src/routes/onboarding/claim/+page.svelte
+++ b/src/routes/onboarding/claim/+page.svelte
@@ -35,6 +35,7 @@ let isClaiming = $state(false);
 			<Input
 				id="bootstrap-token"
 				name="token"
+				type="password"
 				bind:value={token}
 				class="bootstrap-token-input"
 				autocomplete="one-time-code"

--- a/src/routes/wrapped/+layout.svelte
+++ b/src/routes/wrapped/+layout.svelte
@@ -3,6 +3,7 @@ import type { Snippet } from 'svelte';
 import { untrack } from 'svelte';
 import { browser } from '$app/environment';
 import { invalidateAll } from '$app/navigation';
+import { page } from '$app/stores';
 import SyncLoadingOverlay from '$lib/components/SyncLoadingOverlay.svelte';
 import { toast } from '$lib/services/toast';
 import { createSyncStatusStore, type SyncStatusStore } from '$lib/stores/sync-status.svelte';
@@ -178,8 +179,16 @@ $effect(() => {
 // Use reactive store values if available, otherwise fall back to server data
 const inProgress = $derived(syncStatusStore?.inProgress ?? data.syncStatus?.inProgress ?? false);
 const progress = $derived(syncStatusStore?.progress ?? data.syncStatus?.progress ?? null);
+
+// Suppress the sync status region entirely on error pages (403/404/+error.svelte).
+// When $page.error is set, the overlay's role="status" aria-live region must be
+// absent from the a11y tree — not just visually hidden — so screen readers don't
+// announce "Syncing your viewing history…" over an error (ISSUE-023).
+const hasPageError = $derived(Boolean($page.error));
 </script>
 
-<SyncLoadingOverlay visible={isLoading || inProgress} {progress} syncInProgress={inProgress} />
+{#if !hasPageError}
+	<SyncLoadingOverlay visible={isLoading || inProgress} {progress} syncInProgress={inProgress} />
+{/if}
 
 {@render children()}

--- a/tests/unit/admin/ui-source-regressions.test.ts
+++ b/tests/unit/admin/ui-source-regressions.test.ts
@@ -752,4 +752,72 @@ describe('admin UI source regressions', () => {
 		expect(source).toContain('placeholder="gpt-5-mini"');
 		expect(source).not.toContain('placeholder="gpt-4o-mini"');
 	});
+
+	it('normalizes every settings tab <title> to "<Tab> — Settings — Obzorarr" (ISSUE-013)', async () => {
+		const tabs: Array<[string, string]> = [
+			['appearance', 'Appearance'],
+			['connections', 'Connections'],
+			['data', 'Data'],
+			['privacy', 'Privacy'],
+			['security', 'Security'],
+			['system', 'System']
+		];
+		for (const [slug, label] of tabs) {
+			const source = await readSource(`src/routes/admin/settings/${slug}/+page.svelte`);
+			expect(source).toContain(`<title>${label} — Settings — Obzorarr</title>`);
+			// No leftover un-suffixed title.
+			expect(source).not.toContain(`<title>${label} — Settings</title>`);
+		}
+	});
+
+	it('surfaces a visible warning when no effective OpenAI key is in effect (ISSUE-016)', async () => {
+		const client = await readSource('src/routes/admin/settings/connections/+page.svelte');
+		const server = await readSource('src/routes/admin/settings/connections/+page.server.ts');
+
+		// Server load derives effective-key presence from the merged env-over-DB value.
+		expect(server).toContain(
+			'const hasEffectiveOpenAIKey = Boolean(apiConfig.openai.apiKey.value.trim());'
+		);
+		expect(server).toContain('hasEffectiveOpenAIKey,');
+
+		// Client gates a visible, non-blocking warning on the absence of an effective key.
+		expect(client).toContain(
+			'const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiKeyInput.trim());'
+		);
+		expect(client).toContain('{#if showOpenaiKeyWarning}');
+		expect(client).toContain('class="ai-key-warning"');
+		expect(client).toContain('AI fun facts will not run');
+	});
+
+	it('shows inline range messages for out-of-range log settings (ISSUE-017)', async () => {
+		// The disabled-submit guard alone gave no feedback because Form.FieldErrors
+		// only render after a submit the disabled button prevents. Assert the
+		// client-derived inline messages exist and drive the submit guard.
+		const source = await readSource('src/routes/admin/settings/system/+page.svelte');
+
+		expect(source).toContain('const retentionDaysError = $derived(');
+		expect(source).toContain("'Retention days must be at least 1'");
+		expect(source).toContain("'Retention days cannot exceed 365'");
+		expect(source).toContain('const maxCountError = $derived(');
+		expect(source).toContain("'Max log count must be at least 1000'");
+		expect(source).toContain("'Max log count cannot exceed 1,000,000'");
+		expect(source).toContain(
+			'const isLoggingFormInvalid = $derived(Boolean(retentionDaysError) || Boolean(maxCountError));'
+		);
+		expect(source).toContain('{#if retentionDaysError}');
+		expect(source).toContain('{#if maxCountError}');
+		expect(source).toContain('<p class="text-sm text-destructive">{retentionDaysError}</p>');
+		expect(source).toContain('<p class="text-sm text-destructive">{maxCountError}</p>');
+	});
+
+	it('only shows the ENV-locked Plex helper copy when a Plex field is locked (ISSUE-004)', async () => {
+		const source = await readSource('src/routes/admin/settings/connections/+page.svelte');
+
+		// The "set via environment variables" clarification is gated on plexAnyLocked
+		// so it does not appear when nothing is actually locked.
+		expect(source).toContain('{#if plexAnyLocked}');
+		expect(source).toContain('Locked fields are set via environment variables');
+		// Clarifies that placeholder env values are ignored (not authoritative).
+		expect(source).toContain('Placeholder env values');
+	});
 });

--- a/tests/unit/admin/users.service.test.ts
+++ b/tests/unit/admin/users.service.test.ts
@@ -1,7 +1,18 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import { getAllUsersWithStats, getSyncedViewerCount } from '$lib/server/admin/users.service';
+import {
+	deriveEffectiveShareBadge,
+	getAllUsersWithStats,
+	getSyncedViewerCount
+} from '$lib/server/admin/users.service';
 import { db } from '$lib/server/db/client';
-import { playHistory, shareSettings, users } from '$lib/server/db/schema';
+import { appSettings, playHistory, shareSettings, users } from '$lib/server/db/schema';
+import {
+	ShareMode,
+	ShareModePrivacyLevel,
+	ShareModeSource,
+	type ShareModeType,
+	ShareSettingsKey
+} from '$lib/server/sharing/types';
 import { createTimestamp } from '../../helpers/factories';
 
 describe('admin users service', () => {
@@ -9,6 +20,7 @@ describe('admin users service', () => {
 		await db.delete(shareSettings);
 		await db.delete(playHistory);
 		await db.delete(users);
+		await db.delete(appSettings);
 	});
 
 	it('returns play counts and watch-history state for the selected year', async () => {
@@ -118,6 +130,104 @@ describe('admin users service', () => {
 			]);
 
 			expect(await getSyncedViewerCount()).toBe(2);
+		});
+	});
+
+	// ISSUE-007: the Users badge must reflect EFFECTIVE access (stored mode clamped
+	// by the global floor) so it never reads more permissive than what a viewer
+	// actually gets.
+	describe('deriveEffectiveShareBadge (ISSUE-007)', () => {
+		const allModes: ShareModeType[] = [
+			ShareMode.PUBLIC,
+			ShareMode.PRIVATE_LINK,
+			ShareMode.PRIVATE_OAUTH
+		];
+		const classToMode: Record<'public' | 'oauth' | 'link', ShareModeType> = {
+			public: ShareMode.PUBLIC,
+			oauth: ShareMode.PRIVATE_OAUTH,
+			link: ShareMode.PRIVATE_LINK
+		};
+
+		it('clamps an explicit stored mode by the floor (Public stored, OAuth floor → OAuth)', () => {
+			const badge = deriveEffectiveShareBadge(
+				ShareMode.PUBLIC,
+				ShareModeSource.EXPLICIT,
+				ShareMode.PRIVATE_OAUTH
+			);
+			expect(badge.effectiveShareMode).toBe(ShareMode.PRIVATE_OAUTH);
+			expect(badge.effectiveLabel).toBe('OAuth');
+			expect(badge.effectiveClass).toBe('oauth');
+		});
+
+		it('shows "Default" with no class for default-sourced rows', () => {
+			const badge = deriveEffectiveShareBadge(
+				ShareMode.PUBLIC,
+				ShareModeSource.DEFAULT,
+				ShareMode.PUBLIC
+			);
+			expect(badge.effectiveLabel).toBe('Default');
+			expect(badge.effectiveClass).toBe('');
+		});
+
+		it('shows "Default" when there is no stored row at all', () => {
+			const badge = deriveEffectiveShareBadge(null, null, ShareMode.PRIVATE_OAUTH);
+			expect(badge.effectiveLabel).toBe('Default');
+			expect(badge.effectiveClass).toBe('');
+			expect(badge.effectiveShareMode).toBe(ShareMode.PRIVATE_OAUTH);
+		});
+
+		it('keeps label and CSS class in lockstep with the effective mode', () => {
+			for (const stored of allModes) {
+				for (const floor of allModes) {
+					const badge = deriveEffectiveShareBadge(stored, ShareModeSource.EXPLICIT, floor);
+					if (badge.effectiveClass !== '') {
+						expect(classToMode[badge.effectiveClass]).toBe(badge.effectiveShareMode);
+					}
+				}
+			}
+		});
+
+		it('badge mode is NEVER more permissive than effective access (the floor)', () => {
+			for (const stored of [...allModes, null]) {
+				for (const source of [ShareModeSource.EXPLICIT, ShareModeSource.DEFAULT, null]) {
+					for (const floor of allModes) {
+						const badge = deriveEffectiveShareBadge(stored, source, floor);
+						// Higher privacy level = less permissive. Effective must be at least
+						// as private as the floor.
+						expect(ShareModePrivacyLevel[badge.effectiveShareMode]).toBeGreaterThanOrEqual(
+							ShareModePrivacyLevel[floor]
+						);
+					}
+				}
+			}
+		});
+	});
+
+	describe('getAllUsersWithStats badge clamping (ISSUE-007)', () => {
+		it('reports effective (clamped) badge fields, not the raw stored mode', async () => {
+			// Floor is OAuth (most restrictive); a row explicitly set to Public must
+			// surface an OAuth badge, never "Public".
+			await db.insert(appSettings).values({
+				key: ShareSettingsKey.DEFAULT_SHARE_MODE,
+				value: ShareMode.PRIVATE_OAUTH,
+				updatedAt: new Date()
+			});
+
+			await db.insert(users).values({ id: 1, plexId: 1001, accountId: 2001, username: 'viewer' });
+			await db.insert(shareSettings).values({
+				userId: 1,
+				year: 2025,
+				mode: ShareMode.PUBLIC,
+				modeSource: ShareModeSource.EXPLICIT,
+				shareToken: null,
+				canUserControl: false
+			});
+
+			const [row] = await getAllUsersWithStats(2025);
+			expect(row?.shareMode).toBe(ShareMode.PUBLIC); // raw stored value preserved
+			expect(row?.effectiveShareMode).toBe(ShareMode.PRIVATE_OAUTH);
+			expect(row?.effectiveLabel).toBe('OAuth');
+			expect(row?.effectiveClass).toBe('oauth');
 		});
 	});
 });

--- a/tests/unit/auth/logout.test.ts
+++ b/tests/unit/auth/logout.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+// NOTE: deliberately does NOT mock `$lib/server/auth/session`. bun's
+// `mock.module` is process-global and leaks across test files, so replacing the
+// whole session module here would break every other test that imports
+// `createSessionFromPlexToken` etc. We assert the observable cookie behavior
+// instead; `invalidateSession` runs for real against the empty in-memory
+// sessions table (a harmless no-op for an unknown id).
+const { load, actions } = await import('../../../src/routes/auth/logout/+page.server');
+
+interface FakeCookies {
+	get: (name: string) => string | undefined;
+	delete: ReturnType<typeof mock>;
+}
+
+function makeCookies(sessionId: string | undefined): FakeCookies {
+	return {
+		get: () => sessionId,
+		delete: mock(() => {})
+	};
+}
+
+function isRedirect(thrown: unknown): thrown is { status: number; location: string } {
+	return (
+		typeof thrown === 'object' && thrown !== null && 'status' in thrown && 'location' in thrown
+	);
+}
+
+describe('logout route — POST-only (ISSUE-024)', () => {
+	it('GET load redirects to / WITHOUT clearing the session cookie', async () => {
+		const cookies = makeCookies('session-abc');
+
+		let thrown: unknown;
+		try {
+			await (load as unknown as (e: unknown) => Promise<unknown>)({ cookies });
+		} catch (e) {
+			thrown = e;
+		}
+
+		expect(isRedirect(thrown)).toBe(true);
+		if (isRedirect(thrown)) {
+			expect(thrown.status).toBe(303);
+			expect(thrown.location).toBe('/');
+		}
+
+		// The GET path must not mutate — no session cookie cleared.
+		expect(cookies.delete).not.toHaveBeenCalled();
+	});
+
+	it('POST action clears the session cookie and redirects to /', async () => {
+		const cookies = makeCookies('session-abc');
+
+		let thrown: unknown;
+		try {
+			await (actions.default as unknown as (e: unknown) => Promise<unknown>)({ cookies });
+		} catch (e) {
+			thrown = e;
+		}
+
+		expect(isRedirect(thrown)).toBe(true);
+		if (isRedirect(thrown)) {
+			expect(thrown.status).toBe(303);
+			expect(thrown.location).toBe('/');
+		}
+
+		// The POST path is the sole session-clearing path.
+		expect(cookies.delete).toHaveBeenCalledWith('session', { path: '/' });
+	});
+});

--- a/tests/unit/onboarding/settings-substep-walk.test.ts
+++ b/tests/unit/onboarding/settings-substep-walk.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+
+/**
+ * ISSUE-003 (verified resolved): the onboarding Configure step must walk all
+ * four substeps — Appearance -> Privacy -> Slides -> AI — before the
+ * `saveSettings` action can fire. The reported "Privacy -> complete" jump was
+ * traced to the separate "Skip setup" (`skipSettings`) action / substep-dot
+ * navigation, NOT the linear "Next" path, which is monotonic and only exposes
+ * the Save submit button on the last substep.
+ *
+ * These are behavior-pinning source assertions (same read-source pattern as
+ * tests/unit/sharing/presets.test.ts and csrf-page-source.test.ts). They lock
+ * the structure so a future refactor cannot silently let `saveSettings` become
+ * reachable before the AI substep.
+ */
+
+const pageSourcePath = join(
+	import.meta.dir,
+	'..',
+	'..',
+	'..',
+	'src/routes/onboarding/settings/+page.svelte'
+);
+
+async function readPageSource(): Promise<string> {
+	return Bun.file(pageSourcePath).text();
+}
+
+describe('onboarding settings substep walk (ISSUE-003)', () => {
+	it('declares the four substeps in order: appearance -> privacy -> slides -> ai', async () => {
+		const src = await readPageSource();
+		const ids = [...src.matchAll(/id:\s*'(appearance|privacy|slides|ai)'/g)].map((m) => m[1]);
+		expect(ids).toEqual(['appearance', 'privacy', 'slides', 'ai']);
+	});
+
+	it('only renders the saveSettings submit button when on the last substep', async () => {
+		const src = await readPageSource();
+		// The footer Next/Save control is gated: the Save & Continue SubmitButton
+		// (submits the ?/saveSettings form) appears only behind {#if isLastSubStep};
+		// the non-last branch is a plain type="button" Next control.
+		const footerGate = src.match(/\{#if isLastSubStep\}([\s\S]*?)\{:else\}([\s\S]*?)\{\/if\}/);
+		expect(footerGate).not.toBeNull();
+		const ifBranch = footerGate?.[1] ?? '';
+		const elseBranch = footerGate?.[2] ?? '';
+		// Only the last-step branch carries the Save submit control.
+		expect(ifBranch).toContain('Save & Continue');
+		// The non-last branch advances via nextSubStep and cannot submit the form.
+		expect(elseBranch).toContain('onclick={nextSubStep}');
+		expect(elseBranch).not.toContain('Save & Continue');
+	});
+
+	it('isLastSubStep resolves to the final substep index, not Privacy', async () => {
+		const src = await readPageSource();
+		expect(src).toContain('let isLastSubStep = $derived(currentSubStep === totalSubSteps - 1);');
+	});
+
+	it('nextSubStep advances at most one step and never skips to completion', async () => {
+		const src = await readPageSource();
+		// Monotonic single-step increment, bounded by totalSubSteps - 1.
+		expect(src).toMatch(
+			/function nextSubStep\(\)\s*\{[\s\S]*?currentSubStep < totalSubSteps - 1[\s\S]*?currentSubStep \+= 1;[\s\S]*?\}/
+		);
+		// Next never triggers a navigation/redirect or the save action directly.
+		const nextFn = src.match(/function nextSubStep\(\)\s*\{[\s\S]*?\n\t\}/)?.[0] ?? '';
+		expect(nextFn).not.toContain('saveSettings');
+		expect(nextFn).not.toContain('goto');
+	});
+
+	it('the saveSettings form lives on the configure step, not auto-submitted from Privacy', async () => {
+		const src = await readPageSource();
+		// The form uses use:enhance and only submits via an explicit submit control
+		// (the gated Save button or the visually-hidden submit), never on substep change.
+		expect(src).toContain('action="?/saveSettings"');
+		// No $effect / reactive block calls the form's requestSubmit on currentSubStep change.
+		expect(src).not.toMatch(/requestSubmit\s*\(/);
+	});
+});

--- a/tests/unit/security/csrf-handle.test.ts
+++ b/tests/unit/security/csrf-handle.test.ts
@@ -184,4 +184,85 @@ describe('csrfHandle (production mode)', () => {
 			expect(metadata).toContain('<unmatched>');
 		});
 	});
+
+	describe('CSRF self-lockout recovery carve-out (ISSUE-002)', () => {
+		it('lets the security-route updateCsrfOrigin repair POST reach its action despite a mismatched stored origin', async () => {
+			// A bad origin is stored — every normal POST would 403.
+			await setAppSetting(AppSettingsKey.CSRF_ORIGIN, 'https://wrong.example');
+
+			const event = makeEvent({
+				method: 'POST',
+				// Admin is loaded on the real origin and repairs the setting.
+				url: 'https://example.com/admin/settings/security?/updateCsrfOrigin',
+				origin: 'https://example.com',
+				route: { id: '/admin/settings/security' }
+			});
+
+			const response = await invoke(event);
+			// Reaches the action (200 sentinel) — the action's confirm-mismatch
+			// gate governs the actual write, not the hook.
+			expect(response.status).toBe(200);
+			expect(await response.text()).toBe('resolved');
+
+			await flushLogs();
+			const rows = await getCsrfLogByMessage('CSRF self-repair');
+			expect(rows.length).toBeGreaterThan(0);
+		});
+
+		it('does NOT extend the carve-out to a different action on the same route', async () => {
+			await setAppSetting(AppSettingsKey.CSRF_ORIGIN, 'https://example.com');
+
+			const event = makeEvent({
+				method: 'POST',
+				url: 'https://example.com/admin/settings/security?/toggleCsrfSkip',
+				origin: 'https://attacker.example',
+				route: { id: '/admin/settings/security' }
+			});
+
+			const response = await invoke(event);
+			expect(response.status).toBe(403);
+		});
+
+		it('does NOT extend the carve-out to the updateCsrfOrigin action on a different route', async () => {
+			await setAppSetting(AppSettingsKey.CSRF_ORIGIN, 'https://example.com');
+
+			const event = makeEvent({
+				method: 'POST',
+				url: 'https://example.com/admin/settings/connections?/updateCsrfOrigin',
+				origin: 'https://attacker.example',
+				route: { id: '/admin/settings/connections' }
+			});
+
+			const response = await invoke(event);
+			expect(response.status).toBe(403);
+		});
+
+		it('keys on route+action regardless of origin header (forged x-forwarded cannot widen it)', async () => {
+			// Under TRUST_PROXY, proxyHandle rewrites event.url.origin from
+			// x-forwarded-* before csrfHandle runs. The carve-out decision must be
+			// independent of that origin: the repair POST resolves whether or not
+			// the (spoofable) request origin matches, AND a non-repair route still
+			// 403s — so a forged forwarded header cannot exempt anything else.
+			await setAppSetting(AppSettingsKey.CSRF_ORIGIN, 'https://wrong.example');
+
+			const repairWithForgedOrigin = makeEvent({
+				method: 'POST',
+				url: 'https://example.com/admin/settings/security?/updateCsrfOrigin',
+				origin: 'https://attacker.example',
+				route: { id: '/admin/settings/security' }
+			});
+			const repairResponse = await invoke(repairWithForgedOrigin);
+			expect(repairResponse.status).toBe(200);
+
+			// A different state-changing route gets no exemption.
+			const otherRoute = makeEvent({
+				method: 'POST',
+				url: 'https://example.com/admin/users?/deleteUser',
+				origin: 'https://attacker.example',
+				route: { id: '/admin/users' }
+			});
+			const otherResponse = await invoke(otherRoute);
+			expect(otherResponse.status).toBe(403);
+		});
+	});
 });

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
+import { eq } from 'drizzle-orm';
 import { db } from '$lib/server/db/client';
 import { appSettings, shareSettings } from '$lib/server/db/schema';
 import {
@@ -310,44 +311,55 @@ describe('Sharing Service', () => {
 		});
 
 		describe('bulkApplyShareDefaults', () => {
-			it('resets every existing row to the current defaults (PUBLIC + allow=true)', async () => {
+			it('rewrites default-sourced rows but leaves explicit overrides untouched (ISSUE-006)', async () => {
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PUBLIC,
 					allowUserControl: true
 				});
 
+				const explicitToken = generateShareToken();
 				await db.insert(shareSettings).values([
+					// Default-sourced row: should adopt the new default.
 					{
 						userId: 1,
 						year: 2024,
-						mode: ShareMode.PRIVATE_LINK,
-						modeSource: ShareModeSource.EXPLICIT,
-						shareToken: generateShareToken(),
+						mode: ShareMode.PRIVATE_OAUTH,
+						modeSource: ShareModeSource.DEFAULT,
+						shareToken: null,
 						canUserControl: false
 					},
+					// Explicit override: must be preserved verbatim.
 					{
 						userId: 2,
 						year: 2024,
-						mode: ShareMode.PRIVATE_OAUTH,
+						mode: ShareMode.PRIVATE_LINK,
 						modeSource: ShareModeSource.EXPLICIT,
-						shareToken: null,
+						shareToken: explicitToken,
 						canUserControl: false
 					}
 				]);
 
-				const count = await bulkApplyShareDefaults();
-				expect(count).toBe(2);
+				const result = await bulkApplyShareDefaults();
+				expect(result).toEqual({ updated: 1, skipped: 1 });
 
-				const rows = await db.select().from(shareSettings);
-				for (const row of rows) {
-					expect(row.mode).toBe(ShareMode.PUBLIC);
-					expect(row.modeSource).toBe(ShareModeSource.DEFAULT);
-					expect(row.canUserControl).toBe(true);
-					expect(row.shareToken).toBeNull();
-				}
+				const defaultRow = (
+					await db.select().from(shareSettings).where(eq(shareSettings.userId, 1)).limit(1)
+				)[0];
+				expect(defaultRow?.mode).toBe(ShareMode.PUBLIC);
+				expect(defaultRow?.modeSource).toBe(ShareModeSource.DEFAULT);
+				expect(defaultRow?.canUserControl).toBe(true);
+
+				// Explicit row is fully unchanged: mode, source, token, and canUserControl.
+				const explicitRow = (
+					await db.select().from(shareSettings).where(eq(shareSettings.userId, 2)).limit(1)
+				)[0];
+				expect(explicitRow?.mode).toBe(ShareMode.PRIVATE_LINK);
+				expect(explicitRow?.modeSource).toBe(ShareModeSource.EXPLICIT);
+				expect(explicitRow?.shareToken).toBe(explicitToken);
+				expect(explicitRow?.canUserControl).toBe(false);
 			});
 
-			it('mints a token for every row when default is PRIVATE_LINK', async () => {
+			it('mints tokens for default-sourced rows only when default is PRIVATE_LINK', async () => {
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PRIVATE_LINK,
 					allowUserControl: false
@@ -358,34 +370,41 @@ describe('Sharing Service', () => {
 						userId: 1,
 						year: 2024,
 						mode: ShareMode.PUBLIC,
-						modeSource: ShareModeSource.EXPLICIT,
+						modeSource: ShareModeSource.DEFAULT,
 						shareToken: null,
 						canUserControl: true
 					},
+					// Explicit PUBLIC override: must NOT be rotated or given a token.
 					{
 						userId: 2,
 						year: 2024,
-						mode: ShareMode.PRIVATE_OAUTH,
+						mode: ShareMode.PUBLIC,
 						modeSource: ShareModeSource.EXPLICIT,
 						shareToken: null,
 						canUserControl: true
 					}
 				]);
 
-				const count = await bulkApplyShareDefaults();
-				expect(count).toBe(2);
+				const result = await bulkApplyShareDefaults();
+				expect(result).toEqual({ updated: 1, skipped: 1 });
 
-				const rows = await db.select().from(shareSettings);
-				for (const row of rows) {
-					expect(row.mode).toBe(ShareMode.PRIVATE_LINK);
-					expect(row.modeSource).toBe(ShareModeSource.DEFAULT);
-					expect(row.canUserControl).toBe(false);
-					expect(row.shareToken).not.toBeNull();
-					expect(isValidTokenFormat(row.shareToken!)).toBe(true);
-				}
+				const defaultRow = (
+					await db.select().from(shareSettings).where(eq(shareSettings.userId, 1)).limit(1)
+				)[0];
+				expect(defaultRow?.mode).toBe(ShareMode.PRIVATE_LINK);
+				expect(defaultRow?.modeSource).toBe(ShareModeSource.DEFAULT);
+				expect(defaultRow?.shareToken).not.toBeNull();
+				expect(isValidTokenFormat(defaultRow!.shareToken!)).toBe(true);
+
+				const explicitRow = (
+					await db.select().from(shareSettings).where(eq(shareSettings.userId, 2)).limit(1)
+				)[0];
+				expect(explicitRow?.mode).toBe(ShareMode.PUBLIC);
+				expect(explicitRow?.modeSource).toBe(ShareModeSource.EXPLICIT);
+				expect(explicitRow?.shareToken).toBeNull();
 			});
 
-			it('preserves existing tokens when default is PRIVATE_LINK and the row already has one', async () => {
+			it('preserves existing tokens on default-sourced rows when default is PRIVATE_LINK', async () => {
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PRIVATE_LINK,
 					allowUserControl: false
@@ -396,7 +415,7 @@ describe('Sharing Service', () => {
 					userId: 1,
 					year: 2024,
 					mode: ShareMode.PRIVATE_LINK,
-					modeSource: ShareModeSource.EXPLICIT,
+					modeSource: ShareModeSource.DEFAULT,
 					shareToken: stashedToken,
 					canUserControl: true
 				});
@@ -407,14 +426,48 @@ describe('Sharing Service', () => {
 				expect(row[0]?.shareToken).toBe(stashedToken);
 			});
 
-			it('returns 0 when there are no share rows', async () => {
+			it('returns 0/0 when there are no share rows', async () => {
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PUBLIC,
 					allowUserControl: true
 				});
 
-				const count = await bulkApplyShareDefaults();
-				expect(count).toBe(0);
+				const result = await bulkApplyShareDefaults();
+				expect(result).toEqual({ updated: 0, skipped: 0 });
+			});
+
+			it('reports updated=0 with skipped>0 when every row is an explicit override', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: true
+				});
+
+				await db.insert(shareSettings).values([
+					{
+						userId: 1,
+						year: 2024,
+						mode: ShareMode.PRIVATE_OAUTH,
+						modeSource: ShareModeSource.EXPLICIT,
+						shareToken: null,
+						canUserControl: false
+					},
+					{
+						userId: 2,
+						year: 2024,
+						mode: ShareMode.PRIVATE_LINK,
+						modeSource: ShareModeSource.EXPLICIT,
+						shareToken: generateShareToken(),
+						canUserControl: false
+					}
+				]);
+
+				const result = await bulkApplyShareDefaults();
+				expect(result).toEqual({ updated: 0, skipped: 2 });
+
+				const rows = await db.select().from(shareSettings);
+				for (const row of rows) {
+					expect(row.modeSource).toBe(ShareModeSource.EXPLICIT);
+				}
 			});
 		});
 	});

--- a/tests/unit/stats/calculators.test.ts
+++ b/tests/unit/stats/calculators.test.ts
@@ -324,6 +324,23 @@ describe('Ranking Calculator', () => {
 			const result = calculateTopGenres([]);
 			expect(result).toEqual([]);
 		});
+
+		// ISSUE-010 — Plex enrichment can persist the literal strings
+		// "undefined"/"null" (or whitespace) into the nullable genres column.
+		// Those must be skipped without throwing or logging a parse warning.
+		it('skips literal "undefined"/"null"/whitespace genre values', () => {
+			const records = [
+				createRecord({ genres: 'undefined' }),
+				createRecord({ id: 2, historyKey: 'key-2', genres: 'null' }),
+				createRecord({ id: 3, historyKey: 'key-3', genres: '   ' }),
+				createRecord({ id: 4, historyKey: 'key-4', genres: '["Action"]' })
+			];
+
+			const result = calculateTopGenres(records);
+
+			expect(result.length).toBe(1);
+			expect(result[0]?.title).toBe('Action');
+		});
 	});
 });
 

--- a/tests/unit/stats/format.test.ts
+++ b/tests/unit/stats/format.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import { formatWatchHours } from '$lib/stats/format';
+
+/**
+ * ISSUE-011 — the admin dashboard ("Hours Watched") and the Wrapped
+ * "Total Time" slide must report identical hours for the same
+ * `totalWatchTimeMinutes`. They previously drifted (Math.round vs
+ * Math.floor); formatWatchHours is now the single rounding authority.
+ */
+describe('formatWatchHours', () => {
+	it('rounds minutes to the nearest hour', () => {
+		expect(formatWatchHours(120)).toBe(2);
+		// 6029 min = 100.48h -> 100h (the dashboard/slide drift case)
+		expect(formatWatchHours(6029)).toBe(100);
+		// 6030 min = 100.5h -> 101h (rounds up at the half)
+		expect(formatWatchHours(6030)).toBe(101);
+		// 90 min = 1.5h -> 2h
+		expect(formatWatchHours(90)).toBe(2);
+		// 89 min = 1.48h -> 1h
+		expect(formatWatchHours(89)).toBe(1);
+	});
+
+	it('returns 0 for zero, negative, or non-finite input', () => {
+		expect(formatWatchHours(0)).toBe(0);
+		expect(formatWatchHours(-50)).toBe(0);
+		expect(formatWatchHours(Number.NaN)).toBe(0);
+		expect(formatWatchHours(Number.POSITIVE_INFINITY)).toBe(0);
+	});
+});

--- a/tests/unit/sync/single-flight.test.ts
+++ b/tests/unit/sync/single-flight.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import * as fc from 'fast-check';
+import { db } from '$lib/server/db/client';
+import { syncStatus } from '$lib/server/db/schema';
+
+// Mock the Plex-facing dependencies so `startSync` runs to completion without
+// any network access: it claims the single-flight slot, then finds no history
+// to fetch and completes with zero records. This isolates the atomic-claim and
+// startup-sweep behavior (ISSUE-001) from Plex connectivity.
+mock.module('$lib/server/plex/client', () => ({
+	async plexRequest() {
+		throw new Error('plexRequest not available in single-flight test');
+	},
+	// eslint-disable-next-line require-yield
+	async *fetchAllHistory() {
+		// no history to fetch in tests
+	},
+	async fetchAllHistoryArray() {
+		return [];
+	},
+	async checkConnection() {
+		return true;
+	},
+	async getServerUrl() {
+		return 'https://test-plex-server:32400';
+	},
+	async fetchMediaMetadata() {
+		return null;
+	},
+	async fetchMetadataBatch() {
+		return new Map();
+	},
+	async fetchShowMetadata() {
+		return null;
+	},
+	async fetchShowsMetadataBatch() {
+		return new Map();
+	}
+}));
+
+mock.module('$lib/server/sync/plex-accounts.service', () => ({
+	async syncPlexAccounts() {
+		return 0;
+	}
+}));
+
+const { startSync, reconcileInterruptedSyncs } = await import('$lib/server/sync/service');
+
+async function countSyncRows(): Promise<number> {
+	const rows = await db.select({ id: syncStatus.id }).from(syncStatus);
+	return rows.length;
+}
+
+async function countRunningRows(): Promise<number> {
+	const rows = await db
+		.select({ id: syncStatus.id })
+		.from(syncStatus)
+		.where(eq(syncStatus.status, 'running'));
+	return rows.length;
+}
+
+function isAlreadyRunningError(reason: unknown): boolean {
+	return reason instanceof Error && /already in progress/i.test(reason.message);
+}
+
+describe('sync single-flight via atomic DB claim (ISSUE-001)', () => {
+	beforeEach(() => {
+		db.delete(syncStatus).run();
+	});
+
+	afterEach(() => {
+		db.delete(syncStatus).run();
+	});
+
+	it('lets exactly one of N concurrent startSync calls claim the running slot', async () => {
+		const N = 6;
+		const results = await Promise.allSettled(Array.from({ length: N }, () => startSync()));
+
+		const fulfilled = results.filter((r) => r.status === 'fulfilled');
+		const rejected = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+
+		// Exactly one caller claimed the slot and ran to completion; the rest were
+		// rejected with the "already in progress" error.
+		expect(fulfilled).toHaveLength(1);
+		expect(rejected).toHaveLength(N - 1);
+		expect(rejected.every((r) => isAlreadyRunningError(r.reason))).toBe(true);
+
+		// Only one row was ever inserted — losers' INSERT ... WHERE NOT EXISTS
+		// inserted zero rows — and none remain in the running state.
+		expect(await countSyncRows()).toBe(1);
+		expect(await countRunningRows()).toBe(0);
+	});
+
+	it('keeps single-flight when triggerImmediateSync races a manual startSync', async () => {
+		const { triggerImmediateSync } = await import('$lib/server/sync/scheduler');
+
+		const results = await Promise.allSettled([
+			startSync(),
+			triggerImmediateSync(),
+			startSync(),
+			triggerImmediateSync()
+		]);
+
+		const fulfilled = results.filter((r) => r.status === 'fulfilled');
+		// triggerImmediateSync resolves to a SyncResult even on the loser path
+		// (its failure is surfaced via the result/throw); count rows as the
+		// authoritative single-flight assertion.
+		expect(fulfilled.length).toBeGreaterThanOrEqual(1);
+		expect(await countSyncRows()).toBe(1);
+		expect(await countRunningRows()).toBe(0);
+	});
+});
+
+describe('reconcileInterruptedSyncs startup sweep (ISSUE-001)', () => {
+	beforeEach(() => {
+		db.delete(syncStatus).run();
+	});
+
+	afterEach(() => {
+		db.delete(syncStatus).run();
+	});
+
+	it('marks a stale running row as failed and unblocks a fresh sync', async () => {
+		// Seed a row orphaned in `running` by a previous crash/restart.
+		db.insert(syncStatus)
+			.values({ startedAt: new Date(Date.now() - 60_000), status: 'running', recordsProcessed: 0 })
+			.run();
+
+		const reconciled = await reconcileInterruptedSyncs();
+		expect(reconciled).toBe(1);
+
+		const swept = await db.select().from(syncStatus).where(eq(syncStatus.status, 'failed'));
+		expect(swept).toHaveLength(1);
+		expect(swept[0]?.error).toBe('Interrupted by restart');
+		expect(swept[0]?.completedAt).not.toBeNull();
+		expect(await countRunningRows()).toBe(0);
+
+		// A fresh sync can now claim the slot.
+		const result = await startSync();
+		expect(result.status).toBe('completed');
+	});
+
+	it('returns 0 and changes nothing when there is no orphaned row', async () => {
+		const reconciled = await reconcileInterruptedSyncs();
+		expect(reconciled).toBe(0);
+		expect(await countSyncRows()).toBe(0);
+	});
+
+	it('never sweeps a sync started after boot (sweep runs once at boot)', async () => {
+		// Boot sweep runs exactly once against an empty table.
+		expect(await reconcileInterruptedSyncs()).toBe(0);
+
+		// A sync started AFTER boot leaves a running row. Because the sweep does
+		// not run again per-request, this row must remain untouched.
+		db.insert(syncStatus)
+			.values({ startedAt: new Date(), status: 'running', recordsProcessed: 0 })
+			.run();
+
+		// No further boot sweep happens — assert the post-boot running row survives.
+		expect(await countRunningRows()).toBe(1);
+	});
+});
+
+describe('sync single-flight property (ISSUE-001)', () => {
+	it('for any K concurrent startSync, exactly one running row is ever claimed', async () => {
+		await fc.assert(
+			fc.asyncProperty(fc.integer({ min: 2, max: 8 }), async (k) => {
+				db.delete(syncStatus).run();
+
+				const results = await Promise.allSettled(Array.from({ length: k }, () => startSync()));
+
+				// Exactly one INSERT succeeded (losers' WHERE NOT EXISTS inserted
+				// nothing), and no row is left running after all settle.
+				expect(await countSyncRows()).toBe(1);
+				expect(await countRunningRows()).toBe(0);
+
+				// Exactly one caller avoided the "already in progress" rejection.
+				const claimers = results.filter(
+					(r) =>
+						r.status === 'fulfilled' || !isAlreadyRunningError((r as PromiseRejectedResult).reason)
+				);
+				expect(claimers).toHaveLength(1);
+			}),
+			{ numRuns: 25 }
+		);
+
+		db.delete(syncStatus).run();
+	});
+});


### PR DESCRIPTION
## Summary

Remediates the 23 H/M/L findings from the dogfood report, organized into seven severity-batched areas. The two HIGH security fixes (sync single-flight, CSRF self-lockout recovery) and the logout hardening land first; the remaining UX, sharing, and accessibility work follows. No schema/migration changes.

## HIGH — Security

### Sync single-flight (ISSUE-001)
- `createSyncRecord` now claims the single running slot atomically with `INSERT ... SELECT ... WHERE NOT EXISTS (status='running') ... RETURNING id`, which is race-free under SQLite WAL (single writer). This is the sole correctness boundary, and every entry path (`startSync`, `triggerImmediateSync`, the Cron callback, `startBackgroundSync`, live-sync) funnels through it.
- The previous read-then-act `isSyncRunning()` pre-check in `startSync` (a TOCTOU window) is removed; the in-memory `syncLock` is demoted to an advisory fast-path only.
- Adds `reconcileInterruptedSyncs()` to sweep rows orphaned in the `running` state by a crash/restart, run exactly once at process start in `db/client.ts` (after migrations, inside the in-memory guard) so it can never clobber a sync started by this process. Extracted into a lightweight `sync/reconcile.ts` so the boot path does not pull the Plex/`$env` module graph.

### CSRF self-lockout recovery (ISSUE-002)
- Adds one narrowly scoped carve-out in `csrfHandle`, keyed purely on `event.route.id` (the security settings route) plus the resolved `updateCsrfOrigin` form action. There is no same-origin/`event.url` derivation in the hook, so a forged `x-forwarded-*` under `TRUST_PROXY` cannot widen it.
- The carve-out only lets the repair POST reach its action; the action's existing confirm-mismatch gate still governs the write. Every other state-changing route keeps strict origin matching. The lockout dialog copy is updated to describe in-app self-repair (no database edit or restart required).

### Logout CSRF via GET (ISSUE-024)
- Logout is now POST-only: the GET `load` no longer mutates session state (it only redirects), and the POST action remains the sole session-clearing path. This closes a GET-reachable logout vector (SvelteKit's built-in origin check is disabled via `trustedOrigins:['*']`, and the custom CSRF handle skips GET).

## Onboarding and Settings UX
- Mask the bootstrap claim token (`type="password"`); keep the durable inline `role="alert"` surface for invalid-token errors.
- Normalize the six settings-tab titles to a single format; surface a visible inline validation message for out-of-range log retention; add a prominent non-blocking notice when AI fun facts are enabled with no effective OpenAI key; gate the ENV-locked Plex helper copy on actual lock state.

## Sharing consistency
- `bulkApplyShareDefaults` no longer clobbers explicit per-user overrides (scoped to non-explicit rows) and now reports updated vs skipped counts; private-link token rotation applies only to updated rows.
- The admin Users table badge label and CSS class both derive from the effective mode (stored mode clamped by the global floor), so a row can no longer read more permissively than actual access. The "Default" tag shows only for default-sourced rows.
- ShareModal explains disabled share-mode options and links non-admins to user-scoped settings instead of the admin page.

## Accessibility and content
- Guard `JSON.parse` at the `genres` parse site (`calculateTopGenres`).
- Share a single watch-hours formatting helper between the dashboard and the Wrapped total-time slide (both read the same source field), removing a rounding-convention drift.
- Add a "Configure schedule" CTA for the not-configured scheduler state; clarify 0h admin watch time; add per-slide and logo-toggle accessible names; add a POST logout control to the dashboard Account tab; remove the sync overlay from the accessibility tree on Wrapped error pages.

## Verify-first findings
ISSUE-003, 004, 005, and 015 were confirmed already-correct on `main` and pinned with behavior-locking regression tests rather than refactored, per the plan's verify-before-fix principle.

## Testing
- New coverage: sync single-flight (concurrent claims, a `triggerImmediateSync` race, a fast-check property, and the once-at-boot sweep), the CSRF carve-out (including a forged `x-forwarded-host` case), POST-only logout, the shared watch-hours helper, sharing defaults, and the onboarding substep walk.
- Full gate green: `bun run check:biome`, `bun run check` (svelte-check, 0 errors / 0 warnings), and `bun run test` (2122 pass / 0 fail).

## Notes
The sync claim is intentionally migration-free (`WHERE NOT EXISTS` rather than a partial unique index), which is equally race-safe under the single-process, single-SQLite deployment; the stronger index variant is documented as a follow-up should a multi-writer deployment ever be introduced.
