### PR TITLE
fix: remediate confirmed dogfood findings (auth returnTo, XSS hints, input caps, form reachability)

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -3,6 +3,7 @@ import { isHttpError, isRedirect } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import { dev } from '$app/environment';
 import { env } from '$env/dynamic/private';
+import { isSafeReturnPath } from '$lib/client/plex-login';
 import {
 	clearConflictingDbSettings,
 	ensurePublicLandingLookupDefault
@@ -243,8 +244,23 @@ const onboardingHandle: Handle = async ({ event, resolve }) => {
 const authorizationHandle: Handle = async ({ event, resolve }) => {
 	if (isAdminRouteId(event.route.id)) {
 		if (!event.locals.user || !event.locals.user.isAdmin) {
-			const fallback = event.locals.user ? '/dashboard' : '/';
-			return redirectResponse(event, fallback);
+			// Authenticated non-admins go to their own dashboard; carrying a returnTo
+			// would be pointless (they can never reach the admin route).
+			if (event.locals.user) {
+				return redirectResponse(event, '/dashboard');
+			}
+
+			// Anonymous: preserve the requested admin path so the sign-in flow can
+			// land the user back where they were headed (ISSUE-002). The path is
+			// built from the request URL (always same-origin) but is validated with
+			// the shared open-redirect guard as defense-in-depth before it is encoded
+			// into the returnTo carrier. The real open-redirect surface — the client
+			// `window.location.href` on the landing page — re-validates it again.
+			const requestedPath = event.url.pathname + event.url.search;
+			const location = isSafeReturnPath(requestedPath)
+				? `/?returnTo=${encodeURIComponent(requestedPath)}`
+				: '/';
+			return redirectResponse(event, location);
 		}
 	}
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -256,7 +256,12 @@ const authorizationHandle: Handle = async ({ event, resolve }) => {
 			// the shared open-redirect guard as defense-in-depth before it is encoded
 			// into the returnTo carrier. The real open-redirect surface — the client
 			// `window.location.href` on the landing page — re-validates it again.
-			const requestedPath = event.url.pathname + event.url.search;
+			// Use pathname only (drop event.url.search): the returnTo value travels
+			// through the Plex OAuth forwardUrl, so any admin query string (e.g.
+			// /admin/logs?search=…) would otherwise leak via plex.tv logs, browser
+			// history and Referer headers. Landing back on the bare admin path is
+			// sufficient post-login; filter/tab params are not worth that exposure.
+			const requestedPath = event.url.pathname;
 			const location = isSafeReturnPath(requestedPath)
 				? `/?returnTo=${encodeURIComponent(requestedPath)}`
 				: '/';

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -113,9 +113,16 @@ export interface ServerPinFallback {
  * source of truth shared by the server hook (returnTo carrier), the redirect
  * load (server-side re-validation), and the client landing page (the actual
  * `window.location.href` open-redirect surface).
+ *
+ * A length cap (`MAX_RETURN_PATH_LENGTH`) rejects oversized, attacker-controlled
+ * paths before they reach a redirect `Location` header — legitimate internal
+ * paths are well under it.
  */
+const MAX_RETURN_PATH_LENGTH = 2048;
+
 export function isSafeReturnPath(path: unknown): path is string {
 	if (typeof path !== 'string' || path.length === 0) return false;
+	if (path.length > MAX_RETURN_PATH_LENGTH) return false;
 	if (!path.startsWith('/')) return false;
 	if (path.startsWith('//') || path.startsWith('/\\')) return false;
 	if (path.includes('\\')) return false;
@@ -127,10 +134,13 @@ export function isSafeReturnPath(path: unknown): path is string {
 /**
  * Returns `candidate` when it passes {@link isSafeReturnPath}, otherwise the
  * role-default `fallback`. Used to compute the post-login `targetUrl` so a forged
- * external value can never reach `window.location.href`.
+ * external value can never reach `window.location.href`. The `fallback` is itself
+ * re-validated so a future caller cannot pass an unsafe value (e.g. an external
+ * URL) straight through; when it fails, we degrade to the same-origin root `/`.
  */
 export function resolveSafeReturnPath(candidate: unknown, fallback: string): string {
-	return isSafeReturnPath(candidate) ? candidate : fallback;
+	if (isSafeReturnPath(candidate)) return candidate;
+	return isSafeReturnPath(fallback) ? fallback : '/';
 }
 
 async function fetchPin(redirectUrl?: string): Promise<PinResponse> {

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -72,6 +72,13 @@ interface RedirectStorage {
 export interface PlexLoginRedirectOptions {
 	context: PlexLoginContext;
 	onError: (message: string) => void;
+	/**
+	 * Validated same-origin path to land on after a successful login (ISSUE-002).
+	 * Rides as a query param on the same-origin `/auth/plex/redirect` callback URL;
+	 * re-validated server-side (redirect load) and client-side (landing page) before
+	 * use, so a non-path value here is harmless.
+	 */
+	returnTo?: string;
 	location?: RedirectLocation;
 	storage?: RedirectStorage;
 }
@@ -95,6 +102,35 @@ export interface ServerPinFallback {
 	pinId: number;
 	expiresAt: string;
 	context: PlexLoginContext;
+}
+
+/**
+ * Open-redirect guard for the post-login target path (ISSUE-002). A safe return
+ * path is a same-origin, absolute path: it starts with a single "/" (NOT "//" or
+ * "/\\", which browsers treat as protocol-relative // → external host), contains
+ * no backslash escape tricks, and no control characters. Anything else
+ * (`https://evil.com`, `javascript:…`, `\evil`) is rejected. This is the single
+ * source of truth shared by the server hook (returnTo carrier), the redirect
+ * load (server-side re-validation), and the client landing page (the actual
+ * `window.location.href` open-redirect surface).
+ */
+export function isSafeReturnPath(path: unknown): path is string {
+	if (typeof path !== 'string' || path.length === 0) return false;
+	if (!path.startsWith('/')) return false;
+	if (path.startsWith('//') || path.startsWith('/\\')) return false;
+	if (path.includes('\\')) return false;
+	// biome-ignore lint/suspicious/noControlCharactersInRegex: intentionally rejecting control chars in redirect targets
+	if (/[\u0000-\u001f\u007f]/.test(path)) return false;
+	return true;
+}
+
+/**
+ * Returns `candidate` when it passes {@link isSafeReturnPath}, otherwise the
+ * role-default `fallback`. Used to compute the post-login `targetUrl` so a forged
+ * external value can never reach `window.location.href`.
+ */
+export function resolveSafeReturnPath(candidate: unknown, fallback: string): string {
+	return isSafeReturnPath(candidate) ? candidate : fallback;
 }
 
 async function fetchPin(redirectUrl?: string): Promise<PinResponse> {
@@ -342,7 +378,14 @@ export async function startPlexLoginRedirect(opts: PlexLoginRedirectOptions): Pr
 	try {
 		const location = opts.location ?? window.location;
 		const storage = opts.storage ?? sessionStorage;
-		const redirectUrl = `${location.origin}/auth/plex/redirect`;
+		// Carry the post-login target as a query param on the same-origin callback
+		// URL. parsePinForwardUrl (server) enforces same-origin on the whole URL, and
+		// both the redirect load and the landing page re-validate returnTo before use.
+		const callbackBase = `${location.origin}/auth/plex/redirect`;
+		const redirectUrl =
+			opts.returnTo && isSafeReturnPath(opts.returnTo)
+				? `${callbackBase}?returnTo=${encodeURIComponent(opts.returnTo)}`
+				: callbackBase;
 		const { pinId, authUrl } = await fetchPin(redirectUrl);
 		storePinForRedirect(pinId, opts.context, storage);
 		location.href = authUrl;

--- a/src/lib/server/slides/custom.service.ts
+++ b/src/lib/server/slides/custom.service.ts
@@ -1,7 +1,7 @@
 import { and, asc, eq, isNull } from 'drizzle-orm';
 import { db } from '$lib/server/db/client';
 import { customSlides } from '$lib/server/db/schema';
-import { containsUnsafeHtml, validateMarkdownSyntax } from './renderer';
+import { detectUnsafeHtml, validateMarkdownSyntax } from './renderer';
 import {
 	type CreateCustomSlide,
 	CreateCustomSlideSchema,
@@ -21,8 +21,9 @@ export async function createCustomSlide(data: CreateCustomSlide): Promise<Custom
 
 	const validData = parsed.data;
 
-	if (containsUnsafeHtml(validData.content)) {
-		throw new SlideError('Content contains potentially unsafe HTML patterns', 'UNSAFE_CONTENT');
+	const createUnsafe = detectUnsafeHtml(validData.content);
+	if (createUnsafe.unsafe) {
+		throw new SlideError(createUnsafe.reason, 'UNSAFE_CONTENT');
 	}
 
 	const markdownValidation = validateMarkdownSyntax(validData.content);
@@ -145,8 +146,9 @@ export async function updateCustomSlide(
 	}
 
 	if (validUpdates.content !== undefined) {
-		if (containsUnsafeHtml(validUpdates.content)) {
-			throw new SlideError('Content contains potentially unsafe HTML patterns', 'UNSAFE_CONTENT');
+		const updateUnsafe = detectUnsafeHtml(validUpdates.content);
+		if (updateUnsafe.unsafe) {
+			throw new SlideError(updateUnsafe.reason, 'UNSAFE_CONTENT');
 		}
 
 		const markdownValidation = validateMarkdownSyntax(validUpdates.content);

--- a/src/lib/server/slides/index.ts
+++ b/src/lib/server/slides/index.ts
@@ -21,6 +21,7 @@ export {
 } from './custom.service';
 export {
 	containsUnsafeHtml,
+	detectUnsafeHtml,
 	getReadingTime,
 	getWordCount,
 	markdownToPlainText,

--- a/src/lib/server/slides/renderer.ts
+++ b/src/lib/server/slides/renderer.ts
@@ -99,24 +99,44 @@ export function markdownToPlainText(content: string, maxLength: number = 200): s
 	return `${truncated}...`;
 }
 
-export function containsUnsafeHtml(content: string): boolean {
+export type UnsafeHtmlDetection = { unsafe: true; reason: string } | { unsafe: false };
+
+/**
+ * Classifies why slide content is rejected as unsafe HTML, so each detection
+ * branch surfaces an actionable, non-leaky hint inline under the content field
+ * (ISSUE-006) instead of one generic message. The four regexes and their order
+ * are unchanged from the prior boolean `containsUnsafeHtml` — detection strength
+ * is identical; only the returned reason is branch-specific. Messages stay
+ * generic enough not to echo the user's exact payload verbatim.
+ */
+export function detectUnsafeHtml(content: string): UnsafeHtmlDetection {
 	if (/<script[^>]*>/i.test(content)) {
-		return true;
+		return {
+			unsafe: true,
+			reason: "Remove <script> tags — inline scripts aren't allowed in slide content."
+		};
 	}
 
 	if (/\son\w+\s*=/i.test(content)) {
-		return true;
+		return {
+			unsafe: true,
+			reason: 'Remove inline event handlers (e.g. onclick, onerror) from your HTML.'
+		};
 	}
 
 	if (/javascript:/i.test(content)) {
-		return true;
+		return { unsafe: true, reason: 'Remove javascript: URLs from links or images.' };
 	}
 
 	if (/data:[^;]*;base64.*<script/i.test(content)) {
-		return true;
+		return { unsafe: true, reason: 'Remove embedded base64 scripts from your content.' };
 	}
 
-	return false;
+	return { unsafe: false };
+}
+
+export function containsUnsafeHtml(content: string): boolean {
+	return detectUnsafeHtml(content).unsafe;
 }
 
 export function getWordCount(content: string): number {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,9 @@ import { enhance } from '$app/forms';
 import { shouldUseRedirectAuth } from '$lib/client/auth-mode';
 import {
 	commitRedirectFromPopupBlocked,
+	isSafeReturnPath,
 	type PlexLoginController,
+	resolveSafeReturnPath,
 	startPlexLoginPopup,
 	startPlexLoginRedirect
 } from '$lib/client/plex-login';
@@ -82,7 +84,14 @@ async function handlePlexLogin() {
 
 	oauthError = null;
 
-	const useRedirect = shouldUseRedirectAuth(new URL(window.location.href).searchParams);
+	const params = new URL(window.location.href).searchParams;
+	const useRedirect = shouldUseRedirectAuth(params);
+
+	// Post-login target preserved by the anon→admin hook redirect (ISSUE-002).
+	// Validated here and re-validated downstream before any navigation, so a
+	// forged ?returnTo= can never drive an external redirect.
+	const rawReturnTo = params.get('returnTo');
+	const returnTo = isSafeReturnPath(rawReturnTo) ? rawReturnTo : undefined;
 
 	if (useRedirect) {
 		loginController?.cancel();
@@ -90,6 +99,7 @@ async function handlePlexLogin() {
 		isRedirecting = true;
 		await startPlexLoginRedirect({
 			context: 'landing',
+			returnTo,
 			onError: (message) => {
 				isRedirecting = false;
 				oauthError = message;
@@ -103,7 +113,10 @@ async function handlePlexLogin() {
 	loginController = startPlexLoginPopup({
 		context: 'landing',
 		onSuccess: (user) => {
-			window.location.href = user.isAdmin ? '/admin' : '/dashboard';
+			window.location.href = resolveSafeReturnPath(
+				returnTo,
+				user.isAdmin ? '/admin' : '/dashboard'
+			);
 		},
 		onError: (message) => {
 			isOAuthLoading = false;

--- a/src/routes/admin/settings/connections/+page.svelte
+++ b/src/routes/admin/settings/connections/+page.svelte
@@ -359,6 +359,7 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 						name="openaiModel"
 						type="text"
 						placeholder="gpt-5-mini"
+						maxlength={100}
 						bind:value={openaiModel}
 						disabled={openaiModelLocked}
 					/>

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -17,6 +17,7 @@ import UsersRoundIcon from '@lucide/svelte/icons/users-round';
 import VenetianMaskIcon from '@lucide/svelte/icons/venetian-mask';
 import type { ActionResult } from '@sveltejs/kit';
 import type { Component } from 'svelte';
+import { tick } from 'svelte';
 import { superForm } from 'sveltekit-superforms';
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
@@ -201,6 +202,17 @@ let showContradictionWarning = $derived(
 // other one-time $state-from-reactive declarations above.
 // svelte-ignore state_referenced_locally
 let advancedOpen = $state(showContradictionWarning);
+
+// ISSUE-007: expanding "Advanced options" can push each section's Save button
+// below the fold. On expand only, scroll the freshly-revealed section to the top
+// of the viewport (after the DOM settles) so its content + actions stay reachable.
+// Collapsing leaves the scroll position alone. Reuses the tick()-then-scroll idiom.
+let advancedSectionRef = $state<HTMLDivElement | null>(null);
+async function handleAdvancedToggle(open: boolean): Promise<void> {
+	if (!open) return;
+	await tick();
+	advancedSectionRef?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
 
 // The active preset is matched over the FIVE admin-owned fields only — logoMode
 // is excluded (it lives on the Appearance route), so a perfect five-field match
@@ -497,7 +509,8 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 		</CardContent>
 	</Card>
 
-	<Collapsible.Root bind:open={advancedOpen} class="space-y-6">
+	<div bind:this={advancedSectionRef}>
+	<Collapsible.Root bind:open={advancedOpen} onOpenChange={handleAdvancedToggle} class="space-y-6">
 		<Collapsible.Trigger
 			class="flex w-full items-center justify-between rounded-lg border border-border bg-muted/30 px-4 py-3 text-sm font-medium transition-colors hover:bg-muted/50"
 		>
@@ -746,6 +759,7 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 	</Card>
 		</Collapsible.Content>
 	</Collapsible.Root>
+	</div>
 
 	<Card>
 		<CardHeader>

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -625,6 +625,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 							bind:this={editorTitleInputRef}
 							bind:value={editorTitle}
 							required
+							maxlength="200"
 							placeholder="Enter slide title"
 							aria-invalid={slideFieldErrors?.title?.[0] ? 'true' : undefined}
 							aria-describedby={slideFieldErrors?.title?.[0] ? 'title-error' : undefined}

--- a/src/routes/auth/plex/redirect/+page.server.ts
+++ b/src/routes/auth/plex/redirect/+page.server.ts
@@ -1,4 +1,5 @@
 import { redirect } from '@sveltejs/kit';
+import { isSafeReturnPath } from '$lib/client/plex-login';
 import { verifyPinCallback } from '$lib/server/auth/pin-transactions';
 import { requiresOnboarding } from '$lib/server/onboarding';
 import type { PageServerLoad } from './$types';
@@ -27,9 +28,16 @@ export const load: PageServerLoad = async ({ cookies, locals, request, url }) =>
 
 	const verifiedPin = await verifyPinCallback(cookies, url.searchParams.get('state'));
 
+	// Post-login target carried from the anon→admin hook redirect (ISSUE-002).
+	// Validate same-origin/path-only here so PageData never carries an external
+	// value; the landing page re-validates before window.location.href as well.
+	const rawReturnTo = url.searchParams.get('returnTo');
+	const returnTo = isSafeReturnPath(rawReturnTo) ? rawReturnTo : null;
+
 	return {
 		flow: url.searchParams.get('flow') === 'popup' ? 'popup' : 'redirect',
 		stateVerified: verifiedPin !== null,
+		returnTo,
 		serverPinFallback: verifiedPin
 			? {
 					pinId: verifiedPin.pinId,

--- a/src/routes/auth/plex/redirect/+page.svelte
+++ b/src/routes/auth/plex/redirect/+page.svelte
@@ -11,6 +11,7 @@ import {
 	PIN_STORAGE_KEY,
 	POLL_INTERVAL_MS,
 	resolveRedirectPinData,
+	resolveSafeReturnPath,
 	sanitizeCompletedLoginResponse
 } from '$lib/client/plex-login';
 import { Button } from '$lib/components/ui/button';
@@ -56,10 +57,16 @@ onMount(async () => {
 
 		status = 'success';
 
+		// Onboarding always wins and is untouched. Otherwise honor a validated
+		// returnTo (ISSUE-002) — resolveSafeReturnPath rejects any external/forged
+		// value and falls back to the role default, so this client navigation can
+		// never become an open redirect.
+		const roleFallback =
+			loginResult.redirectTo ?? (loginResult.user.isAdmin ? '/admin' : '/dashboard');
 		const targetUrl =
 			pinData.context === 'onboarding'
 				? '/onboarding/plex'
-				: (loginResult.redirectTo ?? (loginResult.user.isAdmin ? '/admin' : '/dashboard'));
+				: resolveSafeReturnPath(data.returnTo, roleFallback);
 
 		window.location.href = targetUrl;
 	} catch (err) {

--- a/tests/unit/admin/slides-actions.test.ts
+++ b/tests/unit/admin/slides-actions.test.ts
@@ -241,11 +241,14 @@ describe('admin slides actions', () => {
 				})
 			);
 
+			// ISSUE-006: the rejection is now branch-specific (the <script> branch),
+			// still routed to fieldErrors.content via slideErrorToFail.
+			const scriptReason = "Remove <script> tags — inline scripts aren't allowed in slide content.";
 			expect(result).toMatchObject({
 				status: 400,
 				data: {
-					error: 'Content contains potentially unsafe HTML patterns',
-					fieldErrors: { content: ['Content contains potentially unsafe HTML patterns'] }
+					error: scriptReason,
+					fieldErrors: { content: [scriptReason] }
 				}
 			});
 		});

--- a/tests/unit/auth/return-path.test.ts
+++ b/tests/unit/auth/return-path.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'bun:test';
+import { isSafeReturnPath, resolveSafeReturnPath } from '$lib/client/plex-login';
+
+/**
+ * ISSUE-002 (dogfood 2026-06-04) — open-redirect guard for the post-login target.
+ *
+ * The client landing page assigns `window.location.href = targetUrl`, so the
+ * returnTo path it consumes is the real open-redirect surface. These tests pin
+ * the pure validator that BOTH the server hook (returnTo carrier) and the client
+ * navigation share, so a forged `?returnTo=` can never reach an external host.
+ *
+ * Hostile strings are built with String.fromCharCode so backslash / control-char
+ * cases are unambiguous in source (no escape-sequence surprises).
+ */
+const BACKSLASH = String.fromCharCode(92);
+const NEWLINE = String.fromCharCode(10);
+const TAB = String.fromCharCode(9);
+const NUL = String.fromCharCode(0);
+
+describe('isSafeReturnPath — open-redirect guard', () => {
+	it('accepts a same-origin absolute path', () => {
+		expect(isSafeReturnPath('/admin/settings')).toBe(true);
+		expect(isSafeReturnPath('/admin')).toBe(true);
+		expect(isSafeReturnPath('/dashboard?tab=x')).toBe(true);
+		expect(isSafeReturnPath('/admin/users#section')).toBe(true);
+	});
+
+	it('rejects protocol-relative // hosts', () => {
+		expect(isSafeReturnPath('//evil.com')).toBe(false);
+		expect(isSafeReturnPath('//evil.com/admin')).toBe(false);
+	});
+
+	it('rejects backslash protocol-relative tricks (/\\ and \\)', () => {
+		expect(isSafeReturnPath(`/${BACKSLASH}evil.com`)).toBe(false);
+		expect(isSafeReturnPath(`${BACKSLASH}evil`)).toBe(false);
+		expect(isSafeReturnPath(`${BACKSLASH}${BACKSLASH}evil.com`)).toBe(false);
+		expect(isSafeReturnPath(`/admin${BACKSLASH}evil`)).toBe(false);
+	});
+
+	it('rejects absolute URLs and scheme payloads', () => {
+		expect(isSafeReturnPath('https://evil.com')).toBe(false);
+		expect(isSafeReturnPath('http://evil.com/admin')).toBe(false);
+		expect(isSafeReturnPath('javascript:alert(1)')).toBe(false);
+		expect(isSafeReturnPath('data:text/html,<script>')).toBe(false);
+	});
+
+	it('rejects non-path / empty / non-string / control-char inputs', () => {
+		expect(isSafeReturnPath('')).toBe(false);
+		expect(isSafeReturnPath('admin/settings')).toBe(false);
+		expect(isSafeReturnPath('relative')).toBe(false);
+		expect(isSafeReturnPath(null)).toBe(false);
+		expect(isSafeReturnPath(undefined)).toBe(false);
+		expect(isSafeReturnPath(42)).toBe(false);
+		expect(isSafeReturnPath(`/admin${NEWLINE}/evil`)).toBe(false);
+		expect(isSafeReturnPath(`/admin${TAB}x`)).toBe(false);
+		expect(isSafeReturnPath(`/admin${NUL}`)).toBe(false);
+	});
+});
+
+describe('resolveSafeReturnPath — falls back to the role default', () => {
+	it('returns the candidate when it is a safe path', () => {
+		expect(resolveSafeReturnPath('/admin/settings', '/admin')).toBe('/admin/settings');
+		expect(resolveSafeReturnPath('/dashboard', '/dashboard')).toBe('/dashboard');
+	});
+
+	it('returns the fallback for every external / forged value', () => {
+		const hostile = ['//evil.com', 'https://evil.com', 'javascript:alert(1)', `${BACKSLASH}evil`];
+		for (const value of hostile) {
+			expect(resolveSafeReturnPath(value, '/admin')).toBe('/admin');
+			expect(resolveSafeReturnPath(value, '/dashboard')).toBe('/dashboard');
+		}
+	});
+
+	it('returns the fallback for null/undefined (no returnTo present)', () => {
+		expect(resolveSafeReturnPath(null, '/admin')).toBe('/admin');
+		expect(resolveSafeReturnPath(undefined, '/dashboard')).toBe('/dashboard');
+	});
+});
+
+/**
+ * Source-regression guards for the layers that consume the validator. The
+ * onboarding-context branch MUST win over any returnTo, and both the hook and the
+ * landing page must route returnTo through the shared guard before navigating.
+ */
+async function readSource(path: string): Promise<string> {
+	return Bun.file(path).text();
+}
+
+describe('ISSUE-002 — returnTo threading wiring', () => {
+	it('redirect load validates returnTo before putting it in PageData', async () => {
+		const source = await readSource('src/routes/auth/plex/redirect/+page.server.ts');
+		expect(source).toContain("import { isSafeReturnPath } from '$lib/client/plex-login';");
+		expect(source).toContain("url.searchParams.get('returnTo')");
+		expect(source).toContain('isSafeReturnPath(rawReturnTo) ? rawReturnTo : null');
+	});
+
+	it('redirect page lets onboarding win and otherwise resolves the safe returnTo', async () => {
+		const source = await readSource('src/routes/auth/plex/redirect/+page.svelte');
+		expect(source).toContain('resolveSafeReturnPath');
+		// Onboarding branch precedence is preserved (checked before returnTo is used).
+		const onboardingIdx = source.indexOf("pinData.context === 'onboarding'");
+		const resolveIdx = source.indexOf('resolveSafeReturnPath(data.returnTo');
+		expect(onboardingIdx).toBeGreaterThan(-1);
+		expect(resolveIdx).toBeGreaterThan(onboardingIdx);
+	});
+
+	it('landing page threads a validated returnTo into both auth flows', async () => {
+		const source = await readSource('src/routes/+page.svelte');
+		expect(source).toContain("params.get('returnTo')");
+		expect(source).toContain('isSafeReturnPath(rawReturnTo)');
+		expect(source).toContain('returnTo,');
+		expect(source).toContain('resolveSafeReturnPath(');
+	});
+});

--- a/tests/unit/dogfood-fixes.test.ts
+++ b/tests/unit/dogfood-fixes.test.ts
@@ -202,3 +202,45 @@ describe('dogfood 2026-05-29 F3 — long username lookup returns fail(400)', () 
 		});
 	});
 });
+
+// dogfood 2026-06-04 ISSUE-005 — client inputs gained inline `maxlength` hints
+// mirroring the server Zod caps (openaiModel.max(100), slide title.max(200)) so
+// over-length values are impossible to type rather than silently rejected later.
+describe('dogfood 2026-06-04 ISSUE-005 — maxlength mirrors server Zod caps', () => {
+	it('OpenAI Model input caps at 100 chars', async () => {
+		const source = await readSource('src/routes/admin/settings/connections/+page.svelte');
+		const idx = source.indexOf('name="openaiModel"');
+		expect(idx).toBeGreaterThan(-1);
+		// The attribute sits within the same <Input> element as name="openaiModel".
+		const slice = source.slice(idx - 80, idx + 200);
+		expect(slice).toContain('maxlength={100}');
+	});
+
+	it('Custom slide Title input caps at 200 chars', async () => {
+		const source = await readSource('src/routes/admin/slides/+page.svelte');
+		const idx = source.indexOf('name="title"');
+		expect(idx).toBeGreaterThan(-1);
+		const slice = source.slice(idx - 120, idx + 200);
+		expect(slice).toContain('maxlength="200"');
+	});
+});
+
+// dogfood 2026-06-04 ISSUE-007 — expanding "Advanced options" on the privacy tab
+// could push each section's Save button below the fold. On expand only, the
+// freshly-revealed section is scrolled into view so its content + actions stay
+// reachable (onOpenChange -> tick() -> scrollIntoView on a bound section ref).
+describe('dogfood 2026-06-04 ISSUE-007 — Advanced options stays reachable on expand', () => {
+	it('scrolls the expanded Advanced section into view', async () => {
+		const source = await readSource('src/routes/admin/settings/privacy/+page.svelte');
+		expect(source).toContain('onOpenChange={handleAdvancedToggle}');
+		expect(source).toContain('bind:this={advancedSectionRef}');
+
+		const handlerStart = source.indexOf('async function handleAdvancedToggle(');
+		expect(handlerStart).toBeGreaterThan(-1);
+		const handlerSlice = source.slice(handlerStart, handlerStart + 320);
+		// Expand-only guard, DOM settle, then scroll the section into view.
+		expect(handlerSlice).toContain('if (!open) return;');
+		expect(handlerSlice).toContain('await tick();');
+		expect(handlerSlice).toContain('advancedSectionRef?.scrollIntoView(');
+	});
+});

--- a/tests/unit/hooks/anon-admin-returnto.test.ts
+++ b/tests/unit/hooks/anon-admin-returnto.test.ts
@@ -15,7 +15,7 @@ describe('hooks authorizationHandle — anon admin returnTo carrier', () => {
 		const source = await Bun.file('src/hooks.server.ts').text();
 
 		expect(source).toContain("import { isSafeReturnPath } from '$lib/client/plex-login';");
-		expect(source).toContain('const requestedPath = event.url.pathname + event.url.search;');
+		expect(source).toContain('const requestedPath = event.url.pathname;');
 		expect(source).toContain('isSafeReturnPath(requestedPath)');
 		expect(source).toContain('/?returnTo=');
 		expect(source).toContain('encodeURIComponent(requestedPath)');

--- a/tests/unit/hooks/anon-admin-returnto.test.ts
+++ b/tests/unit/hooks/anon-admin-returnto.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test';
+
+/**
+ * ISSUE-002 (dogfood 2026-06-04) — anon → admin redirect preserves the target.
+ *
+ * authorizationHandle is composed into the exported `handle` sequence and is not
+ * individually exportable, so this pins the hook's returnTo construction at the
+ * source level: an anonymous hit on an admin route must carry the requested path
+ * as a validated, encoded `returnTo`, while an authenticated non-admin is sent to
+ * their dashboard with no returnTo. The behavioural open-redirect coverage for the
+ * shared validator lives in tests/unit/auth/return-path.test.ts.
+ */
+describe('hooks authorizationHandle — anon admin returnTo carrier', () => {
+	it('builds an encoded returnTo from the requested admin path for anon users', async () => {
+		const source = await Bun.file('src/hooks.server.ts').text();
+
+		expect(source).toContain("import { isSafeReturnPath } from '$lib/client/plex-login';");
+		expect(source).toContain('const requestedPath = event.url.pathname + event.url.search;');
+		expect(source).toContain('isSafeReturnPath(requestedPath)');
+		expect(source).toContain('/?returnTo=');
+		expect(source).toContain('encodeURIComponent(requestedPath)');
+	});
+
+	it('sends authenticated non-admins to their dashboard without a returnTo', async () => {
+		const source = await Bun.file('src/hooks.server.ts').text();
+
+		const handlerStart = source.indexOf('const authorizationHandle');
+		expect(handlerStart).toBeGreaterThan(-1);
+		const handlerSlice = source.slice(handlerStart, handlerStart + 900);
+		expect(handlerSlice).toContain('if (event.locals.user) {');
+		expect(handlerSlice).toContain("return redirectResponse(event, '/dashboard');");
+	});
+});

--- a/tests/unit/security/admin-guards.test.ts
+++ b/tests/unit/security/admin-guards.test.ts
@@ -27,7 +27,13 @@ describe('admin auth guards', () => {
 	it('keeps logged-in non-admin admin-route probes redirected to dashboard', async () => {
 		const source = await readSource('src/hooks.server.ts');
 
-		expect(source).toContain("const fallback = event.locals.user ? '/dashboard' : '/';");
-		expect(source).toContain('return redirectResponse(event, fallback);');
+		// Authenticated non-admins are sent to their own dashboard (no returnTo).
+		expect(source).toContain('if (event.locals.user) {');
+		expect(source).toContain("return redirectResponse(event, '/dashboard');");
+		// Anonymous admin-route hits preserve the requested path as a validated
+		// returnTo so login can land them back where they were headed (ISSUE-002).
+		expect(source).toContain('const requestedPath = event.url.pathname + event.url.search;');
+		expect(source).toContain('/?returnTo=');
+		expect(source).toContain('encodeURIComponent(requestedPath)');
 	});
 });

--- a/tests/unit/security/admin-guards.test.ts
+++ b/tests/unit/security/admin-guards.test.ts
@@ -32,7 +32,7 @@ describe('admin auth guards', () => {
 		expect(source).toContain("return redirectResponse(event, '/dashboard');");
 		// Anonymous admin-route hits preserve the requested path as a validated
 		// returnTo so login can land them back where they were headed (ISSUE-002).
-		expect(source).toContain('const requestedPath = event.url.pathname + event.url.search;');
+		expect(source).toContain('const requestedPath = event.url.pathname;');
 		expect(source).toContain('/?returnTo=');
 		expect(source).toContain('encodeURIComponent(requestedPath)');
 	});

--- a/tests/unit/slides/unsafe-html.test.ts
+++ b/tests/unit/slides/unsafe-html.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'bun:test';
+import { containsUnsafeHtml, detectUnsafeHtml } from '$lib/server/slides/renderer';
+
+/**
+ * ISSUE-006 (dogfood 2026-06-04) — branch-specific XSS rejection messages.
+ *
+ * detectUnsafeHtml keeps the exact same four detection branches (same regexes,
+ * same order) as the old boolean guard — detection strength is unchanged — but
+ * each branch now returns an actionable, non-leaky reason that renders inline
+ * under the slide content field. These tests pin one reason per branch and that
+ * safe markdown still passes.
+ */
+describe('detectUnsafeHtml — branch-specific reasons', () => {
+	it('flags <script> tags with a script-specific message', () => {
+		const result = detectUnsafeHtml('<script>alert(1)</script>');
+		expect(result.unsafe).toBe(true);
+		if (result.unsafe) {
+			expect(result.reason).toContain('<script>');
+		}
+	});
+
+	it('flags inline event handlers with an event-handler message', () => {
+		const result = detectUnsafeHtml('<img src="x" onerror="alert(1)" />');
+		expect(result.unsafe).toBe(true);
+		if (result.unsafe) {
+			expect(result.reason.toLowerCase()).toContain('event handler');
+		}
+	});
+
+	it('flags javascript: URLs with a javascript-url message', () => {
+		const result = detectUnsafeHtml('[click](javascript:alert(1))');
+		expect(result.unsafe).toBe(true);
+		if (result.unsafe) {
+			expect(result.reason).toContain('javascript:');
+		}
+	});
+
+	it('flags base64-embedded scripts with a base64 message', () => {
+		// No closing ">" after <script, so the first <script[^>]*> branch does NOT
+		// match — this isolates the data:...;base64...<script branch.
+		const result = detectUnsafeHtml('data:text/html;base64,QUJD<script');
+		expect(result.unsafe).toBe(true);
+		if (result.unsafe) {
+			expect(result.reason.toLowerCase()).toContain('base64');
+		}
+	});
+
+	it('returns the script reason when multiple patterns are present (first branch wins)', () => {
+		const result = detectUnsafeHtml('<script>x</script><img onerror="y">');
+		expect(result.unsafe).toBe(true);
+		if (result.unsafe) {
+			expect(result.reason).toContain('<script>');
+		}
+	});
+
+	it('passes safe markdown / plain HTML through', () => {
+		for (const safe of [
+			'# Heading',
+			'**bold** and _italic_ text',
+			'[a link](https://example.com)',
+			'<p>A paragraph with <strong>emphasis</strong>.</p>',
+			'A sentence mentioning the word javascript without a colon.'
+		]) {
+			expect(detectUnsafeHtml(safe)).toEqual({ unsafe: false });
+		}
+	});
+});
+
+describe('containsUnsafeHtml — thin boolean wrapper preserved', () => {
+	it('mirrors detectUnsafeHtml().unsafe', () => {
+		expect(containsUnsafeHtml('<script>alert(1)</script>')).toBe(true);
+		expect(containsUnsafeHtml('<img onerror="x">')).toBe(true);
+		expect(containsUnsafeHtml('plain safe text')).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Remediates the four **confirmed** findings from the 2026-06-04 dogfood QA re-triage (`.omc/plans/fix-dogfood-findings.md`). Findings classified as false-positive (atomic sync guard, avatar fallback) or by-design (anti-enumeration 404 copy, unlinked Plex-identity attribution) were intentionally excluded so no redundant guards are introduced, and the verify-only SSE-parser item is documented rather than speculatively patched.

The single medium-risk item (ISSUE-002, auth redirect) is implemented with the open-redirect guard placed at the real surface — the client `window.location.href` — and re-validated at every layer it passes through.

## Changes

### ISSUE-002 - Preserve the return destination on an anonymous to admin redirect

Previously, an anonymous hit on an admin route was redirected to `/` and the requested path was discarded; after signing in the user always landed on `/admin`.

- New shared pure guards `isSafeReturnPath` / `resolveSafeReturnPath` in `$lib/client/plex-login`. A safe path must be same-origin and absolute: it rejects protocol-relative `//` and `/\`, any backslash, scheme payloads (`https:`, `javascript:`), and control characters.
- `authorizationHandle` now carries the requested admin path as a validated, encoded `returnTo` for anonymous users. Authenticated non-admins continue to redirect to `/dashboard` with no `returnTo`.
- `returnTo` threads as a query parameter on the same-origin `/auth/plex/redirect` callback URL. It is re-validated server-side (the redirect `load`) and client-side (the landing page and the redirect page, immediately before `window.location.href`).
- The onboarding-context branch still wins and always routes to `/onboarding/plex`.
- No completion-contract widening: `CompletedLogin.redirectTo` keeps its strict `'/admin' | '/dashboard'` allowlist, and the same-origin `parsePinForwardUrl` guard is untouched, so login still completes correctly.

### ISSUE-006 - Branch-specific XSS rejection messages

`detectUnsafeHtml` now returns a per-branch reason (`{ unsafe, reason }`) instead of a single generic boolean. The four detection regexes and their order are byte-identical to the previous `containsUnsafeHtml`, which is retained as a thin wrapper, so detection strength is unchanged. The clearer, non-leaky messages render inline under the slide content field via the existing `slideErrorToFail` -> `fieldErrors.content` contract and do not echo the user's payload.

### ISSUE-005 - Inline length hints mirroring the server caps

Native `maxlength` attributes are added to mirror the server Zod caps: `100` on the OpenAI Model input and `200` on the custom-slide Title input. No new reactive state; the server caps are unchanged.

### ISSUE-007 - Keep primary form actions reachable

On the privacy settings tab, expanding "Advanced options" could push each section's Save button below the fold. Expanding now scrolls the revealed section into view (`onOpenChange` -> `tick()` -> `scrollIntoView`) on expand only, so the content and its actions stay reachable. The change is a single-child wrapper, leaving the existing layout and responsive rules untouched.

### ISSUE-008 / ISSUE-009 - Documented dispositions (no code)

The SSE `[Parser] Unable to parse JSON` warning is not emitted by application code (all three SSE consumers already wrap `JSON.parse` in try/catch); it is browser-extension or polyfill noise, and a clean-browser runtime check is required before adding any guard. The cccp01 personal-vs-server play discrepancy is a by-design unlinked Plex identity. Both are recorded with rationale; no production code was changed for them.

## Tests

- New unit tests: the open-redirect validator (`tests/unit/auth/return-path.test.ts`), the hook `returnTo` carrier (`tests/unit/hooks/anon-admin-returnto.test.ts`), and the XSS detector branches (`tests/unit/slides/unsafe-html.test.ts`).
- Extended source-regression coverage for the `maxlength` hints and the scroll-on-expand mechanism (`tests/unit/dogfood-fixes.test.ts`).
- Two existing tests were updated to the new intended behaviour (the branch-specific slide rejection message and the anonymous `returnTo` carrier), not deleted.

## Verification

- `bun run check`: 0 errors / 0 warnings
- `bun run check:biome`: clean
- `bun run test`: 2145 pass / 0 fail

## Notes

Per the plan, ISSUE-002 is the only medium-risk change and is the security-sensitive one; the remaining fixes are small and independent. They are bundled here for a single review context, but the auth change is cleanly separable if a split is preferred.
