### PR TITLE
refactor: audit code comments

### DIFF
--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,9 +1,3 @@
-/**
- * Database migration script for Obzorarr
- *
- * Run with: bun run scripts/migrate.ts
- */
-
 import { Database } from 'bun:sqlite';
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -14,25 +14,21 @@ const databasePath = process.env.DATABASE_PATH ?? 'data/obzorarr.db';
 
 console.log(`Migrating database at: ${databasePath}`);
 
-// Ensure the directory exists before opening the database
 if (databasePath !== ':memory:') {
 	mkdirSync(dirname(databasePath), { recursive: true });
 }
 
-// Create database connection
 const sqlite = new Database(databasePath, {
 	strict: true,
 	create: true
 });
 
-// Enable WAL mode
 sqlite.exec('PRAGMA journal_mode = WAL');
 sqlite.exec('PRAGMA synchronous = NORMAL');
 sqlite.exec('PRAGMA foreign_keys = ON');
 
 const db = drizzle(sqlite);
 
-// Run migrations
 console.log('Running migrations...');
 migrate(db, { migrationsFolder: './drizzle' });
 

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,8 +1,5 @@
-// See https://svelte.dev/docs/kit/types#app.d.ts
-// for information about these interfaces
 declare global {
 	namespace App {
-		// interface Error {}
 		interface Locals {
 			user?: {
 				id: number;
@@ -11,9 +8,6 @@ declare global {
 				isAdmin: boolean;
 			};
 		}
-		// interface PageData {}
-		// interface PageState {}
-		// interface Platform {}
 	}
 }
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -115,18 +115,14 @@ const initializationHandle: Handle = async ({ event, resolve }) => {
 };
 
 const authHandle: Handle = async ({ event, resolve }) => {
-	// Check for dev bypass mode (development only)
 	if (isDevBypassEnabled()) {
-		// Get or create dev session
 		const devSessionId = await getOrCreateDevSession();
 
-		// Set cookie if not already set
 		const existingSessionId = event.cookies.get('session');
 		if (existingSessionId !== devSessionId) {
 			event.cookies.set('session', devSessionId, COOKIE_OPTIONS);
 		}
 
-		// Validate the dev session
 		const session = await validateSession(devSessionId);
 
 		if (session) {
@@ -137,7 +133,6 @@ const authHandle: Handle = async ({ event, resolve }) => {
 				isAdmin: session.isAdmin
 			};
 
-			// Log dev bypass activation once per server instance
 			if (!devBypassLogged) {
 				logger.warn(
 					`🔓 DEV_BYPASS_AUTH is enabled - using simulated user (${session.username})`,
@@ -150,7 +145,6 @@ const authHandle: Handle = async ({ event, resolve }) => {
 		}
 	}
 
-	// Normal authentication flow
 	const sessionId = event.cookies.get('session');
 
 	if (sessionId) {
@@ -205,20 +199,16 @@ const authHandle: Handle = async ({ event, resolve }) => {
 };
 
 const onboardingHandle: Handle = async ({ event, resolve }) => {
-	// Skip if dev bypass is enabled for onboarding
 	if (isDevBypassEnabled() && env.DEV_BYPASS_ONBOARDING === 'true') {
 		return resolve(event);
 	}
 
-	// Paths that should skip onboarding check
 	const skipPaths = ['/_app', '/favicon', '/auth', '/api/onboarding', '/api/sync', '/onboarding'];
 
-	// Skip check for excluded paths
 	if (skipPaths.some((p) => event.url.pathname.startsWith(p))) {
 		return resolve(event);
 	}
 
-	// Check if onboarding is required
 	try {
 		const needsOnboarding = await requiresOnboarding();
 
@@ -233,7 +223,6 @@ const onboardingHandle: Handle = async ({ event, resolve }) => {
 		}
 
 		// Log actual errors but don't block the request
-		// This prevents onboarding check failures from breaking the app
 		const errorMessage = error instanceof Error ? error.message : String(error);
 		logger.error(`Onboarding check failed: ${errorMessage}`, 'OnboardingHandle');
 	}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -217,12 +217,10 @@ const onboardingHandle: Handle = async ({ event, resolve }) => {
 			return redirectResponse(event, `/onboarding/${currentStep}`);
 		}
 	} catch (error) {
-		// Re-throw redirects - they are expected behavior, not errors
 		if (isRedirect(error)) {
 			throw error;
 		}
 
-		// Log actual errors but don't block the request
 		const errorMessage = error instanceof Error ? error.message : String(error);
 		logger.error(`Onboarding check failed: ${errorMessage}`, 'OnboardingHandle');
 	}

--- a/src/lib/components/Logo.svelte
+++ b/src/lib/components/Logo.svelte
@@ -2,9 +2,7 @@
 import obzorarrIcon from '$lib/assets/obzorarr-icon.svg';
 
 interface Props {
-	/** Size preset or pixel value */
 	size?: 'sm' | 'md' | 'lg' | 'xl' | number;
-	/** Additional CSS classes */
 	class?: string;
 }
 

--- a/src/lib/components/SyncIndicator.svelte
+++ b/src/lib/components/SyncIndicator.svelte
@@ -2,15 +2,12 @@
 import type { LiveSyncProgress } from '$lib/sync/types';
 
 interface Props {
-	/** Whether a sync is currently in progress */
 	inProgress: boolean;
-	/** Current sync progress data */
 	progress?: LiveSyncProgress | null;
 }
 
 let { inProgress, progress = null }: Props = $props();
 
-// Derive status text based on sync phase
 const statusText = $derived.by(() => {
 	if (!inProgress || !progress) return 'Updating data...';
 

--- a/src/lib/components/SyncLoadingOverlay.svelte
+++ b/src/lib/components/SyncLoadingOverlay.svelte
@@ -4,11 +4,8 @@ import { fade } from 'svelte/transition';
 import type { LiveSyncProgress } from '$lib/sync/types';
 
 interface Props {
-	/** Whether the overlay should be visible */
 	visible: boolean;
-	/** Current sync progress data */
 	progress?: LiveSyncProgress | null;
-	/** Whether sync is actually in progress (vs just showing loading state) */
 	syncInProgress?: boolean;
 }
 
@@ -17,7 +14,6 @@ let { visible, progress = null, syncInProgress = false }: Props = $props();
 // Transition duration respecting reduced motion preference
 const transitionDuration = $derived(prefersReducedMotion.current ? 0 : 300);
 
-// Derive status text based on sync phase
 const statusText = $derived.by(() => {
 	if (!syncInProgress || !progress) {
 		return 'Loading your wrapped...';
@@ -38,7 +34,6 @@ const statusText = $derived.by(() => {
 	return 'Syncing your viewing history...';
 });
 
-// Secondary status text for additional context
 const secondaryText = $derived.by(() => {
 	if (!syncInProgress) {
 		return 'Preparing your year in review';

--- a/src/lib/components/SyncLoadingOverlay.svelte
+++ b/src/lib/components/SyncLoadingOverlay.svelte
@@ -11,7 +11,6 @@ interface Props {
 
 let { visible, progress = null, syncInProgress = false }: Props = $props();
 
-// Transition duration respecting reduced motion preference
 const transitionDuration = $derived(prefersReducedMotion.current ? 0 : 300);
 
 const statusText = $derived.by(() => {

--- a/src/lib/components/forms/SubmitButton.svelte
+++ b/src/lib/components/forms/SubmitButton.svelte
@@ -3,13 +3,9 @@ import type { Snippet } from 'svelte';
 import type { ButtonProps } from '$lib/components/ui/button/button.svelte';
 
 export type SubmitButtonProps = Omit<ButtonProps, 'type' | 'children'> & {
-	/** True while the form action is in flight. Disables clicks + flips aria-busy. */
 	submitting?: boolean;
-	/** Optional snippet for the resting button label (overrides default text). */
 	children?: Snippet;
-	/** Optional snippet for the submitting state (overrides "Saving…"). */
 	submittingLabel?: Snippet;
-	/** Plain-text label if no children snippet is supplied. */
 	label?: string;
 };
 </script>

--- a/src/lib/components/onboarding/OnboardingCard.svelte
+++ b/src/lib/components/onboarding/OnboardingCard.svelte
@@ -62,7 +62,7 @@ $effect(() => {
 			width: 100%;
 			max-width: 560px;
 			margin: 0 auto;
-			opacity: 0; /* Start hidden for animation */
+			opacity: 0;
 		}
 
 		.card-glow {

--- a/src/lib/components/onboarding/OnboardingCard.svelte
+++ b/src/lib/components/onboarding/OnboardingCard.svelte
@@ -14,7 +14,6 @@ let { title, subtitle, children, footer, class: className = '' }: Props = $props
 
 let cardRef: HTMLElement | undefined = $state();
 
-// Entrance animation
 $effect(() => {
 	if (!cardRef) return;
 
@@ -66,7 +65,6 @@ $effect(() => {
 			opacity: 0; /* Start hidden for animation */
 		}
 
-		/* Ambient glow effect - uses theme primary color */
 		.card-glow {
 			position: absolute;
 			inset: -1px;
@@ -138,7 +136,6 @@ $effect(() => {
 			background: rgba(0, 0, 0, 0.15);
 		}
 
-		/* Responsive */
 		@media (max-width: 640px) {
 			.onboarding-card {
 				max-width: 100%;

--- a/src/lib/components/onboarding/StepIndicator.svelte
+++ b/src/lib/components/onboarding/StepIndicator.svelte
@@ -89,7 +89,7 @@ $effect(() => {
 			align-items: center;
 			flex: 1;
 			max-width: 140px;
-			opacity: 0; /* Start hidden for animation */
+			opacity: 0;
 		}
 
 		.step-node {
@@ -162,7 +162,7 @@ $effect(() => {
 		.step-connector {
 			position: absolute;
 			left: calc(50% + 18px + 4px); /* Circle center + radius + gap */
-			right: calc(-50% + 18px + 4px); /* Extend to next circle edge */
+			right: calc(-50% + 18px + 4px);
 			top: 50%;
 			transform: translateY(-50%);
 			height: 2px;

--- a/src/lib/components/onboarding/StepIndicator.svelte
+++ b/src/lib/components/onboarding/StepIndicator.svelte
@@ -161,7 +161,7 @@ $effect(() => {
 
 		.step-connector {
 			position: absolute;
-			left: calc(50% + 18px + 4px); /* Circle center + radius + gap */
+			left: calc(50% + 18px + 4px); /* Keep connector lines outside the badge. */
 			right: calc(-50% + 18px + 4px);
 			top: 50%;
 			transform: translateY(-50%);
@@ -223,7 +223,7 @@ $effect(() => {
 			}
 
 			.step-connector {
-				left: calc(50% + 16px + 3px); /* Smaller circle radius + smaller gap */
+				left: calc(50% + 16px + 3px);
 				right: calc(-50% + 16px + 3px);
 			}
 		}

--- a/src/lib/components/onboarding/StepIndicator.svelte
+++ b/src/lib/components/onboarding/StepIndicator.svelte
@@ -161,7 +161,7 @@ $effect(() => {
 
 		.step-connector {
 			position: absolute;
-			left: calc(50% + 18px + 4px); /* Keep connector lines outside the badge. */
+			left: calc(50% + 18px + 4px);
 			right: calc(-50% + 18px + 4px);
 			top: 50%;
 			transform: translateY(-50%);

--- a/src/lib/components/onboarding/StepIndicator.svelte
+++ b/src/lib/components/onboarding/StepIndicator.svelte
@@ -22,7 +22,6 @@ const getStepStatus = (index: number): 'completed' | 'active' | 'pending' => {
 	return 'pending';
 };
 
-// Animate on mount
 $effect(() => {
 	if (!containerRef) return;
 
@@ -116,14 +115,12 @@ $effect(() => {
 			flex-shrink: 0;
 		}
 
-		/* Pending state */
 		.pending .step-circle {
 			background: rgba(255, 255, 255, 0.05);
 			border: 2px solid rgba(255, 255, 255, 0.15);
 			color: rgba(255, 255, 255, 0.4);
 		}
 
-		/* Active state - uses theme primary color */
 		.active .step-circle {
 			background: linear-gradient(135deg, oklch(var(--primary)) 0%, oklch(var(--accent)) 100%);
 			border: 2px solid oklch(var(--primary));
@@ -135,7 +132,6 @@ $effect(() => {
 			animation: pulse-glow 2s ease-in-out infinite;
 		}
 
-		/* Completed state */
 		.completed .step-circle {
 			background: linear-gradient(135deg, oklch(0.7205 0.192 149.49) 0%, oklch(0.5988 0.1576 149.72) 100%);
 			border: 2px solid oklch(0.7794 0.2087 149.41);
@@ -211,7 +207,6 @@ $effect(() => {
 			color: rgba(255, 255, 255, 0.7);
 		}
 
-		/* Responsive */
 		@media (max-width: 480px) {
 			.step-indicator {
 				padding: 0 0.5rem;

--- a/src/lib/components/security/CsrfWarningBanner.svelte
+++ b/src/lib/components/security/CsrfWarningBanner.svelte
@@ -74,7 +74,6 @@ async function handlePermanentDismiss() {
 	</div>
 </div>
 
-<!-- First Confirmation Dialog -->
 <AlertDialog.Root bind:open={showFirstConfirmation}>
 	<AlertDialog.Content class="csrf-dialog">
 		<AlertDialog.Header>
@@ -105,7 +104,6 @@ async function handlePermanentDismiss() {
 	</AlertDialog.Content>
 </AlertDialog.Root>
 
-<!-- Second Confirmation Dialog -->
 <AlertDialog.Root bind:open={showSecondConfirmation}>
 	<AlertDialog.Content class="csrf-dialog">
 		<AlertDialog.Header>

--- a/src/lib/components/slides/BaseSlide.svelte
+++ b/src/lib/components/slides/BaseSlide.svelte
@@ -46,7 +46,6 @@ let { active = true, class: klass = '', variant = 'default', children }: Props =
 		}
 
 		/* Variant styles - all use transparent background, effects from parent */
-		/* Variants can add additional content-level styling if needed */
 
 		/* Highlight variant - adds subtle glow overlay (content-level effect) */
 		.variant-highlight::before {
@@ -66,7 +65,6 @@ let { active = true, class: klass = '', variant = 'default', children }: Props =
 
 		/* Glass variant - no background change, relies on glass containers */
 
-		/* Glass variant applies glass effect to direct content children */
 		.variant-glass > :global(.content),
 		.variant-glass > :global(.slide-content),
 		.variant-glass > :global(.glass-container) {
@@ -83,7 +81,6 @@ let { active = true, class: klass = '', variant = 'default', children }: Props =
 			z-index: 3;
 		}
 
-		/* Glass top highlight line */
 		.variant-glass > :global(.content)::before,
 		.variant-glass > :global(.slide-content)::before,
 		.variant-glass > :global(.glass-container)::before {
@@ -97,7 +94,6 @@ let { active = true, class: klass = '', variant = 'default', children }: Props =
 			border-radius: inherit;
 		}
 
-		/* Mobile: compact padding */
 		@media (max-width: 767px) {
 			.slide {
 				padding: 1.25rem 1rem;
@@ -111,14 +107,12 @@ let { active = true, class: klass = '', variant = 'default', children }: Props =
 			}
 		}
 
-		/* Tablet: medium padding */
 		@media (min-width: 768px) {
 			.slide {
 				padding: 2rem 1.5rem;
 			}
 		}
 
-		/* Desktop: generous padding */
 		@media (min-width: 1024px) {
 			.slide {
 				padding: 2.5rem 2rem;
@@ -131,7 +125,6 @@ let { active = true, class: klass = '', variant = 'default', children }: Props =
 			}
 		}
 
-		/* Ensure content is above background layers */
 		.slide > :global(*) {
 			position: relative;
 			z-index: 3;

--- a/src/lib/components/slides/BaseSlide.svelte
+++ b/src/lib/components/slides/BaseSlide.svelte
@@ -37,17 +37,13 @@ let { active = true, class: klass = '', variant = 'default', children }: Props =
 			overflow: visible;
 		}
 
-		/* Note: Noise and vignette effects are now applied at the StoryMode/ScrollMode level
-		   to ensure seamless full-viewport coverage without visible "card" boundaries */
+		/* StoryMode/ScrollMode own noise and vignette so they cover the full viewport without card seams. */
 
 		.slide:not(.active) {
 			visibility: hidden;
 			position: absolute;
 		}
 
-		/* Variant styles - all use transparent background, effects from parent */
-
-		/* Highlight variant - adds subtle glow overlay (content-level effect) */
 		.variant-highlight::before {
 			content: '';
 			position: absolute;
@@ -60,10 +56,6 @@ let { active = true, class: klass = '', variant = 'default', children }: Props =
 			pointer-events: none;
 			z-index: 0;
 		}
-
-		/* Dark variant - no additional styling needed, uses parent background */
-
-		/* Glass variant - no background change, relies on glass containers */
 
 		.variant-glass > :global(.content),
 		.variant-glass > :global(.slide-content),

--- a/src/lib/components/slides/BingeSlide.svelte
+++ b/src/lib/components/slides/BingeSlide.svelte
@@ -34,20 +34,17 @@ function formatDuration(totalMinutes: number): string {
 	return `${hours}h ${minutes}m`;
 }
 
-// Wall-clock session duration (endTime - startTime)
 const sessionDuration = $derived.by(() => {
 	if (!longestBinge) return '';
 	const sessionMinutes = (longestBinge.endTime - longestBinge.startTime) / 60;
 	return formatDuration(sessionMinutes);
 });
 
-// Total content runtime (sum of episode durations)
 const contentDuration = $derived.by(() => {
 	if (!longestBinge) return '';
 	return formatDuration(longestBinge.totalMinutes);
 });
 
-// Format date
 const bingeDate = $derived.by(() => {
 	if (!longestBinge) return '';
 	const date = new Date(longestBinge.startTime * 1000);
@@ -57,12 +54,10 @@ const bingeDate = $derived.by(() => {
 	});
 });
 
-// Element references
 let container: HTMLElement | undefined = $state();
 let statEl: HTMLElement | undefined = $state();
 let detailsEl: HTMLElement | undefined = $state();
 
-// Animation effect with cleanup
 $effect(() => {
 	if (!container || !active) return;
 
@@ -83,7 +78,6 @@ $effect(() => {
 		return;
 	}
 
-	// Animate container with impactful reveal
 	const containerAnim = animate(
 		container,
 		{ opacity: [0, 1], transform: ['scale(0.95) translateY(20px)', 'scale(1) translateY(0)'] },
@@ -93,7 +87,6 @@ $effect(() => {
 	const animations = [containerAnim];
 
 	if (statEl) {
-		// Stat with bouncy scale animation
 		const statAnim = animate(
 			statEl,
 			{
@@ -207,7 +200,6 @@ $effect(() => {
 			position: relative;
 		}
 
-		/* Top highlight line */
 		.stat-container::before {
 			content: '';
 			position: absolute;
@@ -223,7 +215,6 @@ $effect(() => {
 			font-size: clamp(2.5rem, 8vw, 4rem);
 			font-weight: 800;
 			letter-spacing: -0.02em;
-			/* Gradient text effect */
 			background: linear-gradient(
 				180deg,
 				oklch(var(--primary)) 0%,
@@ -303,7 +294,6 @@ $effect(() => {
 			margin-top: 1.5rem;
 		}
 
-		/* Mobile: compact container */
 		@media (max-width: 767px) {
 			.content {
 				gap: 2rem;
@@ -339,7 +329,6 @@ $effect(() => {
 			}
 		}
 
-		/* Tablet: medium container */
 		@media (min-width: 768px) and (max-width: 1023px) {
 			.title {
 				font-size: 1.75rem;
@@ -374,7 +363,6 @@ $effect(() => {
 			}
 		}
 
-		/* Desktop: large container */
 		@media (min-width: 1024px) {
 			.title {
 				font-size: 2rem;

--- a/src/lib/components/slides/CustomSlide.svelte
+++ b/src/lib/components/slides/CustomSlide.svelte
@@ -19,12 +19,10 @@ let {
 	children
 }: Props = $props();
 
-// Element references
 let container: HTMLElement | undefined = $state();
 let titleEl: HTMLElement | undefined = $state();
 let contentEl: HTMLElement | undefined = $state();
 
-// Animation effect with cleanup
 $effect(() => {
 	if (!container || !active) return;
 
@@ -40,7 +38,6 @@ $effect(() => {
 
 	const animations: ReturnType<typeof animate>[] = [];
 
-	// Animate container with gentle spring
 	const containerAnim = animate(
 		container,
 		{ opacity: [0, 1], transform: ['translateY(20px)', 'translateY(0)'] },
@@ -48,7 +45,6 @@ $effect(() => {
 	);
 	animations.push(containerAnim);
 
-	// Animate title with simple fade
 	if (titleEl) {
 		const titleAnim = animate(
 			titleEl,
@@ -58,7 +54,6 @@ $effect(() => {
 		animations.push(titleAnim);
 	}
 
-	// Animate content with simple fade
 	if (contentEl) {
 		const contentAnim = animate(
 			contentEl,
@@ -135,7 +130,6 @@ $effect(() => {
 			word-break: break-word;
 		}
 
-		/* Markdown styling */
 		.markdown-content :global(h1),
 		.markdown-content :global(h2),
 		.markdown-content :global(h3) {
@@ -228,7 +222,6 @@ $effect(() => {
 			margin-top: 1rem;
 		}
 
-		/* Mobile: compact content */
 		@media (max-width: 767px) {
 			.content {
 				max-width: 100%;
@@ -255,7 +248,6 @@ $effect(() => {
 			}
 		}
 
-		/* Tablet: medium content */
 		@media (min-width: 768px) and (max-width: 1023px) {
 			.content {
 				max-width: var(--content-max-md, 800px);
@@ -283,7 +275,6 @@ $effect(() => {
 			}
 		}
 
-		/* Desktop: wide content */
 		@media (min-width: 1024px) {
 			.content {
 				max-width: var(--content-max-lg, 950px);

--- a/src/lib/components/slides/CustomSlide.svelte
+++ b/src/lib/components/slides/CustomSlide.svelte
@@ -86,7 +86,6 @@ $effect(() => {
 				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 				{@html renderedHtml}
 			{:else}
-				<!-- Fallback: display raw content if no rendered HTML provided -->
 				<p>{content}</p>
 			{/if}
 		</div>

--- a/src/lib/components/slides/DistributionSlide.svelte
+++ b/src/lib/components/slides/DistributionSlide.svelte
@@ -163,7 +163,6 @@ $effect(() => {
 	animations.push(containerAnim);
 
 	if (showDualView) {
-		// Dual view: animate monthly bars first, then hourly with staggered delay
 		const validMonthlyBars = monthlyBars.filter(Boolean);
 		const validHourlyBars = hourlyBars.filter(Boolean);
 		const monthlyStagger = getAdaptiveStagger(validMonthlyBars.length);
@@ -653,10 +652,6 @@ function formatPlays(plays: number): string {
 			margin: 0;
 		}
 
-		/* ==========================================================================
-		   Dual-view styles (tablet/desktop side-by-side charts)
-		   ========================================================================== */
-
 		.content.dual-view {
 			max-width: var(--content-max-xl, 1100px);
 		}
@@ -711,10 +706,6 @@ function formatPlays(plays: number): string {
 			font-size: 0.875rem;
 		}
 
-		/* ==========================================================================
-		   Mobile-only styles (single chart with toggle)
-		   ========================================================================== */
-
 		.mobile-header {
 			display: flex;
 			flex-direction: column;
@@ -762,10 +753,6 @@ function formatPlays(plays: number): string {
 			outline: 2px solid oklch(var(--primary) / 0.5);
 			outline-offset: 2px;
 		}
-
-		/* ==========================================================================
-		   Responsive breakpoints
-		   ========================================================================== */
 
 		@media (max-width: 767px) {
 			.content {

--- a/src/lib/components/slides/DistributionSlide.svelte
+++ b/src/lib/components/slides/DistributionSlide.svelte
@@ -34,7 +34,6 @@ let {
 	messagingContext = createPersonalContext()
 }: Props = $props();
 
-// Viewport detection for responsive dual-view
 let isDesktopViewport = $state(false);
 
 $effect(() => {
@@ -51,29 +50,23 @@ $effect(() => {
 	return () => mediaQuery.removeEventListener('change', handleChange);
 });
 
-// Mobile toggle state - explicit type annotation for union type
 type MobileViewType = 'monthly' | 'hourly';
 let mobileView: MobileViewType = $state<MobileViewType>('monthly');
 
-// Derive whether we have data for both views
 const hasMonthlyData = $derived(watchTimeByMonth.minutes.some((m) => m > 0));
 const hasHourlyData = $derived(watchTimeByHour.minutes.some((m) => m > 0));
 const hasBothData = $derived(hasMonthlyData && hasHourlyData);
 
-// Show dual view on tablet/desktop when both datasets have data
 const showDualView = $derived(
 	isDesktopViewport && hasBothData && view !== 'monthly' && view !== 'hourly'
 );
 
-// Get messaging helpers
 const subject = $derived(getSubject(messagingContext));
 const possessive = $derived(getPossessive(messagingContext));
 const watchVerb = $derived(getWatchVerb(messagingContext));
 
-// Month labels
 const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
-// Full month names for tooltips
 const monthsFull = [
 	'January',
 	'February',
@@ -89,11 +82,9 @@ const monthsFull = [
 	'December'
 ];
 
-// Calculate max values for scaling
 const maxMonthly = $derived(Math.max(...watchTimeByMonth.minutes, 1));
 const maxHourly = $derived(Math.max(...watchTimeByHour.minutes, 1));
 
-// Prepare data with percentages
 const monthlyData = $derived(
 	watchTimeByMonth.minutes.map((minutes, i) => ({
 		label: months[i] ?? '',
@@ -114,13 +105,11 @@ const hourlyData = $derived(
 	}))
 );
 
-// Active dataset based on mobile view selection
 const activeData = $derived(mobileView === 'hourly' ? hourlyData : monthlyData);
 const mobileTitle = $derived(
 	mobileView === 'hourly' ? `When ${subject} Watch` : `${possessive} Year in Months`
 );
 
-// Find peaks for each dataset (independent peak highlighting)
 const monthlyPeakIndex = $derived(
 	monthlyData.reduce((maxIdx, curr, idx, arr) => {
 		const maxItem = arr[maxIdx];
@@ -135,16 +124,13 @@ const hourlyPeakIndex = $derived(
 	}, 0)
 );
 
-// For mobile single view
 const activePeakIndex = $derived(mobileView === 'hourly' ? hourlyPeakIndex : monthlyPeakIndex);
 
-// Element references
 let container: HTMLElement | undefined = $state();
 let monthlyBars: HTMLElement[] = $state([]);
 let hourlyBars: HTMLElement[] = $state([]);
 let singleViewBars: HTMLElement[] = $state([]);
 
-// Animation effect with cleanup
 $effect(() => {
 	if (!container || !active) return;
 
@@ -170,7 +156,6 @@ $effect(() => {
 		return;
 	}
 
-	// Animate container with subtle fade (let bars be the focus)
 	const containerAnim = animate(
 		container,
 		{ opacity: [0, 1] },
@@ -199,7 +184,6 @@ $effect(() => {
 		}
 
 		if (validHourlyBars.length > 0) {
-			// 100ms delay between charts
 			const hourlyAnim = animate(
 				validHourlyBars,
 				{ transform: ['scaleY(0)', 'scaleY(1)'] },
@@ -223,7 +207,6 @@ $effect(() => {
 			}
 		}
 	} else {
-		// Single view: animate all bars with adaptive stagger
 		const validBars = singleViewBars.filter(Boolean);
 		const adaptiveStagger = getAdaptiveStagger(validBars.length);
 
@@ -276,12 +259,10 @@ function formatPlays(plays: number): string {
 <BaseSlide {active} class="distribution-slide {klass}">
 	<div bind:this={container} class="content" class:dual-view={showDualView}>
 		{#if showDualView}
-			<!-- Desktop/Tablet: Side-by-side charts -->
 			<h2 class="title">{possessive} Viewing Patterns</h2>
 
 			<Tooltip.Provider>
 				<div class="charts-grid">
-					<!-- Monthly Chart -->
 					<div class="chart-section">
 						<h3 class="section-title">Year in Months</h3>
 						<div class="chart-container monthly">
@@ -323,7 +304,6 @@ function formatPlays(plays: number): string {
 						{/if}
 					</div>
 
-					<!-- Hourly Chart -->
 					<div class="chart-section">
 						<h3 class="section-title">When {subject} {watchVerb}</h3>
 						<div class="chart-container hourly">
@@ -367,7 +347,6 @@ function formatPlays(plays: number): string {
 				</div>
 			</Tooltip.Provider>
 		{:else}
-			<!-- Mobile: Single chart with toggle -->
 			<div class="mobile-header">
 				<h2 class="title">{mobileTitle}</h2>
 				{#if hasBothData}
@@ -488,7 +467,6 @@ function formatPlays(plays: number): string {
 			position: relative;
 		}
 
-		/* Glass top highlight line */
 		.chart-container::before {
 			content: '';
 			position: absolute;
@@ -645,7 +623,6 @@ function formatPlays(plays: number): string {
 			margin-top: 1rem;
 		}
 
-		/* Tooltip styling - premium glass effect */
 		:global(.tooltip-content) {
 			background: var(--slide-glass-bg) !important;
 			backdrop-filter: blur(12px);
@@ -707,7 +684,6 @@ function formatPlays(plays: number): string {
 			letter-spacing: 0.05em;
 		}
 
-		/* Dual-view chart adjustments */
 		.dual-view .chart-container {
 			height: 180px;
 		}
@@ -792,7 +768,6 @@ function formatPlays(plays: number): string {
 		   Responsive breakpoints
 		   ========================================================================== */
 
-		/* Mobile: compact layout */
 		@media (max-width: 767px) {
 			.content {
 				gap: 1.5rem;
@@ -836,7 +811,6 @@ function formatPlays(plays: number): string {
 			}
 		}
 
-		/* Tablet: stacked dual-view with larger charts */
 		@media (min-width: 768px) {
 			.content {
 				max-width: var(--content-max-md, 800px);
@@ -869,7 +843,6 @@ function formatPlays(plays: number): string {
 			}
 		}
 
-		/* Desktop: side-by-side dual-view */
 		@media (min-width: 1024px) {
 			.content {
 				max-width: var(--content-max-lg, 900px);

--- a/src/lib/components/slides/DistributionSlide.svelte
+++ b/src/lib/components/slides/DistributionSlide.svelte
@@ -137,7 +137,6 @@ $effect(() => {
 	const shouldAnimate = !prefersReducedMotion.current;
 	const animations: { stop: () => void; finished: Promise<void> }[] = [];
 
-	// Helper to set bars visible without animation
 	const setVisible = (bars: HTMLElement[]) => {
 		bars.forEach((el) => {
 			if (el) el.style.transform = 'scaleY(1)';

--- a/src/lib/components/slides/FirstLastSlide.svelte
+++ b/src/lib/components/slides/FirstLastSlide.svelte
@@ -97,7 +97,6 @@ $effect(() => {
 
 	const animations: ReturnType<typeof animate>[] = [];
 
-	// Container: opacity fade only (cards provide motion)
 	const containerAnim = animate(
 		container,
 		{ opacity: [0, 1] },

--- a/src/lib/components/slides/FirstLastSlide.svelte
+++ b/src/lib/components/slides/FirstLastSlide.svelte
@@ -28,7 +28,6 @@ const hasFirst = $derived(firstWatch !== null);
 const hasLast = $derived(lastWatch !== null);
 const hasAny = $derived(hasFirst || hasLast);
 
-// Format dates
 const firstDate = $derived.by(() => {
 	if (!firstWatch) return '';
 	return new Date(firstWatch.viewedAt * 1000).toLocaleDateString('en-US', {
@@ -45,7 +44,6 @@ const lastDate = $derived.by(() => {
 	});
 });
 
-// Format type labels
 const firstTypeLabel = $derived.by(() => {
 	if (!firstWatch) return '';
 	switch (firstWatch.type) {
@@ -74,12 +72,10 @@ const lastTypeLabel = $derived.by(() => {
 	}
 });
 
-// Element references
 let container: HTMLElement | undefined = $state();
 let firstCard: HTMLElement | undefined = $state();
 let lastCard: HTMLElement | undefined = $state();
 
-// Animation effect with cleanup
 $effect(() => {
 	if (!container || !active) return;
 
@@ -109,7 +105,6 @@ $effect(() => {
 	);
 	animations.push(containerAnim);
 
-	// Animate first card from left
 	if (firstCard) {
 		const firstAnim = animate(firstCard, KEYFRAMES.cardFromLeft, {
 			type: 'spring',
@@ -119,7 +114,6 @@ $effect(() => {
 		animations.push(firstAnim);
 	}
 
-	// Animate last card from right
 	if (lastCard) {
 		const lastAnim = animate(lastCard, KEYFRAMES.cardFromRight, {
 			type: 'spring',
@@ -242,7 +236,6 @@ $effect(() => {
 				border-color 0.3s ease;
 		}
 
-		/* Top highlight line */
 		.card::before {
 			content: '';
 			position: absolute;
@@ -341,7 +334,6 @@ $effect(() => {
 			margin-top: 1rem;
 		}
 
-		/* Mobile: stacked cards */
 		@media (max-width: 767px) {
 			.content {
 				gap: 1.5rem;
@@ -374,7 +366,6 @@ $effect(() => {
 			}
 		}
 
-		/* Tablet: side-by-side with medium sizing */
 		@media (min-width: 768px) and (max-width: 1023px) {
 			.content {
 				max-width: var(--content-max-md, 750px);
@@ -408,7 +399,6 @@ $effect(() => {
 			}
 		}
 
-		/* Desktop: large cards with prominent thumbnails */
 		@media (min-width: 1024px) {
 			.content {
 				max-width: var(--content-max-lg, 900px);

--- a/src/lib/components/slides/FunFactSlide.svelte
+++ b/src/lib/components/slides/FunFactSlide.svelte
@@ -22,13 +22,11 @@ let {
 	messagingContext = createPersonalContext()
 }: Props = $props();
 
-// Element references
 let container: HTMLElement | undefined = $state();
 let iconEl: HTMLElement | undefined = $state();
 let factEl: HTMLElement | undefined = $state();
 let comparisonEl: HTMLElement | undefined = $state();
 
-// Animation effect with cleanup
 $effect(() => {
 	if (!container || !factEl || !active) return;
 
@@ -53,14 +51,12 @@ $effect(() => {
 
 	const animations: ReturnType<typeof animate>[] = [];
 
-	// Animate container with playful entry
 	const containerAnim = animate(container, KEYFRAMES.playfulEntry, {
 		type: 'spring',
 		...SPRING_PRESETS.snappy
 	});
 	animations.push(containerAnim);
 
-	// Animate icon with bounce-in
 	if (iconEl) {
 		const iconAnim = animate(
 			iconEl,
@@ -77,7 +73,6 @@ $effect(() => {
 		animations.push(iconAnim);
 	}
 
-	// Animate fact text
 	const factAnim = animate(
 		factEl,
 		{ opacity: [0, 1], transform: ['translateY(25px)', 'translateY(0)'] },
@@ -85,7 +80,6 @@ $effect(() => {
 	);
 	animations.push(factAnim);
 
-	// Animate comparison if present
 	if (comparisonEl && comparison) {
 		const comparisonAnim = animate(
 			comparisonEl,
@@ -154,7 +148,6 @@ $effect(() => {
 			position: relative;
 		}
 
-		/* Top highlight line */
 		.content::before {
 			content: '';
 			position: absolute;
@@ -171,7 +164,6 @@ $effect(() => {
 			line-height: 1;
 			margin-bottom: 0.5rem;
 			filter: drop-shadow(0 0 25px var(--slide-glow-color, oklch(var(--primary) / 0.4)));
-			/* Floating animation */
 			animation: float 3s ease-in-out infinite;
 		}
 
@@ -222,7 +214,6 @@ $effect(() => {
 			margin-top: 1.5rem;
 		}
 
-		/* Mobile: compact content */
 		@media (max-width: 767px) {
 			.content {
 				max-width: 100%;
@@ -243,7 +234,6 @@ $effect(() => {
 			}
 		}
 
-		/* Tablet: medium content */
 		@media (min-width: 768px) and (max-width: 1023px) {
 			.content {
 				max-width: var(--content-max-md, 750px);
@@ -267,7 +257,6 @@ $effect(() => {
 			}
 		}
 
-		/* Desktop: large content */
 		@media (min-width: 1024px) {
 			.content {
 				max-width: var(--content-max-lg, 850px);

--- a/src/lib/components/slides/FunFactSlide.svelte
+++ b/src/lib/components/slides/FunFactSlide.svelte
@@ -177,7 +177,6 @@ $effect(() => {
 			}
 		}
 
-		/* Disable animation for reduced motion preference */
 		@media (prefers-reduced-motion: reduce) {
 			.icon {
 				animation: none;

--- a/src/lib/components/slides/GenresSlide.svelte
+++ b/src/lib/components/slides/GenresSlide.svelte
@@ -123,7 +123,6 @@ $effect(() => {
 			}
 		);
 
-		// Animate bars with dramatic spring and additional per-bar delay
 		if (validBars.length > 0) {
 			const barsAnim = animate(
 				validBars,

--- a/src/lib/components/slides/GenresSlide.svelte
+++ b/src/lib/components/slides/GenresSlide.svelte
@@ -74,12 +74,10 @@ const genresWithPercentage = $derived(
 	}))
 );
 
-// Element references
 let container: HTMLElement | undefined = $state();
 let genreItems: HTMLElement[] = $state([]);
 let bars: HTMLElement[] = $state([]);
 
-// Animation effect with cleanup
 $effect(() => {
 	if (!container || !active || !hasGenres) return;
 
@@ -101,14 +99,12 @@ $effect(() => {
 		return;
 	}
 
-	// Animate container with subtle lift
 	const containerAnim = animate(
 		container,
 		{ opacity: [0, 1], transform: ['translateY(25px) scale(0.98)', 'translateY(0) scale(1)'] },
 		{ type: 'spring', ...SPRING_PRESETS.snappy }
 	);
 
-	// Animate genre items with stagger
 	const validItems = genreItems.filter(Boolean);
 	const validBars = bars.filter(Boolean);
 	const adaptiveStagger = getAdaptiveStagger(validItems.length);
@@ -258,7 +254,6 @@ $effect(() => {
 			position: relative;
 		}
 
-		/* Glass top highlight line */
 		.genre-list::before {
 			content: '';
 			position: absolute;
@@ -290,7 +285,6 @@ $effect(() => {
 			box-shadow: 0 2px 12px oklch(0 0 0 / 0.25);
 		}
 
-		/* First genre gets special treatment */
 		.genre-item.first {
 			border-color: oklch(var(--primary) / 0.25);
 			background: linear-gradient(
@@ -429,7 +423,6 @@ $effect(() => {
 			margin-top: 1rem;
 		}
 
-		/* Tooltip styling - premium glass effect */
 		:global(.tooltip-content) {
 			background: var(--slide-glass-bg) !important;
 			backdrop-filter: blur(12px);
@@ -460,7 +453,6 @@ $effect(() => {
 			margin: 0;
 		}
 
-		/* Mobile: compact layout */
 		@media (max-width: 767px) {
 			.content {
 				gap: 1.5rem;
@@ -504,7 +496,6 @@ $effect(() => {
 			}
 		}
 
-		/* Tablet: medium layout */
 		@media (min-width: 768px) and (max-width: 1023px) {
 			.content {
 				max-width: var(--content-max-md, 700px);
@@ -545,7 +536,6 @@ $effect(() => {
 			}
 		}
 
-		/* Desktop: wide layout */
 		@media (min-width: 1024px) {
 			.content {
 				max-width: var(--content-max-lg, 800px);

--- a/src/lib/components/slides/PercentileSlide.svelte
+++ b/src/lib/components/slides/PercentileSlide.svelte
@@ -23,7 +23,6 @@ let {
 
 const possessive = $derived(getPossessive(messagingContext));
 
-// Compute the "top X%" value
 const topPercentage = $derived(Math.max(1, Math.round(100 - percentileRank)));
 const isTopPerformer = $derived(topPercentage <= 10);
 

--- a/src/lib/components/slides/PercentileSlide.svelte
+++ b/src/lib/components/slides/PercentileSlide.svelte
@@ -27,7 +27,6 @@ const possessive = $derived(getPossessive(messagingContext));
 const topPercentage = $derived(Math.max(1, Math.round(100 - percentileRank)));
 const isTopPerformer = $derived(topPercentage <= 10);
 
-// Generate message based on percentile
 const message = $derived.by(() => {
 	if (topPercentage <= 1) return "You're the #1 viewer!";
 	if (topPercentage <= 5) return "You're in the top 5%!";
@@ -37,12 +36,10 @@ const message = $derived.by(() => {
 	return 'Keep watching!';
 });
 
-// Element references
 let container: HTMLElement | undefined = $state();
 let numberEl: HTMLElement | undefined = $state();
 let messageEl: HTMLElement | undefined = $state();
 
-// Animation effect with cleanup
 $effect(() => {
 	if (!container || !numberEl || !messageEl || !active) return;
 
@@ -61,7 +58,6 @@ $effect(() => {
 
 	const animations: ReturnType<typeof animate>[] = [];
 
-	// Animate container with dramatic center focus
 	const containerAnim = animate(
 		container,
 		{ opacity: [0, 1], transform: ['scale(0.9)', 'scale(1)'] },
@@ -69,7 +65,6 @@ $effect(() => {
 	);
 	animations.push(containerAnim);
 
-	// Animate number with bouncy scale
 	const numberAnim = animate(
 		numberEl,
 		{
@@ -84,7 +79,6 @@ $effect(() => {
 	);
 	animations.push(numberAnim);
 
-	// Animate message with gentle lift
 	const messageAnim = animate(
 		messageEl,
 		{ opacity: [0, 1], transform: ['translateY(20px)', 'translateY(0)'] },
@@ -154,7 +148,6 @@ $effect(() => {
 			letter-spacing: 0.1em;
 		}
 
-		/* Wrapper for gradient ring effect */
 		.stat-wrapper {
 			position: relative;
 			width: 240px;
@@ -166,7 +159,6 @@ $effect(() => {
 			justify-content: center;
 		}
 
-		/* Rotating conic gradient ring */
 		.gradient-ring {
 			position: absolute;
 			inset: 0;
@@ -211,7 +203,6 @@ $effect(() => {
 			}
 		}
 
-		/* Top performer gold gradient */
 		.top-performer .gradient-ring {
 			background: conic-gradient(
 				from 0deg,
@@ -247,7 +238,6 @@ $effect(() => {
 			z-index: 1;
 		}
 
-		/* Glow effect for top performer */
 		.top-performer .stat-container {
 			box-shadow:
 				inset 0 2px 4px oklch(1 0 0 / 0.15),
@@ -268,7 +258,6 @@ $effect(() => {
 			font-size: clamp(3rem, 8vw, 4.5rem);
 			font-weight: 800;
 			letter-spacing: -0.02em;
-			/* Gradient text effect */
 			background: linear-gradient(
 				180deg,
 				oklch(var(--primary)) 0%,
@@ -280,7 +269,6 @@ $effect(() => {
 			filter: drop-shadow(0 0 15px oklch(var(--primary) / 0.4));
 		}
 
-		/* Gold gradient for top performer */
 		.top-performer .percentage {
 			background: linear-gradient(180deg, oklch(0.8309 0.1622 87.87) 0%, oklch(0.7358 0.1599 66.01) 100%);
 			-webkit-background-clip: text;
@@ -300,7 +288,6 @@ $effect(() => {
 			box-shadow: inset 0 1px 0 oklch(1 0 0 / 0.05);
 		}
 
-		/* Gold styling for top performer message */
 		.top-performer ~ .message {
 			background: oklch(0.8153 0.1652 85.67 / 0.12);
 			color: oklch(0.8394 0.1254 91.1);
@@ -321,7 +308,6 @@ $effect(() => {
 			margin-top: 1.5rem;
 		}
 
-		/* Mobile: compact circle */
 		@media (max-width: 767px) {
 			.content {
 				gap: 1.5rem;
@@ -364,7 +350,6 @@ $effect(() => {
 			}
 		}
 
-		/* Tablet: medium circle */
 		@media (min-width: 768px) and (max-width: 1023px) {
 			.title {
 				font-size: 1.75rem;
@@ -392,7 +377,6 @@ $effect(() => {
 			}
 		}
 
-		/* Desktop: large circle */
 		@media (min-width: 1024px) {
 			.content {
 				gap: 2.5rem;

--- a/src/lib/components/slides/PercentileSlide.svelte
+++ b/src/lib/components/slides/PercentileSlide.svelte
@@ -195,7 +195,6 @@ $effect(() => {
 			}
 		}
 
-		/* Disable animation for reduced motion preference */
 		@media (prefers-reduced-motion: reduce) {
 			.gradient-ring.animate-spin {
 				animation: none;

--- a/src/lib/components/slides/TopMoviesSlide.svelte
+++ b/src/lib/components/slides/TopMoviesSlide.svelte
@@ -29,15 +29,12 @@ let {
 
 const possessive = $derived(getPossessive(messagingContext));
 
-// Limit the displayed movies
 const displayedMovies = $derived(topMovies.slice(0, limit));
 const hasMovies = $derived(displayedMovies.length > 0);
 
-// Element references
 let container: HTMLElement | undefined = $state();
 let listItems: HTMLElement[] = $state([]);
 
-// Animation effect with cleanup
 $effect(() => {
 	if (!container || !active || !hasMovies) return;
 
@@ -55,18 +52,15 @@ $effect(() => {
 		return;
 	}
 
-	// Animate container with directional entry from left
 	const containerAnim = animate(container, KEYFRAMES.slideFromLeft, {
 		type: 'spring',
 		...SPRING_PRESETS.snappy
 	});
 
-	// Animate list items with adaptive stagger
 	const validItems = listItems.filter(Boolean);
 	if (validItems.length > 0) {
 		const adaptiveStagger = getAdaptiveStagger(validItems.length);
 
-		// Animate first item with bouncy spring for emphasis
 		const firstItemAnim =
 			validItems[0] &&
 			animate(
@@ -82,7 +76,6 @@ $effect(() => {
 				}
 			);
 
-		// Animate remaining items with listItem spring
 		const remainingItems = validItems.slice(1);
 		const itemsAnim =
 			remainingItems.length > 0 &&
@@ -200,7 +193,6 @@ $effect(() => {
 				border-color 0.3s ease;
 		}
 
-		/* Top highlight line for all items */
 		.movie-item::before {
 			content: '';
 			position: absolute;
@@ -224,7 +216,6 @@ $effect(() => {
 			border-color: oklch(var(--primary) / 0.4);
 		}
 
-		/* First item gets special treatment */
 		.movie-item.first {
 			border-color: oklch(var(--primary) / 0.3);
 			background: linear-gradient(
@@ -311,7 +302,6 @@ $effect(() => {
 			margin-top: 1rem;
 		}
 
-		/* Mobile: compact single column */
 		@media (max-width: 767px) {
 			.content {
 				gap: 1.5rem;
@@ -346,7 +336,6 @@ $effect(() => {
 			}
 		}
 
-		/* Tablet: wider single column */
 		@media (min-width: 768px) and (max-width: 1023px) {
 			.movie-item {
 				padding: 1rem 1.25rem;
@@ -359,7 +348,6 @@ $effect(() => {
 			}
 		}
 
-		/* Desktop: 2-column grid */
 		@media (min-width: 1024px) {
 			.content {
 				max-width: var(--content-max-lg, 900px);

--- a/src/lib/components/slides/TopShowsSlide.svelte
+++ b/src/lib/components/slides/TopShowsSlide.svelte
@@ -32,11 +32,9 @@ const possessive = $derived(getPossessive(messagingContext));
 const displayedShows = $derived(topShows.slice(0, limit));
 const hasShows = $derived(displayedShows.length > 0);
 
-// Element references
 let container: HTMLElement | undefined = $state();
 let listItems: HTMLElement[] = $state([]);
 
-// Animation effect with cleanup
 $effect(() => {
 	if (!container || !active || !hasShows) return;
 
@@ -54,18 +52,15 @@ $effect(() => {
 		return;
 	}
 
-	// Animate container with directional entry from left
 	const containerAnim = animate(container, KEYFRAMES.slideFromLeft, {
 		type: 'spring',
 		...SPRING_PRESETS.snappy
 	});
 
-	// Animate list items with adaptive stagger
 	const validItems = listItems.filter(Boolean);
 	if (validItems.length > 0) {
 		const adaptiveStagger = getAdaptiveStagger(validItems.length);
 
-		// Animate first item with bouncy spring for emphasis
 		const firstItemAnim =
 			validItems[0] &&
 			animate(
@@ -81,7 +76,6 @@ $effect(() => {
 				}
 			);
 
-		// Animate remaining items with listItem spring
 		const remainingItems = validItems.slice(1);
 		const itemsAnim =
 			remainingItems.length > 0 &&
@@ -201,7 +195,6 @@ $effect(() => {
 				border-color 0.3s ease;
 		}
 
-		/* Top highlight line for all items */
 		.show-item::before {
 			content: '';
 			position: absolute;
@@ -225,7 +218,6 @@ $effect(() => {
 			border-color: oklch(var(--primary) / 0.4);
 		}
 
-		/* First item gets special treatment */
 		.show-item.first {
 			border-color: oklch(var(--primary) / 0.3);
 			background: linear-gradient(
@@ -312,7 +304,6 @@ $effect(() => {
 			margin-top: 1rem;
 		}
 
-		/* Mobile: compact single column */
 		@media (max-width: 767px) {
 			.content {
 				gap: 1.5rem;
@@ -347,7 +338,6 @@ $effect(() => {
 			}
 		}
 
-		/* Tablet: wider single column */
 		@media (min-width: 768px) and (max-width: 1023px) {
 			.show-item {
 				padding: 1rem 1.25rem;
@@ -360,7 +350,6 @@ $effect(() => {
 			}
 		}
 
-		/* Desktop: 2-column grid */
 		@media (min-width: 1024px) {
 			.content {
 				max-width: var(--content-max-lg, 900px);

--- a/src/lib/components/slides/TopViewersSlide.svelte
+++ b/src/lib/components/slides/TopViewersSlide.svelte
@@ -28,7 +28,6 @@ const medalColors = {
 const displayedViewers = $derived(topViewers.slice(0, limit));
 const hasViewers = $derived(displayedViewers.length > 0);
 
-// Element references
 let container: HTMLElement | undefined = $state();
 let listItems: HTMLElement[] = $state([]);
 
@@ -70,7 +69,6 @@ function formatWatchTimeDetailed(minutes: number): string {
 	return `${days}d ${remainingHours}h`;
 }
 
-// Animation effect with cleanup
 $effect(() => {
 	if (!container || !active || !hasViewers) return;
 
@@ -90,19 +88,16 @@ $effect(() => {
 
 	const animations: ReturnType<typeof animate>[] = [];
 
-	// Animate container with directional entry from left
 	const containerAnim = animate(container, KEYFRAMES.slideFromLeft, {
 		type: 'spring',
 		...SPRING_PRESETS.snappy
 	});
 	animations.push(containerAnim);
 
-	// Animate list items with adaptive stagger
 	const validItems = listItems.filter(Boolean);
 	if (validItems.length > 0) {
 		const adaptiveStagger = getAdaptiveStagger(validItems.length);
 
-		// Animate first item with bouncy spring for emphasis
 		const firstItemAnim =
 			validItems[0] &&
 			animate(
@@ -119,7 +114,6 @@ $effect(() => {
 			);
 		if (firstItemAnim) animations.push(firstItemAnim);
 
-		// Animate remaining items with listItem spring
 		const remainingItems = validItems.slice(1);
 		const itemsAnim =
 			remainingItems.length > 0 &&
@@ -267,7 +261,6 @@ $effect(() => {
 				border-color 0.3s ease;
 		}
 
-		/* Top highlight line */
 		.viewer-item::before {
 			content: '';
 			position: absolute;
@@ -293,7 +286,6 @@ $effect(() => {
 			opacity: 1;
 		}
 
-		/* Top 3 special styling */
 		.viewer-item.top-three {
 			background: var(--slide-glass-bg);
 			border-color: oklch(var(--primary) / 0.25);
@@ -333,7 +325,6 @@ $effect(() => {
 			text-align: center;
 		}
 
-		/* Medal badge for top 3 */
 		.medal-badge {
 			width: 40px;
 			height: 40px;
@@ -439,7 +430,6 @@ $effect(() => {
 			margin-top: 1.5rem;
 		}
 
-		/* Mobile: compact single column */
 		@media (max-width: 767px) {
 			.content {
 				gap: 1.5rem;
@@ -487,7 +477,6 @@ $effect(() => {
 			}
 		}
 
-		/* Tablet: wider single column */
 		@media (min-width: 768px) and (max-width: 1023px) {
 			.content {
 				max-width: var(--content-max-md, 750px);
@@ -522,7 +511,6 @@ $effect(() => {
 			}
 		}
 
-		/* Desktop: 2-column grid */
 		@media (min-width: 1024px) {
 			.content {
 				max-width: var(--content-max-lg, 900px);

--- a/src/lib/components/slides/TopViewersSlide.svelte
+++ b/src/lib/components/slides/TopViewersSlide.svelte
@@ -20,9 +20,9 @@ let {
 }: TopViewersSlideProps = $props();
 
 const medalColors = {
-	1: { bg: 'oklch(0.8153 0.1652 85.67)', glow: 'oklch(0.8153 0.1652 85.67 / 0.4)' }, // Gold
-	2: { bg: 'oklch(0.7615 0.0139 248.01)', glow: 'oklch(0.7615 0.0139 248.01 / 0.4)' }, // Silver
-	3: { bg: 'oklch(0.6165 0.1196 61.92)', glow: 'oklch(0.6165 0.1196 61.92 / 0.4)' } // Bronze
+	1: { bg: 'oklch(0.8153 0.1652 85.67)', glow: 'oklch(0.8153 0.1652 85.67 / 0.4)' },
+	2: { bg: 'oklch(0.7615 0.0139 248.01)', glow: 'oklch(0.7615 0.0139 248.01 / 0.4)' },
+	3: { bg: 'oklch(0.6165 0.1196 61.92)', glow: 'oklch(0.6165 0.1196 61.92 / 0.4)' }
 } as const;
 
 const displayedViewers = $derived(topViewers.slice(0, limit));

--- a/src/lib/components/slides/TotalTimeSlide.svelte
+++ b/src/lib/components/slides/TotalTimeSlide.svelte
@@ -36,7 +36,8 @@ const weeks = $derived(Number((totalWatchTimeMinutes / 60 / 24 / 7).toFixed(1)))
 
 let displayedHours = $state(0);
 
-// Separate number and unit to prevent layout jitter during animation
+// Keep the unit outside the animated number so changing digit widths do not
+// shift the label during the count-up.
 const formattedValue = $derived.by(() => {
 	if (totalWatchTimeMinutes < 60) {
 		return `${Math.round(totalWatchTimeMinutes)}`;
@@ -80,7 +81,8 @@ $effect(() => {
 		return;
 	}
 
-	// Update DOM directly to avoid triggering Svelte reactivity ~60 times/second
+	// Keep the ~60fps count-up out of Svelte's reactive graph; only publish the
+	// final value once the animation settles.
 	const stopNumberAnim =
 		hours >= 24
 			? (() => {

--- a/src/lib/components/slides/TotalTimeSlide.svelte
+++ b/src/lib/components/slides/TotalTimeSlide.svelte
@@ -29,13 +29,11 @@ let {
 
 const subject = $derived(getSubject(messagingContext));
 
-// Derived computed values
 const hours = $derived(formatWatchHours(totalWatchTimeMinutes));
 const minutes = $derived(Math.round(totalWatchTimeMinutes % 60));
 const days = $derived(Number((totalWatchTimeMinutes / 60 / 24).toFixed(1)));
 const weeks = $derived(Number((totalWatchTimeMinutes / 60 / 24 / 7).toFixed(1)));
 
-// State for animated number display
 let displayedHours = $state(0);
 
 // Separate number and unit to prevent layout jitter during animation
@@ -61,13 +59,11 @@ const comparisonText = $derived.by(() => {
 	return `That's ${hours} ${hours === 1 ? 'hour' : 'hours'} of entertainment!`;
 });
 
-// Element references for animation
 let container: HTMLElement | undefined = $state();
 let numberEl: HTMLElement | undefined = $state();
 let valueEl: HTMLElement | undefined = $state();
 let subtitleEl: HTMLElement | undefined = $state();
 
-// Animation effect with cleanup
 $effect(() => {
 	if (!container || !numberEl || !valueEl || !subtitleEl || !active) return;
 
@@ -86,7 +82,6 @@ $effect(() => {
 		return;
 	}
 
-	// Start number animation (odometer effect)
 	// Update DOM directly to avoid triggering Svelte reactivity ~60 times/second
 	const stopNumberAnim =
 		hours >= 24
@@ -105,7 +100,6 @@ $effect(() => {
 					return () => {};
 				})();
 
-	// Animate container with zoom-in effect
 	const containerAnim = animate(container, KEYFRAMES.zoomFadeIn, {
 		type: 'spring',
 		...SPRING_PRESETS.snappy
@@ -125,7 +119,6 @@ $effect(() => {
 		}
 	);
 
-	// Animate subtitle with gentle fade-up
 	const subtitleAnim = animate(
 		subtitleEl,
 		{ opacity: [0, 1], transform: ['translateY(15px)', 'translateY(0)'] },
@@ -136,12 +129,10 @@ $effect(() => {
 		}
 	);
 
-	// Call completion callback
 	subtitleAnim.finished.then(() => {
 		onAnimationComplete?.();
 	});
 
-	// Cleanup function
 	return () => {
 		containerAnim.stop();
 		numberAnim.stop();
@@ -242,7 +233,6 @@ $effect(() => {
 			margin-top: 2rem;
 		}
 
-		/* Mobile: compact typography */
 		@media (max-width: 767px) {
 			.content {
 				gap: 1.25rem;
@@ -269,7 +259,6 @@ $effect(() => {
 			}
 		}
 
-		/* Tablet: medium typography */
 		@media (min-width: 768px) and (max-width: 1023px) {
 			.title {
 				font-size: 1.125rem;
@@ -288,7 +277,6 @@ $effect(() => {
 			}
 		}
 
-		/* Desktop: large typography with enhanced glow */
 		@media (min-width: 1024px) {
 			.content {
 				gap: 2rem;

--- a/src/lib/components/slides/TotalTimeSlide.svelte
+++ b/src/lib/components/slides/TotalTimeSlide.svelte
@@ -103,7 +103,6 @@ $effect(() => {
 		...SPRING_PRESETS.snappy
 	});
 
-	// Animate number with impactful scale (more pronounced overshoot)
 	const numberAnim = animate(
 		numberEl,
 		{

--- a/src/lib/components/slides/TotalTimeSlide.svelte
+++ b/src/lib/components/slides/TotalTimeSlide.svelte
@@ -67,11 +67,9 @@ let subtitleEl: HTMLElement | undefined = $state();
 $effect(() => {
 	if (!container || !numberEl || !valueEl || !subtitleEl || !active) return;
 
-	// Check reduced motion preference
 	const shouldAnimate = !prefersReducedMotion.current;
 
 	if (!shouldAnimate) {
-		// Instant display for reduced motion
 		container.style.opacity = '1';
 		container.style.transform = 'none';
 		numberEl.style.opacity = '1';

--- a/src/lib/components/slides/WeekdayPatternsSlide.svelte
+++ b/src/lib/components/slides/WeekdayPatternsSlide.svelte
@@ -30,8 +30,7 @@ const WEEKDAY_FULL_NAMES = [
 	'Saturday'
 ];
 
-// Display order: Monday-first (Mon, Tue, Wed, Thu, Fri, Sat, Sun)
-// Maps display position to original data index (where 0=Sunday in JS getDay())
+// UI copy is Monday-first, while the stats array follows JavaScript's Sunday-first getDay().
 const DISPLAY_ORDER = [1, 2, 3, 4, 5, 6, 0] as const;
 const DISPLAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 

--- a/src/lib/components/ui/accordion/index.ts
+++ b/src/lib/components/ui/accordion/index.ts
@@ -9,7 +9,6 @@ export {
 	Item,
 	Item as AccordionItem,
 	Root,
-	//
 	Root as Accordion,
 	Trigger,
 	Trigger as AccordionTrigger

--- a/src/lib/components/ui/alert-dialog/index.ts
+++ b/src/lib/components/ui/alert-dialog/index.ts
@@ -31,7 +31,6 @@ export {
 	Portal,
 	Portal as AlertDialogPortal,
 	Root,
-	//
 	Root as AlertDialog,
 	Title,
 	Title as AlertDialogTitle,

--- a/src/lib/components/ui/alert/index.ts
+++ b/src/lib/components/ui/alert/index.ts
@@ -11,7 +11,6 @@ export {
 	Description,
 	Description as AlertDescription,
 	Root,
-	//
 	Root as Alert,
 	Title,
 	Title as AlertTitle

--- a/src/lib/components/ui/breadcrumb/index.ts
+++ b/src/lib/components/ui/breadcrumb/index.ts
@@ -18,7 +18,6 @@ export {
 	Page,
 	Page as BreadcrumbPage,
 	Root,
-	//
 	Root as Breadcrumb,
 	Separator,
 	Separator as BreadcrumbSeparator

--- a/src/lib/components/ui/button/index.ts
+++ b/src/lib/components/ui/button/index.ts
@@ -12,6 +12,5 @@ export {
 	type ButtonVariant,
 	buttonVariants,
 	Root,
-	//
 	Root as Button
 };

--- a/src/lib/components/ui/card/index.ts
+++ b/src/lib/components/ui/card/index.ts
@@ -18,7 +18,6 @@ export {
 	Header,
 	Header as CardHeader,
 	Root,
-	//
 	Root as Card,
 	Title,
 	Title as CardTitle

--- a/src/lib/components/ui/checkbox/index.ts
+++ b/src/lib/components/ui/checkbox/index.ts
@@ -1,7 +1,3 @@
 import Root from './checkbox.svelte';
 
-export {
-	Root,
-	//
-	Root as Checkbox
-};
+export { Root, Root as Checkbox };

--- a/src/lib/components/ui/collapsible/index.ts
+++ b/src/lib/components/ui/collapsible/index.ts
@@ -6,7 +6,6 @@ export {
 	Content,
 	Content as CollapsibleContent,
 	Root,
-	//
 	Root as Collapsible,
 	Trigger,
 	Trigger as CollapsibleTrigger

--- a/src/lib/components/ui/command/index.ts
+++ b/src/lib/components/ui/command/index.ts
@@ -28,7 +28,6 @@ export {
 	Loading,
 	Loading as CommandLoading,
 	Root,
-	//
 	Root as Command,
 	Separator,
 	Separator as CommandSeparator,

--- a/src/lib/components/ui/context-menu/index.ts
+++ b/src/lib/components/ui/context-menu/index.ts
@@ -35,7 +35,6 @@ export {
 	RadioItem,
 	RadioItem as ContextMenuRadioItem,
 	Root,
-	//
 	Root as ContextMenu,
 	Separator,
 	Separator as ContextMenuSeparator,

--- a/src/lib/components/ui/dialog/index.ts
+++ b/src/lib/components/ui/dialog/index.ts
@@ -25,7 +25,6 @@ export {
 	Portal,
 	Portal as DialogPortal,
 	Root,
-	//
 	Root as Dialog,
 	Title,
 	Title as DialogTitle,

--- a/src/lib/components/ui/form/index.ts
+++ b/src/lib/components/ui/form/index.ts
@@ -20,7 +20,6 @@ export {
 	ElementField,
 	ElementField as FormElementField,
 	Field,
-	//
 	Field as FormField,
 	FieldErrors,
 	FieldErrors as FormFieldErrors,

--- a/src/lib/components/ui/input-group/index.ts
+++ b/src/lib/components/ui/input-group/index.ts
@@ -13,7 +13,6 @@ export {
 	Input,
 	Input as InputGroupInput,
 	Root,
-	//
 	Root as InputGroup,
 	Text,
 	Text as InputGroupText,

--- a/src/lib/components/ui/input/index.ts
+++ b/src/lib/components/ui/input/index.ts
@@ -1,7 +1,3 @@
 import Root from './input.svelte';
 
-export {
-	Root,
-	//
-	Root as Input
-};
+export { Root, Root as Input };

--- a/src/lib/components/ui/label/index.ts
+++ b/src/lib/components/ui/label/index.ts
@@ -1,7 +1,3 @@
 import Root from './label.svelte';
 
-export {
-	Root,
-	//
-	Root as Label
-};
+export { Root, Root as Label };

--- a/src/lib/components/ui/menubar/index.ts
+++ b/src/lib/components/ui/menubar/index.ts
@@ -38,7 +38,6 @@ export {
 	RadioItem,
 	RadioItem as MenubarRadioItem,
 	Root,
-	//
 	Root as Menubar,
 	Separator,
 	Separator as MenubarSeparator,

--- a/src/lib/components/ui/popover/index.ts
+++ b/src/lib/components/ui/popover/index.ts
@@ -19,7 +19,6 @@ export {
 	Portal,
 	Portal as PopoverPortal,
 	Root,
-	//
 	Root as Popover,
 	Title,
 	Title as PopoverTitle,

--- a/src/lib/components/ui/progress/index.ts
+++ b/src/lib/components/ui/progress/index.ts
@@ -1,7 +1,3 @@
 import Root from './progress.svelte';
 
-export {
-	Root,
-	//
-	Root as Progress
-};
+export { Root, Root as Progress };

--- a/src/lib/components/ui/radio-group/index.ts
+++ b/src/lib/components/ui/radio-group/index.ts
@@ -1,10 +1,4 @@
 import Root from './radio-group.svelte';
 import Item from './radio-group-item.svelte';
 
-export {
-	Item,
-	Item as RadioGroupItem,
-	Root,
-	//
-	Root as RadioGroup
-};
+export { Item, Item as RadioGroupItem, Root, Root as RadioGroup };

--- a/src/lib/components/ui/scroll-area/index.ts
+++ b/src/lib/components/ui/scroll-area/index.ts
@@ -1,10 +1,4 @@
 import Root from './scroll-area.svelte';
 import Scrollbar from './scroll-area-scrollbar.svelte';
 
-export {
-	Root,
-	//,
-	Root as ScrollArea,
-	Scrollbar,
-	Scrollbar as ScrollAreaScrollbar
-};
+export { Root, Root as ScrollArea, Scrollbar, Scrollbar as ScrollAreaScrollbar };

--- a/src/lib/components/ui/select/index.ts
+++ b/src/lib/components/ui/select/index.ts
@@ -24,7 +24,6 @@ export {
 	Portal,
 	Portal as SelectPortal,
 	Root,
-	//
 	Root as Select,
 	ScrollDownButton,
 	ScrollDownButton as SelectScrollDownButton,

--- a/src/lib/components/ui/separator/index.ts
+++ b/src/lib/components/ui/separator/index.ts
@@ -1,7 +1,3 @@
 import Root from './separator.svelte';
 
-export {
-	Root,
-	//
-	Root as Separator
-};
+export { Root, Root as Separator };

--- a/src/lib/components/ui/separator/separator.svelte
+++ b/src/lib/components/ui/separator/separator.svelte
@@ -15,7 +15,7 @@ let {
 	data-slot={dataSlot}
 	class={cn(
 		"bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px",
-		// this is different in shadcn/ui but self-stretch breaks things for us
+		// The upstream self-stretch class collapses in Obzorarr's vertical layouts.
 		"data-[orientation=vertical]:h-full",
 		className
 	)}

--- a/src/lib/components/ui/sheet/index.ts
+++ b/src/lib/components/ui/sheet/index.ts
@@ -25,7 +25,6 @@ export {
 	Portal,
 	Portal as SheetPortal,
 	Root,
-	//
 	Root as Sheet,
 	Title,
 	Title as SheetTitle,

--- a/src/lib/components/ui/sidebar/context.svelte.ts
+++ b/src/lib/components/ui/sidebar/context.svelte.ts
@@ -59,6 +59,10 @@ class SidebarState {
 
 const SYMBOL_KEY = 'scn-sidebar';
 
+/**
+ * Keeps `Sidebar.Provider` as the single writer for `bind:open` while exposing
+ * the same state object to nested sidebar primitives through Svelte context.
+ */
 export function setSidebar(props: SidebarStateProps): SidebarState {
 	return setContext(Symbol.for(SYMBOL_KEY), new SidebarState(props));
 }

--- a/src/lib/components/ui/sidebar/context.svelte.ts
+++ b/src/lib/components/ui/sidebar/context.svelte.ts
@@ -34,12 +34,11 @@ class SidebarState {
 		this.props = props;
 	}
 
-	// without this, we would need to use `sidebar.isMobile.current` everywhere
+	// Keep consumers from depending on the internal IsMobile rune wrapper.
 	get isMobile() {
 		return this.#isMobile.current;
 	}
 
-	// Event handler to apply to the `<svelte:window>`
 	handleShortcutKeydown = (e: KeyboardEvent) => {
 		if (e.key === SIDEBAR_KEYBOARD_SHORTCUT && (e.metaKey || e.ctrlKey)) {
 			e.preventDefault();

--- a/src/lib/components/ui/sidebar/context.svelte.ts
+++ b/src/lib/components/ui/sidebar/context.svelte.ts
@@ -34,7 +34,6 @@ class SidebarState {
 		this.props = props;
 	}
 
-	// Convenience getter for checking if the sidebar is mobile
 	// without this, we would need to use `sidebar.isMobile.current` everywhere
 	get isMobile() {
 		return this.#isMobile.current;

--- a/src/lib/components/ui/sidebar/context.svelte.ts
+++ b/src/lib/components/ui/sidebar/context.svelte.ts
@@ -6,16 +6,14 @@ type Getter<T> = () => T;
 
 export type SidebarStateProps = {
 	/**
-	 * A getter function that returns the current open state of the sidebar.
-	 * We use a getter function here to support `bind:open` on the `Sidebar.Provider`
-	 * component.
+	 * Getter-backed so `Sidebar.Provider` can support `bind:open` without
+	 * letting child components own the source of truth.
 	 */
 	open: Getter<boolean>;
 
 	/**
-	 * A function that sets the open state of the sidebar. To support `bind:open`, we need
-	 * a source of truth for changing the open state to ensure it will be synced throughout
-	 * the sub-components and any `bind:` references.
+	 * Setter paired with {@link open}; keeping writes routed through the provider
+	 * keeps nested sidebar pieces and any external `bind:` reference in sync.
 	 */
 	setOpen: (open: boolean) => void;
 };
@@ -34,7 +32,7 @@ class SidebarState {
 		this.props = props;
 	}
 
-	// Keep consumers from depending on the internal IsMobile rune wrapper.
+	// Expose only the boolean so consumers cannot depend on the internal IsMobile rune wrapper.
 	get isMobile() {
 		return this.#isMobile.current;
 	}
@@ -61,20 +59,13 @@ class SidebarState {
 
 const SYMBOL_KEY = 'scn-sidebar';
 
-/**
- * Instantiates a new `SidebarState` instance and sets it in the context.
- *
- * @param props The constructor props for the `SidebarState` class.
- * @returns  The `SidebarState` instance.
- */
 export function setSidebar(props: SidebarStateProps): SidebarState {
 	return setContext(Symbol.for(SYMBOL_KEY), new SidebarState(props));
 }
 
 /**
- * Retrieves the `SidebarState` instance from the context. This is a class instance,
- * so you cannot destructure it.
- * @returns The `SidebarState` instance.
+ * Returns a class instance; do not destructure it, or Svelte will lose access
+ * to the reactive getters on the prototype.
  */
 export function useSidebar(): SidebarState {
 	return getContext(Symbol.for(SYMBOL_KEY));

--- a/src/lib/components/ui/sidebar/index.ts
+++ b/src/lib/components/ui/sidebar/index.ts
@@ -65,7 +65,6 @@ export {
 	Rail,
 	Rail as SidebarRail,
 	Root,
-	//
 	Root as Sidebar,
 	Separator,
 	Separator as SidebarSeparator,

--- a/src/lib/components/ui/sidebar/sidebar-menu-skeleton.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-menu-skeleton.svelte
@@ -13,7 +13,6 @@ let {
 	showIcon?: boolean;
 } = $props();
 
-// Random width between 50% and 90%
 const width = `${Math.floor(Math.random() * 40) + 50}%`;
 </script>
 

--- a/src/lib/components/ui/sidebar/sidebar-provider.svelte
+++ b/src/lib/components/ui/sidebar/sidebar-provider.svelte
@@ -29,7 +29,6 @@ const sidebar = setSidebar({
 		open = value;
 		onOpenChange(value);
 
-		// This sets the cookie to keep the sidebar state.
 		// biome-ignore lint/suspicious/noDocumentCookie: shadcn-svelte sidebar primitive persists open/closed state directly via document.cookie; Cookie Store API is async + not Safari-stable
 		document.cookie = `${SIDEBAR_COOKIE_NAME}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
 	}

--- a/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/src/lib/components/ui/sidebar/sidebar.svelte
@@ -69,7 +69,6 @@ const sidebar = useSidebar();
 		data-side={side}
 		data-slot="sidebar"
 	>
-		<!-- This is what handles the sidebar gap on desktop -->
 		<div
 			data-slot="sidebar-gap"
 			class={cn(
@@ -88,7 +87,6 @@ const sidebar = useSidebar();
 				side === "left"
 					? "start-0 group-data-[collapsible=offcanvas]:start-[calc(var(--sidebar-width)*-1)]"
 					: "end-0 group-data-[collapsible=offcanvas]:end-[calc(var(--sidebar-width)*-1)]",
-				// Adjust the padding for floating and inset variants.
 				variant === "floating" || variant === "inset"
 					? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
 					: "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-e group-data-[side=right]:border-s",

--- a/src/lib/components/ui/skeleton/index.ts
+++ b/src/lib/components/ui/skeleton/index.ts
@@ -1,7 +1,3 @@
 import Root from './skeleton.svelte';
 
-export {
-	Root,
-	//
-	Root as Skeleton
-};
+export { Root, Root as Skeleton };

--- a/src/lib/components/ui/switch/index.ts
+++ b/src/lib/components/ui/switch/index.ts
@@ -1,7 +1,3 @@
 import Root from './switch.svelte';
 
-export {
-	Root,
-	//
-	Root as Switch
-};
+export { Root, Root as Switch };

--- a/src/lib/components/ui/table/index.ts
+++ b/src/lib/components/ui/table/index.ts
@@ -21,7 +21,6 @@ export {
 	Header,
 	Header as TableHeader,
 	Root,
-	//
 	Root as Table,
 	Row,
 	Row as TableRow

--- a/src/lib/components/ui/tabs/index.ts
+++ b/src/lib/components/ui/tabs/index.ts
@@ -9,7 +9,6 @@ export {
 	List,
 	List as TabsList,
 	Root,
-	//
 	Root as Tabs,
 	type TabsListVariant,
 	Trigger,

--- a/src/lib/components/ui/textarea/index.ts
+++ b/src/lib/components/ui/textarea/index.ts
@@ -1,7 +1,3 @@
 import Root from './textarea.svelte';
 
-export {
-	Root,
-	//
-	Root as Textarea
-};
+export { Root, Root as Textarea };

--- a/src/lib/components/ui/toggle-group/index.ts
+++ b/src/lib/components/ui/toggle-group/index.ts
@@ -1,10 +1,4 @@
 import Root from './toggle-group.svelte';
 import Item from './toggle-group-item.svelte';
 
-export {
-	Item,
-	Item as ToggleGroupItem,
-	Root,
-	//
-	Root as ToggleGroup
-};
+export { Item, Item as ToggleGroupItem, Root, Root as ToggleGroup };

--- a/src/lib/components/ui/toggle-group/toggle-group.svelte
+++ b/src/lib/components/ui/toggle-group/toggle-group.svelte
@@ -54,10 +54,10 @@ export function getToggleGroupCtx() {
 	});
 </script>
 
-<!--
-Discriminated Unions + Destructing (required for bindable) do not
-get along, so we shut typescript up by casting `value` to `never`.
--->
+	<!--
+	Bits UI's discriminated union type does not compose with Svelte's
+	bindable destructuring here, so the bind target is narrowed manually.
+	-->
 <ToggleGroupPrimitive.Root
 	bind:value={value as never}
 	bind:ref

--- a/src/lib/components/ui/toggle/index.ts
+++ b/src/lib/components/ui/toggle/index.ts
@@ -7,8 +7,4 @@ export {
 	toggleVariants
 } from './toggle.svelte';
 
-export {
-	Root,
-	//
-	Root as Toggle
-};
+export { Root, Root as Toggle };

--- a/src/lib/components/ui/tooltip/index.ts
+++ b/src/lib/components/ui/tooltip/index.ts
@@ -12,7 +12,6 @@ export {
 	Provider,
 	Provider as TooltipProvider,
 	Root,
-	//
 	Root as Tooltip,
 	Trigger,
 	Trigger as TooltipTrigger

--- a/src/lib/components/wrapped/ModeToggle.svelte
+++ b/src/lib/components/wrapped/ModeToggle.svelte
@@ -2,7 +2,6 @@
 type ViewMode = 'story' | 'scroll';
 
 interface Props {
-	/** Current view mode */
 	mode: ViewMode;
 	/** Callback when mode changes */
 	onModeChange: (newMode: ViewMode) => void;

--- a/src/lib/components/wrapped/ModeToggle.svelte
+++ b/src/lib/components/wrapped/ModeToggle.svelte
@@ -3,9 +3,7 @@ type ViewMode = 'story' | 'scroll';
 
 interface Props {
 	mode: ViewMode;
-	/** Callback when mode changes */
 	onModeChange: (newMode: ViewMode) => void;
-	/** Additional CSS classes */
 	class?: string;
 }
 

--- a/src/lib/components/wrapped/ProgressBar.svelte
+++ b/src/lib/components/wrapped/ProgressBar.svelte
@@ -2,7 +2,6 @@
 interface Props {
 	current: number;
 	total: number;
-	/** Additional CSS classes */
 	class?: string;
 }
 

--- a/src/lib/components/wrapped/ProgressBar.svelte
+++ b/src/lib/components/wrapped/ProgressBar.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 interface Props {
-	/** Current slide index (0-based) */
 	current: number;
-	/** Total number of slides */
 	total: number;
 	/** Additional CSS classes */
 	class?: string;

--- a/src/lib/components/wrapped/ScrollMode.svelte
+++ b/src/lib/components/wrapped/ScrollMode.svelte
@@ -224,7 +224,7 @@ function handleKeyDown(event: KeyboardEvent): void {
 		.scroll-content {
 			padding-bottom: 50vh;
 			position: relative;
-			z-index: 1; /* Above noise and vignette layers */
+			z-index: 1;
 		}
 
 		.scroll-section {
@@ -360,7 +360,6 @@ function handleKeyDown(event: KeyboardEvent): void {
 			}
 		}
 
-		/* Reduced motion - instant visibility */
 		@media (prefers-reduced-motion: reduce) {
 			.slide-content {
 				opacity: 1 !important;

--- a/src/lib/components/wrapped/ScrollMode.svelte
+++ b/src/lib/components/wrapped/ScrollMode.svelte
@@ -144,7 +144,6 @@ function handleKeyDown(event: KeyboardEvent): void {
 <svelte:window onkeydown={handleKeyDown} />
 
 <div bind:this={container} class="scroll-mode {klass}" role="main" aria-label="Wrapped statistics">
-	<!-- Scrollable content -->
 	<div class="scroll-content">
 		{#each enabledSlides as slide, index (`${slide.type}-${index}`)}
 			<section
@@ -160,12 +159,10 @@ function handleKeyDown(event: KeyboardEvent): void {
 		{/each}
 	</div>
 
-	<!-- Scroll progress indicator -->
 	<div class="scroll-progress" aria-hidden="true">
 		<span class="progress-text">{visibleSectionIndex + 1} / {totalSlides}</span>
 	</div>
 
-	<!-- Close button (if onClose provided) -->
 	{#if onClose}
 		<button
 			type="button"
@@ -195,13 +192,11 @@ function handleKeyDown(event: KeyboardEvent): void {
 					oklch(var(--slide-bg-end)) 100%
 				)
 			);
-			/* Fix background to viewport for seamless scrolling */
 			background-attachment: fixed;
 			color: var(--foreground, white);
 			position: relative;
 		}
 
-		/* Noise texture layer - fixed to viewport */
 		.scroll-mode::before {
 			content: '';
 			position: fixed;
@@ -213,7 +208,6 @@ function handleKeyDown(event: KeyboardEvent): void {
 			z-index: 0;
 		}
 
-		/* Vignette overlay - fixed to viewport */
 		.scroll-mode::after {
 			content: '';
 			position: fixed;
@@ -228,7 +222,6 @@ function handleKeyDown(event: KeyboardEvent): void {
 		}
 
 		.scroll-content {
-			/* Extra space at bottom for last section to scroll into view */
 			padding-bottom: 50vh;
 			position: relative;
 			z-index: 1; /* Above noise and vignette layers */
@@ -243,7 +236,6 @@ function handleKeyDown(event: KeyboardEvent): void {
 			position: relative;
 		}
 
-		/* Alternate background for visual separation */
 		.scroll-section:nth-child(even) {
 			background: rgba(255, 255, 255, 0.02);
 		}
@@ -310,7 +302,6 @@ function handleKeyDown(event: KeyboardEvent): void {
 			height: 1.25rem;
 		}
 
-		/* Mobile: compact layout */
 		@media (max-width: 767px) {
 			.scroll-section {
 				padding: 3rem 1rem;
@@ -341,7 +332,6 @@ function handleKeyDown(event: KeyboardEvent): void {
 			}
 		}
 
-		/* Tablet: medium layout */
 		@media (min-width: 768px) {
 			.scroll-section {
 				padding: 4rem 3rem;
@@ -352,7 +342,6 @@ function handleKeyDown(event: KeyboardEvent): void {
 			}
 		}
 
-		/* Desktop: generous layout with wider content */
 		@media (min-width: 1024px) {
 			.scroll-section {
 				padding: 5rem 4rem;

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -124,7 +124,7 @@ async function copyUrl(): Promise<void> {
 			copied = false;
 		}, 2000);
 	} catch {
-		// Fallback for older browsers
+		// Clipboard APIs can be unavailable outside secure contexts or in older browsers.
 		const input = document.createElement('input');
 		input.value = shareUrl;
 		document.body.appendChild(input);
@@ -511,7 +511,6 @@ $effect(() => {
 			</div>
 		{/if}
 
-			<!-- Disabled visibility controls need an in-flow explanation and a recovery path. -->
 		{#if showNoControlNotice}
 			<div class="control-notice">
 				<p class="control-notice-text">
@@ -523,7 +522,6 @@ $effect(() => {
 			</div>
 		{/if}
 
-			<!-- Non-admin users cannot access the admin privacy destination. -->
 		<div class="advanced-section">
 			<a
 				href={isAdmin ? '/admin/settings?tab=privacy' : '/dashboard/settings'}

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -467,7 +467,6 @@ $effect(() => {
 					</div>
 				</form>
 
-				<!-- Regenerate Token (admin only, private-link mode) -->
 				{#if canRegenerateToken}
 					<form
 						method="POST"
@@ -512,7 +511,7 @@ $effect(() => {
 			</div>
 		{/if}
 
-		<!-- ISSUE-019: explain why visibility controls are unavailable + a path to act -->
+			<!-- Disabled visibility controls need an in-flow explanation and a recovery path. -->
 		{#if showNoControlNotice}
 			<div class="control-notice">
 				<p class="control-notice-text">
@@ -524,7 +523,7 @@ $effect(() => {
 			</div>
 		{/if}
 
-		<!-- Advanced Options Link: admin-scoped vs user-scoped (ISSUE-020) -->
+			<!-- Non-admin users cannot access the admin privacy destination. -->
 		<div class="advanced-section">
 			<a
 				href={isAdmin ? '/admin/settings?tab=privacy' : '/dashboard/settings'}

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -41,7 +41,6 @@ function isBelowFloor(mode: ShareModeType): boolean {
 	return ShareModePrivacyLevel[mode] < floorLevel;
 }
 
-// State
 let copied = $state(false);
 let copyTimeout: ReturnType<typeof setTimeout> | undefined;
 let isUpdating = $state(false);
@@ -53,7 +52,6 @@ const displayMode = $derived(localMode);
 const displayShareToken = $derived(localShareToken);
 const controlsDisabled = $derived(isUpdating || isRefreshing);
 
-// Computed URL based on mode
 const shareUrl = $derived.by(() => {
 	const origin = typeof window !== 'undefined' ? window.location.origin : '';
 	const baseUrl = canonicalUrl ?? currentUrl;
@@ -76,7 +74,6 @@ const shareUrl = $derived.by(() => {
 // members-only notice instead of a copyable URL. Access control is unchanged.
 const isMembersOnly = $derived(displayMode === 'private-oauth');
 
-// Can show share mode controls
 const canControlShare = $derived(
 	(isOwner || isAdmin) && (shareSettings?.canUserControl || isAdmin) && !isServerWrapped
 );
@@ -95,14 +92,12 @@ const showNoControlNotice = $derived(
 	isOwner && !isAdmin && !isServerWrapped && !(shareSettings?.canUserControl ?? false)
 );
 
-// Available modes based on permissions
 const availableModes = $derived.by(() => {
 	if (isAdmin) return ['public', 'private-link', 'private-oauth'] as const;
 	if (shareSettings?.canUserControl) return ['public', 'private-link', 'private-oauth'] as const;
 	return [] as const;
 });
 
-// Mode display labels
 const modeLabels: Record<ShareModeType, { label: string; description: string }> = {
 	public: {
 		label: 'Public',
@@ -263,15 +258,14 @@ async function navigateAfterTokenRouteUpdate(data: unknown): Promise<boolean> {
 	return false;
 }
 
-// Cleanup on unmount
 $effect(() => {
 	return () => {
 		clearTimeout(copyTimeout);
 	};
 });
 
-// Reset optimistic state when the modal transitions from closed to open
-// so a freshly-loaded shareSettings prop (e.g., token rotated elsewhere) is used.
+// Reset only when reopening so freshly-loaded shareSettings (for example, a
+// token rotated elsewhere) replaces the previous optimistic local state.
 let prevOpen = false;
 $effect(() => {
 	if (open && !prevOpen) {
@@ -302,7 +296,6 @@ $effect(() => {
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 
-		<!-- Copy URL Section -->
 		{#if isMembersOnly}
 			<div class="url-section">
 				<span class="label">Share Link</span>
@@ -390,7 +383,6 @@ $effect(() => {
 		</div>
 		{/if}
 
-		<!-- Share Mode Controls (conditional) -->
 		{#if canControlShare && availableModes.length > 0}
 			<div class="share-modes">
 				<span class="label" id="visibility-label">Visibility</span>

--- a/src/lib/components/wrapped/SlideRenderer.svelte
+++ b/src/lib/components/wrapped/SlideRenderer.svelte
@@ -46,23 +46,19 @@ let {
 	messagingContext = createPersonalContext()
 }: Props = $props();
 
-// Type guard for user stats
 function isUserStats(s: UserStats | ServerStats): s is UserStats {
 	return 'userId' in s && 'percentileRank' in s;
 }
 
-// Get custom slide data if applicable
 const customSlideData = $derived(
 	slide.type === 'custom' && slide.customSlideId !== undefined
 		? customSlides?.get(slide.customSlideId)
 		: undefined
 );
 
-// Get percentile rank (only available in UserStats)
 const percentileRank = $derived(isUserStats(stats) ? stats.percentileRank : 50);
 const totalUsers = $derived(!isUserStats(stats) ? stats.totalUsers : undefined);
 
-// Get top viewers (only available in ServerStats)
 const topViewers = $derived(!isUserStats(stats) ? stats.topViewers : []);
 </script>
 

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -130,7 +130,6 @@ function startNavigation(direction: 'forward' | 'backward', move: () => boolean)
 
 function goToNext(): void {
 	if (isTransitioning || !navigation.canGoNext) {
-		// If on last slide and trying to go next, call onComplete
 		if (navigation.isLast && !isTransitioning) {
 			onComplete?.();
 		}
@@ -374,12 +373,9 @@ function handleSlideAnimationComplete(): void {}
 	ontouchend={handleTouchEnd}
 	tabindex="0"
 >
-	<!-- Progress indicator -->
 	<ProgressBar current={navigation.currentSlide} total={slides.length} />
 
-	<!-- Slide container -->
 	<div class="slides-container">
-		<!-- Previous slide (for exit animation) -->
 		{#if showPreviousSlide && previousSlide}
 			<div bind:this={previousSlideEl} class="slide previous-slide">
 				<SlideRenderer
@@ -392,7 +388,6 @@ function handleSlideAnimationComplete(): void {}
 			</div>
 		{/if}
 
-		<!-- Current slide -->
 		{#if currentSlide}
 			{#key navigation.currentSlide}
 				<div bind:this={currentSlideEl} class="slide current-slide">
@@ -409,14 +404,12 @@ function handleSlideAnimationComplete(): void {}
 		{/if}
 	</div>
 
-	<!-- Navigation hint (first slide only) -->
 	{#if navigation.isFirst && !isTransitioning}
 		<div class="navigation-hint">
 			<span>Tap to continue</span>
 		</div>
 	{/if}
 
-	<!-- Mobile navigation arrows -->
 	<div class="nav-arrows">
 		{#if !navigation.isFirst}
 			<button
@@ -450,7 +443,6 @@ function handleSlideAnimationComplete(): void {}
 		{/if}
 	</div>
 
-	<!-- Close button -->
 	{#if onClose}
 		<button
 			type="button"
@@ -511,7 +503,6 @@ function handleSlideAnimationComplete(): void {}
 			opacity: 1;
 		}
 
-		/* Noise texture layer - covers entire viewport */
 		.story-mode::before {
 			content: '';
 			position: absolute;
@@ -523,7 +514,6 @@ function handleSlideAnimationComplete(): void {}
 			z-index: 1;
 		}
 
-		/* Vignette overlay - covers entire viewport */
 		.story-mode::after {
 			content: '';
 			position: absolute;
@@ -627,7 +617,6 @@ function handleSlideAnimationComplete(): void {}
 			height: 1.25rem;
 		}
 
-		/* Mobile: compact layout */
 		@media (max-width: 767px) {
 			.slide {
 				padding: 2rem 1rem;
@@ -655,7 +644,6 @@ function handleSlideAnimationComplete(): void {}
 		}
 
 
-		/* Mobile nav arrows */
 		.nav-arrows {
 			display: none;
 		}
@@ -707,7 +695,6 @@ function handleSlideAnimationComplete(): void {}
 				height: 1.5rem;
 			}
 		}
-		/* Tablet: medium layout */
 		@media (min-width: 768px) {
 			.slide {
 				padding: 3rem 2rem;
@@ -715,7 +702,6 @@ function handleSlideAnimationComplete(): void {}
 			}
 		}
 
-		/* Desktop: generous layout */
 		@media (min-width: 1024px) {
 			.slide {
 				padding: 4rem 3rem;

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -543,7 +543,7 @@ function handleSlideAnimationComplete(): void {}
 			align-items: center;
 			justify-content: center;
 			padding: 3rem 1.5rem;
-			padding-top: 4rem; /* Space for progress bar */
+			padding-top: 4rem; /* Keep slide content below the progress bar. */
 			overflow-y: auto;
 		}
 
@@ -719,7 +719,7 @@ function handleSlideAnimationComplete(): void {}
 			}
 		}
 
-		/* Reduced motion */
+		/* Respect users who request reduced motion. */
 		@media (prefers-reduced-motion: reduce) {
 			.navigation-hint {
 				animation: none;

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -313,9 +313,6 @@ function handleKeyDown(event: KeyboardEvent): void {
 			return;
 	}
 
-	// Drop key repeats arriving faster than the throttle window. The OS auto-
-	// repeats held arrow keys at 30+/sec which piles up against the animations
-	// and freezes the main thread.
 	const now = performance.now();
 	if (now - lastKeyTime < KEYDOWN_THROTTLE_MS) {
 		event.preventDefault();

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -533,7 +533,7 @@ function handleSlideAnimationComplete(): void {}
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			z-index: 3; /* Above noise and vignette layers */
+			z-index: 3;
 		}
 
 		.slide {
@@ -719,7 +719,6 @@ function handleSlideAnimationComplete(): void {}
 			}
 		}
 
-		/* Respect users who request reduced motion. */
 		@media (prefers-reduced-motion: reduce) {
 			.navigation-hint {
 				animation: none;

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -543,7 +543,7 @@ function handleSlideAnimationComplete(): void {}
 			align-items: center;
 			justify-content: center;
 			padding: 3rem 1.5rem;
-			padding-top: 4rem; /* Keep slide content below the progress bar. */
+			padding-top: 4rem;
 			overflow-y: auto;
 		}
 

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -17,7 +17,6 @@ interface Props {
 
 let { stats, year, username, onRestart, onHome, onShare, class: klass = '' }: Props = $props();
 
-// Computed stats
 const hasHistory = $derived(hasWatchHistory(stats));
 const hours = $derived(Math.floor(stats.totalWatchTimeMinutes / 60));
 const topMovie = $derived(stats.topMovies[0]?.title ?? null);
@@ -30,7 +29,6 @@ const bingeHours = $derived(
 );
 const bingeEpisodes = $derived(stats.longestBinge?.plays ?? null);
 
-// Element refs for animations
 let container: HTMLElement | undefined = $state();
 let header: HTMLElement | undefined = $state();
 let title: HTMLElement | undefined = $state();
@@ -84,7 +82,6 @@ $effect(() => {
 	}
 });
 
-// Entrance animation
 $effect(() => {
 	if (!container || !header || !statsGrid || !buttonsRow) return;
 
@@ -107,11 +104,9 @@ $effect(() => {
 
 	const animations: ReturnType<typeof animate>[] = [];
 
-	// Animate container
 	const containerAnim = animate(container, { opacity: [0, 1] }, { duration: 0.4, delay: 0.1 });
 	animations.push(containerAnim);
 
-	// Animate header
 	const headerAnim = animate(
 		header,
 		{ opacity: [0, 1], transform: ['translateY(-20px)', 'translateY(0)'] },
@@ -119,7 +114,6 @@ $effect(() => {
 	);
 	animations.push(headerAnim);
 
-	// Animate stats grid container
 	const gridAnim = animate(
 		statsGrid,
 		{ opacity: [0, 1] },
@@ -127,7 +121,6 @@ $effect(() => {
 	);
 	animations.push(gridAnim);
 
-	// Animate individual stat cards with stagger
 	const validCards = statCards.filter(Boolean);
 	if (validCards.length > 0) {
 		const cardsAnim = animate(
@@ -145,7 +138,6 @@ $effect(() => {
 		animations.push(cardsAnim);
 	}
 
-	// Animate buttons
 	const buttonsAnim = animate(
 		buttonsRow,
 		{ opacity: [0, 1], transform: ['translateY(20px)', 'translateY(0)'] },
@@ -181,14 +173,12 @@ $effect(() => {
 
 	{#if hasHistory}
 		<div bind:this={statsGrid} class="stats-grid">
-		<!-- Total Watch Time -->
 		<div bind:this={statCards[0]} class="stat-card highlight">
 			<span class="stat-icon">&#128249;</span>
 			<span class="stat-value">{hours.toLocaleString()}</span>
 			<span class="stat-label">hours watched</span>
 		</div>
 
-		<!-- Top Movie -->
 		{#if topMovie}
 			<div bind:this={statCards[1]} class="stat-card">
 				<span class="stat-icon">&#127909;</span>
@@ -197,7 +187,6 @@ $effect(() => {
 			</div>
 		{/if}
 
-		<!-- Top Show -->
 		{#if topShow}
 			<div bind:this={statCards[2]} class="stat-card">
 				<span class="stat-icon">&#128250;</span>
@@ -206,7 +195,6 @@ $effect(() => {
 			</div>
 		{/if}
 
-		<!-- Top Genre -->
 		{#if topGenre}
 			<div bind:this={statCards[3]} class="stat-card">
 				<span class="stat-icon">&#127916;</span>
@@ -215,7 +203,6 @@ $effect(() => {
 			</div>
 		{/if}
 
-		<!-- Percentile (User only) -->
 		{#if percentile !== null}
 			<div bind:this={statCards[4]} class="stat-card accent">
 				<span class="stat-icon">&#127942;</span>
@@ -224,7 +211,6 @@ $effect(() => {
 			</div>
 		{/if}
 
-		<!-- Active Viewers (Server only) -->
 		{#if totalUsers !== null}
 			<div bind:this={statCards[4]} class="stat-card accent">
 				<span class="stat-icon">&#128101;</span>
@@ -233,7 +219,6 @@ $effect(() => {
 			</div>
 		{/if}
 
-		<!-- Longest Binge -->
 		{#if bingeHours}
 			<div bind:this={statCards[5]} class="stat-card">
 				<span class="stat-icon">&#128164;</span>
@@ -354,7 +339,6 @@ $effect(() => {
 			overflow-y: auto;
 		}
 
-		/* Radial overlay for depth */
 		.summary-page::before {
 			content: '';
 			position: absolute;
@@ -363,7 +347,6 @@ $effect(() => {
 			pointer-events: none;
 		}
 
-		/* Noise texture */
 		.summary-page::after {
 			content: '';
 			position: absolute;
@@ -398,7 +381,6 @@ $effect(() => {
 			font-size: clamp(1.75rem, 5vw, 3rem);
 			font-weight: 800;
 			margin: 0 0 0.75rem;
-			/* Gradient text effect */
 			background: linear-gradient(
 				180deg,
 				oklch(var(--primary)) 0%,
@@ -460,7 +442,6 @@ $effect(() => {
 				border-color 0.3s ease;
 		}
 
-		/* Top highlight line */
 		.stat-card::before {
 			content: '';
 			position: absolute;
@@ -486,7 +467,6 @@ $effect(() => {
 			opacity: 1;
 		}
 
-		/* Highlight card (Total Watch Time) */
 		.stat-card.highlight {
 			border-color: oklch(var(--primary) / 0.4);
 			background: linear-gradient(
@@ -515,7 +495,6 @@ $effect(() => {
 			background-clip: text;
 		}
 
-		/* Accent card (Percentile/Ranking) */
 		.stat-card.accent {
 			border-color: oklch(0.8153 0.1652 85.67 / 0.4);
 			background: linear-gradient(135deg, oklch(0.8153 0.1652 85.67 / 0.15) 0%, oklch(0.8153 0.1652 85.67 / 0.05) 100%);
@@ -635,7 +614,6 @@ $effect(() => {
 				0 0 15px oklch(var(--primary) / 0.1);
 		}
 
-		/* Mobile: stack buttons vertically */
 		@media (max-width: 479px) {
 			.summary-page {
 				padding: 1.5rem 1rem;
@@ -671,14 +649,12 @@ $effect(() => {
 			}
 		}
 
-		/* Tablet */
 		@media (min-width: 480px) and (max-width: 767px) {
 			.stats-grid {
 				grid-template-columns: repeat(2, 1fr);
 			}
 		}
 
-		/* Desktop */
 		@media (min-width: 768px) {
 			.stats-grid {
 				grid-template-columns: repeat(3, 1fr);

--- a/src/lib/components/wrapped/SummaryPage.svelte
+++ b/src/lib/components/wrapped/SummaryPage.svelte
@@ -74,8 +74,8 @@ function handleActionClick(event: MouseEvent, action: () => void): void {
 	}
 }
 
-// Move initial focus to the heading instead of the first button so
-// stray Enter/Space presses don't trigger navigation away from the page.
+// Focus the heading first so stray Enter/Space presses cannot immediately
+// activate a navigation button.
 $effect(() => {
 	if (title) {
 		title.focus({ preventScroll: true });

--- a/src/lib/cron/validation.ts
+++ b/src/lib/cron/validation.ts
@@ -26,7 +26,6 @@ function isFieldInRange(token: string, min: number, max: number): boolean {
 		// Exactly one "/" — reject tokens like "*/5/2"
 		if (parts.length !== 2) return false;
 		const [base, step] = parts;
-		// Step value must be a positive integer
 		const stepNum = Number(step);
 		if (!step || !Number.isInteger(stepNum) || stepNum < 1) return false;
 		// Base must be present (reject "/5") — can be "*", a plain number, or a range

--- a/src/lib/cron/validation.ts
+++ b/src/lib/cron/validation.ts
@@ -3,7 +3,6 @@ export const CRON_ALLOWED_CHARS_MESSAGE = 'Only digits, spaces, and * / - , are 
 export const CRON_FIELD_COUNT_MESSAGE = 'Cron expression must have exactly 5 fields';
 export const CRON_RANGE_MESSAGE = 'Cron expression contains an out-of-range value';
 
-// [min, max] for each of the 5 cron fields (minute, hour, dom, month, dow)
 const FIELD_RANGES: [number, number][] = [
 	[0, 59],
 	[0, 23],
@@ -13,20 +12,19 @@ const FIELD_RANGES: [number, number][] = [
 ];
 
 /**
- * Returns true when every atomic numeric token in the cron field token falls
- * within [min, max]. Handles *, step (/), range (-), and list (,).
+ * Keeps cron validation app-owned instead of delegating to `croner`, so admins
+ * get stable form messages for malformed tokens before the scheduler sees them.
  */
 function isFieldInRange(token: string, min: number, max: number): boolean {
 	if (token === '*') return true;
 
 	if (token.includes('/')) {
 		const parts = token.split('/');
-		// Exactly one "/" — reject tokens like "*/5/2"
+		// Cron syntax permits only one step operator; `*/5/2` is ambiguous.
 		if (parts.length !== 2) return false;
 		const [base, step] = parts;
 		const stepNum = Number(step);
 		if (!step || !Number.isInteger(stepNum) || stepNum < 1) return false;
-		// Base must be present (reject "/5") — can be "*", a plain number, or a range
 		if (!base) return false;
 		if (base !== '*' && !isFieldInRange(base, min, max)) return false;
 		return true;
@@ -38,7 +36,7 @@ function isFieldInRange(token: string, min: number, max: number): boolean {
 
 	if (token.includes('-')) {
 		const parts = token.split('-');
-		// Exactly two non-empty segments — reject "-1", "1-", "1-5-2"
+		// Open-ended or chained ranges have no portable cron meaning.
 		if (parts.length !== 2 || !parts[0] || !parts[1]) return false;
 		const [lo, hi] = parts.map(Number);
 		return (

--- a/src/lib/cron/validation.ts
+++ b/src/lib/cron/validation.ts
@@ -5,11 +5,11 @@ export const CRON_RANGE_MESSAGE = 'Cron expression contains an out-of-range valu
 
 // [min, max] for each of the 5 cron fields (minute, hour, dom, month, dow)
 const FIELD_RANGES: [number, number][] = [
-	[0, 59], // minute
-	[0, 23], // hour
-	[1, 31], // day-of-month
-	[1, 12], // month
-	[0, 7] //  day-of-week (0 and 7 both mean Sunday)
+	[0, 59],
+	[0, 23],
+	[1, 31],
+	[1, 12],
+	[0, 7]
 ];
 
 /**
@@ -17,10 +17,8 @@ const FIELD_RANGES: [number, number][] = [
  * within [min, max]. Handles *, step (/), range (-), and list (,).
  */
 function isFieldInRange(token: string, min: number, max: number): boolean {
-	// Wildcard — always valid
 	if (token === '*') return true;
 
-	// Step — e.g. "*/5" or "1-5/2" or "0/15"
 	if (token.includes('/')) {
 		const parts = token.split('/');
 		// Exactly one "/" — reject tokens like "*/5/2"
@@ -34,12 +32,10 @@ function isFieldInRange(token: string, min: number, max: number): boolean {
 		return true;
 	}
 
-	// List — e.g. "1,3,5"
 	if (token.includes(',')) {
 		return token.split(',').every((part) => isFieldInRange(part, min, max));
 	}
 
-	// Range — e.g. "1-5"
 	if (token.includes('-')) {
 		const parts = token.split('-');
 		// Exactly two non-empty segments — reject "-1", "1-", "1-5-2"

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -883,7 +883,6 @@ export async function clearPlayHistory(year?: number): Promise<number> {
 			.where(between(playHistory.viewedAt, startTimestamp, endTimestamp))
 			.returning();
 
-		// Invalidate cached stats since they're now stale
 		await clearStatsCache(year);
 
 		return result.length;

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -692,7 +692,7 @@ export async function getWrappedTheme(): Promise<ThemePresetType> {
 		return theme as ThemePresetType;
 	}
 
-	// Fall back to legacy CURRENT_THEME for backward compatibility
+	// Existing installs may still have only the pre-rename key.
 	const legacyTheme = await getAppSetting(AppSettingsKey.CURRENT_THEME);
 	if (legacyTheme && Object.values(ThemePresets).includes(legacyTheme as ThemePresetType)) {
 		return legacyTheme as ThemePresetType;
@@ -1065,9 +1065,8 @@ export interface PlexConfig {
 }
 
 /**
- * Get the merged Plex configuration (environment takes priority over database).
- * This should be used by all Plex-related services to ensure they use
- * settings configured via environment variables when available.
+ * Centralizes env-over-DB precedence and URL normalization so Plex callers never
+ * accidentally use a shadowed or unsafe server URL.
  */
 export async function getPlexConfig(): Promise<PlexConfig> {
 	const config = await getApiConfigWithSources();
@@ -1087,7 +1086,6 @@ export async function getPlexConfig(): Promise<PlexConfig> {
 	};
 }
 
-/** Check if Plex is configured (either via database or environment variables). */
 export async function isPlexConfigured(): Promise<boolean> {
 	const config = await getPlexConfig();
 	return Boolean(config.serverUrl && config.token);
@@ -1137,9 +1135,8 @@ export async function getTrustProxy(): Promise<boolean> {
 }
 
 /**
- * Clear database settings that conflict with environment variables.
- * When ENV takes precedence, we auto-clear conflicting DB values to avoid confusion.
- * Returns the list of setting labels that were cleared.
+ * Removes DB values shadowed by authoritative ENV settings so the admin UI
+ * cannot display stale, ignored configuration as if it were active.
  */
 export async function clearConflictingDbSettings(): Promise<string[]> {
 	const clearedSettings: string[] = [];

--- a/src/lib/server/admin/users.service.ts
+++ b/src/lib/server/admin/users.service.ts
@@ -151,7 +151,7 @@ export async function getAllUsersWithStats(year: number): Promise<UserWithStats[
 	}
 
 	return allUsers.map((user) => {
-		// Try accountId first (matches playHistory.accountId), then fall back to plexId
+		// Legacy rows predate accountId, so plexId remains the compatibility fallback.
 		const stats = (user.accountId !== null ? watchTimeMap.get(user.accountId) : undefined) ??
 			watchTimeMap.get(user.plexId) ?? { totalDuration: 0, totalPlays: 0 };
 		const settings = shareSettingsMap.get(user.id);

--- a/src/lib/server/admin/users.service.ts
+++ b/src/lib/server/admin/users.service.ts
@@ -30,9 +30,7 @@ export interface UserWithStats {
 	 * admin Users badge can't read "Public"/"Link" while access is private-oauth.
 	 */
 	effectiveShareMode: ShareModeType;
-	/** Badge label derived from {@link effectiveShareMode} (or "Default" for default-sourced rows). */
 	effectiveLabel: string;
-	/** Badge CSS class derived from {@link effectiveShareMode} ('' for default-sourced rows). */
 	effectiveClass: '' | 'public' | 'oauth' | 'link';
 }
 
@@ -54,8 +52,8 @@ export function deriveEffectiveShareBadge(
 	const baseMode = storedMode ?? globalFloor;
 	const effectiveShareMode = getMoreRestrictiveMode(baseMode, globalFloor);
 
-	// A default-sourced row (no explicit override) is shown as "Default" with no
-	// color class — it tracks whatever the global default is.
+	// Default-sourced rows track the global default, so avoid coloring them as if
+	// they were explicit per-user overrides.
 	if (source === ShareModeSource.DEFAULT || source === null) {
 		return { effectiveShareMode, effectiveLabel: 'Default', effectiveClass: '' };
 	}

--- a/src/lib/server/admin/users.service.ts
+++ b/src/lib/server/admin/users.service.ts
@@ -152,7 +152,6 @@ export async function getAllUsersWithStats(year: number): Promise<UserWithStats[
 
 	return allUsers.map((user) => {
 		// Try accountId first (matches playHistory.accountId), then fall back to plexId
-		// This handles the accountId/plexId mismatch for server owners
 		const stats = (user.accountId !== null ? watchTimeMap.get(user.accountId) : undefined) ??
 			watchTimeMap.get(user.plexId) ?? { totalDuration: 0, totalPlays: 0 };
 		const settings = shareSettingsMap.get(user.id);

--- a/src/lib/server/anonymization/service.ts
+++ b/src/lib/server/anonymization/service.ts
@@ -16,7 +16,6 @@ export function applyAnonymization<T extends AnonymizableUser>(
 	mode: AnonymizationModeType,
 	viewingUserId: number | null
 ): T[] {
-	// Hybrid mode falls back to anonymous if no authenticated user
 	const effectiveMode =
 		mode === AnonymizationMode.HYBRID && viewingUserId === null
 			? AnonymizationMode.ANONYMOUS

--- a/src/lib/server/auth/dev-bypass.ts
+++ b/src/lib/server/auth/dev-bypass.ts
@@ -110,7 +110,6 @@ async function resolveTargetUser(): Promise<NormalizedServerUser> {
 	const bypassUserSetting = env.DEV_BYPASS_USER?.trim() ?? '';
 	const devPlexToken = getDevPlexToken();
 
-	// Check if main Plex server is configured
 	const config = await getPlexConfig();
 	const hasConfiguredServer = Boolean(config.serverUrl && config.token);
 
@@ -149,7 +148,6 @@ async function resolveTargetUser(): Promise<NormalizedServerUser> {
 		}
 
 		if (bypassUserSetting.toLowerCase() === 'random') {
-			// Return cached random user if available
 			if (cachedRandomUser) {
 				return cachedRandomUser;
 			}
@@ -243,7 +241,6 @@ async function getOrCreateDevUser(targetUser: NormalizedServerUser): Promise<num
 	});
 
 	if (existingUser) {
-		// Update user data to match current Plex data
 		await db
 			.update(users)
 			.set({
@@ -302,7 +299,6 @@ export async function getOrCreateDevSession(): Promise<string> {
 		await db.delete(sessions).where(eq(sessions.id, DEV_SESSION_ID));
 	}
 
-	// Get the Plex token for the session
 	// Priority: DEV_PLEX_TOKEN (for onboarding testing) > configured token > fallback
 	const devPlexToken = getDevPlexToken();
 	const config = await getPlexConfig();

--- a/src/lib/server/auth/dev-bypass.ts
+++ b/src/lib/server/auth/dev-bypass.ts
@@ -34,7 +34,6 @@ export function isDevBypassEnabled(): boolean {
 }
 
 async function getFallbackUser(): Promise<NormalizedServerUser> {
-	// Try to find an existing admin user in the database
 	const adminUser = await db.query.users.findFirst({
 		where: eq(users.isAdmin, true)
 	});
@@ -62,7 +61,6 @@ async function getFallbackUser(): Promise<NormalizedServerUser> {
 	const firstUserWithHistory = userWithHistory[0];
 	if (firstUserWithHistory) {
 		const accountId = firstUserWithHistory.accountId;
-		// Check if this accountId has a corresponding user in the database
 		const existingUser = await db.query.users.findFirst({
 			where: eq(users.plexId, accountId)
 		});
@@ -95,7 +93,6 @@ async function getFallbackUser(): Promise<NormalizedServerUser> {
 		};
 	}
 
-	// No existing users with history - fall back to mock user
 	logger.warn(
 		'Dev bypass: No existing users found in database, using mock user (stats will be empty)',
 		'DevBypass'
@@ -138,12 +135,10 @@ async function resolveTargetUser(): Promise<NormalizedServerUser> {
 				`Dev bypass: Failed to fetch user info using DEV_PLEX_TOKEN: ${error instanceof Error ? error.message : 'Unknown error'}`,
 				'DevBypass'
 			);
-			// Fall through to existing flow
 		}
 	}
 
 	try {
-		// Case 1: No setting - use server owner
 		if (!bypassUserSetting) {
 			const owner = await getServerOwner();
 			logger.info(
@@ -153,7 +148,6 @@ async function resolveTargetUser(): Promise<NormalizedServerUser> {
 			return owner;
 		}
 
-		// Case 2: Random user selection
 		if (bypassUserSetting.toLowerCase() === 'random') {
 			// Return cached random user if available
 			if (cachedRandomUser) {
@@ -171,7 +165,6 @@ async function resolveTargetUser(): Promise<NormalizedServerUser> {
 				return randomUser;
 			}
 
-			// No shared users - fall back to owner
 			logger.warn(
 				'Dev bypass: No shared users found for random selection, using server owner',
 				'DevBypass'
@@ -181,7 +174,6 @@ async function resolveTargetUser(): Promise<NormalizedServerUser> {
 			return owner;
 		}
 
-		// Case 3: Specific user by ID or username
 		const specificUser = await resolveUserIdentifier(bypassUserSetting);
 
 		if (specificUser) {
@@ -198,7 +190,6 @@ async function resolveTargetUser(): Promise<NormalizedServerUser> {
 			'DevBypass'
 		);
 
-		// Check if user exists in local database by plexId or username
 		const plexIdNum = parseInt(bypassUserSetting, 10);
 		const dbUser = await db.query.users.findFirst({
 			where: Number.isNaN(plexIdNum)
@@ -220,13 +211,11 @@ async function resolveTargetUser(): Promise<NormalizedServerUser> {
 			};
 		}
 
-		// User not found anywhere - fall back to owner
 		logger.warn(
 			`Dev bypass: User "${bypassUserSetting}" not found in Plex or database, falling back to owner`,
 			'DevBypass'
 		);
 
-		// List available users for developer convenience
 		const { owner, sharedUsers } = await getServerUsers();
 		const availableUsers = [owner, ...sharedUsers]
 			.map((u) => `${u.plexId} (${u.username})`)
@@ -245,11 +234,10 @@ async function resolveTargetUser(): Promise<NormalizedServerUser> {
 }
 
 async function getOrCreateDevUser(targetUser: NormalizedServerUser): Promise<number> {
-	// Determine accountId for matching with playHistory
-	// Server owners have local accountId = 1, shared users have accountId = plexId
+	// Plex history keys owner playback as accountId=1, while shared users use
+	// their Plex ID; matching that split keeps dev-bypass stats populated.
 	const accountId = targetUser.isOwner ? 1 : targetUser.plexId;
 
-	// Check if user already exists
 	const existingUser = await db.query.users.findFirst({
 		where: eq(users.plexId, targetUser.plexId)
 	});
@@ -270,7 +258,6 @@ async function getOrCreateDevUser(targetUser: NormalizedServerUser): Promise<num
 		return existingUser.id;
 	}
 
-	// Create new user
 	const result = await db
 		.insert(users)
 		.values({
@@ -296,13 +283,10 @@ async function getOrCreateDevUser(targetUser: NormalizedServerUser): Promise<num
 }
 
 export async function getOrCreateDevSession(): Promise<string> {
-	// Resolve which user to simulate
 	const targetUser = await resolveTargetUser();
 
-	// Get or create the user in database
 	const userId = await getOrCreateDevUser(targetUser);
 
-	// Check if dev session exists and is valid
 	const existingSession = await db.query.sessions.findFirst({
 		where: eq(sessions.id, DEV_SESSION_ID)
 	});
@@ -310,14 +294,11 @@ export async function getOrCreateDevSession(): Promise<string> {
 	const now = new Date();
 
 	if (existingSession && existingSession.expiresAt > now) {
-		// Check if session is for the same user
 		if (existingSession.userId === userId) {
 			return DEV_SESSION_ID;
 		}
-		// Different user - delete old session
 		await db.delete(sessions).where(eq(sessions.id, DEV_SESSION_ID));
 	} else if (existingSession) {
-		// Expired session - delete it
 		await db.delete(sessions).where(eq(sessions.id, DEV_SESSION_ID));
 	}
 
@@ -327,7 +308,6 @@ export async function getOrCreateDevSession(): Promise<string> {
 	const config = await getPlexConfig();
 	const plexToken = devPlexToken || config.token || 'dev-token';
 
-	// Create new dev session with long expiration
 	const expiresAt = new Date(Date.now() + SESSION_DURATION_MS);
 
 	await db.insert(sessions).values({

--- a/src/lib/server/auth/dev-bypass.ts
+++ b/src/lib/server/auth/dev-bypass.ts
@@ -25,7 +25,7 @@ function getDevPlexToken(): string | undefined {
 }
 
 export function isDevBypassEnabled(): boolean {
-	// SECURITY: Never enable in production
+	// Development-only: never permit an auth bypass outside SvelteKit dev mode.
 	if (!dev) {
 		return false;
 	}
@@ -52,7 +52,7 @@ async function getFallbackUser(): Promise<NormalizedServerUser> {
 		};
 	}
 
-	// Try to find any user who has play history (so stats aren't empty)
+	// Prefer a history-backed fallback so dev dashboards exercise real stats.
 	const userWithHistory = await db
 		.selectDistinct({ accountId: playHistory.accountId })
 		.from(playHistory)
@@ -79,7 +79,7 @@ async function getFallbackUser(): Promise<NormalizedServerUser> {
 			};
 		}
 
-		// User doesn't exist in users table but has history - use their accountId
+		// Orphaned history still has a usable local Plex account id for stats joins.
 		logger.info(
 			`Dev bypass: Using orphaned play history accountId ${accountId} as fallback (user may be deleted)`,
 			'DevBypass'
@@ -113,8 +113,8 @@ async function resolveTargetUser(): Promise<NormalizedServerUser> {
 	const config = await getPlexConfig();
 	const hasConfiguredServer = Boolean(config.serverUrl && config.token);
 
-	// When DEV_PLEX_TOKEN is set and main Plex is not configured,
-	// use the dev token to fetch user identity for onboarding testing
+	// DEV_PLEX_TOKEN lets onboarding tests use a real Plex identity before the
+	// main server credentials exist.
 	if (devPlexToken && !hasConfiguredServer && !bypassUserSetting) {
 		try {
 			const userInfo = await getPlexUserInfo(devPlexToken);

--- a/src/lib/server/auth/dev-bypass.ts
+++ b/src/lib/server/auth/dev-bypass.ts
@@ -182,7 +182,6 @@ async function resolveTargetUser(): Promise<NormalizedServerUser> {
 			return specificUser;
 		}
 
-		// User not found on Plex - try local database
 		logger.info(
 			`Dev bypass: User "${bypassUserSetting}" not found on Plex server, checking local database`,
 			'DevBypass'
@@ -222,7 +221,6 @@ async function resolveTargetUser(): Promise<NormalizedServerUser> {
 
 		return owner;
 	} catch (error) {
-		// Plex API failed - fall back to existing user from database
 		logger.warn(
 			`Dev bypass: Failed to fetch Plex users, attempting to use existing database user. Error: ${error instanceof Error ? error.message : 'Unknown error'}`,
 			'DevBypass'
@@ -299,7 +297,6 @@ export async function getOrCreateDevSession(): Promise<string> {
 		await db.delete(sessions).where(eq(sessions.id, DEV_SESSION_ID));
 	}
 
-	// Priority: DEV_PLEX_TOKEN (for onboarding testing) > configured token > fallback
 	const devPlexToken = getDevPlexToken();
 	const config = await getPlexConfig();
 	const plexToken = devPlexToken || config.token || 'dev-token';

--- a/src/lib/server/auth/dev-users.ts
+++ b/src/lib/server/auth/dev-users.ts
@@ -132,8 +132,8 @@ async function fetchSharedUsers(
 		);
 	}
 
-	// Filter friends to only those with a usable username and access to this specific server,
-	// then map to PlexSharedServerUser format for compatibility.
+	// Keep only friends who actually share this server; the Plex friends endpoint
+	// can include unrelated accounts from the owner account.
 	return friends
 		.filter(
 			(friend): friend is PlexFriend & { username: string } =>
@@ -159,7 +159,6 @@ export async function getServerUsers(): Promise<{
 		return { owner: usersCache.owner, sharedUsers: usersCache.sharedUsers };
 	}
 
-	// Get merged config (database takes priority over environment)
 	const config = await getPlexConfig();
 
 	if (!config.token) {
@@ -176,7 +175,6 @@ export async function getServerUsers(): Promise<{
 		isOwner: true
 	};
 
-	// Fetch server machine identifier and shared users
 	const machineIdentifier = await getServerMachineIdentifier(config);
 	const sharedUsersData = await fetchSharedUsers(machineIdentifier, config.token);
 
@@ -248,7 +246,6 @@ export async function resolveUserIdentifier(
 		return getUserById(numericId);
 	}
 
-	// Otherwise treat as username
 	return getUserByUsername(identifier);
 }
 

--- a/src/lib/server/auth/dev-users.ts
+++ b/src/lib/server/auth/dev-users.ts
@@ -154,7 +154,6 @@ export async function getServerUsers(): Promise<{
 	owner: NormalizedServerUser;
 	sharedUsers: NormalizedServerUser[];
 }> {
-	// Return cached data if still valid
 	if (usersCache && Date.now() - usersCache.fetchedAt < CACHE_DURATION_MS) {
 		return { owner: usersCache.owner, sharedUsers: usersCache.sharedUsers };
 	}
@@ -165,7 +164,6 @@ export async function getServerUsers(): Promise<{
 		throw new PlexAuthApiError('Plex token is not configured', undefined, '/dev-users');
 	}
 
-	// Fetch owner info using the admin token
 	const ownerData = await getPlexUserInfo(config.token);
 	const owner: NormalizedServerUser = {
 		plexId: ownerData.id,
@@ -178,7 +176,6 @@ export async function getServerUsers(): Promise<{
 	const machineIdentifier = await getServerMachineIdentifier(config);
 	const sharedUsersData = await fetchSharedUsers(machineIdentifier, config.token);
 
-	// Normalize shared users
 	const sharedUsers: NormalizedServerUser[] = sharedUsersData.map((user) => ({
 		plexId: user.id,
 		username: user.username,
@@ -187,7 +184,6 @@ export async function getServerUsers(): Promise<{
 		isOwner: false
 	}));
 
-	// Update cache
 	usersCache = {
 		owner,
 		sharedUsers,
@@ -239,7 +235,6 @@ export async function getRandomNonOwnerUser(): Promise<NormalizedServerUser | nu
 export async function resolveUserIdentifier(
 	identifier: string
 ): Promise<NormalizedServerUser | null> {
-	// Try parsing as numeric Plex ID first
 	const numericId = parseInt(identifier, 10);
 
 	if (!Number.isNaN(numericId) && numericId > 0) {

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -37,14 +37,12 @@ const PLEX_TV_HEADERS = {
 function normalizeUrl(url: string): string {
 	try {
 		const parsed = new URL(url);
-		// Remove default ports
 		if (parsed.port === '80' || parsed.port === '443') {
 			parsed.port = '';
 		}
 		// Return normalized form without trailing slash
 		return parsed.origin.toLowerCase();
 	} catch {
-		// If URL parsing fails, do basic normalization
 		return url.toLowerCase().replace(/\/+$/, '');
 	}
 }
@@ -71,7 +69,6 @@ export function extractPlexDirectMachineId(url: string): string | undefined {
 		// Format: {ip}.{machineId}.plex.direct
 		const machineId = parts[parts.length - 3];
 
-		// Machine ID should be a 32-character hex string
 		if (machineId && /^[a-f0-9]{32}$/i.test(machineId)) {
 			return machineId.toLowerCase();
 		}
@@ -106,16 +103,13 @@ export function extractPlexDirectIpAndPort(url: string): { ip: string; port: str
 			return undefined;
 		}
 
-		// Validate that ipPart looks like an IPv4 address with dashes
 		// Format: digits separated by exactly 3 dashes (e.g., 89-150-152-18)
 		const ipSegments = ipPart.split('-');
 
-		// IPv4 has exactly 4 octets
 		if (ipSegments.length !== 4) {
 			return undefined;
 		}
 
-		// Validate each segment is a valid octet (0-255)
 		for (const segment of ipSegments) {
 			const num = parseInt(segment, 10);
 			if (Number.isNaN(num) || num < 0 || num > 255 || segment !== num.toString()) {
@@ -123,10 +117,8 @@ export function extractPlexDirectIpAndPort(url: string): { ip: string; port: str
 			}
 		}
 
-		// Convert dashes to dots to get the actual IP
 		const ip = ipSegments.join('.');
 
-		// Get port (default to empty string if not specified)
 		const port = parsed.port || '';
 
 		return { ip, port };
@@ -151,7 +143,6 @@ function matchesByIpAndPort(
 	const { ip: configuredIp, port: configuredPort } = extracted;
 
 	return connections.some((conn) => {
-		// Compare IP addresses (case-insensitive for safety)
 		const connectionIp = conn.address.toLowerCase();
 		const matchesIp = connectionIp === configuredIp.toLowerCase();
 
@@ -184,7 +175,6 @@ function urlsMatch(url1: string, url2: string): boolean {
 		}
 	}
 
-	// Fall back to exact origin comparison
 	return normalizeUrl(url1) === normalizeUrl(url2);
 }
 
@@ -267,7 +257,6 @@ function matchesPlainHost(configuredUrl: string, server: PlexResource): boolean 
 		return connPort.toString() === configuredPort;
 	};
 
-	// Direct address/port match against advertised connections.
 	if (
 		server.connections?.some(
 			(conn) => conn.address.toLowerCase() === configuredHost && portsMatch(conn.port)
@@ -368,7 +357,6 @@ function findConfiguredServer(
 		}
 	}
 
-	// Strategy 4: Fall back to connection URI matching
 	return servers.find((server) => {
 		if (server.connections) {
 			return server.connections.some((conn) => urlsMatch(conn.uri, configuredUrl));
@@ -378,17 +366,14 @@ function findConfiguredServer(
 }
 
 export async function verifyServerMembership(userToken: string): Promise<MembershipResult> {
-	// Get all resources the user has access to
 	const resources = await getPlexResources(userToken);
 
-	// Filter to only server resources
 	const servers = filterServerResources(resources);
 
 	// Get configured server URL from merged config (database takes priority over env)
 	const apiConfig = await getApiConfigWithSources();
 	const configuredUrl = apiConfig.plex.serverUrl.value;
 
-	// Debug logging to help diagnose membership issues
 	logger.debug(
 		`Configured PLEX_SERVER_URL diagnostic=${formatPlexUrlDiagnostic(
 			configuredUrl,
@@ -457,7 +442,6 @@ export async function verifyServerMembership(userToken: string): Promise<Members
 		};
 	}
 
-	// Find the configured server
 	const configuredServer = findConfiguredServer(
 		servers,
 		configuredUrl,
@@ -644,7 +628,6 @@ export function selectBestConnection(server: PlexResource): string | undefined {
 		return localConnection.uri;
 	}
 
-	// Last resort: use any available connection
 	const anyConnection = connections[0];
 	if (anyConnection) {
 		logger.debug(
@@ -665,10 +648,10 @@ export function generatePlexDirectUrl(
 		return undefined;
 	}
 
-	// Strategy 1: Use provided machineIdentifier
 	let machineId: string | undefined = machineIdentifier;
 
-	// Strategy 2: Extract from existing plex.direct connection (fallback)
+	// Fall back to an advertised plex.direct connection when Plex did not provide
+	// a machineIdentifier separately.
 	if (!machineId && server.connections) {
 		const plexDirectConn = server.connections.find((c) => c.uri.includes('.plex.direct'));
 		if (plexDirectConn) {
@@ -701,20 +684,16 @@ export function generatePlexDirectUrl(
 }
 
 export async function verifyServerOwnership(userToken: string): Promise<OwnershipResult> {
-	// Get all resources the user has access to
 	const resources = await getPlexResources(userToken);
 
-	// Filter to only server resources
 	const servers = filterServerResources(resources);
 
-	// Debug logging
 	logger.debug(`Found ${servers.length} server(s) accessible to user`, 'Membership');
 
 	for (const [index, server] of servers.entries()) {
 		logger.debug(`Server resource: ${formatPlexResourceDiagnostic(server, index)}`, 'Membership');
 	}
 
-	// Find the first server that the user owns
 	const ownedServer = servers.find((server) => server.owned);
 
 	if (!ownedServer) {
@@ -724,7 +703,6 @@ export async function verifyServerOwnership(userToken: string): Promise<Ownershi
 		};
 	}
 
-	// Select the best connection URL
 	// Priority: .plex.direct > public IP > local IP
 	let bestConnectionUrl = selectBestConnection(ownedServer);
 

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -267,7 +267,7 @@ function matchesPlainHost(configuredUrl: string, server: PlexResource): boolean 
 		}
 	}
 
-	// Match against server.publicAddress when any advertised connection uses the configured port.
+	// Some resources expose the host only as publicAddress; require a matching advertised port too.
 	if (
 		server.publicAddress &&
 		server.publicAddress.toLowerCase() === configuredHost &&
@@ -284,8 +284,8 @@ function findConfiguredServer(
 	configuredUrl: string,
 	configuredMachineIdFromIdentity?: string
 ): PlexResource | undefined {
-	// Strategy 0: Match by machineIdentifier fetched from GET {PLEX_SERVER_URL}/identity.
-	// This works for any reachable URL form — IP, hostname, .plex.direct, reverse proxy.
+	// A live /identity machineIdentifier is the strongest match because it works
+	// across IP, hostname, .plex.direct, and reverse-proxy URLs.
 	if (configuredMachineIdFromIdentity) {
 		const serverByConfiguredId = servers.find(
 			(s) => s.clientIdentifier.toLowerCase() === configuredMachineIdFromIdentity.toLowerCase()
@@ -301,7 +301,6 @@ function findConfiguredServer(
 		}
 	}
 
-	// Strategy 1: For .plex.direct URLs, try matching by machine ID (most reliable when IDs match)
 	const configuredMachineId = extractPlexDirectMachineId(configuredUrl);
 
 	if (configuredMachineId) {
@@ -318,8 +317,8 @@ function findConfiguredServer(
 			return serverByMachineId;
 		}
 
-		// Strategy 2: For .plex.direct URLs, try matching by embedded IP address
-		// This handles cases where the machineId in the URL differs from clientIdentifier
+		// Some .plex.direct URLs carry a stale machine id while the embedded IP/port
+		// still matches an advertised connection.
 		const serverByIp = servers.find((s) => matchesByIpAndPort(configuredUrl, s.connections));
 		if (serverByIp) {
 			logger.debug(
@@ -332,8 +331,6 @@ function findConfiguredServer(
 			return serverByIp;
 		}
 	} else {
-		// Strategy 3: For plain-host URLs (e.g. http://192.168.1.34:32400), match against
-		// connection address/port, IPs embedded in .plex.direct URIs, or publicAddress.
 		const serverByPlainHost = servers.find((s) => matchesPlainHost(configuredUrl, s));
 		if (serverByPlainHost) {
 			logger.debug(

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -40,7 +40,6 @@ function normalizeUrl(url: string): string {
 		if (parsed.port === '80' || parsed.port === '443') {
 			parsed.port = '';
 		}
-		// Return normalized form without trailing slash
 		return parsed.origin.toLowerCase();
 	} catch {
 		return url.toLowerCase().replace(/\/+$/, '');
@@ -52,21 +51,18 @@ export function extractPlexDirectMachineId(url: string): string | undefined {
 		const parsed = new URL(url);
 		const host = parsed.hostname.toLowerCase();
 
-		// Check if this is a .plex.direct domain
 		if (!host.endsWith('.plex.direct')) {
 			return undefined;
 		}
 
-		// Split by dots: [ip-part, machineId, 'plex', 'direct']
+		// Plex .plex.direct hostnames encode the server machine id as
+		// {ip}.{machineId}.plex.direct.
 		const parts = host.split('.');
 
-		// Need at least 4 parts: ip.machineId.plex.direct
 		if (parts.length < 4) {
 			return undefined;
 		}
 
-		// Machine ID is the second-to-last before 'plex.direct'
-		// Format: {ip}.{machineId}.plex.direct
 		const machineId = parts[parts.length - 3];
 
 		if (machineId && /^[a-f0-9]{32}$/i.test(machineId)) {
@@ -84,26 +80,22 @@ export function extractPlexDirectIpAndPort(url: string): { ip: string; port: str
 		const parsed = new URL(url);
 		const host = parsed.hostname.toLowerCase();
 
-		// Check if this is a .plex.direct domain
 		if (!host.endsWith('.plex.direct')) {
 			return undefined;
 		}
 
-		// Split by dots: [ip-part, machineId, 'plex', 'direct']
 		const parts = host.split('.');
 
-		// Need at least 4 parts: ip.machineId.plex.direct
 		if (parts.length < 4) {
 			return undefined;
 		}
 
-		// IP part is the first segment (everything before the machineId)
+		// Plex encodes IPv4 octets with dashes in the first .plex.direct label.
 		const ipPart = parts[0];
 		if (!ipPart) {
 			return undefined;
 		}
 
-		// Format: digits separated by exactly 3 dashes (e.g., 89-150-152-18)
 		const ipSegments = ipPart.split('-');
 
 		if (ipSegments.length !== 4) {
@@ -146,7 +138,6 @@ function matchesByIpAndPort(
 		const connectionIp = conn.address.toLowerCase();
 		const matchesIp = connectionIp === configuredIp.toLowerCase();
 
-		// Compare ports - handle default ports and string/number conversion
 		let matchesPort = false;
 		if (configuredPort === '') {
 			// .plex.direct URLs are always https:, so the implicit default port is 443.
@@ -160,11 +151,10 @@ function matchesByIpAndPort(
 }
 
 function urlsMatch(url1: string, url2: string): boolean {
-	// First, try extracting machine IDs for .plex.direct domains
+	// .plex.direct IP labels can vary, so compare stable machine ids before origins.
 	const machineId1 = extractPlexDirectMachineId(url1);
 	const machineId2 = extractPlexDirectMachineId(url2);
 
-	// If both are .plex.direct URLs with valid machine IDs, compare machine IDs and ports
 	if (machineId1 && machineId2) {
 		try {
 			const parsed1 = new URL(url1);
@@ -370,7 +360,6 @@ export async function verifyServerMembership(userToken: string): Promise<Members
 
 	const servers = filterServerResources(resources);
 
-	// Get configured server URL from merged config (database takes priority over env)
 	const apiConfig = await getApiConfigWithSources();
 	const configuredUrl = apiConfig.plex.serverUrl.value;
 
@@ -584,7 +573,7 @@ export function selectBestConnection(server: PlexResource): string | undefined {
 		return undefined;
 	}
 
-	// Priority 1: Find public .plex.direct URL (best for external access)
+	// Prefer stable Plex DNS names, then public connections, then local fallbacks.
 	const publicPlexDirect = connections.find(
 		(c) => c.uri.includes('.plex.direct') && !c.local && !c.relay
 	);
@@ -596,7 +585,6 @@ export function selectBestConnection(server: PlexResource): string | undefined {
 		return publicPlexDirect.uri;
 	}
 
-	// Priority 2: Find local .plex.direct URL (for same-network access)
 	const localPlexDirect = connections.find(
 		(c) => c.uri.includes('.plex.direct') && c.local && !c.relay
 	);
@@ -608,7 +596,6 @@ export function selectBestConnection(server: PlexResource): string | undefined {
 		return localPlexDirect.uri;
 	}
 
-	// Priority 3: Find public (non-local, non-relay) connection
 	const publicConnection = connections.find((c) => !c.local && !c.relay);
 	if (publicConnection) {
 		logger.debug(
@@ -618,7 +605,6 @@ export function selectBestConnection(server: PlexResource): string | undefined {
 		return publicConnection.uri;
 	}
 
-	// Priority 4: Find local (non-relay) connection as fallback
 	const localConnection = connections.find((c) => c.local && !c.relay);
 	if (localConnection) {
 		logger.debug(
@@ -703,10 +689,9 @@ export async function verifyServerOwnership(userToken: string): Promise<Ownershi
 		};
 	}
 
-	// Priority: .plex.direct > public IP > local IP
 	let bestConnectionUrl = selectBestConnection(ownedServer);
 
-	// If no .plex.direct URL found in connections, try to generate one
+	// Plex can omit a direct URL while still reporting publicAddress + machine id.
 	if (!bestConnectionUrl?.includes('.plex.direct')) {
 		const generatedUrl = generatePlexDirectUrl(ownedServer);
 		if (generatedUrl) {

--- a/src/lib/server/auth/plex-oauth.ts
+++ b/src/lib/server/auth/plex-oauth.ts
@@ -144,7 +144,6 @@ export async function pollPinForToken(
 			return pin.authToken;
 		}
 
-		// Wait before next attempt
 		await new Promise((resolve) => setTimeout(resolve, intervalMs));
 	}
 
@@ -213,7 +212,6 @@ export function buildPlexOAuthUrl(pinCode: string, forwardUrl?: string): string 
 		'context[device][model]': 'hosted'
 	});
 
-	// Add forward URL if provided
 	if (forwardUrl) {
 		params.set('forwardUrl', forwardUrl);
 	}

--- a/src/lib/server/auth/plex-oauth.ts
+++ b/src/lib/server/auth/plex-oauth.ts
@@ -32,7 +32,7 @@ const DEFAULT_POLL_OPTIONS: Required<PollPinOptions> = {
 	intervalMs: 5000
 };
 
-/** Request a new PIN from Plex.tv. The PIN expires after 15 minutes. */
+/** Plex.tv PINs expire after 15 minutes, so callers must start polling immediately. */
 export async function requestPin(): Promise<PlexPinResponse> {
 	const endpoint = `${PLEX_TV_URL}/api/v2/pins`;
 
@@ -81,7 +81,7 @@ export async function requestPin(): Promise<PlexPinResponse> {
 	}
 }
 
-/** Check if a PIN has been authorized. Returns authToken if authorized. */
+/** Plex.tv reports expired or unknown PINs as 404; normalize that into PinExpiredError. */
 export async function checkPinStatus(pinId: number): Promise<PlexPinResponse> {
 	const endpoint = `${PLEX_TV_URL}/api/v2/pins/${pinId}`;
 
@@ -130,7 +130,7 @@ export async function checkPinStatus(pinId: number): Promise<PlexPinResponse> {
 	}
 }
 
-/** Poll a PIN until the user authorizes it or timeout is reached. */
+/** Keep polling server-side so callers get one expiry error for both Plex expiry and UI timeout. */
 export async function pollPinForToken(
 	pinId: number,
 	options: PollPinOptions = {}
@@ -150,7 +150,7 @@ export async function pollPinForToken(
 	throw new PinExpiredError('Login timed out. Please try again.');
 }
 
-/** Get Plex user profile information using an auth token. */
+/** Validate Plex's external profile payload before onboarding/auth code trusts its identifiers. */
 export async function getPlexUserInfo(authToken: string): Promise<PlexUser> {
 	const endpoint = `${PLEX_TV_URL}/api/v2/user`;
 
@@ -198,7 +198,7 @@ export async function getPlexUserInfo(authToken: string): Promise<PlexUser> {
 	}
 }
 
-/** Build the Plex OAuth authorization URL for a given PIN code. */
+/** Plex expects app/device context in the hash fragment that the hosted auth page reads. */
 export function buildPlexOAuthUrl(pinCode: string, forwardUrl?: string): string {
 	const params = new URLSearchParams({
 		clientID: PLEX_CLIENT_ID,
@@ -219,7 +219,7 @@ export function buildPlexOAuthUrl(pinCode: string, forwardUrl?: string): string 
 	return `${PLEX_AUTH_URL}#?${params.toString()}`;
 }
 
-/** Get complete PIN info for initiating OAuth flow from the client. */
+/** Bundle the PIN and hosted-auth URL so the client and polling loop share one expiry window. */
 export async function getPinInfo(forwardUrl?: string): Promise<PinInfo> {
 	const pin = await requestPin();
 

--- a/src/lib/server/auth/session.ts
+++ b/src/lib/server/auth/session.ts
@@ -58,7 +58,6 @@ export async function validateSession(sessionId: string): Promise<SessionData | 
 			expiresAt: session.expiresAt
 		};
 	} catch (error) {
-		// Graceful degradation when database is not ready
 		console.error('[Session] Database error during validation:', error);
 		return null;
 	}

--- a/src/lib/server/db/client.ts
+++ b/src/lib/server/db/client.ts
@@ -33,7 +33,6 @@ const sqlite: BunDatabase = new Database(databasePath, {
 	create: true
 });
 
-// WAL mode for concurrent reads - persistent settings
 sqlite.exec('PRAGMA journal_mode = WAL');
 sqlite.exec('PRAGMA synchronous = NORMAL');
 sqlite.exec('PRAGMA foreign_keys = ON');

--- a/src/lib/server/db/client.ts
+++ b/src/lib/server/db/client.ts
@@ -7,7 +7,7 @@ import * as schema from './schema';
 
 const databasePath = process.env.DATABASE_PATH ?? 'data/obzorarr.db';
 
-// Prevent test environment from accessing production database
+// Fail closed if a test run is not explicitly pointed at an in-memory/test database.
 if (
 	process.env.NODE_ENV === 'test' &&
 	databasePath !== ':memory:' &&

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -157,7 +157,6 @@ export const metadataCache = sqliteTable('metadata_cache', {
 	fetchFailed: integer('fetch_failed', { mode: 'boolean' }).default(false)
 });
 
-// Export table types for type inference
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type PlayHistoryRecord = typeof playHistory.$inferSelect;

--- a/src/lib/server/funfacts/ai/context-enricher.ts
+++ b/src/lib/server/funfacts/ai/context-enricher.ts
@@ -10,7 +10,6 @@ export function enrichContext(baseContext: FactGenerationContext): FactGeneratio
 
 	return {
 		...baseContext,
-		// Entertainment trivia calculations
 		gotCount: round1(hours / ENTERTAINMENT_FACTORS.GAME_OF_THRONES_HOURS),
 		friendsCount: round1(hours / ENTERTAINMENT_FACTORS.FRIENDS_HOURS),
 		theOfficeCount: round1(hours / ENTERTAINMENT_FACTORS.THE_OFFICE_HOURS),

--- a/src/lib/server/funfacts/ai/index.ts
+++ b/src/lib/server/funfacts/ai/index.ts
@@ -1,11 +1,3 @@
-/**
- * AI Module
- *
- * Exports for AI-based fun fact generation.
- *
- * @module server/funfacts/ai
- */
-
 export { enrichContext, ensureEnrichedContext, isContextEnriched } from './context-enricher';
 export {
 	AI_PERSONAS,

--- a/src/lib/server/funfacts/ai/prompts.ts
+++ b/src/lib/server/funfacts/ai/prompts.ts
@@ -57,7 +57,6 @@ export function buildUserPrompt(context: FactGenerationContext, count: number): 
 
 	parts.push(`Generate ${count} unique, creative fun facts based on these viewing statistics:\n`);
 
-	// Basic stats
 	parts.push('## Viewing Summary');
 	parts.push(`- Total watch time: ${context.hours} hours (${context.days} days)`);
 	parts.push(`- Total plays: ${context.plays}`);
@@ -65,7 +64,6 @@ export function buildUserPrompt(context: FactGenerationContext, count: number): 
 	parts.push(`- Unique shows watched: ${context.uniqueShows}`);
 	parts.push('');
 
-	// Top content
 	parts.push('## Favorites');
 	if (context.topMovie) {
 		parts.push(`- Top movie: "${context.topMovie}" (watched ${context.topMovieCount} times)`);
@@ -75,7 +73,6 @@ export function buildUserPrompt(context: FactGenerationContext, count: number): 
 	}
 	parts.push('');
 
-	// Viewing patterns
 	parts.push('## Viewing Patterns');
 	parts.push(`- Peak viewing time: ${formatHour(context.peakHour)}`);
 	parts.push(`- Peak viewing month: ${MONTH_NAMES[context.peakMonth]}`);
@@ -87,7 +84,6 @@ export function buildUserPrompt(context: FactGenerationContext, count: number): 
 	}
 	parts.push('');
 
-	// Rankings
 	parts.push('## Rankings');
 	const topPercent = Math.round(100 - context.percentile);
 	if (topPercent <= 50) {
@@ -97,7 +93,6 @@ export function buildUserPrompt(context: FactGenerationContext, count: number): 
 	}
 	parts.push('');
 
-	// Temporal bookends
 	if (context.firstWatchTitle || context.lastWatchTitle) {
 		parts.push('## Year Bookends');
 		if (context.firstWatchTitle) {
@@ -109,7 +104,6 @@ export function buildUserPrompt(context: FactGenerationContext, count: number): 
 		parts.push('');
 	}
 
-	// Entertainment comparisons (if enriched)
 	if (context.gotCount || context.friendsCount || context.starWarsCount) {
 		parts.push('## For Reference (use creatively):');
 		if (context.gotCount && context.gotCount >= 1) {

--- a/src/lib/server/funfacts/index.ts
+++ b/src/lib/server/funfacts/index.ts
@@ -23,19 +23,14 @@ export {
 } from './registry';
 
 export {
-	// Context building (for testing/advanced usage)
 	buildGenerationContext,
 	generateFromTemplate,
 	generateFromTemplates,
-	// Main entry points
 	generateFunFacts,
-	// AI generation (for direct AI usage)
 	generateWithAI,
-	// Configuration
 	getFunFactsConfig,
 	interpolateTemplate,
 	isAIAvailable,
-	// Template utilities (for testing/customization)
 	isTemplateApplicable,
 	selectRandomTemplates
 } from './service';

--- a/src/lib/server/funfacts/registry.ts
+++ b/src/lib/server/funfacts/registry.ts
@@ -120,7 +120,6 @@ export function selectWeightedTemplates(
 		}
 	);
 
-	// Weighted random selection without replacement
 	const selected: FactTemplate[] = [];
 	const remaining = [...weightedPool];
 

--- a/src/lib/server/funfacts/service.ts
+++ b/src/lib/server/funfacts/service.ts
@@ -120,7 +120,6 @@ export function buildGenerationContext(stats: UserStats | ServerStats): FactGene
 		scope
 	};
 
-	// Enrich with entertainment trivia calculations
 	return enrichContext(baseContext);
 }
 
@@ -128,7 +127,6 @@ export function isTemplateApplicable(
 	template: FactTemplate,
 	context: FactGenerationContext
 ): boolean {
-	// Check required stats presence
 	for (const stat of template.requiredStats) {
 		const value = context[stat as keyof FactGenerationContext];
 		if (value === null || value === undefined) {
@@ -144,7 +142,6 @@ export function isTemplateApplicable(
 		}
 	}
 
-	// Check minimum thresholds
 	if (template.minThresholds) {
 		for (const [key, minValue] of Object.entries(template.minThresholds) as [string, number][]) {
 			const actualValue = context[key as keyof FactGenerationContext];
@@ -164,7 +161,6 @@ export function isTemplateApplicable(
 		return false;
 	}
 
-	// Exclude percentile-based templates from server stats
 	// These are user-specific comparisons that don't make sense for collective stats
 	if (context.scope === 'server' && template.requiredStats.includes('percentile')) {
 		return false;
@@ -207,7 +203,6 @@ export function interpolateTemplate(template: string, context: FactGenerationCon
 		PODCAST_EPISODE_HOURS
 	} = EQUIVALENCY_FACTORS;
 
-	// Calculate derived values
 	const flightCount = Math.round((context.hours / FLIGHT_NYC_TOKYO_HOURS) * 10) / 10;
 	const lotrCount = Math.round((context.hours / LOTR_EXTENDED_TOTAL_HOURS) * 10) / 10;
 	const bookCount = Math.round(context.hours / AVERAGE_BOOK_HOURS);
@@ -218,18 +213,15 @@ export function interpolateTemplate(template: string, context: FactGenerationCon
 	const daysBetweenMovies = Math.max(1, Math.round(365 / Math.max(1, context.uniqueMovies)));
 	const playsPerDay = Math.round((context.plays / 365) * 10) / 10;
 
-	// New calculated values for low-threshold templates
 	const coffeeBreaks = Math.round(context.hours / COFFEE_BREAK_HOURS);
 	const commuteTrips = Math.round(context.hours / COMMUTE_HOURS);
 	const podcastEpisodes = Math.round(context.hours / PODCAST_EPISODE_HOURS);
 	const topPercentile = 100 - Math.round(context.percentile);
 	const year = new Date().getFullYear(); // Current year for the year-participant template
 
-	// Get pronoun replacements based on scope (user vs server)
 	const pronounReplacements = getPronounReplacements(context.scope);
 
 	const replacements: Record<string, string | number> = {
-		// Pronoun placeholders (context-aware)
 		...pronounReplacements,
 		hours: context.hours,
 		days: context.days,
@@ -250,7 +242,6 @@ export function interpolateTemplate(template: string, context: FactGenerationCon
 		uniqueMovies: context.uniqueMovies,
 		uniqueShows: context.uniqueShows,
 
-		// Calculated equivalencies
 		flightCount,
 		lotrCount,
 		bookCount,
@@ -261,14 +252,12 @@ export function interpolateTemplate(template: string, context: FactGenerationCon
 		daysBetweenMovies,
 		playsPerDay,
 
-		// New low-threshold equivalencies
 		coffeeBreaks,
 		commuteTrips,
 		podcastEpisodes,
 		topPercentile,
 		year,
 
-		// Entertainment trivia (from enriched context)
 		gotCount: context.gotCount ?? 0,
 		friendsCount: context.friendsCount ?? 0,
 		theOfficeCount: context.theOfficeCount ?? 0,
@@ -332,7 +321,6 @@ function parseAIResponse(data: unknown): FunFact[] {
 			throw new AIGenerationError('Empty AI response');
 		}
 
-		// Parse JSON from response
 		const parsed = JSON.parse(content) as {
 			facts?: Array<{ fact: string; comparison?: string; icon?: string }>;
 		};
@@ -406,7 +394,6 @@ export async function generateWithAI(
 					throw statusError;
 				}
 
-				// Retryable error - store and continue
 				lastError = statusError;
 				continue;
 			}
@@ -414,12 +401,10 @@ export async function generateWithAI(
 			const data: unknown = await response.json();
 			return parseAIResponse(data);
 		} catch (error) {
-			// Clear timeout before handling error
 			clearTimeout(timeoutId);
 
 			// Don't retry AIGenerationErrors from parsing or non-retryable conditions
 			if (error instanceof AIGenerationError) {
-				// Check if it's a client error (non-retryable)
 				if ((error as AIGenerationError).message.includes('OpenAI API error: 4')) {
 					throw error;
 				}
@@ -427,20 +412,17 @@ export async function generateWithAI(
 				continue;
 			}
 
-			// Handle timeout
 			if ((error as Error).name === 'AbortError') {
 				lastError = new AIGenerationError('AI generation timed out');
 				continue;
 			}
 
-			// Network error - retryable
 			lastError = new AIGenerationError(`AI generation failed: ${(error as Error).message}`, error);
 		} finally {
 			clearTimeout(timeoutId);
 		}
 	}
 
-	// All retries exhausted
 	throw lastError ?? new AIGenerationError('AI generation failed after retries');
 }
 
@@ -450,29 +432,23 @@ export function generateFromTemplates(
 ): FunFact[] {
 	const { count = 3, categories, excludeIds = [], useWeightedSelection = true } = options;
 
-	// Get templates from registry (includes new categories)
 	let templates = getAllTemplates();
 
-	// Filter by category if specified
 	if (categories) {
 		templates = templates.filter((t) => categories.includes(t.category as FactCategory));
 	}
 
-	// Filter by applicability
 	const applicableTemplates = templates.filter((t) => isTemplateApplicable(t, context));
 
 	if (applicableTemplates.length === 0) {
 		// Graceful degradation - return empty array instead of throwing
-		// The page will simply not display fun facts
 		return [];
 	}
 
-	// Select templates (weighted or random)
 	const selected = useWeightedSelection
 		? selectWeightedTemplates(applicableTemplates, count, excludeIds)
 		: selectRandomTemplates(applicableTemplates, count, excludeIds);
 
-	// Generate facts from templates
 	return selected.map((template) => generateFromTemplate(template, context));
 }
 
@@ -485,7 +461,6 @@ export async function generateFunFacts(
 	const config = await getFunFactsConfig();
 	const context = buildGenerationContext(stats);
 
-	// Try AI generation first if preferred and available
 	if (preferAI && config.aiEnabled && config.openaiApiKey) {
 		try {
 			const aiFacts = await generateWithAI(stats, config, count);
@@ -502,10 +477,8 @@ export async function generateFunFacts(
 			return [...aiFacts, ...templateFacts].slice(0, count);
 		} catch (error) {
 			console.warn('AI fun fact generation failed, falling back to templates:', error);
-			// Fall through to template generation
 		}
 	}
 
-	// Fall back to template-based generation
 	return generateFromTemplates(context, { count, categories, excludeIds });
 }

--- a/src/lib/server/funfacts/service.ts
+++ b/src/lib/server/funfacts/service.ts
@@ -132,11 +132,9 @@ export function isTemplateApplicable(
 		if (value === null || value === undefined) {
 			return false;
 		}
-		// For strings, check they're not empty
 		if (typeof value === 'string' && value.length === 0) {
 			return false;
 		}
-		// For numbers, check they're positive (except peakHour which can be 0)
 		if (typeof value === 'number' && value <= 0 && stat !== 'peakHour' && stat !== 'peakMonth') {
 			return false;
 		}
@@ -151,12 +149,11 @@ export function isTemplateApplicable(
 		}
 	}
 
-	// Special case: early bird requires peakHour <= 9
+	// Template thresholds express minimums only; early-bird needs the opposite bound.
 	if (template.id === 'early-bird' && context.peakHour > 9) {
 		return false;
 	}
 
-	// Special case: night owl requires peakHour >= 21
 	if (template.id === 'night-owl' && context.peakHour < 21) {
 		return false;
 	}
@@ -177,11 +174,11 @@ const PRONOUNS = {
 function getPronounReplacements(scope: 'user' | 'server'): Record<string, string> {
 	const p = PRONOUNS[scope];
 	return {
-		Subject: p.subject, // "You" / "We"
-		subject: p.subject.toLowerCase(), // "you" / "we"
-		Possessive: p.possessive, // "Your" / "Our"
-		possessive: p.possessive.toLowerCase(), // "your" / "our"
-		object: p.object // "you" / "us"
+		Subject: p.subject,
+		subject: p.subject.toLowerCase(),
+		Possessive: p.possessive,
+		possessive: p.possessive.toLowerCase(),
+		object: p.object
 	};
 }
 
@@ -217,7 +214,7 @@ export function interpolateTemplate(template: string, context: FactGenerationCon
 	const commuteTrips = Math.round(context.hours / COMMUTE_HOURS);
 	const podcastEpisodes = Math.round(context.hours / PODCAST_EPISODE_HOURS);
 	const topPercentile = 100 - Math.round(context.percentile);
-	const year = new Date().getFullYear(); // Current year for the year-participant template
+	const year = new Date().getFullYear();
 
 	const pronounReplacements = getPronounReplacements(context.scope);
 
@@ -467,7 +464,6 @@ export async function generateFunFacts(
 			if (aiFacts.length >= count) {
 				return aiFacts.slice(0, count);
 			}
-			// If AI returned fewer than requested, supplement with templates
 			const remaining = count - aiFacts.length;
 			const templateFacts = generateFromTemplates(context, {
 				count: remaining,

--- a/src/lib/server/funfacts/service.ts
+++ b/src/lib/server/funfacts/service.ts
@@ -82,7 +82,7 @@ export async function isAIAvailable(): Promise<boolean> {
 }
 
 export function buildGenerationContext(stats: UserStats | ServerStats): FactGenerationContext {
-	// Use Math.floor to avoid rounding < 30 mins to 0 hours
+	// Floor partial hours so comparison facts never exaggerate a user's watch time.
 	const hours = Math.floor(stats.totalWatchTimeMinutes / 60);
 	const days = Math.round((hours / 24) * 10) / 10;
 
@@ -158,7 +158,7 @@ export function isTemplateApplicable(
 		return false;
 	}
 
-	// These are user-specific comparisons that don't make sense for collective stats
+	// Percentile comparisons are user-specific; a server aggregate has no peer rank.
 	if (context.scope === 'server' && template.requiredStats.includes('percentile')) {
 		return false;
 	}
@@ -386,7 +386,7 @@ export async function generateWithAI(
 					`OpenAI API error: ${response.status} - ${errorText}`
 				);
 
-				// Don't retry client errors (4xx) except rate limiting (429)
+				// 4xx usually means bad config or payload; only 429 is expected to heal with retry.
 				if (response.status >= 400 && response.status < 500 && response.status !== 429) {
 					throw statusError;
 				}
@@ -400,7 +400,7 @@ export async function generateWithAI(
 		} catch (error) {
 			clearTimeout(timeoutId);
 
-			// Don't retry AIGenerationErrors from parsing or non-retryable conditions
+			// Parser/config failures will repeat with the same response; retry only status/timeout paths.
 			if (error instanceof AIGenerationError) {
 				if ((error as AIGenerationError).message.includes('OpenAI API error: 4')) {
 					throw error;
@@ -438,7 +438,7 @@ export function generateFromTemplates(
 	const applicableTemplates = templates.filter((t) => isTemplateApplicable(t, context));
 
 	if (applicableTemplates.length === 0) {
-		// Graceful degradation - return empty array instead of throwing
+		// A sparse Wrapped should omit fun facts rather than fail the whole recap.
 		return [];
 	}
 

--- a/src/lib/server/funfacts/templates/achievement.ts
+++ b/src/lib/server/funfacts/templates/achievement.ts
@@ -1,14 +1,5 @@
 import { defineTemplateCategory } from './base';
 
-/**
- * Achievement Templates
- *
- * Milestone-based templates celebrating viewing accomplishments
- * (Century Club, Marathon Master, milestones)
- *
- * @module server/funfacts/templates/achievement
- */
-
 export const ACHIEVEMENT_TEMPLATES = defineTemplateCategory('achievement', [
 	{
 		id: 'century-club',

--- a/src/lib/server/funfacts/templates/achievement.ts
+++ b/src/lib/server/funfacts/templates/achievement.ts
@@ -17,7 +17,7 @@ export const ACHIEVEMENT_TEMPLATES = defineTemplateCategory('achievement', [
 		icon: '💯',
 		requiredStats: ['hours'],
 		minThresholds: { hours: 100 },
-		priority: 70 // Higher priority for major milestones
+		priority: 70
 	},
 	{
 		id: 'movie-marathon-master',
@@ -35,7 +35,7 @@ export const ACHIEVEMENT_TEMPLATES = defineTemplateCategory('achievement', [
 		icon: '🏆',
 		requiredStats: ['plays'],
 		minThresholds: { plays: 1000 },
-		priority: 75 // Very high priority for rare achievement
+		priority: 75
 	},
 	{
 		id: 'five-hundred-plays',

--- a/src/lib/server/funfacts/templates/behavioral-insight.ts
+++ b/src/lib/server/funfacts/templates/behavioral-insight.ts
@@ -65,7 +65,7 @@ export const BEHAVIORAL_TEMPLATES = defineTemplateCategory('behavioral-insight',
 		comparisonTemplate: 'Each session a moment of entertainment!',
 		icon: '▶️',
 		requiredStats: ['plays'],
-		minThresholds: { plays: 1 } // Very low threshold
+		minThresholds: { plays: 1 }
 	},
 	{
 		id: 'any-percentile',
@@ -73,6 +73,6 @@ export const BEHAVIORAL_TEMPLATES = defineTemplateCategory('behavioral-insight',
 		comparisonTemplate: 'Keep on watching!',
 		icon: '📊',
 		requiredStats: ['percentile'],
-		minThresholds: {} // No minimum - always applicable
+		minThresholds: {}
 	}
 ]);

--- a/src/lib/server/funfacts/templates/behavioral-insight.ts
+++ b/src/lib/server/funfacts/templates/behavioral-insight.ts
@@ -31,7 +31,8 @@ export const BEHAVIORAL_TEMPLATES = defineTemplateCategory('behavioral-insight',
 		comparisonTemplate: 'Early bird catches the best shows!',
 		icon: '🐦',
 		requiredStats: ['peakHour', 'plays'],
-		// Special handling: peakHour <= 9, plus minimum plays to be meaningful
+		// The generic threshold engine only models lower bounds; the early-bird
+		// upper-bound check is handled by its selector.
 		minThresholds: { plays: 10 }
 	},
 	{
@@ -40,7 +41,8 @@ export const BEHAVIORAL_TEMPLATES = defineTemplateCategory('behavioral-insight',
 		comparisonTemplate: '{Subject} really went all-in that month!',
 		icon: '📅',
 		requiredStats: ['peakMonth', 'plays'],
-		minThresholds: { plays: 10 } // Need actual viewing data for this to be meaningful
+		// Avoid declaring a "biggest month" from a token amount of viewing data.
+		minThresholds: { plays: 10 }
 	},
 	{
 		id: 'steady-watcher',

--- a/src/lib/server/funfacts/templates/behavioral-insight.ts
+++ b/src/lib/server/funfacts/templates/behavioral-insight.ts
@@ -23,7 +23,7 @@ export const BEHAVIORAL_TEMPLATES = defineTemplateCategory('behavioral-insight',
 		comparisonTemplate: 'The night owl life suits {object} perfectly!',
 		icon: '🦉',
 		requiredStats: ['peakHour'],
-		minThresholds: { peakHour: 21 } // 9 PM or later
+		minThresholds: { peakHour: 21 }
 	},
 	{
 		id: 'early-bird',
@@ -48,7 +48,7 @@ export const BEHAVIORAL_TEMPLATES = defineTemplateCategory('behavioral-insight',
 		comparisonTemplate: 'Consistency is key!',
 		icon: '📊',
 		requiredStats: ['plays'],
-		minThresholds: { plays: 100 } // At least ~every 3-4 days
+		minThresholds: { plays: 100 }
 	},
 	{
 		id: 'consistent-viewer',

--- a/src/lib/server/funfacts/templates/behavioral-insight.ts
+++ b/src/lib/server/funfacts/templates/behavioral-insight.ts
@@ -1,14 +1,5 @@
 import { defineTemplateCategory } from './base';
 
-/**
- * Behavioral Insight Templates
- *
- * Templates based on percentile, viewing patterns, and comparisons
- * (night owl, early bird, peak month)
- *
- * @module server/funfacts/templates/behavioral-insight
- */
-
 export const BEHAVIORAL_TEMPLATES = defineTemplateCategory('behavioral-insight', [
 	{
 		id: 'top-percentile-elite',

--- a/src/lib/server/funfacts/templates/binge-related.ts
+++ b/src/lib/server/funfacts/templates/binge-related.ts
@@ -1,14 +1,5 @@
 import { defineTemplateCategory } from './base';
 
-/**
- * Binge-Related Templates
- *
- * Templates based on binge watching sessions
- * (marathon sessions, dedication)
- *
- * @module server/funfacts/templates/binge-related
- */
-
 export const BINGE_TEMPLATES = defineTemplateCategory('binge-related', [
 	{
 		id: 'marathon-session-epic',

--- a/src/lib/server/funfacts/templates/content-comparison.ts
+++ b/src/lib/server/funfacts/templates/content-comparison.ts
@@ -1,14 +1,5 @@
 import { defineTemplateCategory } from './base';
 
-/**
- * Content Comparison Templates
- *
- * Templates based on top content and play patterns
- * (favorite movies, shows, variety)
- *
- * @module server/funfacts/templates/content-comparison
- */
-
 export const CONTENT_COMPARISON_TEMPLATES = defineTemplateCategory('content-comparison', [
 	{
 		id: 'top-movie-obsession',

--- a/src/lib/server/funfacts/templates/content-comparison.ts
+++ b/src/lib/server/funfacts/templates/content-comparison.ts
@@ -23,7 +23,7 @@ export const CONTENT_COMPARISON_TEMPLATES = defineTemplateCategory('content-comp
 		comparisonTemplate: "That's a new movie every {daysBetweenMovies} days on average!",
 		icon: '🎞️',
 		requiredStats: ['uniqueMovies'],
-		minThresholds: { uniqueMovies: 12 } // At least monthly
+		minThresholds: { uniqueMovies: 12 }
 	},
 	{
 		id: 'show-explorer',

--- a/src/lib/server/funfacts/templates/content-comparison.ts
+++ b/src/lib/server/funfacts/templates/content-comparison.ts
@@ -48,7 +48,7 @@ export const CONTENT_COMPARISON_TEMPLATES = defineTemplateCategory('content-comp
 		comparisonTemplate: 'Every movie is a new adventure!',
 		icon: '🎬',
 		requiredStats: ['uniqueMovies'],
-		minThresholds: { uniqueMovies: 1 } // Very low threshold
+		minThresholds: { uniqueMovies: 1 }
 	},
 	{
 		id: 'show-sampler',
@@ -56,6 +56,6 @@ export const CONTENT_COMPARISON_TEMPLATES = defineTemplateCategory('content-comp
 		comparisonTemplate: "That's some serious channel surfing!",
 		icon: '📺',
 		requiredStats: ['uniqueShows'],
-		minThresholds: { uniqueShows: 1 } // Very low threshold
+		minThresholds: { uniqueShows: 1 }
 	}
 ]);

--- a/src/lib/server/funfacts/templates/entertainment-trivia.ts
+++ b/src/lib/server/funfacts/templates/entertainment-trivia.ts
@@ -1,14 +1,5 @@
 import { defineTemplateCategory } from './base';
 
-/**
- * Entertainment Trivia Templates
- *
- * Pop culture comparison templates using famous shows/movies
- * (Game of Thrones, Friends, Star Wars, etc.)
- *
- * @module server/funfacts/templates/entertainment-trivia
- */
-
 export const ENTERTAINMENT_TRIVIA_TEMPLATES = defineTemplateCategory('entertainment-trivia', [
 	{
 		id: 'game-of-thrones-marathon',

--- a/src/lib/server/funfacts/templates/entertainment-trivia.ts
+++ b/src/lib/server/funfacts/templates/entertainment-trivia.ts
@@ -1,5 +1,7 @@
 import { defineTemplateCategory } from './base';
 
+// Thresholds sit slightly above each source runtime so rounded comparison counts
+// never produce an awkward single-rewatch fact.
 export const ENTERTAINMENT_TRIVIA_TEMPLATES = defineTemplateCategory('entertainment-trivia', [
 	{
 		id: 'game-of-thrones-marathon',
@@ -7,7 +9,7 @@ export const ENTERTAINMENT_TRIVIA_TEMPLATES = defineTemplateCategory('entertainm
 		comparisonTemplate: 'Could get {object} through all of Game of Thrones {gotCount} times!',
 		icon: '🐉',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 74 } // Ensures count > 1 (70 * 1.05 = 73.5)
+		minThresholds: { hours: 74 }
 	},
 	{
 		id: 'friends-forever',
@@ -16,7 +18,7 @@ export const ENTERTAINMENT_TRIVIA_TEMPLATES = defineTemplateCategory('entertainm
 			'{Subject} could have seen every Friends episode {friendsCount} times and still been there for them!',
 		icon: '☕',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 95 } // Ensures count > 1 (90 * 1.05 = 94.5)
+		minThresholds: { hours: 95 }
 	},
 	{
 		id: 'the-office-hours',
@@ -25,7 +27,7 @@ export const ENTERTAINMENT_TRIVIA_TEMPLATES = defineTemplateCategory('entertainm
 			"That's {theOfficeCount} complete rewatches of The Office - that's what she said!",
 		icon: '📎',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 78 } // Ensures count > 1 (74 * 1.05 = 77.7)
+		minThresholds: { hours: 78 }
 	},
 	{
 		id: 'stranger-things',
@@ -34,7 +36,7 @@ export const ENTERTAINMENT_TRIVIA_TEMPLATES = defineTemplateCategory('entertainm
 			'Could take {object} to the Upside Down and back {strangerThingsCount} times!',
 		icon: '👾',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 36 } // Ensures count > 1 (34 * 1.05 = 35.7)
+		minThresholds: { hours: 36 }
 	},
 	{
 		id: 'star-wars-saga',
@@ -43,7 +45,7 @@ export const ENTERTAINMENT_TRIVIA_TEMPLATES = defineTemplateCategory('entertainm
 			'{Subject} could watch the original Star Wars trilogy {starWarsCount} times - may the Force be with {object}!',
 		icon: '⭐',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 7 } // Ensures count > 1 (6.4 * 1.05 = 6.72)
+		minThresholds: { hours: 7 }
 	},
 	{
 		id: 'breaking-bad-marathon',
@@ -52,7 +54,7 @@ export const ENTERTAINMENT_TRIVIA_TEMPLATES = defineTemplateCategory('entertainm
 			"Could power through all of Breaking Bad {breakingBadCount} times - {subject}'re the ones who watch!",
 		icon: '🧪',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 66 } // Ensures count > 1 (62 * 1.05 = 65.1)
+		minThresholds: { hours: 66 }
 	},
 	{
 		id: 'the-wire-complete',
@@ -60,7 +62,7 @@ export const ENTERTAINMENT_TRIVIA_TEMPLATES = defineTemplateCategory('entertainm
 		comparisonTemplate: "That's {theWireCount} complete viewings of The Wire - indeed!",
 		icon: '🔌',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 63 } // Ensures count > 1 (60 * 1.05 = 63)
+		minThresholds: { hours: 63 }
 	},
 	{
 		id: 'sopranos-family',
@@ -69,7 +71,7 @@ export const ENTERTAINMENT_TRIVIA_TEMPLATES = defineTemplateCategory('entertainm
 			'Could take {object} through The Sopranos {sopranosCount} times - fuggedaboutit!',
 		icon: '🍝',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 91 } // Ensures count > 1 (86 * 1.05 = 90.3)
+		minThresholds: { hours: 91 }
 	},
 	{
 		id: 'star-wars-quick',

--- a/src/lib/server/funfacts/templates/entertainment-trivia.ts
+++ b/src/lib/server/funfacts/templates/entertainment-trivia.ts
@@ -87,8 +87,8 @@ export const ENTERTAINMENT_TRIVIA_TEMPLATES = defineTemplateCategory('entertainm
 			"{Subject} could've had {starWarsCount} Star Wars movie nights - not bad for a scruffy-looking nerf herder!",
 		icon: '🚀',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 2 }, // Very low - accessible
-		priority: 35 // Lower priority for quick comparison
+		minThresholds: { hours: 2 },
+		priority: 35
 	},
 	{
 		id: 'quick-binge-comparison',

--- a/src/lib/server/funfacts/templates/social-comparison.ts
+++ b/src/lib/server/funfacts/templates/social-comparison.ts
@@ -7,7 +7,7 @@ export const SOCIAL_COMPARISON_TEMPLATES = defineTemplateCategory('social-compar
 		comparisonTemplate: 'The crown is {possessive}, streaming royalty!',
 		icon: '👑',
 		requiredStats: ['percentile'],
-		minThresholds: { percentile: 99 }, // Essentially top 1%
+		minThresholds: { percentile: 99 },
 		priority: 80
 	},
 	{

--- a/src/lib/server/funfacts/templates/social-comparison.ts
+++ b/src/lib/server/funfacts/templates/social-comparison.ts
@@ -17,7 +17,7 @@ export const SOCIAL_COMPARISON_TEMPLATES = defineTemplateCategory('social-compar
 		icon: '👑',
 		requiredStats: ['percentile'],
 		minThresholds: { percentile: 99 }, // Essentially top 1%
-		priority: 80 // Very high priority for top viewer
+		priority: 80
 	},
 	{
 		id: 'top-five',
@@ -62,7 +62,7 @@ export const SOCIAL_COMPARISON_TEMPLATES = defineTemplateCategory('social-compar
 		icon: '🤝',
 		requiredStats: ['plays'],
 		minThresholds: { plays: 10 },
-		priority: 30 // Lower priority - fallback for lower percentiles
+		priority: 30
 	},
 	{
 		id: 'quality-over-quantity',
@@ -71,6 +71,6 @@ export const SOCIAL_COMPARISON_TEMPLATES = defineTemplateCategory('social-compar
 		icon: '💎',
 		requiredStats: ['plays'],
 		minThresholds: { plays: 1 },
-		priority: 25 // Very low priority - catch-all
+		priority: 25
 	}
 ]);

--- a/src/lib/server/funfacts/templates/social-comparison.ts
+++ b/src/lib/server/funfacts/templates/social-comparison.ts
@@ -1,14 +1,5 @@
 import { defineTemplateCategory } from './base';
 
-/**
- * Social Comparison Templates
- *
- * Server-relative comparison templates
- * (rankings, above average, percentiles)
- *
- * @module server/funfacts/templates/social-comparison
- */
-
 export const SOCIAL_COMPARISON_TEMPLATES = defineTemplateCategory('social-comparison', [
 	{
 		id: 'server-champion',

--- a/src/lib/server/funfacts/templates/temporal-pattern.ts
+++ b/src/lib/server/funfacts/templates/temporal-pattern.ts
@@ -1,14 +1,5 @@
 import { defineTemplateCategory } from './base';
 
-/**
- * Temporal Pattern Templates
- *
- * Templates based on first/last watch and temporal patterns
- * (year bookends, milestones)
- *
- * @module server/funfacts/templates/temporal-pattern
- */
-
 export const TEMPORAL_TEMPLATES = defineTemplateCategory('temporal-pattern', [
 	{
 		id: 'first-of-year',

--- a/src/lib/server/funfacts/templates/temporal-pattern.ts
+++ b/src/lib/server/funfacts/templates/temporal-pattern.ts
@@ -37,6 +37,6 @@ export const TEMPORAL_TEMPLATES = defineTemplateCategory('temporal-pattern', [
 		comparisonTemplate: "Here's to another year of great content!",
 		icon: '🎊',
 		requiredStats: [],
-		minThresholds: {} // Always applicable
+		minThresholds: {}
 	}
 ]);

--- a/src/lib/server/funfacts/templates/time-equivalency.ts
+++ b/src/lib/server/funfacts/templates/time-equivalency.ts
@@ -1,5 +1,7 @@
 import { defineTemplateCategory } from './base';
 
+// Thresholds avoid underwhelming 1x/0x comparison facts after the display values
+// are rounded for copy.
 export const TIME_EQUIVALENCY_TEMPLATES = defineTemplateCategory('time-equivalency', [
 	{
 		id: 'flight-tokyo',
@@ -7,7 +9,7 @@ export const TIME_EQUIVALENCY_TEMPLATES = defineTemplateCategory('time-equivalen
 		comparisonTemplate: "That's equivalent to {flightCount} flights from New York to Tokyo!",
 		icon: '✈️',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 15 } // Ensures count > 1 (14 * 1.05 = 14.7)
+		minThresholds: { hours: 15 }
 	},
 	{
 		id: 'lotr-marathon',
@@ -16,7 +18,7 @@ export const TIME_EQUIVALENCY_TEMPLATES = defineTemplateCategory('time-equivalen
 			'Could watch the entire extended Lord of the Rings trilogy {lotrCount} times!',
 		icon: '🧙',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 12 } // 12/11.4 = 1.05 rounds to 1.1 ✓
+		minThresholds: { hours: 12 }
 	},
 	{
 		id: 'books-read',
@@ -24,7 +26,7 @@ export const TIME_EQUIVALENCY_TEMPLATES = defineTemplateCategory('time-equivalen
 		comparisonTemplate: 'In that time, {subject} could have read about {bookCount} novels',
 		icon: '📚',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 9 } // Ensures count > 1 (9/6 = 1.5 rounds to 2)
+		minThresholds: { hours: 9 }
 	},
 	{
 		id: 'walk-distance',
@@ -32,7 +34,7 @@ export const TIME_EQUIVALENCY_TEMPLATES = defineTemplateCategory('time-equivalen
 		comparisonTemplate: '{Subject} could have walked {walkMiles} miles in that time!',
 		icon: '🚶',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 3 } // 3 * 3mph = 9 miles ✓
+		minThresholds: { hours: 3 }
 	},
 	{
 		id: 'sleep-cycles',
@@ -40,7 +42,7 @@ export const TIME_EQUIVALENCY_TEMPLATES = defineTemplateCategory('time-equivalen
 		comparisonTemplate: "That's {sleepCycles} complete sleep cycles of entertainment!",
 		icon: '😴',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 3 } // 3/1.5 = 2 cycles ✓
+		minThresholds: { hours: 3 }
 	},
 	{
 		id: 'mcu-marathon',
@@ -48,7 +50,7 @@ export const TIME_EQUIVALENCY_TEMPLATES = defineTemplateCategory('time-equivalen
 		comparisonTemplate: "That's like binging the entire MCU Infinity Saga {mcuCount} times over!",
 		icon: '🦸',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 53 } // Ensures count > 1 (50 * 1.05 = 52.5)
+		minThresholds: { hours: 53 }
 	},
 	{
 		id: 'harry-potter',
@@ -56,7 +58,7 @@ export const TIME_EQUIVALENCY_TEMPLATES = defineTemplateCategory('time-equivalen
 		comparisonTemplate: 'Could power through all 8 Harry Potter films {hpCount} times!',
 		icon: '⚡',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 21 } // Ensures count > 1 (19.7 * 1.05 = 20.7)
+		minThresholds: { hours: 21 }
 	},
 	{
 		id: 'coffee-breaks',
@@ -64,7 +66,7 @@ export const TIME_EQUIVALENCY_TEMPLATES = defineTemplateCategory('time-equivalen
 		comparisonTemplate: "That's enough time for {coffeeBreaks} coffee breaks!",
 		icon: '☕',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 1 } // 1/0.25 = 4 breaks ✓
+		minThresholds: { hours: 1 }
 	},
 	{
 		id: 'commute-time',
@@ -72,7 +74,7 @@ export const TIME_EQUIVALENCY_TEMPLATES = defineTemplateCategory('time-equivalen
 		comparisonTemplate: 'Would cover {commuteTrips} average work commutes!',
 		icon: '🚗',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 1 } // 1/0.5 = 2 commutes ✓
+		minThresholds: { hours: 1 }
 	},
 	{
 		id: 'podcast-episodes',
@@ -80,6 +82,6 @@ export const TIME_EQUIVALENCY_TEMPLATES = defineTemplateCategory('time-equivalen
 		comparisonTemplate: "That's like listening to {podcastEpisodes} podcast episodes!",
 		icon: '🎙️',
 		requiredStats: ['hours'],
-		minThresholds: { hours: 2 } // Ensures count > 1 (2/0.75 = 2.67 rounds to 3)
+		minThresholds: { hours: 2 }
 	}
 ]);

--- a/src/lib/server/funfacts/templates/time-equivalency.ts
+++ b/src/lib/server/funfacts/templates/time-equivalency.ts
@@ -1,14 +1,5 @@
 import { defineTemplateCategory } from './base';
 
-/**
- * Time Equivalency Templates
- *
- * Convert watch time to relatable real-world comparisons
- * (flights, book reading, marathons, etc.)
- *
- * @module server/funfacts/templates/time-equivalency
- */
-
 export const TIME_EQUIVALENCY_TEMPLATES = defineTemplateCategory('time-equivalency', [
 	{
 		id: 'flight-tokyo',

--- a/src/lib/server/funfacts/types.ts
+++ b/src/lib/server/funfacts/types.ts
@@ -36,7 +36,7 @@ export const FactTemplateSchema = z.object({
 });
 
 export const AIGenerationRequestSchema = z.object({
-	stats: z.any(), // UserStats or ServerStats
+	stats: z.any(),
 	existingFacts: z.array(z.string()).optional(),
 	count: z.number().int().min(1).max(5).default(3)
 });

--- a/src/lib/server/logging/index.ts
+++ b/src/lib/server/logging/index.ts
@@ -1,8 +1,4 @@
-// Types
-
-// Logger instance
 export { logger } from './logger';
-// Retention scheduler
 export {
 	getRetentionSchedulerStatus,
 	isRetentionSchedulerConfigured,
@@ -10,7 +6,6 @@ export {
 	stopLogRetentionScheduler,
 	triggerRetentionCleanup
 } from './retention';
-// Service functions
 export {
 	deleteAllLogs,
 	deleteLogsOlderThan,

--- a/src/lib/server/logging/logger.ts
+++ b/src/lib/server/logging/logger.ts
@@ -14,7 +14,6 @@ class Logger {
 	private readonly DEBUG_CACHE_TTL_MS = 30000;
 
 	async debug(message: string, source?: string, metadata?: Record<string, unknown>): Promise<void> {
-		// Check if debug is enabled (with caching)
 		const debugEnabled = await this.isDebugEnabled();
 		if (!debugEnabled) {
 			return;
@@ -54,13 +53,11 @@ class Logger {
 	private addToBuffer(entry: NewLogEntry): void {
 		this.buffer.push(entry);
 
-		// Flush immediately if buffer is full
 		if (this.buffer.length >= BATCH_SIZE) {
 			this.flush();
 			return;
 		}
 
-		// Schedule flush if not already scheduled
 		if (!this.flushTimer) {
 			this.flushTimer = setTimeout(() => {
 				this.flushTimer = null;
@@ -74,7 +71,6 @@ class Logger {
 			return;
 		}
 
-		// Clear any pending timer
 		if (this.flushTimer) {
 			clearTimeout(this.flushTimer);
 			this.flushTimer = null;
@@ -94,7 +90,6 @@ class Logger {
 			if (this.buffer.length + entries.length <= BATCH_SIZE * 2) {
 				this.buffer = [...entries, ...this.buffer];
 			}
-			// Log to console for visibility
 			console.error('[Logger] Failed to flush logs to database:', error);
 		} finally {
 			this.isFlushing = false;
@@ -114,7 +109,6 @@ class Logger {
 			this.debugEnabledCache = await isDebugEnabled();
 			this.debugCacheExpiry = now + this.DEBUG_CACHE_TTL_MS;
 		} catch {
-			// On error, default to false
 			this.debugEnabledCache = false;
 			this.debugCacheExpiry = now + this.DEBUG_CACHE_TTL_MS;
 		}

--- a/src/lib/server/logging/logger.ts
+++ b/src/lib/server/logging/logger.ts
@@ -99,12 +99,10 @@ class Logger {
 	private async isDebugEnabled(): Promise<boolean> {
 		const now = Date.now();
 
-		// Return cached value if still valid
 		if (this.debugEnabledCache !== null && now < this.debugCacheExpiry) {
 			return this.debugEnabledCache;
 		}
 
-		// Refresh cache
 		try {
 			this.debugEnabledCache = await isDebugEnabled();
 			this.debugCacheExpiry = now + this.DEBUG_CACHE_TTL_MS;

--- a/src/lib/server/logging/logger.ts
+++ b/src/lib/server/logging/logger.ts
@@ -78,15 +78,14 @@ class Logger {
 
 		this.isFlushing = true;
 
-		// Take current buffer (keep reference for potential restore)
 		const entries = this.buffer;
 		this.buffer = [];
 
 		try {
 			await insertLogsBatch(entries);
 		} catch (error) {
-			// Restore entries to buffer on failure (at the start, to preserve order)
-			// Only restore if the buffer hasn't grown too large (avoid memory issues)
+			// A transient DB failure should not silently drop logs, but cap the
+			// restore so an extended outage cannot grow the process unboundedly.
 			if (this.buffer.length + entries.length <= BATCH_SIZE * 2) {
 				this.buffer = [...entries, ...this.buffer];
 			}

--- a/src/lib/server/logging/service.ts
+++ b/src/lib/server/logging/service.ts
@@ -23,7 +23,7 @@ export async function insertLogsBatch(entries: NewLogEntry[]): Promise<void> {
 		message: entry.message,
 		source: entry.source ?? null,
 		metadata: entry.metadata ? JSON.stringify(entry.metadata) : null,
-		// Offset timestamp slightly to preserve order
+		// Batched entries can share the same millisecond; offset keeps UI ordering stable.
 		timestamp: now + index
 	}));
 

--- a/src/lib/server/logo/index.ts
+++ b/src/lib/server/logo/index.ts
@@ -1,10 +1,1 @@
-/**
- * Logo Server Module
- *
- * Provides server-side functionality for managing logo visibility
- * on wrapped pages.
- *
- * @module logo
- */
-
 export { getLogoVisibility, type LogoVisibilityResult, setUserLogoPreference } from './service';

--- a/src/lib/server/onboarding/status.ts
+++ b/src/lib/server/onboarding/status.ts
@@ -38,7 +38,6 @@ export async function isOnboardingComplete(): Promise<boolean> {
 export async function getOnboardingStep(): Promise<OnboardingStep> {
 	const step = await getAppSetting(AppSettingsKey.ONBOARDING_CURRENT_STEP);
 
-	// Validate the step is a valid OnboardingStep
 	if (step && Object.values(OnboardingSteps).includes(step as OnboardingStep)) {
 		return step as OnboardingStep;
 	}

--- a/src/lib/server/plex/client.ts
+++ b/src/lib/server/plex/client.ts
@@ -62,7 +62,6 @@ export async function plexRequest<T>(
 		const data = await response.json();
 		return data as T;
 	} catch (error) {
-		// Re-throw PlexApiError as-is
 		if (error instanceof PlexApiError) {
 			throw error;
 		}

--- a/src/lib/server/plex/client.ts
+++ b/src/lib/server/plex/client.ts
@@ -31,14 +31,12 @@ export async function plexRequest<T>(
 	params?: URLSearchParams,
 	signal?: AbortSignal
 ): Promise<T> {
-	// Get merged config (database takes priority over environment)
 	const config = await getPlexConfig();
 
 	if (!config.serverUrl) {
 		throw new PlexApiError('Plex server URL is not configured', undefined, endpoint);
 	}
 
-	// Build URL with optional query parameters
 	const url = new URL(endpoint, config.serverUrl);
 	if (params) {
 		params.forEach((value, key) => {
@@ -69,12 +67,10 @@ export async function plexRequest<T>(
 			throw error;
 		}
 
-		// Handle abort
 		if (error instanceof Error && error.name === 'AbortError') {
 			throw new PlexApiError('Request aborted', undefined, endpoint, error);
 		}
 
-		// Wrap other errors
 		throw new PlexApiError(
 			`Failed to fetch from Plex: ${error instanceof Error ? error.message : 'Unknown error'}`,
 			undefined,

--- a/src/lib/server/plex/server-name.service.ts
+++ b/src/lib/server/plex/server-name.service.ts
@@ -52,13 +52,11 @@ export async function fetchServerNameFromPlex(): Promise<string | null> {
 }
 
 export async function getServerName(): Promise<string | null> {
-	// Check cache first
 	const cached = await getCachedServerName();
 	if (cached) {
 		return cached;
 	}
 
-	// Fetch from Plex and cache
 	const fetched = await fetchServerNameFromPlex();
 	if (fetched) {
 		await setCachedServerName(fetched);

--- a/src/lib/server/plex/types.ts
+++ b/src/lib/server/plex/types.ts
@@ -69,7 +69,6 @@ export const PlexGenreTagSchema = z.object({
 
 export type PlexGenreTag = z.infer<typeof PlexGenreTagSchema>;
 
-/** Metadata from library endpoint - includes duration, genres, and year not in history */
 export const PlexLibraryMetadataItemSchema = z.object({
 	ratingKey: z.string(),
 	duration: z.number().int().optional(),
@@ -110,7 +109,6 @@ export const PlexShowMetadataResponseSchema = z.object({
 export type PlexShowMetadataItem = z.infer<typeof PlexShowMetadataItemSchema>;
 export type PlexShowMetadataResponse = z.infer<typeof PlexShowMetadataResponseSchema>;
 
-/** History metadata with guaranteed ratingKey and title */
 export type ValidPlexHistoryMetadata = PlexHistoryMetadata & { ratingKey: string; title: string };
 
 /** Plex can omit these fields, but play_history requires them. */

--- a/src/lib/server/plex/types.ts
+++ b/src/lib/server/plex/types.ts
@@ -113,7 +113,7 @@ export type PlexShowMetadataResponse = z.infer<typeof PlexShowMetadataResponseSc
 /** History metadata with guaranteed ratingKey and title */
 export type ValidPlexHistoryMetadata = PlexHistoryMetadata & { ratingKey: string; title: string };
 
-/** Type guard to filter out items without ratingKey or title before database insertion */
+/** Plex can omit these fields, but play_history requires them. */
 export function hasRequiredFields(item: PlexHistoryMetadata): item is ValidPlexHistoryMetadata {
 	return (
 		typeof item.ratingKey === 'string' &&

--- a/src/lib/server/ratelimit/index.ts
+++ b/src/lib/server/ratelimit/index.ts
@@ -1,6 +1,3 @@
-// Types
-
-// Service
 export {
 	checkRateLimit,
 	cleanupRateLimitStore,

--- a/src/lib/server/security/csrf-handle.ts
+++ b/src/lib/server/security/csrf-handle.ts
@@ -64,7 +64,6 @@ export function getOriginFromRequest(request: Request): string | null {
 export const csrfHandle: Handle = async ({ event, resolve }) => {
 	const method = event.request.method;
 
-	// Skip non-state-changing methods
 	if (!STATE_CHANGING_METHODS.includes(method)) {
 		return resolve(event);
 	}
@@ -82,11 +81,9 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 		return resolve(event);
 	}
 
-	// Get origin from database (priority) or environment
 	const config = await getCsrfConfigWithSource();
 	const expectedOrigin = config.origin.value || null;
 
-	// One-time startup status log
 	if (!startupLogged) {
 		startupLogged = true;
 		if (expectedOrigin) {
@@ -102,7 +99,6 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 		}
 	}
 
-	// If ORIGIN not configured anywhere
 	if (!expectedOrigin) {
 		if (dev) return resolve(event);
 
@@ -130,7 +126,6 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 
 	const requestOrigin = getOriginFromRequest(event.request);
 
-	// Missing origin header on state-changing request
 	if (!requestOrigin) {
 		logger.warn('CSRF check failed: missing origin header', 'CSRF', {
 			method,
@@ -145,7 +140,6 @@ export const csrfHandle: Handle = async ({ event, resolve }) => {
 		);
 	}
 
-	// Compare origins (case-insensitive per URL spec)
 	if (requestOrigin.toLowerCase() !== expectedOrigin.toLowerCase()) {
 		logger.warn('CSRF check failed: origin mismatch', 'CSRF', {
 			method,

--- a/src/lib/server/security/forwarded-headers.ts
+++ b/src/lib/server/security/forwarded-headers.ts
@@ -33,8 +33,8 @@ const FORWARDED_HEADER_LOOKUP: Array<[ForwardedHeaderName, string]> = [
 	['X-Real-IP', 'x-real-ip']
 ];
 
-// Take the rightmost (last-hop) value from a comma-separated forwarded header.
-// Returns null if no usable value is present.
+// Trust only the last hop: a correctly configured reverse proxy strips any
+// client-supplied forwarded values before appending its own.
 function lastHopValue(headerValue: string | null): string | null {
 	if (!headerValue) return null;
 	const parts = headerValue.split(',');

--- a/src/lib/server/security/proxy-handle.ts
+++ b/src/lib/server/security/proxy-handle.ts
@@ -19,9 +19,8 @@ let proxyStartupLogged = false;
 // reference via closure. The successful .then path never writes back to the
 // slot on resolution, so it cannot pollute the cache after reset.
 //
-// Rejections are self-evicting with an identity check: if
-// getTrustProxyConfigWithSource() rejects (or the .then callback throws), the
-// chained .catch nulls the slot ONLY when its own promise is still the current
+// If getTrustProxyConfigWithSource() rejects (or the .then callback throws),
+// the chained .catch nulls the slot ONLY when its own promise is still the current
 // one. That guard prevents a late rejection from a pre-reset chain from
 // clobbering a freshly-populated post-reset chain. The current caller still
 // fails fast, and the next miss starts a fresh fetch — so a transient DB error

--- a/src/lib/server/sharing/index.ts
+++ b/src/lib/server/sharing/index.ts
@@ -46,7 +46,6 @@ export {
 	ShareAccessDeniedError,
 	ShareError,
 	ShareMode,
-	// Privacy level helpers for floor enforcement
 	ShareModePrivacyLevel,
 	ShareModeSchema,
 	ShareSettingsKey,

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -170,8 +170,7 @@ export async function bulkApplyShareDefaults(): Promise<BulkApplyShareDefaultsRe
 			: ShareMode.PUBLIC;
 		const allowUserControl = allowResult[0]?.value === 'true';
 
-		// Count explicit rows up front so the caller can report how many were
-		// deliberately left untouched.
+		// Operators need to know explicit per-user overrides were preserved, not missed.
 		const explicitRows = await tx
 			.select({ id: shareSettings.id })
 			.from(shareSettings)
@@ -188,8 +187,7 @@ export async function bulkApplyShareDefaults(): Promise<BulkApplyShareDefaultsRe
 			baseUpdate.shareToken = null;
 		}
 
-		// Scope the bulk update to default-sourced rows ONLY. Explicit overrides
-		// (modeSource = 'explicit') are preserved verbatim.
+		// Bulk apply must never erase a user/admin override.
 		const updated = await tx
 			.update(shareSettings)
 			.set(baseUpdate)

--- a/src/lib/server/slides/custom.service.ts
+++ b/src/lib/server/slides/custom.service.ts
@@ -80,11 +80,9 @@ export async function getAllCustomSlides(year?: number): Promise<CustomSlide[]> 
 	}));
 }
 
-// Retrieves slides that are:
-// 1. Enabled
-// 2. Either matching the specific year OR applicable to all years (year = null)
+// Include all-year slides with the selected year so admins can define evergreen
+// custom content once without copying it into every Wrapped year.
 export async function getEnabledCustomSlides(year: number): Promise<CustomSlide[]> {
-	// Get slides matching the year OR with null year (applicable to all years)
 	const yearMatches = await db
 		.select()
 		.from(customSlides)

--- a/src/lib/server/slides/renderer.ts
+++ b/src/lib/server/slides/renderer.ts
@@ -76,8 +76,8 @@ export function markdownToPlainText(content: string, maxLength: number = 200): s
 	const html = renderMarkdownSync(content);
 
 	const plainText = html
-		.replace(/<[^>]*>/g, ' ') // Replace tags with spaces
-		.replace(/\s+/g, ' ') // Collapse whitespace
+		.replace(/<[^>]*>/g, ' ')
+		.replace(/\s+/g, ' ')
 		.trim();
 
 	if (plainText.length <= maxLength) {

--- a/src/lib/server/slides/renderer.ts
+++ b/src/lib/server/slides/renderer.ts
@@ -62,7 +62,6 @@ export function validateMarkdownSyntax(content: string): MarkdownValidationResul
 
 		const inlineCodeMatches = content.match(/(?<!`)`(?!`)/g) ?? [];
 		if (inlineCodeMatches.length % 2 !== 0) {
-			// Warning only - Markdown can handle unclosed inline code
 		}
 
 		return { valid: true, errors: [] };
@@ -74,21 +73,17 @@ export function validateMarkdownSyntax(content: string): MarkdownValidationResul
 }
 
 export function markdownToPlainText(content: string, maxLength: number = 200): string {
-	// Parse to HTML first
 	const html = renderMarkdownSync(content);
 
-	// Remove HTML tags
 	const plainText = html
 		.replace(/<[^>]*>/g, ' ') // Replace tags with spaces
 		.replace(/\s+/g, ' ') // Collapse whitespace
 		.trim();
 
-	// Truncate if needed
 	if (plainText.length <= maxLength) {
 		return plainText;
 	}
 
-	// Truncate at word boundary
 	const truncated = plainText.slice(0, maxLength);
 	const lastSpace = truncated.lastIndexOf(' ');
 

--- a/src/lib/server/slides/renderer.ts
+++ b/src/lib/server/slides/renderer.ts
@@ -62,6 +62,8 @@ export function validateMarkdownSyntax(content: string): MarkdownValidationResul
 
 		const inlineCodeMatches = content.match(/(?<!`)`(?!`)/g) ?? [];
 		if (inlineCodeMatches.length % 2 !== 0) {
+			// CommonMark treats unmatched single backticks as literal text; only
+			// fenced code blocks are strict enough here to reject author input.
 		}
 
 		return { valid: true, errors: [] };

--- a/src/lib/server/slides/utils.ts
+++ b/src/lib/server/slides/utils.ts
@@ -78,7 +78,7 @@ export function intersperseFunFacts(
 				result.push({
 					type: 'fun-fact',
 					enabled: true,
-					sortOrder: -1, // Will be recalculated
+					sortOrder: -1,
 					funFact: funFactData
 				});
 			}

--- a/src/lib/server/stats/engine.ts
+++ b/src/lib/server/stats/engine.ts
@@ -63,7 +63,7 @@ async function calculateSeriesCompletion(
 				}
 			}
 		} catch {
-			// Plex API unavailable, fall back to watched episodes as total
+			// Wrapped should still render when show metadata enrichment is unavailable.
 		}
 	}
 

--- a/src/lib/server/stats/serialization.ts
+++ b/src/lib/server/stats/serialization.ts
@@ -66,7 +66,6 @@ export function parseStats(json: string): Stats {
 		throw new StatsParseError('Invalid JSON string', error);
 	}
 
-	// Try to determine the type based on discriminating fields
 	if (typeof parsed === 'object' && parsed !== null) {
 		if ('userId' in parsed) {
 			const result = UserStatsSchema.safeParse(parsed);

--- a/src/lib/server/sync/plex-accounts.service.ts
+++ b/src/lib/server/sync/plex-accounts.service.ts
@@ -211,7 +211,6 @@ export interface PlexAccountInfo {
 export async function syncPlexAccounts(): Promise<number> {
 	logger.info('Starting Plex accounts sync...', 'PlexAccountsSync');
 
-	// Get merged config (database takes priority over environment)
 	const config = await getPlexConfig();
 
 	if (!config.serverUrl || !config.token) {

--- a/src/lib/server/sync/scheduler.ts
+++ b/src/lib/server/sync/scheduler.ts
@@ -166,7 +166,6 @@ export async function startBackgroundSync(
 		return { started: false, error: 'A sync is already in progress' };
 	}
 
-	// Use negative timestamp to distinguish from real DB IDs
 	const tempSyncId = -Date.now();
 
 	const signal = startSyncProgress(tempSyncId);

--- a/src/lib/server/sync/service.ts
+++ b/src/lib/server/sync/service.ts
@@ -43,7 +43,6 @@ function mapPlexRecordToDbInsert(record: ValidPlexHistoryMetadata) {
 		accountId: record.accountID,
 		librarySectionId: parseInt(record.librarySectionID, 10),
 		thumb: record.thumb ?? null,
-		// Convert duration from milliseconds to seconds if present
 		duration: record.duration !== undefined ? Math.floor(record.duration / 1000) : null,
 		grandparentTitle: record.grandparentTitle ?? null,
 		grandparentRatingKey: extractRatingKeyFromPath(record.grandparentKey),

--- a/src/lib/server/sync/service.ts
+++ b/src/lib/server/sync/service.ts
@@ -43,6 +43,8 @@ function mapPlexRecordToDbInsert(record: ValidPlexHistoryMetadata) {
 		accountId: record.accountID,
 		librarySectionId: parseInt(record.librarySectionID, 10),
 		thumb: record.thumb ?? null,
+		// Plex history reports milliseconds; stats and enriched metadata rows use
+		// seconds so historical and freshly synced records share one duration unit.
 		duration: record.duration !== undefined ? Math.floor(record.duration / 1000) : null,
 		grandparentTitle: record.grandparentTitle ?? null,
 		grandparentRatingKey: extractRatingKeyFromPath(record.grandparentKey),

--- a/src/lib/server/sync/service.ts
+++ b/src/lib/server/sync/service.ts
@@ -223,7 +223,7 @@ export async function startSync(options: StartSyncOptions = {}): Promise<SyncRes
 	try {
 		if (signal?.aborted) throw new SyncCancelledError();
 
-		// Sync Plex accounts first to ensure usernames are available for stats
+		// Stats attribution depends on Plex account names before history rows are read.
 		try {
 			await syncPlexAccounts();
 		} catch (error) {

--- a/src/lib/services/toast.ts
+++ b/src/lib/services/toast.ts
@@ -13,7 +13,7 @@ function shouldDebounce(message: string): boolean {
 
 	recentToasts.set(message, now);
 
-	// Cleanup old entries to prevent memory leaks
+	// Cap the debounce cache so repeated unique errors cannot grow it forever.
 	if (recentToasts.size > 50) {
 		const oldest = [...recentToasts.entries()].sort((a, b) => a[1] - b[1]).slice(0, 25);
 		oldest.forEach(([key]) => recentToasts.delete(key));

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -136,8 +136,6 @@ export const publicLandingLookupCopy = {
 		'Public lookup is on, but your default share mode is non-public — every lookup will return "not found" until the default share mode is set to Public.'
 } as const;
 
-// "What this exposes" preview-row tooltips
-
 /**
  * Stable identifiers for the four shared "What this exposes" preview rows. They
  * map onto the corresponding {@link PrivacyPreviewModel} fields but are keyed by
@@ -207,8 +205,6 @@ export const PRIVACY_PREVIEW_ROW_TOOLTIPS: Record<
 			'Members normally reach Wrapped pages from the dashboard, so this form mainly affects anonymous visitors on the landing page.'
 	}
 };
-
-// "What this exposes" preview-VALUE tooltips
 
 /**
  * Value literals each preview row can display, mirroring the matching

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -136,9 +136,7 @@ export const publicLandingLookupCopy = {
 		'Public lookup is on, but your default share mode is non-public — every lookup will return "not found" until the default share mode is set to Public.'
 } as const;
 
-// ============================================================================
 // "What this exposes" preview-row tooltips
-// ============================================================================
 
 /**
  * Stable identifiers for the four shared "What this exposes" preview rows. They
@@ -210,9 +208,7 @@ export const PRIVACY_PREVIEW_ROW_TOOLTIPS: Record<
 	}
 };
 
-// ============================================================================
 // "What this exposes" preview-VALUE tooltips
-// ============================================================================
 
 /**
  * Value literals each preview row can display, mirroring the matching
@@ -273,10 +269,6 @@ export const PRIVACY_PREVIEW_VALUE_TOOLTIPS: PrivacyPreviewValueTooltips = {
 		'user-choice': 'Each user decides whether the Obzorarr logo appears on their own Wrapped pages.'
 	}
 };
-
-// ============================================================================
-// Privacy presets (client-only control surface)
-// ============================================================================
 
 /**
  * Privacy preset identifiers. A preset bundles a recommended combination of the

--- a/src/lib/sharing/preset-logic.ts
+++ b/src/lib/sharing/preset-logic.ts
@@ -22,7 +22,6 @@ import {
 	type WrappedLogoOptionValue
 } from '$lib/sharing/options';
 
-/** Result of a preset match: a known preset id, or `'custom'` for any off-map combination. */
 export type PrivacyPresetMatch = PrivacyPresetId | 'custom';
 
 /**
@@ -45,10 +44,8 @@ export function shouldShowCustomPresetNote(
 }
 
 /**
- * Match the full six-field value set against the shipped presets. Used by
- * ONBOARDING, which owns all six fields (including `logoMode`) in one atomic
- * form. Returns the matching preset id, or `'custom'` if no preset matches.
- * Field order is irrelevant — comparison is key-by-key.
+ * Onboarding owns all six privacy fields in one atomic form, including
+ * `logoMode`, so its preset match must include the full value set.
  */
 export function matchPresetFull(values: PrivacyPresetValues): PrivacyPresetMatch {
 	for (const preset of PRIVACY_PRESETS) {

--- a/src/lib/stats/types.ts
+++ b/src/lib/stats/types.ts
@@ -7,7 +7,7 @@ export const RankedItemSchema = z.object({
 	thumb: z.string().nullable()
 });
 
-// Binge session: consecutive plays within 30 minutes
+// Binge sessions use the same 30-minute gap threshold as the server-side detector.
 export const BingeSessionSchema = z.object({
 	startTime: z.number().int(), // Unix timestamp
 	endTime: z.number().int(), // Unix timestamp

--- a/src/lib/stats/types.ts
+++ b/src/lib/stats/types.ts
@@ -9,15 +9,15 @@ export const RankedItemSchema = z.object({
 
 // Binge sessions use the same 30-minute gap threshold as the server-side detector.
 export const BingeSessionSchema = z.object({
-	startTime: z.number().int(), // Unix timestamp
-	endTime: z.number().int(), // Unix timestamp
+	startTime: z.number().int(),
+	endTime: z.number().int(),
 	plays: z.number().int().positive(),
 	totalMinutes: z.number().nonnegative()
 });
 
 export const WatchRecordSchema = z.object({
 	title: z.string(),
-	viewedAt: z.number().int(), // Unix timestamp
+	viewedAt: z.number().int(),
 	thumb: z.string().nullable(),
 	type: z.enum(['movie', 'episode', 'track'])
 });

--- a/src/lib/stores/sync-status.svelte.ts
+++ b/src/lib/stores/sync-status.svelte.ts
@@ -16,18 +16,19 @@ export interface SyncStatusStoreOptions {
 	shouldHandleTerminalEvent?: (event: SyncTerminalEventType) => boolean;
 }
 
-// Converts simplified SSE progress to LiveSyncProgress-compatible format
+// SyncIndicator still consumes the legacy LiveSyncProgress shape, so the
+// stream DTO is padded here until that UI can consume SyncStatusStreamProgress directly.
 function toCompatibleProgress(simple: SyncStatusStreamProgress | null): LiveSyncProgress | null {
 	if (!simple) return null;
 
 	return {
-		syncId: 0, // Not used by SyncIndicator
+		syncId: 0,
 		status: 'running',
 		recordsProcessed: simple.recordsProcessed,
-		recordsInserted: simple.recordsInserted ?? 0, // Not used by SyncIndicator
-		recordsSkipped: 0, // Not used by SyncIndicator
-		currentPage: 0, // Not used by SyncIndicator
-		startedAt: new Date(), // Not used by SyncIndicator
+		recordsInserted: simple.recordsInserted ?? 0,
+		recordsSkipped: 0,
+		currentPage: 0,
+		startedAt: new Date(),
 		phase: simple.phase,
 		enrichmentTotal: simple.enrichmentTotal,
 		enrichmentProcessed: simple.enrichmentProcessed

--- a/src/lib/stores/sync-status.svelte.ts
+++ b/src/lib/stores/sync-status.svelte.ts
@@ -98,7 +98,7 @@ export class SyncStatusStore {
 								try {
 									await callback(terminalEvent);
 								} catch {
-									// Silently ignore callback errors
+									// Terminal-event callbacks should not tear down the SSE loop.
 								}
 							}, 500);
 						}
@@ -108,7 +108,7 @@ export class SyncStatusStore {
 					this.wasSyncing = false;
 				}
 			} catch {
-				// Silently ignore parse errors
+				// Malformed SSE payloads are ignored; the next event carries fresh state.
 			}
 		};
 

--- a/src/lib/utils/animation-presets.ts
+++ b/src/lib/utils/animation-presets.ts
@@ -68,7 +68,6 @@ export function animateNumber(
 		const elapsed = performance.now() - startTime;
 		const progress = Math.min(elapsed / duration, 1);
 
-		// easeOutExpo - fast start, slow end
 		const eased = progress === 1 ? 1 : 1 - 2 ** (-10 * progress);
 		const current = Math.round(from + (to - from) * eased);
 
@@ -108,7 +107,6 @@ export function animateDecimal(
 		const elapsed = performance.now() - startTime;
 		const progress = Math.min(elapsed / duration, 1);
 
-		// easeOutExpo
 		const eased = progress === 1 ? 1 : 1 - 2 ** (-10 * progress);
 		const current = Math.round((from + (to - from) * eased) * multiplier) / multiplier;
 

--- a/src/lib/utils/form-toast.ts
+++ b/src/lib/utils/form-toast.ts
@@ -34,7 +34,6 @@ function isLegacyResponse(value: object): value is LegacyFormResponse {
 export function handleFormToast(form: FormShape): void {
 	if (!form || typeof form !== 'object') return;
 
-	// Superforms ActionResult: discriminated by `type`.
 	if ('type' in form && typeof form.type === 'string') {
 		switch (form.type) {
 			case 'success': {
@@ -64,7 +63,6 @@ export function handleFormToast(form: FormShape): void {
 		}
 	}
 
-	// Legacy `FormResponse` shape.
 	if (isLegacyResponse(form)) {
 		if (form.error) {
 			toast.error(form.error);

--- a/src/lib/utils/theme-fonts.ts
+++ b/src/lib/utils/theme-fonts.ts
@@ -1,11 +1,6 @@
 /**
- * Per-theme font triples (display / body / mono). Display fonts are used for
- * headings + hero typography on /wrapped surfaces; body fonts cover the rest
- * of the UI. Mono fonts are reserved for log viewers / API config blobs.
- *
- * Each entry is a Google Fonts `family=...` spec consumed by `loadThemeFonts`
- * to inject a single `<link>` per theme. Themes whose triple includes only
- * system fonts produce no `<link>` at all.
+ * Themes deliberately carry separate display/body/mono stacks so Wrapped
+ * surfaces can use expressive headings without changing log/API monospace copy.
  */
 type FontTriple = {
 	display: string;
@@ -76,14 +71,9 @@ const THEME_FAMILIES: Record<string, FontTriple> = {
 const loadedThemes = new Set<string>();
 
 /**
- * Load the Google Fonts stylesheet(s) for a theme.
- *
- * Each theme's `<link>` is appended at most once per page lifetime; calling
- * this with the same theme name twice is a no-op. Pure-system-font themes
- * (`soviet-red`) inject nothing.
- *
- * Renamed from `loadThemeFont` (singular) in the v3 UI overhaul to reflect
- * the per-theme display/body/mono triple model.
+ * Font loading is idempotent per page lifetime so repeated theme switches do
+ * not accumulate duplicate Google Fonts links. Pure-system-font themes inject
+ * nothing.
  */
 export function loadThemeFonts(theme: string): void {
 	const specs = THEME_FONT_SPECS[theme];
@@ -106,17 +96,10 @@ export function loadThemeFonts(theme: string): void {
 	loadedThemes.add(theme);
 }
 
-/**
- * Return the CSS `font-family` stack for a theme's body text. Useful when
- * setting `font-family` outside the `--font-sans` custom property path.
- */
 export function getThemeFontFamily(theme: string): string {
 	return THEME_FAMILIES[theme]?.body ?? DEFAULT_TRIPLE.body;
 }
 
-/**
- * Return the full `{ display, body, mono }` triple for a theme.
- */
 export function getThemeFontTriple(theme: string): FontTriple {
 	return THEME_FAMILIES[theme] ?? DEFAULT_TRIPLE;
 }

--- a/src/lib/utils/theme-fonts.ts
+++ b/src/lib/utils/theme-fonts.ts
@@ -18,8 +18,7 @@ const THEME_FONT_SPECS: Record<string, string[]> = {
 	supabase: ['Outfit:wght@400;500;600;700;800'],
 	'doom-64': ['Oxanium:wght@400;500;600;700;800'],
 	'amber-minimal': ['Inter:wght@400;500;600;700;800'],
-	'soviet-red': [], // System fonts only
-	// Premium wrapped themes — bolder weights for hero typography
+	'soviet-red': [],
 	'obsidian-premium': ['Inter:wght@400;500;600;700;800;900'],
 	'aurora-premium': ['Outfit:wght@400;500;600;700;800;900'],
 	'champagne-premium': ['Inter:wght@400;500;600;700;800;900']

--- a/src/lib/utils/theme-fonts.ts
+++ b/src/lib/utils/theme-fonts.ts
@@ -96,10 +96,18 @@ export function loadThemeFonts(theme: string): void {
 	loadedThemes.add(theme);
 }
 
+/**
+ * Unknown or custom themes fall back to the body stack so callers that only
+ * accept one family string do not need to duplicate theme fallback rules.
+ */
 export function getThemeFontFamily(theme: string): string {
 	return THEME_FAMILIES[theme]?.body ?? DEFAULT_TRIPLE.body;
 }
 
+/**
+ * Surfaces that render display/body/mono text together use the full triple to
+ * keep expressive Wrapped typography from changing monospace UI copy.
+ */
 export function getThemeFontTriple(theme: string): FontTriple {
 	return THEME_FAMILIES[theme] ?? DEFAULT_TRIPLE;
 }

--- a/src/params/year.ts
+++ b/src/params/year.ts
@@ -1,4 +1,3 @@
 import type { ParamMatcher } from '@sveltejs/kit';
 
-/** Accepts only exactly four decimal digits, e.g. "2026". */
 export const match: ParamMatcher = (param: string): boolean => /^\d{4}$/.test(param);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -35,7 +35,7 @@ $effect(() => {
 
 	document.body.classList.add(themeClass);
 
-	// Keep <html data-theme> (set by pre-paint script) in sync with live changes
+	// The pre-paint script prevents FOUC; live theme changes must update the same attribute.
 	document.documentElement.setAttribute('data-theme', effectiveTheme);
 
 	if (isWrappedRoute) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -31,23 +31,19 @@ $effect(() => {
 		'theme-champagne-premium'
 	];
 
-	// Remove all existing theme classes
 	document.body.classList.remove(...themeClasses);
 
-	// Add the effective theme class
 	document.body.classList.add(themeClass);
 
 	// Keep <html data-theme> (set by pre-paint script) in sync with live changes
 	document.documentElement.setAttribute('data-theme', effectiveTheme);
 
-	// Add/remove wrapped route class for full-viewport theming
 	if (isWrappedRoute) {
 		document.body.classList.add('wrapped-route');
 	} else {
 		document.body.classList.remove('wrapped-route');
 	}
 
-	// Load the font for this theme (if not already loaded)
 	loadThemeFonts(effectiveTheme);
 });
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -44,13 +44,11 @@ $effect(() => {
 	}
 });
 
-// Plex OAuth state
 let isOAuthLoading = $state(false);
 let isRedirecting = $state(false);
 let oauthError = $state<string | null>(null);
 let loginController: PlexLoginController | null = null;
 
-// Popup fallback state
 let showPopupBlockedModal = $state(false);
 let pendingPinId = $state<number | null>(null);
 let pendingAuthUrl = $state<string | null>(null);
@@ -236,7 +234,6 @@ function handleCancelRedirect(): void {
 				</div>
 			{/if}
 
-			<!-- SECONDARY: Plex OAuth Login -->
 			<div class="login-section">
 				<p class="login-prompt">Want to access your dashboard or change settings?</p>
 				<Button
@@ -631,7 +628,7 @@ function handleCancelRedirect(): void {
 			}
 		}
 
-		/* Reduced motion */
+		/* Respect users who request reduced motion. */
 		@media (prefers-reduced-motion: reduce) {
 			:global(.view-button),
 			:global(.login-button),

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,12 +30,10 @@ import type { ActionData, PageData } from './$types';
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
-// Username lookup state
 let username = $state('');
 let usernameTouched = $state(false);
 let isLookingUp = $state(false);
 
-// Sync username from form response (preserves user input on error).
 // The 403 "public lookup disabled" failure has no `username` field, so narrow
 // the ActionData union with an `in` check before reading it.
 $effect(() => {
@@ -57,10 +55,8 @@ let showPopupBlockedModal = $state(false);
 let pendingPinId = $state<number | null>(null);
 let pendingAuthUrl = $state<string | null>(null);
 
-// Element refs for animation
 let heroContainer: HTMLElement | undefined = $state();
 
-// Entrance animation for hero
 $effect(() => {
 	if (!heroContainer || prefersReducedMotion.current) return;
 	const animation = animate(
@@ -71,7 +67,6 @@ $effect(() => {
 	return () => animation.stop();
 });
 
-// Cleanup polling on unmount
 $effect(() => {
 	return () => {
 		loginController?.cancel();
@@ -151,10 +146,8 @@ function handleCancelRedirect(): void {
 </script>
 
 <div class="landing">
-	<!-- Hero Section -->
 	<section class="hero" bind:this={heroContainer}>
 		<div class="hero-content">
-			<!-- Logo Decorative Element -->
 			<div class="logo-glow" aria-hidden="true">
 				<Logo size={120} />
 			</div>
@@ -170,7 +163,6 @@ function handleCancelRedirect(): void {
 			</p>
 
 			{#if data.publicLookupEnabled}
-				<!-- PRIMARY CTA: Username Lookup -->
 				<div class="username-section">
 					<form
 						method="POST"
@@ -273,7 +265,6 @@ function handleCancelRedirect(): void {
 		</div>
 	</section>
 
-	<!-- Footer -->
 	<footer class="footer">
 		<p>Spotify Wrapped-style summaries for your Plex Media Server</p>
 	</footer>
@@ -293,7 +284,6 @@ function handleCancelRedirect(): void {
 			background: oklch(var(--background));
 		}
 
-		/* Hero Section */
 		.hero {
 			flex: 1;
 			display: flex;
@@ -358,7 +348,6 @@ function handleCancelRedirect(): void {
 			margin: 0 0 2rem;
 		}
 
-		/* Username Section - PRIMARY CTA */
 		.username-section {
 			margin-bottom: 2rem;
 		}
@@ -501,7 +490,6 @@ function handleCancelRedirect(): void {
 			cursor: not-allowed;
 		}
 
-		/* Login Section - SECONDARY */
 		.login-section {
 			padding-top: 1.5rem;
 			border-top: 1px solid oklch(var(--border) / 0.5);
@@ -595,7 +583,6 @@ function handleCancelRedirect(): void {
 			box-shadow: 0 0 0 2px oklch(var(--ring));
 		}
 
-		/* Footer */
 		.footer {
 			padding: 1.5rem 2rem;
 			text-align: center;
@@ -609,7 +596,6 @@ function handleCancelRedirect(): void {
 			letter-spacing: 0.05em;
 		}
 
-		/* Responsive */
 		@media (max-width: 640px) {
 			.hero {
 				min-height: 70vh;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,14 +20,6 @@ import { Button } from '$lib/components/ui/button';
 import { Input } from '$lib/components/ui/input';
 import type { ActionData, PageData } from './$types';
 
-/**
- * Public Landing Page
- *
- * Soviet/communist themed landing page for Obzorarr with:
- * - Username-based quick access to wrapped pages (primary CTA)
- * - Plex OAuth login button for dashboard access (secondary)
- */
-
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
 let username = $state('');

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -479,11 +479,8 @@ function handleCancelRedirect(): void {
 			margin: 0 0 0.75rem;
 		}
 
-		/* `.login-button` is the secondary Plex-OAuth CTA. Same :global hoist
-		   story as .view-button + .username-input above — prep for the
-		   future shadcn Button swap so the child component's rendered
-		   element inherits the styling across Svelte 5's component-scope
-		   boundary. Rule bodies are byte-identical. */
+		/* Keep this hoisted for parity with the shadcn-backed controls above; a
+		   future Button swap should not lose styling across the component boundary. */
 		:global(.login-button) {
 			display: inline-flex;
 			align-items: center;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -347,9 +347,9 @@ function handleCancelRedirect(): void {
 			gap: 0.75rem;
 		}
 
-		/* Sign-in CTA rendered when public lookup is disabled. Reuses the primary
-		   `.view-button` pill look; `.cta-link` only neutralises the anchor's
-		   default underline and centers the CTA within the section. */
+		/* When public lookup is disabled, the fallback sign-in link should keep
+		   the primary CTA affordance; `.cta-link` only neutralises the anchor's
+		   default underline. */
 		.signin-required-note {
 			font-size: 0.95rem;
 			color: oklch(var(--muted-foreground));
@@ -384,13 +384,9 @@ function handleCancelRedirect(): void {
 			border: 0;
 		}
 
-		/* Paired :global hoist for the username form input — same migration
-		   story as `.view-button` above: PR-3 / US-024 swaps the native
-		   <input class="username-input"> for the shadcn Input primitive
-		   which renders inside a child component beyond Svelte 5's
-		   component-scope. Globalising the rules now preserves the
-		   hand-tuned focus ring + max-width without forcing the Input
-		   consumer to re-implement them. */
+		/* shadcn Input renders inside a child component beyond Svelte's scoped
+		   style boundary, so the selector must be global to preserve the custom
+		   max-width and focus ring without duplicating them at the call site. */
 		:global(.username-input) {
 			flex: 1;
 			min-width: 200px;
@@ -429,16 +425,9 @@ function handleCancelRedirect(): void {
 			cursor: not-allowed;
 		}
 
-		/* `.view-button` is consumed at scope today by the native <button> in the
-		   username form, but PR-3 / US-024 will swap that for the shadcn
-		   SubmitButton primitive which renders the button element inside a
-		   child component — Svelte 5 component-scoped CSS doesn't reach
-		   inside a child, so the styling has to be globalised now. The rules
-		   are unchanged; only the selector scope is bumped to :global so the
-		   primitive consumer can keep the hero CTA's hover translate-y + glow
-		   without re-implementing them. The .username-input rules below have
-		   the same migration story; the matching :global hoist is paired with
-		   the shadcn Input swap pre-work. */
+		/* shadcn SubmitButton renders the actual <button> inside a child component,
+		   so the selector must be global for the hero CTA's hover translate-y and
+		   glow to reach the primitive without re-implementing those rules. */
 		:global(.view-button) {
 			display: inline-flex;
 			align-items: center;

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -20,15 +20,6 @@ import Logo from '$lib/components/Logo.svelte';
 import CsrfWarningBanner from '$lib/components/security/CsrfWarningBanner.svelte';
 import type { LayoutData } from './$types';
 
-/**
- * Admin Layout
- *
- * Provides a consistent wrapper for all admin pages with:
- * - Sidebar navigation
- * - Admin user info
- * - Modern command center styling
- */
-
 interface Props {
 	data: LayoutData;
 	children: Snippet;
@@ -36,7 +27,6 @@ interface Props {
 
 let { data, children }: Props = $props();
 
-// Navigation items with Lucide icon components
 const navItems: Array<{ href: string; label: string; icon: Component }> = [
 	{ href: '/admin', label: 'Dashboard', icon: LayoutDashboard },
 	{ href: '/admin/wrapped', label: 'Wrapped', icon: Gift },
@@ -47,17 +37,14 @@ const navItems: Array<{ href: string; label: string; icon: Component }> = [
 	{ href: '/admin/settings', label: 'Settings', icon: Settings }
 ];
 
-// Determine if a nav item is active
 const isActive = $derived((href: string) => {
 	const currentPath = $page.url.pathname;
-	// Exact match for dashboard, prefix match for others
 	if (href === '/admin') {
 		return currentPath === '/admin';
 	}
 	return currentPath.startsWith(href);
 });
 
-// Mobile sidebar state
 let sidebarOpen = $state(false);
 let isMobileSidebar = $state(false);
 let sidebarHiddenFromMobile = $derived(isMobileSidebar && !sidebarOpen);
@@ -93,7 +80,6 @@ async function focusAfterRender(selector: string) {
 	document.querySelector<HTMLElement>(selector)?.focus();
 }
 
-// Reset avatar error when thumb URL changes so a new URL gets a fresh load attempt
 $effect(() => {
 	data.adminUser.thumb;
 	adminAvatarError = false;
@@ -103,7 +89,6 @@ $effect(() => {
 let locallyDismissed = $state(false);
 let showCsrfWarning = $derived(data.csrfWarning.show && !locallyDismissed);
 
-// Reset local dismissed state when server re-enables the warning
 $effect(() => {
 	if (data.csrfWarning.show) {
 		locallyDismissed = false;
@@ -201,7 +186,6 @@ function handleCsrfWarningDismissed() {
 <svelte:window onkeydown={handleWindowKeydown} />
 
 <div class="admin-layout">
-	<!-- Mobile header -->
 		<header class="mobile-header" class:sidebar-open={sidebarOpen}>
 		<button
 			type="button"
@@ -221,7 +205,6 @@ function handleCsrfWarningDismissed() {
 		</div>
 	</header>
 
-	<!-- Sidebar overlay for mobile -->
 	{#if sidebarOpen}
 		<div
 			class="sidebar-overlay"
@@ -233,7 +216,6 @@ function handleCsrfWarningDismissed() {
 		></div>
 	{/if}
 
-	<!-- Sidebar -->
 	<aside
 		class="sidebar"
 		class:open={sidebarOpen}
@@ -322,7 +304,6 @@ function handleCsrfWarningDismissed() {
 		</div>
 	</aside>
 
-	<!-- Main content -->
 	<main
 		class="main-content"
 		inert={mainContentHiddenFromMobile}
@@ -342,7 +323,6 @@ function handleCsrfWarningDismissed() {
 			background: oklch(var(--background));
 		}
 
-		/* Mobile header */
 		.mobile-header {
 			display: none;
 			position: fixed;
@@ -398,7 +378,6 @@ function handleCsrfWarningDismissed() {
 			margin: 0;
 		}
 
-		/* Sidebar overlay */
 		.sidebar-overlay {
 			display: none;
 			position: fixed;
@@ -408,7 +387,6 @@ function handleCsrfWarningDismissed() {
 			z-index: 45;
 		}
 
-		/* Sidebar */
 		.sidebar {
 			position: fixed;
 			top: 0;
@@ -672,7 +650,6 @@ function handleCsrfWarningDismissed() {
 			height: 0.875rem;
 		}
 
-		/* Main content */
 		.main-content {
 			flex: 1;
 			margin-left: 260px;

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -85,7 +85,6 @@ $effect(() => {
 	adminAvatarError = false;
 });
 
-// CSRF warning state - derived from data with local override for immediate dismiss
 let locallyDismissed = $state(false);
 let showCsrfWarning = $derived(data.csrfWarning.show && !locallyDismissed);
 

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -655,8 +655,7 @@ function handleCsrfWarningDismissed() {
 			min-height: 100vh;
 		}
 
-		/* Responsive styles.
-		   768px covers phones through tablets; verified 2026-04 at 375px and 280px
+		/* 768px covers phones through tablets; verified 2026-04 at 375px and 280px
 		   (Galaxy Fold folded). Collapses the sidebar behind an overlay and drops the
 		   main-content left margin, so content fills the viewport without horizontal
 		   scroll at smaller widths. */

--- a/src/routes/admin/+page.server.ts
+++ b/src/routes/admin/+page.server.ts
@@ -11,7 +11,6 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async () => {
 	const year = new Date().getFullYear();
 
-	// Load all dashboard data in parallel
 	const [
 		userCount,
 		syncedViewerCount,

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -20,18 +20,8 @@ import { formatWatchHours } from '$lib/stats/format';
 import { formatDuration } from '$lib/utils/format';
 import type { PageData } from './$types';
 
-/**
- * Admin Dashboard
- *
- * Displays server overview with:
- * - Total users and watch time stats
- * - Sync status and schedule
- * - Quick action links
- */
-
 let { data }: { data: PageData } = $props();
 
-// Format watch time as human-readable
 const formatWatchTime = $derived.by(() => {
 	if (!data.stats) return { hours: 0, days: '0' };
 	const hours = formatWatchHours(data.stats.totalWatchTimeMinutes);
@@ -39,7 +29,6 @@ const formatWatchTime = $derived.by(() => {
 	return { hours, days };
 });
 
-// Format relative time
 function formatRelativeTime(isoDate: string | null): string {
 	if (!isoDate) return 'Never';
 
@@ -58,7 +47,6 @@ function formatRelativeTime(isoDate: string | null): string {
 	return date.toLocaleDateString();
 }
 
-// Format date nicely
 function formatDate(isoDate: string | null): string {
 	if (!isoDate) return 'N/A';
 	return new Date(isoDate).toLocaleString();
@@ -88,7 +76,6 @@ function handleAdminNavigation(event: MouseEvent) {
 	void goto(href);
 }
 
-// Stats configuration with icons and colors
 const statsConfig = $derived([
 	{
 		value: data.userCount,
@@ -122,7 +109,6 @@ const statsConfig = $derived([
 	}
 ]);
 
-// Sync status derived state
 const syncStatus = $derived.by(() => {
 	if (!data.schedulerStatus) return 'unknown';
 	if (data.schedulerStatus.isPaused) return 'paused';
@@ -138,7 +124,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 </svelte:head>
 
 <div class="dashboard">
-	<!-- Header with gradient accent -->
 	<header class="dashboard-header">
 		<div class="header-content">
 			<div class="header-text">
@@ -153,7 +138,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 		<div class="header-glow"></div>
 	</header>
 
-	<!-- Stats Cards Grid -->
 	<div class="stats-grid">
 		{#each statsConfig as stat, i}
 			<div class="stat-card stat-{stat.color}" style="--delay: {i * 0.1}s">
@@ -173,9 +157,7 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 		{/each}
 	</div>
 
-	<!-- Main Content Grid -->
 	<div class="content-grid">
-		<!-- Sync Status Section -->
 		<section class="section sync-section">
 			<div class="section-header">
 				<div class="section-title-wrap">
@@ -289,7 +271,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 			</div>
 		</section>
 
-		<!-- Wrapped Section -->
 		<section class="section wrapped-section">
 			<div class="section-header">
 				<div class="section-title-wrap">
@@ -333,7 +314,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 		</section>
 	</div>
 
-	<!-- Quick Actions Section -->
 	<section class="section actions-section">
 		<h2 class="actions-title">Quick Actions</h2>
 
@@ -381,7 +361,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 			padding: 1.5rem 2rem 3rem;
 		}
 
-		/* Header */
 		.dashboard-header {
 			position: relative;
 			margin-bottom: 2rem;
@@ -440,7 +419,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 			pointer-events: none;
 		}
 
-		/* Stats Grid */
 		.stats-grid {
 			display: grid;
 			grid-template-columns: repeat(4, 1fr);
@@ -576,7 +554,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 			margin-top: 0.125rem;
 		}
 
-		/* Content Grid */
 		.content-grid {
 			display: grid;
 			grid-template-columns: 1fr 1fr;
@@ -584,7 +561,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 			margin-bottom: 1.5rem;
 		}
 
-		/* Sections */
 		.section {
 			background: oklch(var(--card));
 			border: 1px solid oklch(var(--border));
@@ -637,7 +613,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 			gap: 0.5rem;
 		}
 
-		/* Sync Info */
 		.sync-info {
 			display: flex;
 			flex-direction: column;
@@ -781,7 +756,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 			font-weight: 500;
 		}
 
-		/* Wrapped Grid */
 		.wrapped-grid {
 			display: grid;
 			grid-template-columns: repeat(3, 1fr);
@@ -913,7 +887,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 			transform: translateX(0);
 		}
 
-		/* Actions Section */
 		.actions-section {
 			animation-delay: 0.4s;
 		}
@@ -1000,7 +973,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 			transform: translateX(2px);
 		}
 
-		/* Animations */
 		@keyframes slideUp {
 			from {
 				opacity: 0;
@@ -1033,7 +1005,6 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 			}
 		}
 
-		/* Responsive */
 		@media (max-width: 1024px) {
 			.stats-grid {
 				grid-template-columns: repeat(2, 1fr);

--- a/src/routes/admin/logs/+page.server.ts
+++ b/src/routes/admin/logs/+page.server.ts
@@ -61,7 +61,6 @@ function normalizeSearchParam(search: string | null): string | undefined {
 }
 
 export const load: PageServerLoad = async ({ url }) => {
-	// Initialize retention scheduler if not already configured
 	if (!isRetentionSchedulerConfigured()) {
 		setupLogRetentionScheduler();
 	}
@@ -170,7 +169,6 @@ export const actions: Actions = requireAdminActions({
 		const toTimestamp = TimestampSchema.parse(toParam);
 
 		try {
-			// Get all logs matching filters (no limit for export)
 			const result = await queryLogs({
 				levels,
 				search,

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -833,10 +833,8 @@ $effect(() => {
 			margin-bottom: 1rem;
 		}
 
-		/* `.clear-filters-button` is the muted-tertiary "Clear All" CTA
-		   in the filters header. Hoisted to :global so shadcn Button's
-		   child-rendered <button> inherits the transparent background +
-		   border + hover-darken treatment. */
+		/* shadcn Button child-renders the real <button>, so this transparent
+		   treatment must be hoisted. */
 		:global(.clear-filters-button) {
 			padding: 0.25rem 0.5rem;
 			font-size: 0.75rem;
@@ -983,11 +981,8 @@ $effect(() => {
 			display: inline;
 		}
 
-		/* `.control-button` is the log-page actions group (live-view
-		   toggle + Export/Cleanup/Clear). 4 variants (default primary +
-		   .secondary + .danger + .active) all hoisted to :global so the
-		   shadcn Button + SubmitButton consumers inherit each variant's
-		   palette. */
+		/* These actions mix shadcn Button and SubmitButton consumers; hoist the
+		   variant palettes so child-rendered controls inherit them. */
 		:global(.control-button) {
 			padding: 0.5rem 1rem;
 			font-size: 0.875rem;
@@ -1187,10 +1182,8 @@ $effect(() => {
 			overflow-x: auto;
 		}
 
-		/* `.copy-button` is the per-row copy-to-clipboard CTA in the log
-		   table. Hoisted to :global so shadcn Button's child-rendered
-		   <button> inherits the muted-default vs primary-on-hover
-		   palette swap. */
+		/* shadcn Button child-renders the real <button>, so the hover palette
+		   must be hoisted. */
 		:global(.copy-button) {
 			padding: 0.25rem 0.5rem;
 			font-size: 0.6875rem;
@@ -1218,11 +1211,8 @@ $effect(() => {
 			padding: 1rem;
 		}
 
-		/* `.load-more-button` renders as an <a> tag (pagination cursor
-		   link). shadcn Button with `href` prop renders <a> internally.
-		   Hoisted to :global so the rendered anchor inherits the
-		   secondary palette + border + hover-darken. text-decoration:none
-		   stays for the underline-removal. */
+		/* shadcn Button with `href` child-renders an <a>, so the pagination
+		   treatment must be hoisted to reach the anchor. */
 		:global(.load-more-button) {
 			display: inline-block;
 			padding: 0.5rem 1.5rem;

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -332,7 +332,6 @@ $effect(() => {
 	};
 });
 
-// Connect to SSE on mount if autoScroll is enabled (browser-only)
 $effect(() => {
 	if (browser && autoScroll && !eventSource) {
 		connectSSE();

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -11,20 +11,6 @@ import { toast } from '$lib/services/toast';
 import { handleFormToast } from '$lib/utils/form-toast';
 import type { ActionData, PageData } from './$types';
 
-/**
- * Admin Logs Page
- *
- * Real-time log viewer with filtering and SSE streaming.
- *
- * Features:
- * - Log level filtering (multi-select)
- * - Text search with debounce
- * - Source filter dropdown
- * - Date range filtering
- * - Auto-scroll with SSE streaming
- * - Export and clear functionality
- */
-
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
 let selectedLevels = $derived<LogLevelType[]>(data.filters?.levels ?? []);

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -27,7 +27,6 @@ import type { ActionData, PageData } from './$types';
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
-// Filter state (reactive to URL params via data)
 let selectedLevels = $derived<LogLevelType[]>(data.filters?.levels ?? []);
 let selectedSource = $derived(data.filters?.source ?? '');
 
@@ -39,7 +38,6 @@ $effect.pre(() => {
 let normalizedSearchText = $derived(searchText.trim());
 let normalizedSearchLower = $derived(normalizedSearchText.toLowerCase());
 
-// Date range filter state
 let fromDate = $state('');
 let toDate = $state('');
 
@@ -58,24 +56,19 @@ $effect.pre(() => {
 });
 let autoScroll = $state(true);
 
-// Clear-logs confirmation dialog
 let clearLogsDialogOpen = $state(false);
 let isClearingLogs = $state(false);
 
-// Run-cleanup confirmation dialog
 let runCleanupDialogOpen = $state(false);
 let isRunningCleanup = $state(false);
 
-// SSE connection state
 let eventSource: EventSource | null = $state(null);
 let streamedLogs = $state<LogEntry[]>([]);
 let lastSeenStreamId = $state(0);
 let isConnected = $state(false);
 
-// Debounce timer for search
 let searchDebounce: ReturnType<typeof setTimeout> | null = null;
 
-// Filter streamed logs to match active filters
 const filteredStreamedLogs = $derived(
 	streamedLogs.filter((log) => {
 		if (selectedLevels.length > 0 && !selectedLevels.includes(log.level)) return false;
@@ -131,15 +124,12 @@ const visibleSources = $derived.by(() => {
 
 const visibleTotalCount = $derived(visibleLogs.length);
 
-// Available log levels
 const logLevels: LogLevelType[] = ['DEBUG', 'INFO', 'WARN', 'ERROR'];
 
-// Format timestamp
 function formatTimestamp(timestamp: number): string {
 	return new Date(timestamp).toLocaleString();
 }
 
-// Format relative time
 function formatRelativeTime(timestamp: number): string {
 	const now = Date.now();
 	const diffMs = now - timestamp;
@@ -154,7 +144,6 @@ function formatRelativeTime(timestamp: number): string {
 	return new Date(timestamp).toLocaleDateString();
 }
 
-// Get level badge class
 function getLevelClass(level: LogLevelType): string {
 	switch (level) {
 		case 'ERROR':
@@ -176,7 +165,6 @@ const exportAction = $derived.by(() => {
 	return search ? `?${search}&/exportLogs` : '?/exportLogs';
 });
 
-// Apply filters to URL (accepts overrides for derived values)
 function applyFilters(overrides?: { levels?: LogLevelType[]; search?: string; source?: string }) {
 	const params = new URLSearchParams();
 	const levels = overrides?.levels ?? selectedLevels;
@@ -209,7 +197,6 @@ function applyFilters(overrides?: { levels?: LogLevelType[]; search?: string; so
 	goto(`/admin/logs${queryString ? `?${queryString}` : ''}`, { replaceState: true });
 }
 
-// Toggle level filter
 function toggleLevel(level: LogLevelType) {
 	const newLevels = selectedLevels.includes(level)
 		? selectedLevels.filter((l) => l !== level)
@@ -217,7 +204,6 @@ function toggleLevel(level: LogLevelType) {
 	applyFilters({ levels: newLevels });
 }
 
-// Handle search input with debounce
 function handleSearchInput(event: Event) {
 	const target = event.target as HTMLInputElement;
 	searchText = target.value;
@@ -231,13 +217,11 @@ function handleSearchInput(event: Event) {
 	}, 300);
 }
 
-// Handle source change
 function handleSourceChange(event: Event) {
 	const target = event.target as HTMLSelectElement;
 	applyFilters({ source: target.value });
 }
 
-// Clear all filters
 function clearFilters() {
 	// Cancel any pending debounced search so it doesn't race the navigation
 	if (searchDebounce) {
@@ -258,7 +242,6 @@ function clearFilters() {
 	}
 }
 
-// Connect to SSE stream
 function connectSSE() {
 	if (eventSource) {
 		eventSource.close();
@@ -277,13 +260,11 @@ function connectSSE() {
 			const data = JSON.parse(event.data);
 
 			if (data.type === 'log') {
-				// Add new log to streamed logs
 				streamedLogs = [data.log, ...streamedLogs];
 				if (data.log.id > lastSeenStreamId) {
 					lastSeenStreamId = data.log.id;
 				}
 
-				// Scroll to top if auto-scroll is enabled
 				if (autoScroll) {
 					const container = document.querySelector('.logs-table-wrapper');
 					if (container) {
@@ -298,7 +279,6 @@ function connectSSE() {
 
 	eventSource.onerror = () => {
 		isConnected = false;
-		// Attempt to reconnect after 5 seconds
 		setTimeout(() => {
 			if (autoScroll) {
 				connectSSE();
@@ -307,7 +287,6 @@ function connectSSE() {
 	};
 }
 
-// Disconnect from SSE stream
 function disconnectSSE() {
 	if (eventSource) {
 		eventSource.close();
@@ -316,7 +295,6 @@ function disconnectSSE() {
 	isConnected = false;
 }
 
-// Toggle auto-scroll (and SSE connection)
 function toggleAutoScroll() {
 	autoScroll = !autoScroll;
 
@@ -340,7 +318,6 @@ async function refreshAfterLogMutation(update: () => Promise<void>): Promise<voi
 	}
 }
 
-// Copy log entry to clipboard
 async function copyLog(log: LogEntry) {
 	const text = `[${new Date(log.timestamp).toISOString()}] [${log.level}] [${log.source ?? 'App'}] ${log.message}`;
 	try {
@@ -351,7 +328,6 @@ async function copyLog(log: LogEntry) {
 	}
 }
 
-// Parse metadata JSON
 function parseMetadata(metadata: string | null): Record<string, unknown> | null {
 	if (!metadata) return null;
 	try {
@@ -361,7 +337,6 @@ function parseMetadata(metadata: string | null): Record<string, unknown> | null 
 	}
 }
 
-// Cleanup on unmount
 $effect(() => {
 	return () => {
 		disconnectSSE();
@@ -378,7 +353,6 @@ $effect(() => {
 	}
 });
 
-// Show toast notifications for form responses
 $effect(() => {
 	handleFormToast(form);
 });
@@ -394,7 +368,6 @@ $effect(() => {
 		<p class="subtitle">View and filter application log entries</p>
 	</header>
 
-	<!-- Stats Section -->
 	<section class="stats-section">
 		<div class="stat-card">
 			<span class="stat-value">{visibleTotalCount.toLocaleString()}</span>
@@ -414,7 +387,6 @@ $effect(() => {
 		</div>
 	</section>
 
-	<!-- Filters Section -->
 	<section class="section filters-section">
 		<div class="filters-header">
 			<h2>Filters</h2>
@@ -424,7 +396,6 @@ $effect(() => {
 		</div>
 
 		<div class="filters-grid">
-			<!-- Level Filters -->
 			<div class="filter-group">
 				<span class="filter-label">Log Level</span>
 				<div class="level-checkboxes">
@@ -445,7 +416,6 @@ $effect(() => {
 				</div>
 			</div>
 
-			<!-- Search -->
 			<div class="filter-group">
 				<label class="filter-label" for="search">Search</label>
 				<input
@@ -457,7 +427,6 @@ $effect(() => {
 				/>
 			</div>
 
-			<!-- Source Filter -->
 			<div class="filter-group">
 				<label class="filter-label" for="source">Source</label>
 				<select id="source" value={selectedSource} onchange={handleSourceChange}>
@@ -468,7 +437,6 @@ $effect(() => {
 				</select>
 			</div>
 
-			<!-- Date Range: After -->
 			<div class="filter-group">
 				<label class="filter-label" for="from-date">After</label>
 				<input
@@ -485,7 +453,6 @@ $effect(() => {
 				/>
 			</div>
 
-			<!-- Date Range: Before -->
 			<div class="filter-group">
 				<label class="filter-label" for="to-date">Before</label>
 				<input
@@ -504,7 +471,6 @@ $effect(() => {
 		</div>
 	</section>
 
-	<!-- Controls Section -->
 	<section class="section controls-section">
 		<div class="controls-left">
 			<button
@@ -582,7 +548,6 @@ $effect(() => {
 		</div>
 	</section>
 
-	<!-- Logs Table Section -->
 	<section class="section logs-section">
 		<div class="logs-header">
 			<h2>Log Entries</h2>
@@ -663,7 +628,6 @@ $effect(() => {
 		{/if}
 		</section>
 
-	<!-- Settings Info -->
 	<section class="section settings-info">
 		<h2>Retention Settings</h2>
 		<div class="settings-grid">
@@ -821,7 +785,6 @@ $effect(() => {
 			margin: 0;
 		}
 
-		/* Stats Section */
 		.stats-section {
 			display: grid;
 			grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -863,7 +826,6 @@ $effect(() => {
 			margin-top: 0.25rem;
 		}
 
-		/* Section */
 		.section {
 			background: oklch(var(--card));
 			border: 1px solid oklch(var(--border));
@@ -879,7 +841,6 @@ $effect(() => {
 			margin: 0;
 		}
 
-		/* Filters */
 		.filters-header {
 			display: flex;
 			justify-content: space-between;
@@ -1018,7 +979,6 @@ $effect(() => {
 			margin-left: 0.25rem;
 		}
 
-		/* Controls */
 		.controls-section {
 			display: flex;
 			justify-content: space-between;
@@ -1095,7 +1055,6 @@ $effect(() => {
 			}
 		}
 
-		/* Logs Table */
 		.logs-section {
 			padding: 1rem;
 		}
@@ -1294,7 +1253,6 @@ $effect(() => {
 			background: oklch(var(--muted));
 		}
 
-		/* Settings Info */
 		.settings-info h2 {
 			margin-bottom: 1rem;
 		}
@@ -1334,7 +1292,6 @@ $effect(() => {
 			color: oklch(var(--primary));
 		}
 
-		/* Responsive */
 		@media (max-width: 768px) {
 			.logs-page {
 				padding: 1rem;

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -16,7 +16,7 @@ let { data, form }: { data: PageData; form: ActionData } = $props();
 let selectedLevels = $derived<LogLevelType[]>(data.filters?.levels ?? []);
 let selectedSource = $derived(data.filters?.source ?? '');
 
-// Search needs local state for debounce pattern, synced from data
+// Debounced search needs a writable buffer; URL data remains the committed value.
 let searchText = $state('');
 $effect.pre(() => {
 	searchText = data.filters?.search ?? '';
@@ -77,7 +77,7 @@ function matchesVisibleFilters(log: LogEntry): boolean {
 	return true;
 }
 
-// Combined logs (filtered streamed + server-filtered), then narrowed by live local inputs.
+// SSE entries arrive ahead of the next server load; merge by id to avoid duplicates.
 const allLogs = $derived.by(() => {
 	const seen = new Set<number>();
 	const merged: LogEntry[] = [];
@@ -145,7 +145,7 @@ function getLevelClass(level: LogLevelType): string {
 	}
 }
 
-// Preserve current filter query string on the export form so the server action sees them.
+// Export must use the same filters the operator is currently viewing.
 const exportAction = $derived.by(() => {
 	const search = $page.url.searchParams.toString();
 	return search ? `?${search}&/exportLogs` : '?/exportLogs';
@@ -209,7 +209,7 @@ function handleSourceChange(event: Event) {
 }
 
 function clearFilters() {
-	// Cancel any pending debounced search so it doesn't race the navigation
+	// A pending debounced search would re-add the old query after the clear navigation.
 	if (searchDebounce) {
 		clearTimeout(searchDebounce);
 		searchDebounce = null;

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -285,7 +285,7 @@ function toggleAutoScroll() {
 	autoScroll = !autoScroll;
 
 	if (autoScroll) {
-		streamedLogs = []; // Clear old streamed logs
+		streamedLogs = [];
 		lastSeenStreamId = 0;
 		connectSSE();
 	} else {

--- a/src/routes/admin/settings/+layout.svelte
+++ b/src/routes/admin/settings/+layout.svelte
@@ -23,9 +23,8 @@ const tabs = [
 	{ name: 'Privacy', href: '/admin/settings/privacy', icon: LockKeyholeIcon }
 ];
 
-// DF-009: give the settings area a single page-level <h1> for orientation +
-// a11y (the index is a pure redirect and the tab pages only carry per-card
-// CardTitles). The heading reflects the active tab.
+// DF-009: keep one page-level <h1> in the settings shell for orientation and
+// accessibility; the index route redirects and child tabs only have per-card headings.
 const activeTab = $derived(
 	tabs.find((tab) => page.url.pathname.startsWith(tab.href))?.name ?? 'Settings'
 );

--- a/src/routes/admin/settings/connections/+page.server.ts
+++ b/src/routes/admin/settings/connections/+page.server.ts
@@ -196,10 +196,8 @@ export const actions: Actions = requireAdminActions({
 				}
 			}
 
-			// C2: detect submitted-but-locked fields so we can surface a note.
-			// Only the five lockable fields are checked; plexAllowInsecureLocalHttp
-			// is not ENV-lockable and is excluded from both the locks object and the
-			// submitted-locked scan.
+			// Surface ignored edits on ENV-locked fields; plexAllowInsecureLocalHttp is
+			// not ENV-lockable, so it is deliberately excluded.
 			const locks = {
 				plexServerUrl: apiConfig.plex.serverUrl.isLocked,
 				plexToken: apiConfig.plex.token.isLocked,
@@ -215,8 +213,6 @@ export const actions: Actions = requireAdminActions({
 				'openaiBaseUrl',
 				'openaiModel'
 			];
-			// A field counts as "submitted AND locked" when the FormData contained
-			// the key (values[k] !== undefined) AND the field is ENV-locked.
 			const submittedLockedFields = lockableKeys.filter((k) => values[k] !== undefined && locks[k]);
 			const hasLockedFieldSubmission = submittedLockedFields.length > 0;
 
@@ -237,13 +233,11 @@ export const actions: Actions = requireAdminActions({
 				await clearCachedServerMachineId();
 			}
 
-			// A2: read the new version immediately after the atomic write so the
-			// client can bind both panels to the fresh token without waiting for
-			// invalidateAll to complete.
+			// The sibling panel may save next before invalidateAll finishes, so it
+			// needs the just-written OCC token in the action response.
 			const newUpdatedAt = await getAppSettingsUpdatedAt(API_CONFIG_KEYS);
 			const newApiConfigVersion = settingsVersionISO(newUpdatedAt);
 
-			// C2: include informational note when a locked field was submitted.
 			let message = 'API configuration updated';
 			if (hasLockedFieldSubmission) {
 				message =

--- a/src/routes/admin/settings/connections/+page.svelte
+++ b/src/routes/admin/settings/connections/+page.svelte
@@ -44,9 +44,7 @@ let openaiBaseUrl = $state(settings.openaiBaseUrl.value);
 // svelte-ignore state_referenced_locally
 let openaiModel = $state(settings.openaiModel.value);
 
-// A2: track the current OCC version in $state so both panels immediately use
-// the fresh version returned by a successful save, without waiting for
-// invalidateAll to complete.
+// Both panels share one OCC token; keep the successful save's fresh version locally.
 // svelte-ignore state_referenced_locally
 let apiConfigVersion = $state(data.apiConfigVersion);
 
@@ -112,8 +110,7 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 							}
 							await update({ reset: false });
 							if (result.type === 'success') {
-								// A2: advance local version so the OpenAI panel's next save
-								// uses the fresh token without waiting for invalidateAll.
+								// The sibling panel can save next without waiting for invalidateAll.
 								const freshVersion = (result.data as { apiConfigVersion?: string })
 									?.apiConfigVersion;
 								if (freshVersion) apiConfigVersion = freshVersion;
@@ -204,7 +201,7 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 							return;
 						}
 						isTestingPlex = true;
-						// Forward the live form state so the test exercises pending edits.
+						// Connection tests should exercise unsaved edits, not only loaded data.
 						formData.set('plexServerUrl', plexServerUrl);
 						if (plexTokenInput) formData.set('plexToken', plexTokenInput);
 						formData.set(

--- a/src/routes/admin/settings/connections/+page.svelte
+++ b/src/routes/admin/settings/connections/+page.svelte
@@ -50,7 +50,6 @@ let openaiModel = $state(settings.openaiModel.value);
 // svelte-ignore state_referenced_locally
 let apiConfigVersion = $state(data.apiConfigVersion);
 
-// H5: inline field-level error for the OpenAI base URL field.
 let openaiBaseUrlError = $state<string | undefined>(undefined);
 
 let isSavingPlex = $state(false);
@@ -278,7 +277,6 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 									fieldErrors?: Record<string, string[] | undefined>;
 									apiConfigVersion?: string;
 								};
-								// H5: capture inline field error for openaiBaseUrl.
 								if (result.type === 'failure') {
 									openaiBaseUrlError = data?.fieldErrors?.openaiBaseUrl?.[0];
 								} else {
@@ -288,7 +286,6 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 							}
 							await update({ reset: false });
 							if (result.type === 'success') {
-								// A2: advance local version immediately.
 								const freshVersion = (
 									result.data as { apiConfigVersion?: string }
 								)?.apiConfigVersion;

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -349,8 +349,6 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 		</dt>
 	{/snippet}
 
-	<!-- Value tooltip: explains the specific effect of the selected value, mirroring
-	     the tipDt label-trigger styling but right-aligned + emphasized like the value. -->
 	{#snippet previewDd(tip: string, label: string)}
 		<dd class="text-right font-medium">
 			<Tooltip.Root>

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -118,7 +118,6 @@ const serverWrappedForm = superForm(data.serverWrappedForm, {
 	onUpdate: guardSettingsUpdate,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
-			// Advance this section's saved baseline to what was just persisted.
 			savedServerWrapped = {
 				anonymizationMode: updated.data.anonymizationMode,
 				serverWrappedShareMode: updated.data.serverWrappedShareMode
@@ -203,7 +202,7 @@ let advancedOpen = $state(showContradictionWarning);
 // ISSUE-007: expanding "Advanced options" can push each section's Save button
 // below the fold. On expand only, scroll the freshly-revealed section to the top
 // of the viewport (after the DOM settles) so its content + actions stay reachable.
-// Collapsing leaves the scroll position alone. Reuses the tick()-then-scroll idiom.
+// Collapsing leaves the scroll position alone.
 let advancedSectionRef = $state<HTMLDivElement | null>(null);
 async function handleAdvancedToggle(open: boolean): Promise<void> {
 	if (!open) return;

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -189,9 +189,6 @@ let showContradictionWarning = $derived(
 	$publicLandingLookupData.publicLandingLookup && $userDefaultsData.defaultShareMode !== 'public'
 );
 
-// ---------------------------------------------------------------------------
-// Privacy presets (client-only control surface)
-// ---------------------------------------------------------------------------
 // Auto-open Advanced options at mount ONLY when the saved config is already
 // contradictory (public landing lookup on, but the per-user default isn't
 // public), so the contradiction Alert inside Collapsible.Content isn't hidden

--- a/src/routes/admin/settings/security/+page.server.ts
+++ b/src/routes/admin/settings/security/+page.server.ts
@@ -213,7 +213,6 @@ export const actions: Actions = requireAdminActions({
 			}
 		}
 
-		// Clear branch
 		const csrfSkipFlag = await getAppSetting(AppSettingsKey.CSRF_ORIGIN_SKIPPED);
 		if (!env.ORIGIN && csrfSkipFlag !== 'true') {
 			return fail(400, {

--- a/src/routes/admin/settings/system/+page.server.ts
+++ b/src/routes/admin/settings/system/+page.server.ts
@@ -98,7 +98,6 @@ export const actions: Actions = requireAdminActions({
 			return fail(400, { form, error: 'Invalid input' });
 		}
 
-		// Stale-version check via the shared inline OCC helper.
 		if (
 			(await inlineOccCheck(form.data.settingsVersion, LOG_SETTINGS_KEYS)).status === 'conflict'
 		) {

--- a/src/routes/admin/slides/+page.server.ts
+++ b/src/routes/admin/slides/+page.server.ts
@@ -246,9 +246,6 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	/**
-	 * Delete a custom slide
-	 */
 	deleteCustom: async ({ request }) => {
 		const formData = await request.formData();
 		const idStr = formData.get('id');

--- a/src/routes/admin/slides/+page.server.ts
+++ b/src/routes/admin/slides/+page.server.ts
@@ -33,10 +33,8 @@ import {
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	// Initialize default config if needed
 	await initializeDefaultSlideConfig();
 
-	// Load all configurations
 	const [configs, customSlides, funFactFrequency, availableYears] = await Promise.all([
 		getAllSlideConfigs(),
 		getAllCustomSlides(),
@@ -44,7 +42,6 @@ export const load: PageServerLoad = async () => {
 		getAvailableYears()
 	]);
 
-	// Pre-render custom slides for preview
 	const customSlidesWithPreview = customSlides.map((slide) => ({
 		...slide,
 		renderedHtml: renderMarkdownSync(slide.content)
@@ -109,7 +106,6 @@ export const actions: Actions = requireAdminActions({
 				if (!item) continue;
 
 				if (item.type === 'builtin') {
-					// Validate the slide type
 					const parsed = SlideTypeSchema.safeParse(item.id);
 					if (!parsed.success) {
 						return fail(400, { error: `Invalid slide type: ${item.id}` });
@@ -125,12 +121,10 @@ export const actions: Actions = requireAdminActions({
 				}
 			}
 
-			// Update built-in slides with their global sort orders
 			for (const update of builtInUpdates) {
 				await updateSlideConfig(update.type, { sortOrder: update.sortOrder });
 			}
 
-			// Update custom slides with their global sort orders
 			for (const update of customSlideUpdates) {
 				await updateCustomSlide(update.id, { sortOrder: update.sortOrder });
 			}
@@ -195,9 +189,6 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	/**
-	 * Create a custom slide
-	 */
 	createCustom: async ({ request }) => {
 		const formData = await request.formData();
 		const title = formData.get('title');
@@ -327,7 +318,6 @@ export const actions: Actions = requireAdminActions({
 		const mode = formData.get('mode');
 		const customCountStr = formData.get('customCount');
 
-		// Validate mode
 		const validModes = Object.values(FunFactFrequency);
 		if (typeof mode !== 'string' || !validModes.includes(mode as FunFactFrequencyType)) {
 			logger.warn('setFunFactFrequency rejected: invalid mode', 'Slides', {
@@ -336,7 +326,6 @@ export const actions: Actions = requireAdminActions({
 			return fail(400, { error: 'Invalid frequency mode' });
 		}
 
-		// Parse custom count if provided
 		let customCount: number | undefined;
 		if (mode === FunFactFrequency.CUSTOM) {
 			if (typeof customCountStr !== 'string') {

--- a/src/routes/admin/slides/+page.server.ts
+++ b/src/routes/admin/slides/+page.server.ts
@@ -56,9 +56,6 @@ export const load: PageServerLoad = async () => {
 };
 
 export const actions: Actions = requireAdminActions({
-	/**
-	 * Toggle a slide's enabled state
-	 */
 	toggleSlide: async ({ request }) => {
 		const formData = await request.formData();
 		const slideType = formData.get('slideType');
@@ -77,12 +74,8 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	/**
-	 * Reorder slides - supports unified ordering of built-in and custom slides
-	 *
-	 * Handles the new unified format: [{ type: 'builtin' | 'custom', id: string | number }]
-	 * Both built-in and custom slides share the same global sortOrder space.
-	 */
+	// Built-in and custom slides share one global sortOrder space, so the
+	// serialized order carries an explicit item kind for each id.
 	reorder: async ({ request }) => {
 		const formData = await request.formData();
 		const orderJson = formData.get('order');
@@ -97,7 +90,6 @@ export const actions: Actions = requireAdminActions({
 				id: string | number;
 			}>;
 
-			// Process each item and update its sortOrder to match its position in the array
 			const builtInUpdates: Array<{ type: SlideType; sortOrder: number }> = [];
 			const customSlideUpdates: Array<{ id: number; sortOrder: number }> = [];
 
@@ -112,7 +104,6 @@ export const actions: Actions = requireAdminActions({
 					}
 					builtInUpdates.push({ type: item.id as SlideType, sortOrder: i });
 				} else if (item.type === 'custom') {
-					// Custom slide - store its new sort order
 					const customId = typeof item.id === 'string' ? parseInt(item.id, 10) : item.id;
 					if (Number.isNaN(customId)) {
 						return fail(400, { error: `Invalid custom slide ID: ${item.id}` });
@@ -136,9 +127,6 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	/**
-	 * Toggle a custom slide's enabled state
-	 */
 	toggleCustomSlide: async ({ request }) => {
 		const formData = await request.formData();
 		const idStr = formData.get('id');
@@ -161,9 +149,6 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	/**
-	 * Update slide configuration
-	 */
 	updateConfig: async ({ request }) => {
 		const formData = await request.formData();
 		const slideType = formData.get('slideType');
@@ -196,7 +181,6 @@ export const actions: Actions = requireAdminActions({
 		const enabled = formData.get('enabled') !== 'false';
 		const yearStr = formData.get('year');
 
-		// Get next sort order
 		const sortOrder = await getNextSortOrder();
 
 		const data = {
@@ -222,9 +206,6 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	/**
-	 * Update a custom slide
-	 */
 	updateCustom: async ({ request }) => {
 		const formData = await request.formData();
 		const idStr = formData.get('id');

--- a/src/routes/admin/slides/+page.server.ts
+++ b/src/routes/admin/slides/+page.server.ts
@@ -268,9 +268,6 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	/**
-	 * Preview Markdown content
-	 */
 	previewMarkdown: async ({ request }) => {
 		const formData = await request.formData();
 		const content = formData.get('content');
@@ -288,9 +285,6 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	/**
-	 * Set fun fact frequency
-	 */
 	setFunFactFrequency: async ({ request }) => {
 		const formData = await request.formData();
 		const mode = formData.get('mode');

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -154,7 +154,6 @@ type UnifiedSlideItem =
 			renderedHtml?: string;
 	  };
 
-// Combine built-in slides and custom slides into a unified sorted list
 const unifiedSlides = $derived.by(() => {
 	const items: UnifiedSlideItem[] = [];
 

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -12,13 +12,6 @@ import { handleFormToast } from '$lib/utils/form-toast';
 import { submitAction } from '$lib/utils/submit-action';
 import type { ActionData, PageData } from './$types';
 
-/**
- * Admin Slides Page
- *
- * Manages slide configuration (enable/disable, reordering)
- * and custom slides (create, edit, delete with Markdown).
- */
-
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
 $effect(() => {

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -21,7 +21,6 @@ import type { ActionData, PageData } from './$types';
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
-// Show toast notifications for form responses
 $effect(() => {
 	handleFormToast(form);
 });
@@ -35,7 +34,6 @@ const slideFieldErrors = $derived(
 		: undefined
 );
 
-// Slide display names
 const SLIDE_NAMES: Record<SlideType, string> = {
 	'total-time': 'Total Watch Time',
 	'top-movies': 'Top Movies',
@@ -75,7 +73,6 @@ $effect(() => {
 	syncedFrequencyKey = frequencyKey;
 });
 
-// State for custom slide editor
 let showEditor = $state(false);
 let editingSlide = $state<(typeof data.customSlides)[0] | null>(null);
 let editorTitle = $state('');
@@ -146,14 +143,11 @@ $effect(() => {
 	return () => document.removeEventListener('keydown', handler);
 });
 
-// Delete confirmation state
 let deletingSlideId = $state<number | null>(null);
 
-// Drag and drop state
 let draggedIndex = $state<number | null>(null);
 let dragOverIndex = $state<number | null>(null);
 
-// Unified slide item type for the combined list
 type UnifiedSlideItem =
 	| { kind: 'builtin'; slideType: string; enabled: boolean; sortOrder: number }
 	| {
@@ -171,7 +165,6 @@ type UnifiedSlideItem =
 const unifiedSlides = $derived.by(() => {
 	const items: UnifiedSlideItem[] = [];
 
-	// Add built-in slides (only those in DEFAULT_SLIDE_ORDER)
 	for (const config of data.configs) {
 		if (DEFAULT_SLIDE_ORDER.includes(config.slideType as SlideType)) {
 			items.push({
@@ -183,7 +176,6 @@ const unifiedSlides = $derived.by(() => {
 		}
 	}
 
-	// Add custom slides
 	for (const custom of data.customSlides) {
 		items.push({
 			kind: 'custom',
@@ -197,11 +189,9 @@ const unifiedSlides = $derived.by(() => {
 		});
 	}
 
-	// Sort by sortOrder
 	return items.sort((a, b) => a.sortOrder - b.sortOrder);
 });
 
-// Open editor for new slide
 function openNewEditor() {
 	editorTriggerRef = (document.activeElement as HTMLElement) ?? null;
 	editingSlide = null;
@@ -215,7 +205,6 @@ function openNewEditor() {
 	showEditor = true;
 }
 
-// Open editor for existing slide
 function openEditEditor(slide: (typeof data.customSlides)[0]) {
 	editorTriggerRef = (document.activeElement as HTMLElement) ?? null;
 	editingSlide = slide;
@@ -229,7 +218,6 @@ function openEditEditor(slide: (typeof data.customSlides)[0]) {
 	showEditor = true;
 }
 
-// Close editor
 function closeEditor() {
 	showEditor = false;
 	editingSlide = null;
@@ -238,18 +226,15 @@ function closeEditor() {
 	queueMicrotask(() => trigger?.focus());
 }
 
-// Handle drag start
 function handleDragStart(index: number) {
 	draggedIndex = index;
 }
 
-// Handle drag over
 function handleDragOver(event: DragEvent, index: number) {
 	event.preventDefault();
 	dragOverIndex = index;
 }
 
-// Handle drag end
 function handleDragEnd() {
 	draggedIndex = null;
 	dragOverIndex = null;
@@ -257,7 +242,6 @@ function handleDragEnd() {
 
 type SlideOrderEntry = { type: 'builtin'; id: string } | { type: 'custom'; id: number };
 
-// Submit a reordered list through the existing hidden reorder form.
 function submitReorder(newOrder: SlideOrderEntry[]) {
 	const form = document.getElementById('reorder-form') as HTMLFormElement | null;
 	const orderInput = form?.querySelector('input[name="order"]') as HTMLInputElement | null;
@@ -282,7 +266,6 @@ function moveSlide(fromIndex: number, toIndex: number) {
 	submitReorder(newOrder);
 }
 
-// Accessible name for the per-slide reorder controls.
 function reorderItemLabel(item: UnifiedSlideItem): string {
 	if (item.kind === 'builtin') {
 		return SLIDE_NAMES[item.slideType as SlideType] ?? item.slideType;
@@ -290,7 +273,6 @@ function reorderItemLabel(item: UnifiedSlideItem): string {
 	return item.title.trim().length > 0 ? item.title : 'Untitled custom slide';
 }
 
-// Handle drop - reorder unified slides
 function handleDrop(event: DragEvent, dropIndex: number) {
 	event.preventDefault();
 	if (draggedIndex === null || draggedIndex === dropIndex) return;
@@ -298,7 +280,6 @@ function handleDrop(event: DragEvent, dropIndex: number) {
 	handleDragEnd();
 }
 
-// Get custom slide data for editing
 function getCustomSlideForEdit(item: UnifiedSlideItem) {
 	if (item.kind !== 'custom') return null;
 	return data.customSlides.find((s) => s.id === item.id) ?? null;
@@ -332,7 +313,6 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			</Button>
 		</div>
 
-		<!-- Hidden form for reordering -->
 		<form id="reorder-form" method="POST" action="?/reorder" use:enhance>
 			<input type="hidden" name="order" value="" />
 		</form>
@@ -484,7 +464,6 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 		{/if}
 	</section>
 
-	<!-- Fun Fact Frequency Section -->
 	<section class="section">
 		<h2>Fun Fact Frequency</h2>
 		<p class="section-description">
@@ -570,7 +549,6 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 	</section>
 	</div>
 
-	<!-- Custom Slide Editor Modal -->
 	{#if showEditor}
 		<!-- svelte-ignore a11y_click_events_have_key_events -->
 		<div class="modal-overlay" onclick={closeEditor} role="presentation">
@@ -683,7 +661,6 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 						</div>
 					</div>
 
-					<!-- Preview Section -->
 					<div class="preview-section">
 						<h3>Preview</h3>
 						<Button
@@ -714,12 +691,9 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 									if (result.type === 'success') {
 										const html = typeof result.data.html === 'string' ? result.data.html : '';
 										previewHtml = html;
-										// Render the preview region whenever the server returned
-										// success, even if html is empty (e.g. sanitizer stripped
-										// everything). An explicit empty-state line inside the
-										// rendered region is clearer than silently reverting to
-										// the "Click 'Update Preview' …" placeholder, which made
-										// the button look broken.
+										// Mark render success even when sanitization strips everything. A visible
+										// empty-state line is clearer than reverting to the pre-render placeholder,
+										// which made the button look broken.
 										previewRendered = true;
 										previewError = '';
 									} else if (result.type === 'failure') {
@@ -880,7 +854,6 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			border-left: 3px solid oklch(var(--primary));
 		}
 
-		/* Custom slide styling with distinct visual indicator */
 		.slide-item.is-custom {
 			border-left: 3px solid oklch(0.6192 0.2037 312.73);
 			background: linear-gradient(90deg, oklch(0.6192 0.2037 312.73 / 0.08) 0%, oklch(var(--secondary)) 100%);
@@ -946,7 +919,6 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 		.slide-name {
 			flex: 1;
 			font-weight: 500;
-			/* DF-022: truncate long custom-slide titles with ellipsis */
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
@@ -1172,7 +1144,6 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			padding: 2rem;
 		}
 
-		/* Modal Styles */
 		.modal-overlay {
 			position: fixed;
 			inset: 0;
@@ -1447,7 +1418,6 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			opacity: 0.9;
 		}
 
-		/* Markdown preview styling */
 		.preview-content :global(h1),
 		.preview-content :global(h2),
 		.preview-content :global(h3) {
@@ -1499,7 +1469,6 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			font-style: italic;
 		}
 
-		/* Fun Fact Frequency Styles */
 		.frequency-options {
 			display: grid;
 			grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -197,7 +197,7 @@ function openNewEditor() {
 	editingSlide = null;
 	editorTitle = '';
 	editorContent = '';
-	editorYear = null; // Default to "All years"
+	editorYear = null;
 	editorEnabled = true;
 	previewHtml = '';
 	previewError = '';
@@ -297,7 +297,6 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 		<p class="subtitle">Manage slides for Year in Review presentations</p>
 	</header>
 
-	<!-- Slide Order Section -->
 	<section class="section">
 		<div class="section-header">
 			<div class="section-title-content">

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -47,7 +47,7 @@ const SLIDE_NAMES: Record<SlideType, string> = {
 	custom: 'Custom Slide'
 };
 
-// Fun Fact frequency state (synced from server data only when server data changes)
+// Keep local radio edits stable until the server confirms a new frequency value.
 let selectedFrequencyMode = $state<typeof data.funFactFrequency.mode>(
 	untrack(() => data.funFactFrequency.mode)
 );
@@ -1095,12 +1095,10 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			opacity: 0.9;
 		}
 
-		/* `.add-button` is the section-header primary CTA ("Add Custom
-		   Slide"). Hoisted to :global so shadcn Button's child-rendered
-		   <button> inherits the primary palette + hover translate-y.
-		   The `.add-button-icon` descendant rule (lucide Plus sizing)
-		   stays — the previous hybrid scoped+global selector is fully
-		   globalised now. */
+		/* shadcn Button child-renders the actual <button>, so this selector
+		   must be global for the primary palette and hover translate-y to
+		   reach it. The lucide icon descendant stays global for the same
+		   scoped-style boundary. */
 		:global(.add-button) {
 			display: inline-flex;
 			align-items: center;
@@ -1321,13 +1319,10 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			margin: 0 0 0.75rem;
 		}
 
-		/* `.preview-button` is the "Update Preview" CTA inside the slide
-		   editor (triggers an async ?/previewMarkdown submitAction call).
-		   Hoisted to :global so shadcn Button's child-rendered <button>
-		   inherits the secondary palette + hover-darken. The button stays
-		   client-side `type="button"` because the async submitAction
-		   handler manages the preview state directly rather than relying
-		   on form submission. */
+		/* shadcn Button child-renders the actual <button>, so this selector
+		   must be global for the secondary palette and hover-darken to reach it.
+		   The button stays client-side `type="button"` because submitAction
+		   owns preview state instead of native form submission. */
 		:global(.preview-button) {
 			padding: 0.375rem 0.75rem;
 			background: oklch(var(--secondary));

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -242,9 +242,8 @@ function submitReorder(newOrder: SlideOrderEntry[]) {
 	form.requestSubmit();
 }
 
-// Move a slide from one index to another. Shared by drag-and-drop and the
-// keyboard move-up/down buttons (ISSUE-010 a11y: drag-and-drop alone is not
-// keyboard operable).
+// Drag-and-drop alone is not keyboard-operable, so keyboard buttons share the
+// same reorder path (ISSUE-010 a11y).
 function moveSlide(fromIndex: number, toIndex: number) {
 	if (toIndex < 0 || toIndex >= unifiedSlides.length || fromIndex === toIndex) return;
 	const newOrder: SlideOrderEntry[] = unifiedSlides.map((item) =>
@@ -966,13 +965,8 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			gap: 0.375rem;
 		}
 
-		/* `.action-button` is the per-row 28px-square icon-action CTA
-		   (edit-action + delete-action variants). Hoisted to :global so
-		   shadcn Button's child-rendered <button> inherits the muted-
-		   default + primary-on-hover (edit) / destructive-on-hover
-		   (delete) palette swaps. The `.delete-action` button stays
-		   native this iteration (inside the confirm/cancel flow); the
-		   shared rules below cover both consumers. */
+		/* Hoisted to :global so shadcn Button's child-rendered <button>
+		   and the native delete-action button share the same palette rules. */
 		:global(.action-button) {
 			display: inline-flex;
 			align-items: center;
@@ -1030,10 +1024,8 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			font-weight: 600;
 		}
 
-		/* `.confirm-button` + `.cancel-delete-button` are the destructive-
-		   confirmation pair inside each slide row's delete flow. Hoisted
-		   to :global so SubmitButton (confirm) + shadcn Button (cancel)
-		   inherit their respective palettes (destructive vs muted). */
+		/* SubmitButton and shadcn Button child-render the real controls, so
+		   the delete-confirmation palettes must be hoisted. */
 		:global(.confirm-button) {
 			padding: 0.25rem 0.5rem;
 			background: oklch(var(--destructive));
@@ -1067,12 +1059,8 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			margin: 0;
 		}
 
-		/* `.toggle-button` is the per-row Enabled/Disabled toggle CTA
-		   (used by both built-in slides + custom slides). Hoisted to
-		   :global so SubmitButton's child-rendered <button> inherits
-		   the muted-default vs primary-enabled palette swap. The
-		   `.enabled` modifier toggles via template-literal class prop
-		   (same pattern as admin/users iteration 108). */
+		/* SubmitButton child-renders the real <button>, so the enabled/disabled
+		   palette swap must be hoisted out of Svelte's scoped CSS. */
 		:global(.toggle-button) {
 			padding: 0.375rem 0.75rem;
 			border: 1px solid oklch(var(--border));
@@ -1168,9 +1156,8 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			margin: 0;
 		}
 
-		/* `.close-button` is the modal-header X dismiss CTA. Hoisted to
-		   :global so shadcn Button's child-rendered <button> inherits
-		   the transparent background + large × glyph treatment. */
+		/* shadcn Button child-renders the real <button>, so the modal-close
+		   treatment must be hoisted. */
 		:global(.close-button) {
 			background: none;
 			border: none;
@@ -1372,9 +1359,8 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			z-index: 1;
 		}
 
-		/* `.cancel-button` + `.save-button` are the editor modal's footer
-		   action pair. Hoisted to :global so shadcn Button (cancel) +
-		   SubmitButton (save) inherit their secondary/primary palettes. */
+		/* Footer actions mix shadcn Button and SubmitButton, both of which
+		   child-render the real controls; hoist the shared palettes. */
 		:global(.cancel-button) {
 			padding: 0.5rem 1rem;
 			background: oklch(var(--secondary));
@@ -1543,12 +1529,8 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			color: oklch(var(--destructive));
 		}
 
-		/* `.save-frequency-button` is the Fun Fact frequency form's
-		   submit CTA. Hoisted to :global so SubmitButton's child-
-		   rendered <button> inherits the primary palette + hover-fade.
-		   The :disabled fade gates on the custom-count out-of-range
-		   condition (1-15 range enforced by the parent's disabled
-		   predicate). */
+		/* SubmitButton child-renders the real <button>, so the frequency form's
+		   primary palette and disabled state must be hoisted. */
 		:global(.save-frequency-button:disabled) {
 			opacity: 0.5;
 			cursor: not-allowed;

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -237,14 +237,11 @@ const visiblePages = $derived.by(() => {
 	const pages: number[] = [];
 
 	if (totalPages <= 5) {
-		// Show all pages if 5 or fewer
 		for (let i = 1; i <= totalPages; i++) pages.push(i);
 	} else {
-		// Calculate range around current page
 		let start = Math.max(1, page - 2);
 		let end = Math.min(totalPages, page + 2);
 
-		// Adjust if at boundaries
 		if (page <= 3) {
 			end = 5;
 		} else if (page >= totalPages - 2) {
@@ -282,7 +279,6 @@ async function goToPage(page: number) {
 </svelte:head>
 
 <div class="sync-command-center">
-	<!-- Page Header -->
 	<header class="page-header">
 		<div class="header-content">
 			<div class="header-icon">
@@ -305,7 +301,6 @@ async function goToPage(page: number) {
 	</header>
 
 	<div class="content-grid">
-		<!-- Main Sync Panel -->
 		<section class="panel sync-panel" class:active={syncActive || progress}>
 			<div class="panel-header">
 				<h2>
@@ -324,7 +319,6 @@ async function goToPage(page: number) {
 			</div>
 
 			{#if syncActive || progress}
-				<!-- Active Sync Display -->
 				<div class="sync-active-display">
 					{#if syncActive}
 						<!-- ISSUE-009: persistent, AT-announced affordance that a sync is
@@ -456,7 +450,6 @@ async function goToPage(page: number) {
 					{/if}
 				</div>
 			{:else}
-				<!-- Idle State - Start Sync Form -->
 				<form
 					method="POST"
 					action="?/startSync"
@@ -523,7 +516,6 @@ async function goToPage(page: number) {
 			{/if}
 		</section>
 
-		<!-- Scheduler Panel -->
 		<section class="panel scheduler-panel">
 			<div class="panel-header">
 				<h2>
@@ -693,7 +685,6 @@ async function goToPage(page: number) {
 		</section>
 	</div>
 
-	<!-- Sync History Section -->
 	<section class="panel history-panel">
 		<div class="panel-header">
 			<h2>
@@ -782,7 +773,6 @@ async function goToPage(page: number) {
 				{/each}
 			</div>
 
-			<!-- Pagination Controls -->
 			{#if data.pagination.totalPages > 1}
 				<div class="pagination" class:loading={isNavigating}>
 					<div class="pagination-info">
@@ -795,7 +785,6 @@ async function goToPage(page: number) {
 					</div>
 
 					<div class="pagination-controls">
-						<!-- First Page -->
 						<Button
 							type="button"
 							class="pagination-btn tap-target"
@@ -806,7 +795,6 @@ async function goToPage(page: number) {
 							<ChevronsLeftIcon class="size-[18px]" />
 						</Button>
 
-						<!-- Previous Page -->
 						<Button
 							type="button"
 							class="pagination-btn tap-target"
@@ -817,7 +805,6 @@ async function goToPage(page: number) {
 							<ChevronLeftIcon class="size-[18px]" />
 						</Button>
 
-						<!-- Page Numbers -->
 						<div class="pagination-pages">
 							{#if firstVisiblePage !== undefined && firstVisiblePage > 1}
 								<button
@@ -861,7 +848,6 @@ async function goToPage(page: number) {
 							{/if}
 						</div>
 
-						<!-- Next Page -->
 						<Button
 							type="button"
 							class="pagination-btn tap-target"
@@ -872,7 +858,6 @@ async function goToPage(page: number) {
 							<ChevronRightIcon class="size-[18px]" />
 						</Button>
 
-						<!-- Last Page -->
 						<Button
 							type="button"
 							class="pagination-btn tap-target"
@@ -890,14 +875,12 @@ async function goToPage(page: number) {
 </div>
 
 <style>
-	/* ===== Base Layout ===== */
 		.sync-command-center {
 			max-width: 1100px;
 			margin: 0 auto;
 			padding: 1.5rem 2rem 3rem;
 		}
 
-		/* ===== Page Header ===== */
 		.page-header {
 			display: flex;
 			justify-content: space-between;
@@ -969,7 +952,6 @@ async function goToPage(page: number) {
 			letter-spacing: 0.05em;
 		}
 
-		/* ===== Content Grid ===== */
 		.content-grid {
 			display: grid;
 			grid-template-columns: 1fr 380px;
@@ -977,7 +959,6 @@ async function goToPage(page: number) {
 			margin-bottom: 1.5rem;
 		}
 
-		/* ===== Panel Base ===== */
 		.panel {
 			background: oklch(var(--card));
 			border: 1px solid oklch(var(--border));
@@ -1008,7 +989,6 @@ async function goToPage(page: number) {
 			font-size: 1rem;
 		}
 
-		/* ===== Sync Panel ===== */
 		.sync-panel {
 			transition: border-color 0.3s ease;
 		}
@@ -1061,7 +1041,6 @@ async function goToPage(page: number) {
 			}
 		}
 
-		/* ===== Active Sync Display ===== */
 		.sync-active-display {
 			display: flex;
 			flex-direction: column;
@@ -1307,7 +1286,6 @@ async function goToPage(page: number) {
 			cursor: not-allowed;
 		}
 
-		/* ===== Sync Form (Idle State) ===== */
 		.sync-form {
 			padding: 1.5rem;
 			display: flex;
@@ -1431,7 +1409,6 @@ async function goToPage(page: number) {
 			color: oklch(var(--destructive));
 		}
 
-		/* ===== Scheduler Panel ===== */
 		.scheduler-content {
 			padding: 1.25rem;
 			display: flex;
@@ -1663,7 +1640,6 @@ async function goToPage(page: number) {
 			color: oklch(var(--primary-foreground));
 		}
 
-		/* ===== History Panel ===== */
 		.history-panel {
 			margin-top: 0;
 		}
@@ -1833,7 +1809,6 @@ async function goToPage(page: number) {
 			flex-shrink: 0;
 		}
 
-		/* ===== Pagination ===== */
 		.pagination {
 			display: flex;
 			flex-direction: column;
@@ -1945,7 +1920,6 @@ async function goToPage(page: number) {
 			font-size: 0.875rem;
 		}
 
-		/* ===== Responsive Design ===== */
 		@media (max-width: 900px) {
 			.content-grid {
 				grid-template-columns: 1fr;
@@ -1997,7 +1971,6 @@ async function goToPage(page: number) {
 				grid-column: 1 / -1;
 			}
 
-			/* Pagination responsive */
 			.pagination {
 				padding: 1rem;
 			}

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -1255,11 +1255,8 @@ async function goToPage(page: number) {
 			color: oklch(var(--primary));
 		}
 
-		/* `.cancel-btn` is the cancel-sync CTA. Hoisted to :global so
-		   SubmitButton's child-rendered <button> inherits the muted-
-		   default vs destructive-on-hover palette swap. The custom
-		   `.btn-spinner` span is replaced by SubmitButton's built-in
-		   LoaderCircleIcon spinner. */
+		/* SubmitButton child-renders the real <button>, so the cancel palette
+		   swap must be hoisted. */
 		:global(.cancel-btn) {
 			display: flex;
 			align-items: center;
@@ -1334,11 +1331,8 @@ async function goToPage(page: number) {
 			pointer-events: none;
 		}
 
-		/* `.sync-btn` is the primary "Start Sync" CTA. Hoisted to :global
-		   so SubmitButton's child-rendered <button> inherits the
-		   gradient primary palette + hover translate-y + shadow glow.
-		   The `.sync-btn svg` descendant rule is dropped; PlayIcon is
-		   sized inline via `class="size-[18px]"`. */
+		/* SubmitButton child-renders the real <button>, so the primary gradient
+		   and hover treatment must be hoisted. */
 		:global(.sync-btn) {
 			display: flex;
 			align-items: center;
@@ -1477,13 +1471,8 @@ async function goToPage(page: number) {
 			gap: 0.5rem;
 		}
 
-		/* `.control-btn` is the scheduler control quartet (resume / pause
-		   / init / stop). 4 per-variant palettes (green / amber /
-		   primary / muted), each with a hover state. Hoisted to :global
-		   so SubmitButton's child-rendered <button> inherits each
-		   variant's color. The `.control-btn svg` descendant rule is
-		   dropped — PlayIcon / PauseIcon / ClockIcon / SquareIcon are
-		   sized inline via `class="size-4"`. */
+		/* SubmitButton child-renders the real controls, so scheduler variants
+		   need hoisted palettes. */
 		:global(.control-btn) {
 			flex: 1;
 			display: flex;
@@ -1588,11 +1577,8 @@ async function goToPage(page: number) {
 			color: oklch(var(--destructive));
 		}
 
-		/* `.cron-update-btn` is the icon-only commit-cron-expression CTA
-		   (40px wide). Hoisted to :global so SubmitButton's child-
-		   rendered <button> inherits the muted-default vs primary-on-
-		   hover palette swap. `.cron-update-btn svg` descendant rule
-		   dropped — CheckIcon sized inline via `class="size-[18px]"`. */
+		/* SubmitButton child-renders the real <button>, so the cron commit
+		   hover palette must be hoisted. */
 		:global(.cron-update-btn) {
 			display: flex;
 			align-items: center;
@@ -1840,11 +1826,8 @@ async function goToPage(page: number) {
 			gap: 0.375rem;
 		}
 
-		/* `.pagination-btn` is the 4-button nav row (first/prev/next/last).
-		   Hoisted to :global so shadcn Button's child-rendered <button>
-		   inherits the 36px-square shape + muted-default vs primary-on-
-		   hover palette. The `.pagination-btn svg` descendant rule is
-		   dropped — chevron icons sized inline via `class="size-[18px]"`. */
+		/* shadcn Button child-renders the real pagination controls, so the
+		   square shape and hover palette must be hoisted. */
 		:global(.pagination-btn) {
 			display: flex;
 			align-items: center;

--- a/src/routes/admin/sync/stream/+server.ts
+++ b/src/routes/admin/sync/stream/+server.ts
@@ -2,15 +2,6 @@ import { requireAdmin } from '$lib/server/auth/guards';
 import { getSyncProgress, type LiveSyncProgress } from '$lib/server/sync/progress';
 import type { RequestHandler } from './$types';
 
-/**
- * SSE Endpoint for Real-Time Sync Progress Streaming
- *
- * Streams sync progress to connected clients using Server-Sent Events.
- * Polls the in-memory progress store every 500ms.
- *
- * Authorization is handled by hooks.server.ts (requires admin).
- */
-
 const POLL_INTERVAL_MS = 500;
 
 export const GET: RequestHandler = async ({ locals, request }) => {
@@ -27,7 +18,7 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 			);
 
 			let lastProgress: LiveSyncProgress | null = initialProgress;
-			let terminalEventSent = false; // Track if terminal event was already sent
+			let terminalEventSent = false;
 			const intervalId = setInterval(() => {
 				try {
 					const currentProgress = getSyncProgress();
@@ -68,7 +59,7 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 					} else if (lastProgress !== null) {
 						controller.enqueue(formatSSE({ type: 'idle' }));
 						lastProgress = null;
-						terminalEventSent = false; // Reset for next sync
+						terminalEventSent = false;
 					}
 				} catch (_error) {
 					controller.enqueue(
@@ -100,9 +91,6 @@ function formatSSE(data: SSEEvent): string {
 	return `data: ${JSON.stringify(data)}\n\n`;
 }
 
-/**
- * SSE event types
- */
 type SSEEvent =
 	| { type: 'connected'; progress: LiveSyncProgress | null }
 	| { type: 'progress'; progress: LiveSyncProgress }

--- a/src/routes/admin/sync/stream/+server.ts
+++ b/src/routes/admin/sync/stream/+server.ts
@@ -16,10 +16,8 @@ const POLL_INTERVAL_MS = 500;
 export const GET: RequestHandler = async ({ locals, request }) => {
 	requireAdmin(locals);
 
-	// Create a readable stream for SSE
 	const stream = new ReadableStream({
 		async start(controller) {
-			// Send initial connection event with current progress
 			const initialProgress = getSyncProgress();
 			controller.enqueue(
 				formatSSE({
@@ -28,14 +26,12 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 				})
 			);
 
-			// Poll for progress updates
 			let lastProgress: LiveSyncProgress | null = initialProgress;
 			let terminalEventSent = false; // Track if terminal event was already sent
 			const intervalId = setInterval(() => {
 				try {
 					const currentProgress = getSyncProgress();
 
-					// Always send updates while running, or when status changes
 					if (currentProgress) {
 						const hasChanged =
 							!lastProgress ||
@@ -55,7 +51,6 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 							lastProgress = { ...currentProgress };
 						}
 
-						// Send completion events (only once per sync)
 						if (
 							!terminalEventSent &&
 							(currentProgress.status === 'completed' ||
@@ -69,16 +64,13 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 								})
 							);
 							terminalEventSent = true;
-							// Client should disconnect after receiving completion event
 						}
 					} else if (lastProgress !== null) {
-						// Progress was cleared (sync ended)
 						controller.enqueue(formatSSE({ type: 'idle' }));
 						lastProgress = null;
 						terminalEventSent = false; // Reset for next sync
 					}
 				} catch (_error) {
-					// Send error event but keep connection open
 					controller.enqueue(
 						formatSSE({
 							type: 'error',
@@ -88,7 +80,6 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 				}
 			}, POLL_INTERVAL_MS);
 
-			// Handle client disconnect
 			request.signal.addEventListener('abort', () => {
 				clearInterval(intervalId);
 				controller.close();
@@ -105,9 +96,6 @@ export const GET: RequestHandler = async ({ locals, request }) => {
 	});
 };
 
-/**
- * Format data as SSE event
- */
 function formatSSE(data: SSEEvent): string {
 	return `data: ${JSON.stringify(data)}\n\n`;
 }

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -17,12 +17,10 @@ import type { ActionData, PageData } from './$types';
 let { data, form }: { data: PageData; form: ActionData } = $props();
 let failedAvatarUserIds = $state<Set<number>>(new Set());
 
-// Show toast notifications for form responses
 $effect(() => {
 	handleFormToast(form);
 });
 
-// Format watch time as hours
 function formatWatchTime(minutes: number): string {
 	if (minutes === 0) return '0h';
 	if (minutes > 0 && minutes < 60) return '<1h';
@@ -76,7 +74,6 @@ function markAvatarFailed(userId: number): void {
 		</div>
 	</header>
 
-	<!-- Users List Section -->
 	<section class="section">
 		<div class="section-header">
 			<h2>Server Users</h2>
@@ -327,7 +324,6 @@ function markAvatarFailed(userId: number): void {
 		{/if}
 	</section>
 
-	<!-- Legend Section -->
 	<section class="section legend-section">
 		<h3>Legend</h3>
 		<div class="legend-grid">
@@ -480,7 +476,6 @@ function markAvatarFailed(userId: number): void {
 			opacity: 0.85;
 		}
 
-		/* Users Table */
 		.users-table-wrapper {
 			overflow-x: auto;
 			width: 100%;
@@ -729,7 +724,6 @@ function markAvatarFailed(userId: number): void {
 			padding: 2rem;
 		}
 
-		/* Legend */
 		.legend-section {
 			background: oklch(var(--muted) / 0.3);
 		}
@@ -751,7 +745,6 @@ function markAvatarFailed(userId: number): void {
 			color: oklch(var(--muted-foreground));
 		}
 
-		/* Responsive */
 		@media (max-width: 768px) {
 			.users-page {
 				padding: 1rem;

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -612,13 +612,9 @@ function markAvatarFailed(userId: number): void {
 			margin: 0;
 		}
 
-		/* `.toggle-button` is the Yes/No permission toggle in the user
-		   table cells (desktop) + mobile list. Hoisted to :global so
-		   SubmitButton's child-rendered <button> inherits the muted-
-		   default vs green-enabled palettes + hover-fade. The `.enabled`
-		   modifier toggles via a template literal in the consuming
-		   class prop (Svelte `class:foo` syntax doesn't compose with
-		   component class props — only DOM-level). */
+		/* SubmitButton child-renders the real <button>, and component class props
+		   cannot use Svelte's DOM-only `class:foo` directive, so the enabled
+		   palette is driven by a hoisted template-literal class. */
 		:global(.toggle-button) {
 			padding: 0.25rem 0.5rem;
 			border: 1px solid oklch(var(--border));

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -5,15 +5,6 @@ import { handleFormToast } from '$lib/utils/form-toast';
 import { maskEmail } from '$lib/utils/format';
 import type { ActionData, PageData } from './$types';
 
-/**
- * Admin Users Page
- *
- * Manages Plex server users:
- * - View all users with watch time stats
- * - Configure per-user permissions
- * - Preview user wrapped pages
- */
-
 let { data, form }: { data: PageData; form: ActionData } = $props();
 let failedAvatarUserIds = $state<Set<number>>(new Set());
 

--- a/src/routes/admin/wrapped/+page.svelte
+++ b/src/routes/admin/wrapped/+page.svelte
@@ -45,11 +45,9 @@ function handleConfigNavigation(event: MouseEvent): void {
 </svelte:head>
 
 <div class="wrapped-hub">
-	<!-- Atmospheric Background Effects -->
 	<div class="ambient-glow amber"></div>
 	<div class="ambient-glow cyan"></div>
 
-	<!-- Hero Header -->
 	<header class="hero-header">
 		<div class="hero-content">
 			<div class="year-badge">
@@ -69,7 +67,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 		</div>
 	</header>
 
-	<!-- View Wrapped Section -->
 	<section class="wrapped-showcase">
 		<div class="section-label">
 			<Play class="section-icon" />
@@ -77,7 +74,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 		</div>
 
 		<div class="wrapped-cards">
-			<!-- Personal Wrapped Card -->
 			<a href={data.wrappedHref} class="showcase-card personal">
 				<div class="card-glow"></div>
 				<div class="card-shimmer"></div>
@@ -99,7 +95,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 				<div class="card-accent"></div>
 			</a>
 
-			<!-- Server Wrapped Card -->
 			<a href="/wrapped/{data.currentYear}" class="showcase-card server">
 				<div class="card-glow"></div>
 				<div class="card-shimmer"></div>
@@ -121,7 +116,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 		</div>
 	</section>
 
-	<!-- Configuration Section -->
 	<section class="config-section">
 		<div class="section-label">
 			<SlidersHorizontal class="section-icon" />
@@ -174,7 +168,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			overflow: hidden;
 		}
 
-		/* Ambient Background Glows */
 		.ambient-glow {
 			position: absolute;
 			width: 500px;
@@ -203,7 +196,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			animation-delay: 4s;
 		}
 
-		/* Hero Header */
 		.hero-header {
 			position: relative;
 			text-align: center;
@@ -281,7 +273,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			animation: fadeSlideDown 0.6s ease 0.2s backwards;
 		}
 
-		/* Hero Decoration Rings */
 		.hero-decoration {
 			position: absolute;
 			top: 50%;
@@ -324,7 +315,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			animation-delay: 2.6s;
 		}
 
-		/* Section Labels */
 		.section-label {
 			display: flex;
 			align-items: center;
@@ -343,7 +333,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			opacity: 0.7;
 		}
 
-		/* Wrapped Showcase Section */
 		.wrapped-showcase {
 			margin-bottom: 2.5rem;
 			animation: fadeIn 0.6s ease 0.3s backwards;
@@ -355,7 +344,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			gap: 1.25rem;
 		}
 
-		/* Showcase Cards */
 		.showcase-card {
 			position: relative;
 			display: flex;
@@ -377,7 +365,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 				0 0 0 1px oklch(var(--primary) / 0.15);
 		}
 
-		/* Card Glow Effect */
 		.card-glow {
 			position: absolute;
 			top: -100%;
@@ -403,7 +390,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			opacity: 1;
 		}
 
-		/* Card Shimmer Effect */
 		.card-shimmer {
 			position: absolute;
 			top: 0;
@@ -424,7 +410,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			left: 100%;
 		}
 
-		/* Card Content */
 		.card-content {
 			position: relative;
 			z-index: 1;
@@ -490,7 +475,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			line-height: 1.5;
 		}
 
-		/* Card CTA */
 		.card-cta {
 			display: flex;
 			align-items: center;
@@ -532,7 +516,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			transform: translateX(4px);
 		}
 
-		/* Card Accent Line */
 		.card-accent {
 			position: absolute;
 			bottom: 0;
@@ -555,7 +538,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			opacity: 1;
 		}
 
-		/* Configuration Section */
 		.config-section {
 			animation: fadeIn 0.6s ease 0.4s backwards;
 		}
@@ -641,7 +623,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			transform: translateX(2px);
 		}
 
-		/* Animations */
 		@keyframes ambientPulse {
 			0%,
 			100% {
@@ -727,7 +708,6 @@ function handleConfigNavigation(event: MouseEvent): void {
 			}
 		}
 
-		/* Responsive Design */
 		@media (max-width: 768px) {
 			.wrapped-hub {
 				padding: 1rem 1.25rem 2rem;

--- a/src/routes/admin/wrapped/+page.svelte
+++ b/src/routes/admin/wrapped/+page.svelte
@@ -10,14 +10,6 @@ import Star from '@lucide/svelte/icons/star';
 import { goto } from '$app/navigation';
 import type { PageData } from './$types';
 
-/**
- * Admin Wrapped Hub Page
- *
- * Central hub for accessing wrapped presentations and configuration.
- * Features a cinematic, premium design with distinct visual identities
- * for personal and server-wide wrapped experiences.
- */
-
 interface Props {
 	data: PageData;
 }

--- a/src/routes/api/onboarding/servers/+server.ts
+++ b/src/routes/api/onboarding/servers/+server.ts
@@ -42,10 +42,10 @@ export const GET: RequestHandler = async ({ cookies, locals, url }) => {
 
 		const formattedServers = await Promise.all(
 			servers.map(async (server) => {
-				// Filter connections for cleaner UX:
-				// 1. Public plex.direct URLs (recommended for external access)
-				// 2. Local HTTP URLs (for same-network users)
-				// Exclude: local plex.direct URLs (confusing Docker IPs with long hashes)
+				// Prefer connection choices that are useful to admins: public plex.direct
+				// URLs for external access, plus local HTTP URLs for same-network users.
+				// Local plex.direct URLs are skipped because they expose confusing Docker
+				// IP hashes rather than a stable local address.
 				const filteredConnections =
 					server.connections?.flatMap((conn) => {
 						const isPlexDirect = conn.uri.includes('.plex.direct');
@@ -57,8 +57,6 @@ export const GET: RequestHandler = async ({ cookies, locals, url }) => {
 							return [{ uri: conn.uri, local: false, relay: false }];
 						}
 
-						// For local connections, construct HTTP URL from address/port
-						// (skip plex.direct local URLs as they're confusing Docker IPs)
 						if (isLocal && !isRelay) {
 							const httpUri = `http://${conn.address}:${conn.port}`;
 							return [{ uri: httpUri, local: true, relay: false }];

--- a/src/routes/api/onboarding/test-connection/+server.ts
+++ b/src/routes/api/onboarding/test-connection/+server.ts
@@ -88,7 +88,6 @@ export const POST: RequestHandler = async ({ request, locals, cookies, url }) =>
 				clientIdentifier: clientIdentifier!
 			}));
 
-		// Normalize URL - remove trailing slash
 		const normalizedUrl = url.replace(/\/+$/, '');
 		const endpoint = `${normalizedUrl}/identity`;
 
@@ -206,7 +205,6 @@ export const POST: RequestHandler = async ({ request, locals, cookies, url }) =>
 			clearTimeout(timeoutId);
 		}
 	} catch (err) {
-		// Re-throw SvelteKit errors
 		if (err && typeof err === 'object' && 'status' in err) {
 			throw err;
 		}

--- a/src/routes/api/onboarding/test-connection/+server.ts
+++ b/src/routes/api/onboarding/test-connection/+server.ts
@@ -38,7 +38,6 @@ const TestConnectionSchema = z
 const CONNECTION_TIMEOUT_MS = 10000;
 
 export const POST: RequestHandler = async ({ request, locals, cookies, url }) => {
-	// Require authenticated admin user
 	if (!locals.user) {
 		error(401, 'Authentication required');
 	}
@@ -56,7 +55,6 @@ export const POST: RequestHandler = async ({ request, locals, cookies, url }) =>
 	}
 
 	try {
-		// Parse and validate request body
 		const body = await request.json();
 		const parseResult = TestConnectionSchema.safeParse(body);
 
@@ -99,7 +97,6 @@ export const POST: RequestHandler = async ({ request, locals, cookies, url }) =>
 			'Onboarding'
 		);
 
-		// Create abort controller for timeout
 		const controller = new AbortController();
 		const timeoutId = setTimeout(() => controller.abort(), CONNECTION_TIMEOUT_MS);
 
@@ -112,7 +109,6 @@ export const POST: RequestHandler = async ({ request, locals, cookies, url }) =>
 				signal: controller.signal
 			});
 
-			// Check for authentication errors
 			if (response.status === 401) {
 				logger.debug('Connection test failed: Authentication failed', 'Onboarding');
 				return json(
@@ -138,9 +134,9 @@ export const POST: RequestHandler = async ({ request, locals, cookies, url }) =>
 				);
 			}
 
-			// Parse and validate response. A non-JSON body (e.g. an HTML gateway page
-			// from a non-Plex service) means the endpoint is reachable but is not a
-			// Plex Media Server — surface that as 422, not as a 503 connectivity error.
+			// A non-JSON response (for example from a non-Plex service) means the
+			// endpoint is reachable but is not a Plex Media Server — surface that as
+			// 422, not as a 503 connectivity error.
 			let data: unknown;
 			try {
 				data = await response.json();

--- a/src/routes/api/sync/status/stream/+server.ts
+++ b/src/routes/api/sync/status/stream/+server.ts
@@ -150,8 +150,9 @@ export const GET: RequestHandler = async ({ request, locals }) => {
 						terminalEventSent = false;
 					}
 				} catch {
-					// A client can disconnect between the async auth gate and enqueue;
-					// the next tick or abort handler owns cleanup for that benign race.
+					// Keep the stream best-effort: transient onboarding DB checks,
+					// progress reads, or client disconnects should not leak error bodies
+					// or leave overlapping polls armed.
 				} finally {
 					polling = false;
 				}

--- a/src/routes/api/sync/status/stream/+server.ts
+++ b/src/routes/api/sync/status/stream/+server.ts
@@ -150,6 +150,8 @@ export const GET: RequestHandler = async ({ request, locals }) => {
 						terminalEventSent = false;
 					}
 				} catch {
+					// A client can disconnect between the async auth gate and enqueue;
+					// the next tick or abort handler owns cleanup for that benign race.
 				} finally {
 					polling = false;
 				}

--- a/src/routes/api/sync/status/stream/+server.ts
+++ b/src/routes/api/sync/status/stream/+server.ts
@@ -40,7 +40,6 @@ const POLL_INTERVAL_IDLE_MS = 2000;
 
 export const GET: RequestHandler = async ({ request, locals }) => {
 	// Gate: allow anonymous access only while onboarding is incomplete.
-	// Once onboarding is done, a valid session is required.
 	const onboardingPending = await requiresOnboarding();
 	if (!onboardingPending && !locals.user) {
 		return new Response(JSON.stringify({ message: 'Unauthorized' }), {
@@ -85,9 +84,8 @@ export const GET: RequestHandler = async ({ request, locals }) => {
 				if (closed || polling) return;
 				polling = true;
 				try {
-					// Re-validate the connection-open gate: once onboarding is
-					// complete, an anonymous (unauthenticated) stream is no longer
-					// permitted and must be closed.
+					// Anonymous streams are allowed only while onboarding is incomplete; once
+					// setup finishes, the unauthenticated connection must be closed.
 					if (!capturedUser) {
 						const onboardingStillPending = await requiresOnboarding();
 						if (!onboardingStillPending) {
@@ -152,7 +150,6 @@ export const GET: RequestHandler = async ({ request, locals }) => {
 						terminalEventSent = false;
 					}
 				} catch {
-					// Silently ignore errors
 				} finally {
 					polling = false;
 				}

--- a/src/routes/auth/plex/redirect/+page.server.ts
+++ b/src/routes/auth/plex/redirect/+page.server.ts
@@ -29,8 +29,8 @@ export const load: PageServerLoad = async ({ cookies, locals, request, url }) =>
 	const verifiedPin = await verifyPinCallback(cookies, url.searchParams.get('state'));
 
 	// Post-login target carried from the anon→admin hook redirect (ISSUE-002).
-	// Validate same-origin/path-only here so PageData never carries an external
-	// value; the landing page re-validates before window.location.href as well.
+	// Keep only same-origin path values here; the landing page revalidates before
+	// assigning window.location.href as a second open-redirect guard.
 	const rawReturnTo = url.searchParams.get('returnTo');
 	const returnTo = isSafeReturnPath(rawReturnTo) ? rawReturnTo : null;
 

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -13,15 +13,6 @@ import { page } from '$app/stores';
 import Logo from '$lib/components/Logo.svelte';
 import type { LayoutData } from './$types';
 
-/**
- * User Dashboard Layout
- *
- * Provides a consistent wrapper for user dashboard pages with:
- * - Sidebar navigation
- * - User info
- * - Links to wrapped presentations
- */
-
 interface Props {
 	data: LayoutData;
 	children: Snippet;
@@ -29,13 +20,11 @@ interface Props {
 
 let { data, children }: Props = $props();
 
-// Navigation items with Lucide icon components
 const navItems: Array<{ href: string; label: string; icon: Component }> = [
 	{ href: '/dashboard', label: 'Dashboard', icon: LayoutDashboard },
 	{ href: '/dashboard/settings', label: 'Settings', icon: Settings }
 ];
 
-// Determine if a nav item is active
 const isActive = $derived((href: string) => {
 	const currentPath = $page.url.pathname;
 	if (href === '/dashboard') {
@@ -44,7 +33,6 @@ const isActive = $derived((href: string) => {
 	return currentPath.startsWith(href);
 });
 
-// Mobile sidebar state
 let sidebarOpen = $state(false);
 let isMobileSidebar = $state(false);
 let sidebarHiddenFromMobile = $derived(isMobileSidebar && !sidebarOpen);
@@ -80,7 +68,6 @@ async function focusAfterRender(selector: string) {
 	document.querySelector<HTMLElement>(selector)?.focus();
 }
 
-// Reset avatar error when thumb URL changes so a new URL gets a fresh load attempt
 $effect(() => {
 	data.user.thumb;
 	avatarError = false;
@@ -145,7 +132,6 @@ function handleWindowKeydown(event: KeyboardEvent) {
 <svelte:window onkeydown={handleWindowKeydown} />
 
 <div class="dashboard-layout">
-	<!-- Mobile header -->
 	<header class="mobile-header" class:sidebar-open={sidebarOpen}>
 		<button
 			type="button"
@@ -165,7 +151,6 @@ function handleWindowKeydown(event: KeyboardEvent) {
 		</div>
 	</header>
 
-	<!-- Sidebar overlay for mobile -->
 	{#if sidebarOpen}
 		<div
 			class="sidebar-overlay"
@@ -177,7 +162,6 @@ function handleWindowKeydown(event: KeyboardEvent) {
 		></div>
 	{/if}
 
-	<!-- Sidebar -->
 	<aside
 		class="sidebar"
 		class:open={sidebarOpen}
@@ -260,7 +244,6 @@ function handleWindowKeydown(event: KeyboardEvent) {
 		</div>
 	</aside>
 
-	<!-- Main content -->
 	<main
 		class="main-content"
 		inert={mainContentHiddenFromMobile}
@@ -277,7 +260,6 @@ function handleWindowKeydown(event: KeyboardEvent) {
 			background: oklch(var(--background));
 		}
 
-		/* Mobile header */
 		.mobile-header {
 			display: none;
 			position: fixed;
@@ -330,7 +312,6 @@ function handleWindowKeydown(event: KeyboardEvent) {
 			margin: 0;
 		}
 
-		/* Sidebar overlay */
 		.sidebar-overlay {
 			display: none;
 			position: fixed;
@@ -340,7 +321,6 @@ function handleWindowKeydown(event: KeyboardEvent) {
 			z-index: 45;
 		}
 
-		/* Sidebar */
 		.sidebar {
 			position: fixed;
 			top: 0;
@@ -604,14 +584,12 @@ function handleWindowKeydown(event: KeyboardEvent) {
 			height: 0.875rem;
 		}
 
-		/* Main content */
 		.main-content {
 			flex: 1;
 			margin-left: 260px;
 			min-height: 100vh;
 		}
 
-		/* Responsive styles */
 		@media (max-width: 768px) {
 			.mobile-header {
 				display: flex;

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -5,12 +5,6 @@ import Sparkles from '@lucide/svelte/icons/sparkles';
 import Star from '@lucide/svelte/icons/star';
 import type { PageData } from './$types';
 
-/**
- * User Dashboard Page
- *
- * Shows options for viewing personal and server-wide wrapped presentations.
- */
-
 interface Props {
 	data: PageData;
 }

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -26,7 +26,6 @@ type RegenerateTokenActionData = {
 	shareToken?: string;
 };
 
-// Tab state
 const validTabs = ['privacy', 'display', 'account'] as const;
 type TabValue = (typeof validTabs)[number];
 
@@ -41,7 +40,6 @@ function getInitialTab(): TabValue {
 
 let activeTab = $state<TabValue>(getInitialTab());
 
-// Form state
 // svelte-ignore state_referenced_locally
 let selectedShareMode = $state<string>(data.shareSettings.mode);
 let selectedLogoPreference = $state<'show' | 'hide'>('show');
@@ -51,7 +49,6 @@ let wrappedHrefOverride = $state<string | null>(null);
 // svelte-ignore state_referenced_locally
 let syncedWrappedHref = $state(data.wrappedHref);
 
-// Copy state
 let copied = $state(false);
 let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -66,7 +63,6 @@ let regenerateDialogOpen = $state(false);
 // svelte-ignore state_referenced_locally
 let syncedShareMode = $state(data.shareSettings.mode);
 
-// Initialize and sync state with data (runs on mount and when data changes)
 $effect(() => {
 	// Only snap the radio selection back when the server-side mode has changed,
 	// not on every reactive pass.  This prevents the transient "all unchecked"
@@ -107,7 +103,6 @@ function isBelowFloor(mode: string): boolean {
 // radio inputs are not submitted by the browser, so `mode` arrives as null).
 let isSelectedModeBelowFloor = $derived(isBelowFloor(selectedShareMode));
 
-// Icon helpers
 function getShareIcon(mode: string): string {
 	switch (mode) {
 		case 'public':
@@ -121,7 +116,6 @@ function getShareIcon(mode: string): string {
 	}
 }
 
-// Share mode descriptions
 const shareModeDescriptions: Record<string, string> = {
 	public: 'Anyone can view your wrapped page',
 	'private-oauth': 'Only Plex server members can view',
@@ -135,13 +129,11 @@ const shareModeLabels: Record<string, string> = {
 	'private-link': 'Private Link'
 };
 
-// Generate share URL
 function getShareUrl(): string {
 	const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
 	return `${baseUrl}${wrappedHrefOverride ?? data.wrappedHref}`;
 }
 
-// Copy to clipboard
 async function copyShareUrl() {
 	try {
 		await navigator.clipboard.writeText(getShareUrl());
@@ -156,7 +148,6 @@ async function copyShareUrl() {
 	}
 }
 
-// Format date helper
 function formatDate(date: Date | null): string {
 	if (!date) return 'Unknown';
 	return new Intl.DateTimeFormat('en-US', {
@@ -165,7 +156,6 @@ function formatDate(date: Date | null): string {
 	}).format(new Date(date));
 }
 
-// Format relative date
 function formatRelativeDate(date: Date | null): string {
 	if (!date) return 'Unknown';
 	const now = new Date();
@@ -179,7 +169,6 @@ function formatRelativeDate(date: Date | null): string {
 	return formatDate(date);
 }
 
-// Logo mode display text
 function getLogoModeDescription(): string {
 	switch (data.wrappedLogoMode) {
 		case 'always_show':
@@ -209,7 +198,6 @@ function getLogoModeDescription(): string {
 			<Tabs.Trigger value="account">Account</Tabs.Trigger>
 		</Tabs.List>
 
-		<!-- Privacy Tab -->
 		<Tabs.Content value="privacy">
 			<section class="section">
 				<h2>Sharing Settings</h2>
@@ -218,7 +206,6 @@ function getLogoModeDescription(): string {
 				</p>
 
 				{#if data.shareSettings.canUserControl}
-					<!-- User has control -->
 					<form
 						method="POST"
 						action="?/updateShareMode"
@@ -323,7 +310,6 @@ function getLogoModeDescription(): string {
 						</div>
 					</form>
 
-					<!-- Share URL Section -->
 					<div class="share-url-section">
 						<h3>Your Wrapped URL</h3>
 						<div class="url-container">
@@ -408,7 +394,6 @@ function getLogoModeDescription(): string {
 						</div>
 					</div>
 
-					<!-- Still show share URL for copying -->
 					<div class="share-url-section readonly">
 						<h3>Your Wrapped URL</h3>
 						<div class="url-container">
@@ -453,7 +438,6 @@ function getLogoModeDescription(): string {
 			</section>
 		</Tabs.Content>
 
-		<!-- Display Tab -->
 		<Tabs.Content value="display">
 			<section class="section">
 				<h2>Logo Visibility</h2>
@@ -462,7 +446,6 @@ function getLogoModeDescription(): string {
 				</p>
 
 				{#if data.canControlLogo}
-					<!-- User can control logo -->
 					<form
 						method="POST"
 						action="?/updateLogoPreference"
@@ -532,7 +515,6 @@ function getLogoModeDescription(): string {
 			</section>
 		</Tabs.Content>
 
-		<!-- Account Tab -->
 		<Tabs.Content value="account">
 			<section class="section">
 				<h2>Profile Information</h2>
@@ -726,7 +708,6 @@ function getLogoModeDescription(): string {
 			border-bottom-color: oklch(var(--primary));
 		}
 
-		/* Section Styling */
 		.section {
 			background: oklch(var(--card));
 			border: 1px solid oklch(var(--border));
@@ -755,7 +736,6 @@ function getLogoModeDescription(): string {
 			margin: 0 0 1.25rem;
 		}
 
-		/* Privacy Card Grid */
 		.privacy-card-grid {
 			display: grid;
 			grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
@@ -843,7 +823,6 @@ function getLogoModeDescription(): string {
 			line-height: 1.4;
 		}
 
-		/* Form Actions */
 		.form-actions {
 			margin-top: 1.25rem;
 		}
@@ -869,7 +848,6 @@ function getLogoModeDescription(): string {
 			cursor: not-allowed;
 		}
 
-		/* Share URL Section */
 		.share-url-section {
 			margin-top: 1.5rem;
 			padding-top: 1.5rem;
@@ -950,7 +928,6 @@ function getLogoModeDescription(): string {
 			border-color: oklch(var(--destructive));
 		}
 
-		/* Info Banner */
 		.info-banner {
 			display: flex;
 			gap: 1rem;
@@ -1002,7 +979,6 @@ function getLogoModeDescription(): string {
 			font-weight: 500;
 		}
 
-		/* Profile Card */
 		.profile-card {
 			background: oklch(var(--muted));
 			border-radius: var(--radius);
@@ -1103,7 +1079,6 @@ function getLogoModeDescription(): string {
 			font-size: 0.8rem;
 		}
 
-		/* Account Actions */
 		.account-actions {
 			margin-top: 1.5rem;
 		}
@@ -1153,7 +1128,6 @@ function getLogoModeDescription(): string {
 			height: 1rem;
 		}
 
-		/* Responsive */
 		@media (max-width: 640px) {
 			.settings-page {
 				padding: 1.25rem;

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -9,15 +9,6 @@ import { ShareModePrivacyLevel } from '$lib/sharing/types';
 import { handleFormToast } from '$lib/utils/form-toast';
 import type { ActionData, PageData } from './$types';
 
-/**
- * User Settings Page
- *
- * Personal settings management for non-admin users:
- * - Privacy: Share mode controls (when permitted)
- * - Display: Logo visibility preferences
- * - Account: Read-only profile information
- */
-
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
 type RegenerateTokenActionData = {
@@ -52,7 +43,6 @@ let syncedWrappedHref = $state(data.wrappedHref);
 let copied = $state(false);
 let copyTimeout: ReturnType<typeof setTimeout> | null = null;
 
-// Regenerate token dialog
 let regenerateDialogOpen = $state(false);
 
 // DF-019: track the last server-confirmed share mode so we only overwrite the
@@ -79,7 +69,6 @@ $effect(() => {
 	}
 });
 
-// Show toast notifications and snap radio back to server truth on rejection
 $effect(() => {
 	handleFormToast(form);
 	const payload = form as unknown as { action?: string; currentMode?: string } | null | undefined;
@@ -88,7 +77,6 @@ $effect(() => {
 	}
 });
 
-// Privacy floor check — uses shared ShareModePrivacyLevel from $lib/sharing/types
 function isBelowFloor(mode: string): boolean {
 	const floor = data.globalFloor;
 	if (!floor) return false;
@@ -122,7 +110,6 @@ const shareModeDescriptions: Record<string, string> = {
 	'private-link': 'Anyone with the special link can view'
 };
 
-// Human-readable labels used in floor-note hint text
 const shareModeLabels: Record<string, string> = {
 	public: 'Public',
 	'private-oauth': 'Server Members',

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -656,7 +656,7 @@ function getLogoModeDescription(): string {
 			margin: 0;
 		}
 
-		/* Tabs Styling - :global() because class is passed to Tabs.Root component */
+		/* Tabs.Root receives these classes via props, so the selectors must escape Svelte scope. */
 		:global(.settings-tabs) {
 			margin-top: 1.5rem;
 		}
@@ -884,7 +884,6 @@ function getLogoModeDescription(): string {
 			border-color: oklch(0.6318 0.1589 149.73);
 		}
 
-		/* Token Actions */
 		.token-actions {
 			margin-top: 1rem;
 		}

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -354,7 +354,6 @@ function getLogoModeDescription(): string {
 						{/if}
 					</div>
 				{:else}
-					<!-- User doesn't have control -->
 					<div class="info-banner" role="status" aria-live="polite">
 						<span class="info-icon">ℹ️</span>
 						<div class="info-content">
@@ -490,7 +489,6 @@ function getLogoModeDescription(): string {
 						</div>
 					</form>
 				{:else}
-					<!-- User doesn't have control -->
 					<div class="info-banner">
 						<span class="info-icon">ℹ️</span>
 						<div class="info-content">
@@ -573,7 +571,6 @@ function getLogoModeDescription(): string {
 		</Tabs.Content>
 	</Tabs.Root>
 
-	<!-- Regenerate Token Confirmation Dialog -->
 	<AlertDialog.Root bind:open={regenerateDialogOpen}>
 		<AlertDialog.Content>
 			<AlertDialog.Header>

--- a/src/routes/onboarding/+layout.svelte
+++ b/src/routes/onboarding/+layout.svelte
@@ -142,7 +142,7 @@ $effect(() => {
 		.onboarding-header {
 			text-align: center;
 			margin-bottom: 2.5rem;
-			opacity: 0; /* Start hidden for animation */
+			opacity: 0;
 		}
 
 		.logo-wrapper {

--- a/src/routes/onboarding/+layout.svelte
+++ b/src/routes/onboarding/+layout.svelte
@@ -11,10 +11,8 @@ let { data, children }: { data: LayoutData; children: Snippet } = $props();
 let logoRef: HTMLElement | undefined = $state();
 let contentRef: HTMLElement | undefined = $state();
 
-// Theme class derived from layout data
 const themeClass = $derived(`theme-${data.uiTheme ?? 'modern-minimal'}`);
 
-// All available theme classes for removal
 const themeClasses = [
 	'theme-modern-minimal',
 	'theme-supabase',
@@ -26,18 +24,13 @@ const themeClasses = [
 	'theme-champagne-premium'
 ];
 
-// Apply theme class to body and load font
 $effect(() => {
-	// Remove all existing theme classes
 	document.body.classList.remove(...themeClasses);
 
-	// Add the current theme class
 	document.body.classList.add(themeClass);
 
-	// Add onboarding route class for potential styling hooks
 	document.body.classList.add('onboarding-route');
 
-	// Load theme-specific font
 	loadThemeFonts(data.uiTheme ?? 'modern-minimal');
 
 	return () => {
@@ -45,7 +38,6 @@ $effect(() => {
 	};
 });
 
-// Animate logo on mount
 $effect(() => {
 	if (!logoRef) return;
 
@@ -64,14 +56,11 @@ $effect(() => {
 </svelte:head>
 
 <div class="onboarding-layout">
-	<!-- Background effects -->
 	<div class="bg-gradient"></div>
 	<div class="bg-noise"></div>
 	<div class="bg-vignette"></div>
 
-	<!-- Content container -->
 	<div class="onboarding-container">
-		<!-- Logo -->
 		<header bind:this={logoRef} class="onboarding-header">
 			<div class="logo-wrapper">
 				<Logo size="md" class="logo" />
@@ -80,17 +69,14 @@ $effect(() => {
 			<p class="setup-label">Initial Setup</p>
 		</header>
 
-		<!-- Step indicator -->
 		<div class="step-indicator-wrapper">
 			<StepIndicator steps={data.steps} currentStep={data.currentStepIndex} />
 		</div>
 
-		<!-- Page content -->
 		<main bind:this={contentRef} class="onboarding-content">
 			{@render children()}
 		</main>
 
-		<!-- Footer -->
 		<footer class="onboarding-footer">
 			<p>Your Plex viewing history, beautifully wrapped.</p>
 		</footer>
@@ -123,7 +109,6 @@ $effect(() => {
 			pointer-events: none;
 		}
 
-		/* Film grain texture */
 		.bg-noise {
 			position: fixed;
 			inset: 0;
@@ -133,7 +118,6 @@ $effect(() => {
 			pointer-events: none;
 		}
 
-		/* Vignette effect */
 		.bg-vignette {
 			position: fixed;
 			inset: 0;
@@ -219,7 +203,6 @@ $effect(() => {
 			letter-spacing: 0.02em;
 		}
 
-		/* Responsive */
 		@media (max-width: 640px) {
 			.onboarding-container {
 				padding: 1.5rem 1rem;

--- a/src/routes/onboarding/+layout.svelte
+++ b/src/routes/onboarding/+layout.svelte
@@ -96,7 +96,6 @@ $effect(() => {
 			background: oklch(var(--background));
 		}
 
-		/* Background gradient - cinematic theater lighting using theme colors */
 		.bg-gradient {
 			position: fixed;
 			inset: 0;

--- a/src/routes/onboarding/+page.server.ts
+++ b/src/routes/onboarding/+page.server.ts
@@ -2,9 +2,6 @@ import { redirect } from '@sveltejs/kit';
 import { getOnboardingStep } from '$lib/server/onboarding';
 import type { PageServerLoad } from './$types';
 
-/**
- * Root onboarding page redirects to current step
- */
 export const load: PageServerLoad = async () => {
 	const step = await getOnboardingStep();
 	redirect(303, `/onboarding/${step}`);

--- a/src/routes/onboarding/claim/+page.svelte
+++ b/src/routes/onboarding/claim/+page.svelte
@@ -105,12 +105,8 @@ let isClaiming = $state(false);
 		color: oklch(var(--foreground));
 	}
 
-	/* `.bootstrap-token-input` is the monospace token field. Hoisted to
-	   :global so the shadcn Input primitive (renders the <input> inside
-	   a child component) inherits the monospace font + letter-spacing +
-	   focus-ring styling. The shadcn Input default `h-8` is preserved
-	   only because this rule doesn't override height — the monospace
-	   + padding 0.85rem still applies via the cascade. */
+	/* shadcn Input child-renders the real <input>, so the monospace token
+	   treatment must be hoisted. */
 	:global(.bootstrap-token-input) {
 		width: 100%;
 		border: 1px solid oklch(var(--border));
@@ -134,10 +130,8 @@ let isClaiming = $state(false);
 		font-size: 0.875rem;
 	}
 
-	/* `.claim-button` is hoisted to :global so the SubmitButton primitive
-	   (which renders its <button> inside a child component) inherits the
-	   styling — Svelte 5 component-scoped CSS doesn't cross the boundary.
-	   Same visual-coupling pattern proven on the landing page in US-024. */
+	/* SubmitButton child-renders the real <button>, so this styling must cross
+	   Svelte's component-scope boundary via :global. */
 	:global(.claim-button) {
 		border: 0;
 		border-radius: 0.5rem;

--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -19,9 +19,6 @@ import { getGlobalAllowUserControl, getGlobalDefaultShareMode } from '$lib/serve
 import { getPlayHistoryCount, getSyncProgress, isSyncRunning } from '$lib/server/sync';
 import type { Actions, PageServerLoad } from './$types';
 
-/**
- * Load function - marks onboarding complete and provides summary
- */
 export const load: PageServerLoad = async ({ parent, locals, url, cookies }) => {
 	if (!locals.user?.isAdmin) {
 		redirect(303, '/onboarding/claim');
@@ -171,13 +168,7 @@ async function requireOnboardingCompleteClaim(
 	return null;
 }
 
-/**
- * Form actions
- */
 export const actions: Actions = {
-	/**
-	 * Go to dashboard
-	 */
 	goToDashboard: async ({ locals, cookies, url }) => {
 		const guardResult = await requireOnboardingCompleteClaim(cookies, url);
 		if (guardResult) return guardResult;

--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -1,10 +1,3 @@
-/**
- * Onboarding Step 4: Completion
- *
- * Marks onboarding as complete and shows success message.
- * Provides summary of configuration and link to dashboard.
- */
-
 import { fail, redirect } from '@sveltejs/kit';
 import {
 	getAnonymizationMode,
@@ -46,12 +39,10 @@ export const load: PageServerLoad = async ({ parent, locals, url, cookies }) => 
 	const parentData = await parent();
 	const notice = url.searchParams.get('notice');
 
-	// Get sync status (may still be running)
 	const syncRunning = await isSyncRunning();
 	const syncProgress = getSyncProgress();
 	const historyCount = await getPlayHistoryCount();
 
-	// Get configured settings for summary
 	const [
 		serverName,
 		uiTheme,
@@ -101,9 +92,6 @@ export const load: PageServerLoad = async ({ parent, locals, url, cookies }) => 
 	};
 };
 
-/**
- * Format theme name for display
- */
 function formatThemeName(theme: string): string {
 	return theme
 		.split('-')
@@ -111,9 +99,6 @@ function formatThemeName(theme: string): string {
 		.join(' ');
 }
 
-/**
- * Format anonymization mode for display
- */
 function formatAnonymizationMode(mode: string): string {
 	const modes: Record<string, string> = {
 		real: 'Real Names',
@@ -123,9 +108,6 @@ function formatAnonymizationMode(mode: string): string {
 	return modes[mode] || mode;
 }
 
-/**
- * Format share mode for display
- */
 function formatShareMode(mode: string): string {
 	const modes: Record<string, string> = {
 		public: 'Public',

--- a/src/routes/onboarding/complete/+page.svelte
+++ b/src/routes/onboarding/complete/+page.svelte
@@ -679,12 +679,8 @@ const summaryItems = $derived([
 			transform: translateY(0);
 		}
 
-		/* `.btn-dashboard` is hoisted to :global so SubmitButton (which
-		   renders its <button> in a child component) inherits the primary
-		   palette, hover translate-y, and dual-shadow glow. `.arrow-icon`
-		   piggy-backs the same hoist for the arrow-translate-x hover
-		   effect that pairs with the button's lift. Pattern matches
-		   landing-page US-024 (e276772 + downstream). */
+		/* SubmitButton child-renders the real <button>, so the dashboard CTA
+		   palette and paired arrow hover effect must be hoisted. */
 		:global(.btn-dashboard) {
 			display: flex;
 			align-items: center;

--- a/src/routes/onboarding/complete/+page.svelte
+++ b/src/routes/onboarding/complete/+page.svelte
@@ -5,26 +5,15 @@ import SubmitButton from '$lib/components/forms/SubmitButton.svelte';
 import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
 import type { PageData } from './$types';
 
-/**
- * Onboarding Step 4: Completion
- *
- * Celebratory success page with animated elements and configuration summary.
- * Shows sync status if still running in background.
- */
-
 let { data }: { data: PageData } = $props();
 
-// Animation states
 let showCheckmark = $state(false);
 let showContent = $state(false);
 let showParticles = $state(false);
 
-// Submit state for "Go to Dashboard"
 let isNavigating = $state(false);
 
-// Trigger animations on mount
 $effect(() => {
-	// Stagger the animations
 	const checkmarkTimer = setTimeout(() => {
 		showCheckmark = true;
 	}, 100);
@@ -44,7 +33,6 @@ $effect(() => {
 	};
 });
 
-// Summary items with icons
 const summaryItems = $derived([
 	{
 		icon: 'server',
@@ -92,7 +80,6 @@ const summaryItems = $derived([
 <OnboardingCard title="" subtitle="">
 	{#snippet children()}
 		<div class="completion-container">
-			<!-- Floating particles background -->
 			<div class="particles-container" class:active={showParticles}>
 				{#each Array(20) as _, i}
 					<div
@@ -109,7 +96,6 @@ const summaryItems = $derived([
 				{/each}
 			</div>
 
-			<!-- Success Icon with animated checkmark -->
 			<div class="success-icon-container" class:animate={showCheckmark}>
 				<div class="success-glow"></div>
 				<div class="success-ring"></div>
@@ -119,7 +105,6 @@ const summaryItems = $derived([
 				</svg>
 			</div>
 
-			<!-- Title -->
 			<div class="completion-header" class:visible={showContent}>
 				<h1 class="completion-title">Setup Complete!</h1>
 				<p class="completion-subtitle">Your Plex Wrapped is ready to go</p>
@@ -146,7 +131,6 @@ const summaryItems = $derived([
 				</div>
 			{/if}
 
-			<!-- Configuration Summary -->
 			<div class="summary-section" class:visible={showContent}>
 				<h2 class="summary-title">Your Configuration</h2>
 				<div class="summary-grid">
@@ -196,7 +180,6 @@ const summaryItems = $derived([
 				</div>
 			</div>
 
-			<!-- Sync Status (if running) -->
 			{#if data.syncStatus.running}
 				<div class="sync-status" class:visible={showContent}>
 					<div class="sync-indicator">
@@ -261,7 +244,6 @@ const summaryItems = $derived([
 </OnboardingCard>
 
 <style>
-	/* Container */
 		.completion-container {
 			display: flex;
 			flex-direction: column;
@@ -272,7 +254,6 @@ const summaryItems = $derived([
 			min-height: 380px;
 		}
 
-		/* Particles */
 		.particles-container {
 			position: absolute;
 			inset: 0;
@@ -316,7 +297,6 @@ const summaryItems = $derived([
 			}
 		}
 
-		/* Success Icon */
 		.success-icon-container {
 			position: relative;
 			width: 100px;
@@ -400,7 +380,6 @@ const summaryItems = $derived([
 			stroke-dashoffset: 0;
 		}
 
-		/* Header */
 		.completion-header {
 			margin-bottom: 2rem;
 			opacity: 0;
@@ -443,7 +422,6 @@ const summaryItems = $derived([
 			color: rgba(255, 255, 255, 0.6);
 		}
 
-		/* Soft notice (e.g. AI key missing) */
 		.completion-notice {
 			display: flex;
 			align-items: flex-start;
@@ -475,7 +453,6 @@ const summaryItems = $derived([
 			color: rgba(234, 179, 8, 0.85);
 		}
 
-		/* Summary Section */
 		.summary-section {
 			width: 100%;
 			opacity: 0;
@@ -589,7 +566,6 @@ const summaryItems = $derived([
 			text-overflow: ellipsis;
 		}
 
-		/* Sync Status */
 		.sync-status {
 			display: flex;
 			align-items: center;
@@ -660,7 +636,6 @@ const summaryItems = $derived([
 			color: rgba(255, 255, 255, 0.5);
 		}
 
-		/* Sync Complete */
 		.sync-complete {
 			display: flex;
 			align-items: center;
@@ -688,7 +663,6 @@ const summaryItems = $derived([
 			flex-shrink: 0;
 		}
 
-		/* Footer */
 		.footer-content {
 			display: flex;
 			flex-direction: column;

--- a/src/routes/onboarding/csrf/+page.svelte
+++ b/src/routes/onboarding/csrf/+page.svelte
@@ -445,7 +445,6 @@ function useDetectedOrigin() {
 		height: 40px;
 	}
 
-	/* Detection Card */
 	.detection-card {
 		background: rgba(255, 255, 255, 0.03);
 		border: 1px solid rgba(255, 255, 255, 0.08);
@@ -522,7 +521,6 @@ function useDetectedOrigin() {
 		color: rgba(255, 255, 255, 0.7);
 	}
 
-	/* Preconfigured Card */
 	.preconfigured-card {
 		display: flex;
 		align-items: center;
@@ -648,7 +646,6 @@ function useDetectedOrigin() {
 		color: rgba(255, 255, 255, 0.7);
 	}
 
-	/* Input Section */
 	.input-section {
 		display: flex;
 		flex-direction: column;
@@ -837,7 +834,6 @@ function useDetectedOrigin() {
 		line-height: 1.5;
 	}
 
-	/* Info Callout */
 	.info-callout {
 		display: flex;
 		gap: 0.875rem;

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -361,7 +361,7 @@ function sortConnections(
 			if (c.uri.includes('.plex.direct')) return 0;
 			if (!c.local && !c.relay) return 1;
 			if (c.local && !c.relay) return 2;
-			return 3; // relay
+			return 3;
 		};
 		return priority(a) - priority(b);
 	});

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -36,7 +36,7 @@ let showPopupBlockedModal = $state(false);
 let pendingPinId = $state<number | null>(null);
 let pendingAuthUrl = $state<string | null>(null);
 
-// Bypasses SvelteKit data prop reactivity timing issues
+// Local optimistic auth state keeps the Plex step responsive while SvelteKit data invalidates.
 let localAuthState = $state<{
 	isAuthenticated: boolean;
 	isAdmin: boolean;
@@ -91,7 +91,7 @@ $effect(() => {
 $effect(() => {
 	if (!contentRef) return;
 
-	// When these change, new .animate-item elements may be added to the DOM
+	// Read these values solely to re-run the effect when auth/server UI branches add new items.
 	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 	localAuthState?.isAuthenticated;
 	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -103,7 +103,7 @@ $effect(() => {
 	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 	servers.length;
 
-	// Use requestAnimationFrame to ensure DOM has updated after state change
+	// Wait one frame so branch-created `.animate-item` nodes are in the DOM before querying.
 	const rafId = requestAnimationFrame(() => {
 		if (!contentRef) return;
 		const items = contentRef.querySelectorAll('.animate-item');
@@ -1196,7 +1196,6 @@ function formatServerUrl(url: string | null): string {
 			opacity: 0;
 		}
 
-		/* Plex Icon */
 		.plex-icon-wrapper {
 			position: relative;
 			width: 72px;
@@ -1378,12 +1377,10 @@ function formatServerUrl(url: string | null): string {
 			text-align: center;
 		}
 
-		/* Plex Login Button — Plex-orange OAuth CTA. Hoisted to :global so
-		   shadcn Button's child-rendered <button> inherits the gradient,
-		   triple shadow (drop + accent + inset highlight), hover translate-y,
-		   and active translate-back. The `.plex-logo` descendant rule
-		   (18px width/height) is dropped; PlayIcon + LoaderCircleIcon
-		   both sized inline via `class="size-[18px]"`. */
+		/* shadcn Button child-renders the actual <button>, so the OAuth CTA
+		   selector must be global for the gradient, layered shadows, and
+		   hover/active transforms to reach it. Icons stay sized inline to avoid
+		   another descendant override across the scoped-style boundary. */
 		:global(.plex-button) {
 			display: inline-flex;
 			align-items: center;
@@ -2025,14 +2022,11 @@ function formatServerUrl(url: string | null): string {
 			height: 18px;
 		}
 
-		/* Continue Button — hoisted to :global so SubmitButton + Button
-		   (both shadcn primitives render the button element inside a
-		   child component) inherit the primary palette, hover translate-y,
-		   and dual shadow (drop + inset highlight). `.continue-button svg`
-		   descendant rule dropped; ArrowRightIcon is sized inline via
-		   `class="size-[18px]"`. Same migration template as iteration 88's
-		   onboarding/sync continue-button (which uses identical CSS;
-		   eventual consolidation candidate). */
+		/* SubmitButton + Button render the actual <button> inside child
+		   components, so this selector must be global for the primary palette,
+		   hover translate-y, and dual shadow to reach it. The icon stays sized
+		   inline to avoid another descendant override across the scoped-style
+		   boundary. */
 		:global(.continue-button) {
 			display: inline-flex;
 			align-items: center;

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -92,7 +92,6 @@ $effect(() => {
 $effect(() => {
 	if (!contentRef) return;
 
-	// Track underlying state variables that affect DOM structure
 	// When these change, new .animate-item elements may be added to the DOM
 	// eslint-disable-next-line @typescript-eslint/no-unused-expressions
 	localAuthState?.isAuthenticated;
@@ -109,12 +108,10 @@ $effect(() => {
 	const rafId = requestAnimationFrame(() => {
 		if (!contentRef) return;
 		const items = contentRef.querySelectorAll('.animate-item');
-		// Filter to only animate elements that haven't been animated yet
 		const newItems = Array.from(items).filter((item) => !animatedElements.has(item));
 
 		if (newItems.length === 0) return;
 
-		// Mark these elements as animated before starting animation
 		newItems.forEach((item) => animatedElements.add(item));
 
 		// biome-ignore lint/suspicious/noExplicitAny: Motion's animate function has complex overloads that TypeScript cannot infer correctly
@@ -254,7 +251,6 @@ function handleCancelRedirect(): void {
 function handleServerExpand(server: (typeof servers)[0]) {
 	if (!server.owned) return;
 
-	// Toggle expansion - collapse if clicking the same server
 	if (expandedServer === server.clientIdentifier) {
 		expandedServer = null;
 	} else {
@@ -538,7 +534,6 @@ function formatServerUrl(url: string | null): string {
 			</div>
 		</div>
 
-		<!-- Pre-configured flow -->
 		{#if data.hasEnvConfig}
 			<div class="preconfigured-card animate-item">
 				<div class="preconfigured-icon">
@@ -744,7 +739,6 @@ function formatServerUrl(url: string | null): string {
 				</div>
 			{/if}
 		{:else}
-			<!-- Manual configuration flow -->
 			{#if showLoginButton}
 				<div class="action-section animate-item">
 					<p class="instruction">Sign in with Plex to connect your server</p>
@@ -994,15 +988,12 @@ function formatServerUrl(url: string | null): string {
 										</div>
 									{/if}
 
-									<!-- Custom URL Section -->
 									{#if isExpanded && !serverSaved}
 										<div class="custom-url-section">
-											<!-- Divider -->
 											<div class="custom-url-divider">
 												<span>or</span>
 											</div>
 
-											<!-- Toggle Button -->
 											<button
 												type="button"
 												class="custom-url-toggle"
@@ -1023,7 +1014,6 @@ function formatServerUrl(url: string | null): string {
 												</svg>
 											</button>
 
-											<!-- Expanded Form -->
 											{#if showCustomUrl}
 												<div class="custom-url-form">
 													<p class="custom-url-help" id="custom-url-help">
@@ -1071,7 +1061,6 @@ function formatServerUrl(url: string | null): string {
 														</label>
 													{/if}
 
-													<!-- Status Display -->
 													{#if customUrlTestResult}
 														<div
 															class="custom-url-status"
@@ -1126,7 +1115,6 @@ function formatServerUrl(url: string | null): string {
 			{/if}
 		{/if}
 
-		<!-- Error display -->
 		{#if oauthError || form?.error}
 			<div class="error-banner animate-item">
 				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -1248,7 +1236,6 @@ function formatServerUrl(url: string | null): string {
 			height: 100%;
 		}
 
-		/* Pre-configured Server Card */
 		.preconfigured-card {
 			display: flex;
 			align-items: center;
@@ -1378,7 +1365,6 @@ function formatServerUrl(url: string | null): string {
 			height: 15px;
 		}
 
-		/* Action Section */
 		.action-section {
 			display: flex;
 			flex-direction: column;
@@ -1488,7 +1474,6 @@ function formatServerUrl(url: string | null): string {
 			color: rgba(255, 255, 255, 0.85);
 		}
 
-		/* Success Card */
 		.success-card {
 			display: flex;
 			align-items: flex-start;
@@ -1529,7 +1514,6 @@ function formatServerUrl(url: string | null): string {
 			color: rgba(255, 255, 255, 0.55);
 		}
 
-		/* Error Card */
 		.error-card {
 			display: flex;
 			align-items: flex-start;
@@ -1650,7 +1634,6 @@ function formatServerUrl(url: string | null): string {
 			flex-wrap: wrap;
 		}
 
-		/* Server Section */
 		.server-section {
 			width: 100%;
 			display: flex;
@@ -1852,7 +1835,6 @@ function formatServerUrl(url: string | null): string {
 			animation: spin 0.8s linear infinite;
 		}
 
-		/* Connections Panel */
 		.connections-panel {
 			background: rgba(255, 255, 255, 0.02);
 			border: 1px solid rgba(255, 255, 255, 0.08);
@@ -2026,7 +2008,6 @@ function formatServerUrl(url: string | null): string {
 			text-align: center;
 		}
 
-		/* Error Banner */
 		.error-banner {
 			display: flex;
 			align-items: center;
@@ -2087,7 +2068,6 @@ function formatServerUrl(url: string | null): string {
 			box-shadow: none;
 		}
 
-		/* SSL Connection Card Enhancement */
 		.connection-card.ssl {
 			background: linear-gradient(135deg, rgba(34, 197, 94, 0.06) 0%, rgba(255, 255, 255, 0.03) 100%);
 			border-color: rgba(34, 197, 94, 0.15);
@@ -2168,7 +2148,6 @@ function formatServerUrl(url: string | null): string {
 			color: rgba(255, 255, 255, 0.7);
 		}
 
-		/* Custom URL Section */
 		.custom-url-section {
 			padding: 0 1rem 1rem;
 			margin-top: -0.5rem;
@@ -2381,7 +2360,6 @@ function formatServerUrl(url: string | null): string {
 			}
 		}
 
-		/* Responsive */
 		@media (max-width: 480px) {
 			.plex-button {
 				width: 100%;

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -32,7 +32,6 @@ let oauthError = $state<string | null>(null);
 let loginController: PlexLoginController | null = null;
 let confirmOwnershipChecked = $state(false);
 
-// Popup fallback state
 let showPopupBlockedModal = $state(false);
 let pendingPinId = $state<number | null>(null);
 let pendingAuthUrl = $state<string | null>(null);
@@ -500,7 +499,6 @@ function formatServerUrl(url: string | null): string {
 	subtitle="Link your Plex Media Server to unlock your personalized viewing journey"
 >
 	<div class="plex-content" bind:this={contentRef}>
-		<!-- Plex Icon -->
 		<div class="plex-icon-wrapper animate-item" bind:this={iconRef}>
 			<div class="plex-icon-glow"></div>
 			<div class="plex-icon">

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -1563,12 +1563,8 @@ function formatServerUrl(url: string | null): string {
 			margin-top: 0.75rem;
 		}
 
-		/* `.error-action-btn` is the destructive-variant CTA used in 3
-		   error-card panels (configured-url-unreachable, not-in-resources,
-		   etc.). Hoisted to :global so SubmitButton's child-rendered
-		   <button> inherits the red palette + hover-darken + optional
-		   .secondary modifier (white/transparent variant for the
-		   alternative action in the dual-button error card). */
+		/* SubmitButton child-renders the real <button>, so error-action palettes
+		   and the secondary modifier must be hoisted. */
 		:global(.error-action-btn) {
 			display: inline-flex;
 			align-items: center;
@@ -2076,12 +2072,8 @@ function formatServerUrl(url: string | null): string {
 			box-shadow: 0 0 0 1px rgba(34, 197, 94, 0.2);
 		}
 
-		/*
-		 * Tooltip portal z-index override
-		 * bits-ui sets inline `z-index: auto` on portal elements, which can only be
-		 * overridden with !important. This ensures tooltips appear above the card
-		 * (which has z-index: 10 from .onboarding-container).
-		 */
+		/* bits-ui writes `z-index: auto` inline on tooltip portals; use
+		   !important so tooltips can rise above the onboarding card. */
 		:global([id^='bits-']:has(.connection-tooltip)) {
 			z-index: 100 !important;
 		}
@@ -2265,12 +2257,8 @@ function formatServerUrl(url: string | null): string {
 			box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1);
 		}
 
-		/* `.custom-url-test-btn` is the connection-test CTA in the
-		   reverse-proxy URL form. Hoisted to :global so shadcn Button
-		   inherits the primary-tinted background + hover-darken. The
-		   `.custom-url-test-btn svg` descendant rule is dropped;
-		   CircleCheckIcon + LoaderCircleIcon are sized inline via
-		   `class="size-4"`. */
+		/* shadcn Button child-renders the real control, so the connection-test
+		   palette must be hoisted. */
 		:global(.custom-url-test-btn) {
 			display: inline-flex;
 			align-items: center;

--- a/src/routes/onboarding/proxy-trust/+page.svelte
+++ b/src/routes/onboarding/proxy-trust/+page.svelte
@@ -546,7 +546,6 @@ function toggleDetails() {
 		text-align: center;
 	}
 
-	/* Status card */
 	.status-card {
 		display: flex;
 		align-items: flex-start;
@@ -614,7 +613,6 @@ function toggleDetails() {
 		color: rgba(255, 255, 255, 0.62);
 	}
 
-	/* Enable form */
 	.trust-proxy-enable-form {
 		display: flex;
 		flex-direction: column;
@@ -722,7 +720,6 @@ function toggleDetails() {
 		font-weight: 500;
 	}
 
-	/* Details toggle */
 	.details-toggle {
 		align-self: center;
 		display: inline-flex;
@@ -877,7 +874,6 @@ function toggleDetails() {
 		cursor: not-allowed;
 	}
 
-	/* Continue button */
 	.continue-form {
 		display: flex;
 		margin: 0;

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -406,8 +406,8 @@ export const actions: Actions = {
 	},
 
 	/**
-	 * Test OpenAI connection using values submitted from the form.
-	 * Does not fall back to stored values — onboarding submits fresh input.
+	 * Do not fall back to stored OpenAI values here: onboarding submits fresh
+	 * input before the settings are persisted.
 	 */
 	testAIConnection: async ({ request, locals, cookies, url }) => {
 		const guardResult = await requireOnboardingSettingsClaim(cookies, url);

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -62,9 +62,6 @@ import {
 import { ShareMode, type ShareModeType } from '$lib/sharing/types';
 import type { Actions, PageServerLoad } from './$types';
 
-/**
- * Validation schema for settings form
- */
 const SettingsSchema = z.object({
 	uiTheme: z.enum([
 		ThemePresets.MODERN_MINIMAL,
@@ -118,9 +115,6 @@ const SettingsSchema = z.object({
 	aiPersona: AIPersonaSchema.optional()
 });
 
-/**
- * Load function - provides current settings
- */
 export const load: PageServerLoad = async ({ parent }) => {
 	const parentData = await parent();
 
@@ -251,9 +245,6 @@ async function requireOnboardingSettingsClaim(
 	return null;
 }
 
-/**
- * Form actions
- */
 export const actions: Actions = {
 	saveSettings: async ({ request, locals, cookies, url }) => {
 		const guardResult = await requireOnboardingSettingsClaim(cookies, url);

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -388,9 +388,6 @@ export const actions: Actions = {
 		}
 	},
 
-	/**
-	 * Skip settings (use defaults) and continue
-	 */
 	skipSettings: async ({ locals, cookies, url }) => {
 		const guardResult = await requireOnboardingSettingsClaim(cookies, url);
 		if (guardResult) return guardResult;

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -1,10 +1,3 @@
-/**
- * Onboarding Step 3: Settings Configuration
- *
- * Allows admin to configure appearance, privacy, slides, and AI features.
- * Uses simplified settings focused on initial setup.
- */
-
 import { fail, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 import { DEFAULT_SLIDE_ORDER, type SlideType } from '$lib/components/slides/types';
@@ -73,7 +66,6 @@ import type { Actions, PageServerLoad } from './$types';
  * Validation schema for settings form
  */
 const SettingsSchema = z.object({
-	// Appearance
 	uiTheme: z.enum([
 		ThemePresets.MODERN_MINIMAL,
 		ThemePresets.SUPABASE,
@@ -89,7 +81,6 @@ const SettingsSchema = z.object({
 		ThemePresets.SOVIET_RED
 	]),
 
-	// Privacy
 	anonymizationMode: z.enum([
 		AnonymizationMode.REAL,
 		AnonymizationMode.ANONYMOUS,
@@ -110,10 +101,8 @@ const SettingsSchema = z.object({
 	// which returns false when no DB row exists, so it's never public before the admin opts in.
 	publicLandingLookup: z.enum(['true', 'false']).transform((v) => v === 'true'),
 
-	// Slides (comma-separated list of enabled slide types)
 	enabledSlides: z.string().optional(),
 
-	// AI Features
 	enableFunFacts: z.enum(['true', 'false']).transform((v) => v === 'true'),
 	funFactFrequency: z
 		.enum([
@@ -135,10 +124,8 @@ const SettingsSchema = z.object({
 export const load: PageServerLoad = async ({ parent }) => {
 	const parentData = await parent();
 
-	// Initialize slide config if not already done
 	await initializeDefaultSlideConfig();
 
-	// Load all settings in parallel
 	const [
 		uiTheme,
 		wrappedTheme,
@@ -169,14 +156,12 @@ export const load: PageServerLoad = async ({ parent }) => {
 		getAppSetting(AppSettingsKey.FUN_FACTS_AI_PERSONA)
 	]);
 
-	// Check if OpenAI is configured (for AI features section). Reflect both an
-	// env-provided key AND a stored DB key: the AI-key-missing warning must not
-	// nag when AI is already operative from a previously saved DB credential
-	// (env still takes precedence, but a DB key alone is enough to drive AI).
+	// Treat OpenAI as configured when either ENV or the DB supplies a key so the
+	// AI-key-missing warning does not nag after a previously saved credential.
+	// ENV still takes precedence, but a DB key alone is enough to drive AI.
 	const apiConfig = await getApiConfigWithSources();
 	const hasOpenAI = hasOpenAIEnvConfig() || Boolean(apiConfig.openai.apiKey.value.trim());
 
-	// Build theme options
 	const themeOptions = Object.entries(ThemePresets).map(([key, value]) => ({
 		value,
 		label: key
@@ -185,7 +170,6 @@ export const load: PageServerLoad = async ({ parent }) => {
 			.replace(/\b\w/g, (c) => c.toUpperCase())
 	}));
 
-	// Build slide options (only built-in slides)
 	const slideOptions = slideConfigs
 		.filter((config) => DEFAULT_SLIDE_ORDER.includes(config.slideType as SlideType))
 		.map((config) => ({
@@ -194,7 +178,6 @@ export const load: PageServerLoad = async ({ parent }) => {
 			enabled: config.enabled
 		}));
 
-	// Fun fact frequency options
 	const funFactOptions = [
 		{ value: FunFactFrequency.FEW, label: 'Few', description: '1-2 facts' },
 		{ value: FunFactFrequency.NORMAL, label: 'Normal', description: '3-5 facts' },
@@ -231,9 +214,6 @@ export const load: PageServerLoad = async ({ parent }) => {
 	};
 };
 
-/**
- * Format slide type to human-readable label
- */
 function formatSlideLabel(slideType: string): string {
 	const labels: Record<string, string> = {
 		'total-time': 'Total Watch Time',
@@ -275,9 +255,6 @@ async function requireOnboardingSettingsClaim(
  * Form actions
  */
 export const actions: Actions = {
-	/**
-	 * Save all settings and continue to completion
-	 */
 	saveSettings: async ({ request, locals, cookies, url }) => {
 		const guardResult = await requireOnboardingSettingsClaim(cookies, url);
 		if (guardResult) return guardResult;
@@ -289,9 +266,9 @@ export const actions: Actions = {
 		try {
 			const formData = await request.formData();
 
-			// Parse form data. Hidden AI inputs are always rendered (so the form
-			// submits in one click) but emit empty strings when the toggle is off;
-			// coerce those to undefined so optional() and enum() schemas match.
+			// Hidden inputs stay mounted so each carousel step can submit in one click,
+			// but disabled toggles emit empty strings. Coerce those to undefined so
+			// optional() and enum() schemas match.
 			const optionalString = (key: string): string | undefined => {
 				const raw = formData.get(key)?.toString().trim();
 				return raw ? raw : undefined;
@@ -314,7 +291,6 @@ export const actions: Actions = {
 				aiPersona: optionalString('aiPersona')
 			};
 
-			// Validate
 			const parseResult = SettingsSchema.safeParse(rawData);
 			if (!parseResult.success) {
 				const errorMessage = parseResult.error.issues[0]?.message ?? 'Invalid settings';
@@ -347,13 +323,10 @@ export const actions: Actions = {
 			const hasEffectiveApiKey = Boolean(apiConfig.openai.apiKey.value.trim());
 			const aiKeyMissingNotice = data.enableFunFacts && !openaiApiKey && !hasEffectiveApiKey;
 
-			// Save all settings in parallel
 			await Promise.all([
-				// Appearance
 				setUITheme(data.uiTheme as ThemePresetType),
 				setWrappedTheme(data.wrappedTheme as ThemePresetType),
 
-				// Privacy
 				setAnonymizationMode(data.anonymizationMode as AnonymizationModeType),
 				setWrappedLogoMode(data.logoMode as WrappedLogoModeType),
 				setGlobalShareDefaults({
@@ -366,7 +339,6 @@ export const actions: Actions = {
 				setServerWrappedShareMode(data.serverWrappedShareMode),
 				setPublicLandingLookupEnabled(data.publicLandingLookup),
 
-				// AI Features (only if enabled)
 				data.enableFunFacts && data.funFactFrequency
 					? setFunFactFrequency(data.funFactFrequency as FunFactFrequencyType)
 					: Promise.resolve(),
@@ -384,13 +356,11 @@ export const actions: Actions = {
 					: Promise.resolve()
 			]);
 
-			// Update slide configurations
 			if (data.enabledSlides !== undefined) {
 				const enabledSlides = data.enabledSlides
 					? data.enabledSlides.split(',').filter(Boolean)
 					: [];
 
-				// Update each slide's enabled state
 				for (const slideType of DEFAULT_SLIDE_ORDER) {
 					const isEnabled = enabledSlides.includes(slideType);
 					await updateSlideConfig(slideType, { enabled: isEnabled });
@@ -399,14 +369,12 @@ export const actions: Actions = {
 
 			logger.info(`Onboarding: Settings configured by ${locals.user.username}`, 'Onboarding');
 
-			// Advance to completion step
 			await setOnboardingStep(OnboardingSteps.COMPLETE);
 			redirect(
 				303,
 				aiKeyMissingNotice ? '/onboarding/complete?notice=ai-key-missing' : '/onboarding/complete'
 			);
 		} catch (err) {
-			// Handle redirect (expected)
 			if (
 				err instanceof Response ||
 				(err &&
@@ -445,7 +413,6 @@ export const actions: Actions = {
 			'Onboarding'
 		);
 
-		// Advance to completion step
 		await setOnboardingStep(OnboardingSteps.COMPLETE);
 		redirect(303, '/onboarding/complete');
 	},

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -598,7 +598,6 @@ function getThemeColors(themeValue: string) {
 									</Tooltip.Root>
 								</dt>
 							{/snippet}
-							<!-- Value tooltip: explains the specific effect of the selected value -->
 							{#snippet previewDd(tip: string, label: string)}
 								<dd>
 									<Tooltip.Root>
@@ -671,7 +670,6 @@ function getThemeColors(themeValue: string) {
 								{/each}
 							</div>
 
-							<!-- Advanced Options: the six granular controls, collapsed by default -->
 							<div class="advanced-options">
 								<button
 									type="button"

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -79,8 +79,8 @@ let selectedPreset = $derived(
 	})
 );
 
-// Single live preview (onboarding owns logoMode, so the logo line is included).
-// Its `warnings` is the sole source of the landing-lookup contradiction notice.
+// Onboarding owns logoMode, so this preview is the one place that can surface
+// both logo visibility and landing-lookup contradiction warnings.
 let privacyPreview = $derived(
 	derivePreview({
 		anonymizationMode,
@@ -1376,12 +1376,8 @@ function getThemeColors(themeValue: string) {
 			cursor: not-allowed;
 		}
 
-		/* `.btn-nav` is the shared base for the footer nav trio
-		   (btn-prev + btn-next + btn-save). Hoisted to :global so the
-		   SubmitButton-rendered btn-save (this iteration) inherits the
-		   layout while btn-prev + btn-next stay scoped (still native
-		   <button>s in this file's template — they continue to match
-		   the global selector). */
+		/* The save control is SubmitButton-rendered while previous/next are native
+		   buttons, so the shared footer layout must be global. */
 		:global(.btn-nav) {
 			display: flex;
 			align-items: center;

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -224,7 +224,7 @@ interface SubStep {
 	icon: 'appearance' | 'privacy' | 'slides' | 'ai';
 }
 
-// Fun-fact settings work with built-in templates even without OpenAI, so always show the step
+// Built-in templates make the fun-fact step useful even when OpenAI is absent.
 let subSteps = $derived([
 	{ id: 'appearance', label: 'Appearance', icon: 'appearance' },
 	{ id: 'privacy', label: 'Privacy', icon: 'privacy' },
@@ -239,7 +239,7 @@ let animationDirection = $state<'forward' | 'backward'>('forward');
 let totalSubSteps = $derived(subSteps.length);
 let isFirstSubStep = $derived(currentSubStep === 0);
 let isLastSubStep = $derived(currentSubStep === totalSubSteps - 1);
-// subSteps always has at least 3 items, and currentSubStep is bounded by navigation
+// Navigation bounds `currentSubStep`, so the non-null assertion cannot fail.
 let currentStepData = $derived(subSteps[currentSubStep]!);
 
 function nextSubStep() {

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -40,15 +40,8 @@ import { submitAction } from '$lib/utils/submit-action';
 import { loadThemeFonts } from '$lib/utils/theme-fonts';
 import type { ActionData, PageData } from './$types';
 
-/**
- * Onboarding Step 3: Settings Configuration
- *
- * Step-by-step carousel for configuring appearance, privacy, slides, and AI features.
- */
-
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
-// Form state - initialized from server data, editable locally
 let uiTheme = $state(untrack(() => data.settings.uiTheme));
 let wrappedTheme = $state(untrack(() => data.settings.wrappedTheme));
 let anonymizationMode = $state(untrack(() => data.settings.anonymizationMode));
@@ -148,7 +141,6 @@ function handlePresetKeydown(event: KeyboardEvent, index: number) {
 	event.preventDefault();
 	const preset = PRIVACY_PRESETS[target];
 	if (!preset) return;
-	// APG: moving within a radio group selects the focused radio.
 	applyPrivacyPreset(preset);
 	presetButtons[target]?.focus();
 }
@@ -192,7 +184,6 @@ const aiPersonaOptions = [
 	{ value: 'random', label: 'Random', description: 'Mix of styles' }
 ] as const;
 
-// All available theme classes for removal
 const themeClasses = [
 	'theme-modern-minimal',
 	'theme-supabase',
@@ -204,26 +195,20 @@ const themeClasses = [
 	'theme-champagne-premium'
 ];
 
-// Live theme preview: Apply theme class when uiTheme changes
 $effect(() => {
 	const themeClass = `theme-${uiTheme}`;
 
-	// Remove all existing theme classes
 	document.body.classList.remove(...themeClasses);
 
-	// Add the current theme class
 	document.body.classList.add(themeClass);
 
-	// Load theme-specific font
 	loadThemeFonts(uiTheme);
 });
 
-// Slide toggles
 let slideStates = $state<Record<string, boolean>>(
 	untrack(() => Object.fromEntries(data.slideOptions.map((s) => [s.type, s.enabled])))
 );
 
-// Compute enabled slides string
 let enabledSlidesString = $derived(
 	Object.entries(slideStates)
 		.filter(([_, enabled]) => enabled)
@@ -231,12 +216,7 @@ let enabledSlidesString = $derived(
 		.join(',')
 );
 
-// Loading state
 let isSubmitting = $state(false);
-
-// ==========================================================================
-// Carousel State
-// ==========================================================================
 
 interface SubStep {
 	id: string;
@@ -256,14 +236,12 @@ let currentSubStep = $state(0);
 let contentRef: HTMLElement | undefined = $state();
 let animationDirection = $state<'forward' | 'backward'>('forward');
 
-// Derived values
 let totalSubSteps = $derived(subSteps.length);
 let isFirstSubStep = $derived(currentSubStep === 0);
 let isLastSubStep = $derived(currentSubStep === totalSubSteps - 1);
 // subSteps always has at least 3 items, and currentSubStep is bounded by navigation
 let currentStepData = $derived(subSteps[currentSubStep]!);
 
-// Navigation
 function nextSubStep() {
 	if (currentSubStep < totalSubSteps - 1) {
 		animationDirection = 'forward';
@@ -285,7 +263,6 @@ function goToSubStep(index: number) {
 	}
 }
 
-// Animate on sub-step change
 $effect(() => {
 	if (!contentRef) return;
 	const step = currentSubStep; // Track dependency
@@ -303,7 +280,6 @@ $effect(() => {
 	);
 });
 
-// Theme color mapping for swatches
 const defaultColors = { primary: '#3b82f6', accent: '#60a5fa', bg: '#0f172a' };
 const themeColors: Record<string, { primary: string; accent: string; bg: string }> = {
 	'modern-minimal': { primary: '#3b82f6', accent: '#60a5fa', bg: '#0f172a' },
@@ -324,7 +300,6 @@ function getThemeColors(themeValue: string) {
 >
 	{#snippet children()}
 		<div class="settings-container">
-			<!-- Error display -->
 			{#if visibleError}
 				<div class="error-banner" role="alert" aria-live="polite">
 					<svg
@@ -342,7 +317,6 @@ function getThemeColors(themeValue: string) {
 				</div>
 			{/if}
 
-			<!-- Sub-step Progress Indicator -->
 			<div class="substep-indicator">
 				<div class="substep-info">
 					<span class="substep-current">{currentStepData.label}</span>
@@ -450,7 +424,6 @@ function getThemeColors(themeValue: string) {
 					};
 				}}
 			>
-				<!-- Hidden fields for form data (always rendered) -->
 				<input type="hidden" name="uiTheme" value={uiTheme} />
 				<input type="hidden" name="wrappedTheme" value={wrappedTheme} />
 				<input type="hidden" name="anonymizationMode" value={anonymizationMode} />
@@ -475,10 +448,8 @@ function getThemeColors(themeValue: string) {
 				<input type="hidden" name="openaiModel" value={enableFunFacts ? openaiModel : ''} />
 				<input type="hidden" name="aiPersona" value={enableFunFacts ? aiPersona : ''} />
 
-				<!-- Carousel Content -->
 				<div class="carousel-content" bind:this={contentRef}>
 					{#if currentStepData.id === 'appearance'}
-						<!-- Appearance Step -->
 						<div class="step-header">
 							<div class="step-icon appearance-icon">
 								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -548,7 +519,6 @@ function getThemeColors(themeValue: string) {
 							</div>
 						</div>
 					{:else if currentStepData.id === 'privacy'}
-						<!-- Privacy Step -->
 						<div class="step-header">
 							<div class="step-icon privacy-icon">
 								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -563,7 +533,6 @@ function getThemeColors(themeValue: string) {
 						</div>
 
 						<div class="step-fields">
-							<!-- Preset selector: one card sets all six privacy fields below -->
 							<div class="setting-group preset-section">
 								<span class="setting-label">Privacy Preset</span>
 								<p class="setting-description">
@@ -605,7 +574,6 @@ function getThemeColors(themeValue: string) {
 								{/if}
 							</div>
 
-							<!-- Live preview of what this configuration exposes -->
 							{#snippet previewDt(key: PrivacyPreviewRowKey, label: string)}
 								{@const tip = PRIVACY_PREVIEW_ROW_TOOLTIPS[key]}
 								<dt>
@@ -879,7 +847,6 @@ function getThemeColors(themeValue: string) {
 							</div>
 						</div>
 					{:else if currentStepData.id === 'slides'}
-						<!-- Slides Step -->
 						<div class="step-header">
 							<div class="step-icon slides-icon">
 								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -919,7 +886,6 @@ function getThemeColors(themeValue: string) {
 							</div>
 						</div>
 					{:else if currentStepData.id === 'ai'}
-						<!-- AI Features Step -->
 						<div class="step-header">
 							<div class="step-icon ai-icon">
 								<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -1130,7 +1096,6 @@ function getThemeColors(themeValue: string) {
 					{/if}
 				</div>
 
-				<!-- Submit button (hidden) -->
 				<button
 					type="submit"
 					form="onboarding-settings-form"
@@ -1145,7 +1110,6 @@ function getThemeColors(themeValue: string) {
 
 	{#snippet footer()}
 		<div class="footer-actions">
-			<!-- Previous Button -->
 			<Button
 				type="button"
 				class="btn-nav btn-prev tap-target"
@@ -1156,7 +1120,6 @@ function getThemeColors(themeValue: string) {
 				Previous
 			</Button>
 
-			<!-- Skip Link (center) -->
 			<form method="POST" action="?/skipSettings" use:enhance class="skip-form">
 				<SubmitButton class="btn-skip-link tap-target" disabled={isSubmitting}>
 					{#snippet children()}
@@ -1165,7 +1128,6 @@ function getThemeColors(themeValue: string) {
 				</SubmitButton>
 			</form>
 
-			<!-- Next / Save Button -->
 			{#if isLastSubStep}
 				<SubmitButton
 					form="onboarding-settings-form"
@@ -1196,14 +1158,12 @@ function getThemeColors(themeValue: string) {
 </OnboardingCard>
 
 <style>
-	/* Container */
 		.settings-container {
 			display: flex;
 			flex-direction: column;
 			gap: 0.5rem;
 		}
 
-		/* Error Banner */
 		.error-banner {
 			display: flex;
 			align-items: center;
@@ -1224,7 +1184,6 @@ function getThemeColors(themeValue: string) {
 			color: #f87171;
 		}
 
-		/* Hidden submit */
 		.hidden-submit {
 			position: absolute;
 			width: 1px;
@@ -1507,7 +1466,6 @@ function getThemeColors(themeValue: string) {
 		:global(.btn-prev:hover:not(:disabled) .nav-arrow) {
 			transform: translateX(-2px);
 		}
-		/* Setting Groups */
 		.setting-group {
 			margin-top: 1.25rem;
 		}
@@ -1650,7 +1608,6 @@ function getThemeColors(themeValue: string) {
 			color: rgba(255, 255, 255, 0.45);
 		}
 
-		/* Live preview panel */
 		.privacy-preview {
 			margin-top: 1.25rem;
 			padding: 1rem;
@@ -1763,7 +1720,6 @@ function getThemeColors(themeValue: string) {
 			outline-offset: 2px;
 		}
 
-		/* Advanced Options disclosure */
 		.advanced-options {
 			margin-top: 1.25rem;
 			border-top: 1px solid rgba(255, 255, 255, 0.08);
@@ -1810,7 +1766,6 @@ function getThemeColors(themeValue: string) {
 			animation: fadeSlide 0.25s ease;
 		}
 
-		/* Theme Swatches */
 		.theme-swatches {
 			display: grid;
 			grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
@@ -1880,7 +1835,6 @@ function getThemeColors(themeValue: string) {
 			line-height: 1.2;
 		}
 
-		/* Radio Cards */
 		.radio-cards {
 			display: flex;
 			flex-direction: column;
@@ -1977,7 +1931,6 @@ function getThemeColors(themeValue: string) {
 			color: rgba(255, 255, 255, 0.45);
 		}
 
-		/* Toggle Switch */
 		.toggle-row {
 			display: flex;
 			align-items: center;
@@ -2062,7 +2015,6 @@ function getThemeColors(themeValue: string) {
 			transform: translateX(1rem);
 		}
 
-		/* Slides Grid */
 		.slides-grid {
 			display: grid;
 			grid-template-columns: repeat(2, 1fr);
@@ -2114,7 +2066,6 @@ function getThemeColors(themeValue: string) {
 			color: rgba(255, 255, 255, 0.8);
 		}
 
-		/* Frequency Options */
 		.frequency-group {
 			padding-left: 1.5rem;
 			border-left: 2px solid oklch(var(--primary) / 0.2);
@@ -2179,7 +2130,6 @@ function getThemeColors(themeValue: string) {
 			color: rgba(255, 255, 255, 0.45);
 		}
 
-		/* Text inputs (API key, base URL, model) */
 		.field-label {
 			display: block;
 			font-size: 0.875rem;
@@ -2269,7 +2219,6 @@ function getThemeColors(themeValue: string) {
 			color: #fca5a5;
 		}
 
-		/* Spinner */
 		.spinner {
 			width: 1rem;
 			height: 1rem;
@@ -2289,7 +2238,6 @@ function getThemeColors(themeValue: string) {
 		   Mobile Responsive
 		   ========================================================================== */
 		@media (max-width: 480px) {
-			/* Sub-step indicator */
 			.substep-indicator {
 				flex-direction: column;
 				gap: 0.75rem;
@@ -2314,7 +2262,6 @@ function getThemeColors(themeValue: string) {
 				height: 0.75rem;
 			}
 
-			/* Carousel content */
 			.carousel-content {
 				min-height: 280px;
 			}
@@ -2339,12 +2286,10 @@ function getThemeColors(themeValue: string) {
 				font-size: 1rem;
 			}
 
-			/* Theme swatches */
 			.theme-swatches {
 				grid-template-columns: repeat(3, 1fr);
 			}
 
-			/* Footer navigation */
 			.footer-actions {
 				position: relative;
 				justify-content: space-between;

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -265,7 +265,8 @@ function goToSubStep(index: number) {
 
 $effect(() => {
 	if (!contentRef) return;
-	const step = currentSubStep; // Track dependency
+	// Intentionally read currentSubStep so this effect re-runs when the carousel advances.
+	const step = currentSubStep;
 
 	const xOffset = animationDirection === 'forward' ? 30 : -30;
 
@@ -1196,9 +1197,6 @@ function getThemeColors(themeValue: string) {
 			border: 0;
 		}
 
-		/* ==========================================================================
-		   Sub-step Progress Indicator
-		   ========================================================================== */
 		.substep-indicator {
 			display: flex;
 			align-items: center;
@@ -1271,9 +1269,6 @@ function getThemeColors(themeValue: string) {
 			color: white;
 		}
 
-		/* ==========================================================================
-		   Carousel Content
-		   ========================================================================== */
 		.carousel-content {
 			min-height: 320px;
 		}
@@ -1342,9 +1337,6 @@ function getThemeColors(themeValue: string) {
 			gap: 1.25rem;
 		}
 
-		/* ==========================================================================
-		   Navigation Buttons
-		   ========================================================================== */
 		.footer-actions {
 			display: flex;
 			align-items: center;
@@ -2234,9 +2226,6 @@ function getThemeColors(themeValue: string) {
 			}
 		}
 
-		/* ==========================================================================
-		   Mobile Responsive
-		   ========================================================================== */
 		@media (max-width: 480px) {
 			.substep-indicator {
 				flex-direction: column;

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -1479,7 +1479,6 @@ function getThemeColors(themeValue: string) {
 			margin-bottom: 0.75rem;
 		}
 
-		/* AI-key-missing notice (ISSUE-004): AI enabled but no effective key. */
 		.ai-key-warning {
 			margin: 0.625rem 0 0;
 			padding: 0.625rem 0.75rem;
@@ -1491,7 +1490,6 @@ function getThemeColors(themeValue: string) {
 			border-radius: 0.625rem;
 		}
 
-		/* Admin contradiction notice: landing lookup on + non-public default. */
 		.landing-warning {
 			margin: 0.625rem 0 0;
 			padding: 0.625rem 0.75rem;
@@ -1503,9 +1501,6 @@ function getThemeColors(themeValue: string) {
 			border-radius: 0.625rem;
 		}
 
-		/* ==========================================================================
-		   Privacy Presets
-		   ========================================================================== */
 		.preset-grid {
 			display: grid;
 			grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));

--- a/src/routes/onboarding/sync/+page.svelte
+++ b/src/routes/onboarding/sync/+page.svelte
@@ -12,16 +12,8 @@ import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
 import { Button } from '$lib/components/ui/button';
 import type { ActionData, PageData } from './$types';
 
-/**
- * Onboarding Step 2: Initial Data Sync
- *
- * Shows sync progress with SSE updates.
- * User can continue while sync runs in background.
- */
-
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
-// Sync state - initialized from server data, updated via SSE
 // Using untrack() to explicitly capture initial values (state is updated via SSE, not prop changes)
 type SyncStatus = 'idle' | 'running' | 'completed' | 'failed' | 'cancelled';
 
@@ -37,7 +29,6 @@ let isStarting = $state(false);
 let isCancelling = $state(false);
 let error = $state<string | null>(null);
 
-// SSE connection
 let eventSource: EventSource | null = null;
 // Pending auto-reconnect timer + a teardown flag. Without these, the 2s
 // reconnect scheduled in `onerror` outlives component unmount (the user
@@ -46,11 +37,9 @@ let eventSource: EventSource | null = null;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let sseDisconnected = false;
 
-// Animation refs
 let contentRef: HTMLElement | undefined = $state();
 let progressRef: HTMLElement | undefined = $state();
 
-// Computed
 const enrichmentProgress = $derived(
 	enrichmentTotal > 0 ? Math.round((enrichmentProcessed / enrichmentTotal) * 100) : 0
 );
@@ -69,7 +58,6 @@ const phaseText = $derived(() => {
 	return 'Ready to sync';
 });
 
-// Content animation
 $effect(() => {
 	if (!contentRef) return;
 	const items = contentRef.querySelectorAll('.animate-item');
@@ -84,7 +72,6 @@ $effect(() => {
 	return () => animation.stop?.();
 });
 
-// Progress ring animation on complete
 $effect(() => {
 	if (!progressRef || !isComplete) return;
 
@@ -96,7 +83,6 @@ $effect(() => {
 	);
 });
 
-// SSE connection helper with reconnection support
 function setupEventSource(es: EventSource) {
 	es.onmessage = (event) => {
 		try {
@@ -104,7 +90,6 @@ function setupEventSource(es: EventSource) {
 
 			switch (eventData.type) {
 				case 'connected':
-					// Handle initial connection with current progress state
 					if (eventData.inProgress && eventData.progress) {
 						syncStatus = 'running';
 						recordsProcessed = eventData.progress.recordsProcessed ?? 0;
@@ -135,7 +120,6 @@ function setupEventSource(es: EventSource) {
 					syncStatus = 'cancelled';
 					break;
 				case 'idle':
-					// Sync finished before we connected
 					if (syncStatus === 'running') {
 						syncStatus = 'completed';
 					}
@@ -150,7 +134,6 @@ function setupEventSource(es: EventSource) {
 		// Bail if the component was torn down: a closed ES can still deliver a
 		// pending `onerror`, which would otherwise schedule an orphaned timer.
 		if (sseDisconnected) return;
-		// Connection lost - attempt reconnection after delay
 		console.warn('SSE connection lost, attempting reconnect...');
 		es.close();
 		eventSource = null;
@@ -169,7 +152,6 @@ function setupEventSource(es: EventSource) {
 	};
 }
 
-// Connect to SSE when sync starts
 $effect(() => {
 	if (!browser) return;
 	if (!isRunning && !data.syncRunning) return;
@@ -190,7 +172,6 @@ $effect(() => {
 	};
 });
 
-// Handle form submission result
 $effect(() => {
 	if (form?.success) {
 		syncStatus = 'running';
@@ -207,7 +188,6 @@ function handleStartSync() {
 	error = null;
 }
 
-// Format number with animation-friendly display
 function formatNumber(n: number): string {
 	return n.toLocaleString();
 }
@@ -218,7 +198,6 @@ function formatNumber(n: number): string {
 	subtitle="Import your {data.currentYear} Plex viewing data to generate your personalized Wrapped"
 >
 	<div class="sync-content" bind:this={contentRef}>
-		<!-- Progress Ring -->
 		<div class="progress-wrapper animate-item" bind:this={progressRef}>
 			<div
 				class="progress-ring"
@@ -226,12 +205,10 @@ function formatNumber(n: number): string {
 				class:complete={isComplete}
 				class:failed={hasFailed}
 			>
-				<!-- Background ring -->
 				<svg class="ring-bg" viewBox="0 0 120 120">
 					<circle cx="60" cy="60" r="52" />
 				</svg>
 
-				<!-- Progress ring -->
 				<svg class="ring-progress" viewBox="0 0 120 120">
 					<circle
 						cx="60"
@@ -241,7 +218,6 @@ function formatNumber(n: number): string {
 					/>
 				</svg>
 
-				<!-- Center content -->
 				<div class="ring-center">
 					{#if !hasStarted}
 						<div class="ring-icon idle">
@@ -273,12 +249,10 @@ function formatNumber(n: number): string {
 					{/if}
 				</div>
 
-				<!-- Glow effect -->
 				<div class="ring-glow"></div>
 			</div>
 		</div>
 
-		<!-- Phase indicator -->
 		<div class="phase-section animate-item">
 			<p
 				class="phase-text"
@@ -315,7 +289,6 @@ function formatNumber(n: number): string {
 			{/if}
 		</div>
 
-		<!-- Start button (when idle) -->
 		{#if !hasStarted}
 			<form
 				method="POST"
@@ -342,7 +315,6 @@ function formatNumber(n: number): string {
 			</p>
 		{/if}
 
-		<!-- Error display -->
 		{#if error}
 			<div class="error-banner">
 				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -354,7 +326,6 @@ function formatNumber(n: number): string {
 			</div>
 		{/if}
 
-		<!-- Warning banner (while running) -->
 		{#if isRunning}
 			<div class="warning-banner">
 				<div class="warning-icon">
@@ -375,7 +346,6 @@ function formatNumber(n: number): string {
 			</div>
 		{/if}
 
-		<!-- Success message -->
 		{#if isComplete}
 			<div class="success-banner">
 				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -389,7 +359,6 @@ function formatNumber(n: number): string {
 			</div>
 		{/if}
 
-		<!-- Info about continuing -->
 		{#if hasStarted && !hasFailed}
 			<p class="continue-hint">
 				{#if isComplete}
@@ -459,7 +428,6 @@ function formatNumber(n: number): string {
 			opacity: 0;
 		}
 
-		/* Progress Ring */
 		.progress-wrapper {
 			position: relative;
 			width: 120px;
@@ -520,7 +488,6 @@ function formatNumber(n: number): string {
 			stroke: oklch(0.6356 0.2082 25.38);
 		}
 
-		/* Ring center */
 		.ring-center {
 			position: absolute;
 			inset: 0;
@@ -554,7 +521,6 @@ function formatNumber(n: number): string {
 			color: oklch(0.6356 0.2082 25.38);
 		}
 
-		/* Spinner dots */
 		.spinner-dots {
 			display: flex;
 			gap: 6px;
@@ -591,7 +557,6 @@ function formatNumber(n: number): string {
 			}
 		}
 
-		/* Ring glow */
 		.ring-glow {
 			position: absolute;
 			inset: -10px;
@@ -624,7 +589,6 @@ function formatNumber(n: number): string {
 			}
 		}
 
-		/* Phase section */
 		.phase-section {
 			text-align: center;
 			width: 100%;
@@ -656,7 +620,6 @@ function formatNumber(n: number): string {
 			color: oklch(0.6356 0.2082 25.38);
 		}
 
-		/* Stats row */
 		.stats-row {
 			display: flex;
 			justify-content: center;
@@ -710,7 +673,6 @@ function formatNumber(n: number): string {
 			background: rgba(255, 255, 255, 0.1);
 		}
 
-		/* Enrichment progress */
 		.enrichment-progress {
 			margin-top: 1rem;
 			width: 100%;
@@ -779,7 +741,6 @@ function formatNumber(n: number): string {
 		}
 
 
-		/* Warning banner */
 		.warning-banner {
 			display: flex;
 			align-items: flex-start;
@@ -822,7 +783,6 @@ function formatNumber(n: number): string {
 			line-height: 1.5;
 		}
 
-		/* Success banner */
 		.success-banner {
 			display: flex;
 			align-items: center;
@@ -843,7 +803,6 @@ function formatNumber(n: number): string {
 			height: 20px;
 		}
 
-		/* Error banner */
 		.error-banner {
 			display: flex;
 			align-items: center;
@@ -864,7 +823,6 @@ function formatNumber(n: number): string {
 			height: 18px;
 		}
 
-		/* Pre-sync hint */
 		.pre-sync-hint {
 			margin: 0.5rem 0 0;
 			font-size: 0.8rem;
@@ -872,7 +830,6 @@ function formatNumber(n: number): string {
 			text-align: center;
 		}
 
-		/* Continue hint */
 		.continue-hint {
 			margin: 0;
 			font-size: 0.85rem;
@@ -881,7 +838,6 @@ function formatNumber(n: number): string {
 			animation: fade-slide-in 0.3s ease-out;
 		}
 
-		/* Footer actions (Cancel + Continue) */
 		.footer-actions {
 			display: flex;
 			gap: 0.75rem;
@@ -959,7 +915,6 @@ function formatNumber(n: number): string {
 			box-shadow: none;
 		}
 
-		/* Responsive */
 		@media (max-width: 480px) {
 			.progress-wrapper {
 				width: 100px;

--- a/src/routes/onboarding/sync/+page.svelte
+++ b/src/routes/onboarding/sync/+page.svelte
@@ -14,9 +14,9 @@ import type { ActionData, PageData } from './$types';
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
 
-// Using untrack() to explicitly capture initial values (state is updated via SSE, not prop changes)
 type SyncStatus = 'idle' | 'running' | 'completed' | 'failed' | 'cancelled';
 
+// SSE owns progress after mount; prop changes should not rewind the live state.
 let syncStatus = $state<SyncStatus>(untrack(() => (data.syncRunning ? 'running' : 'idle')));
 let recordsProcessed = $state(untrack(() => data.currentProgress?.recordsProcessed ?? 0));
 let recordsInserted = $state(untrack(() => data.currentProgress?.recordsInserted ?? 0));
@@ -49,7 +49,7 @@ const isRunning = $derived(syncStatus === 'running');
 const isComplete = $derived(syncStatus === 'completed');
 const hasFailed = $derived(syncStatus === 'failed' || syncStatus === 'cancelled');
 
-// Phase display text - check terminal states FIRST to avoid stale phase text
+// Terminal states win over the last streamed phase so completion/failure copy cannot go stale.
 const phaseText = $derived(() => {
 	if (isComplete) return 'Sync complete!';
 	if (hasFailed) return 'Sync failed';
@@ -138,9 +138,8 @@ function setupEventSource(es: EventSource) {
 		es.close();
 		eventSource = null;
 
-		// Attempt to reconnect after 2 seconds if sync should still be running.
-		// Track the timer so the effect cleanup can cancel a pending reconnect,
-		// and bail if the component was torn down in the meantime.
+		// The delayed reconnect must be cancellable because onboarding can advance
+		// before the timer fires.
 		if (reconnectTimer) clearTimeout(reconnectTimer);
 		reconnectTimer = setTimeout(() => {
 			reconnectTimer = null;
@@ -156,7 +155,7 @@ $effect(() => {
 	if (!browser) return;
 	if (!isRunning && !data.syncRunning) return;
 
-	// Connect to public SSE endpoint (doesn't require admin auth)
+	// Onboarding sync streams before an admin session exists.
 	sseDisconnected = false;
 	eventSource = new EventSource('/api/sync/status/stream');
 	setupEventSource(eventSource);
@@ -700,12 +699,10 @@ function formatNumber(n: number): string {
 			text-align: center;
 		}
 
-		/* Start button — hoisted to :global so SubmitButton's
-		   child-rendered <button> inherits the primary palette, hover
-		   translate-y (-2px), and triple shadow (drop + accent + inset
-		   highlight). The `.btn-icon` descendant rule was dropped when
-		   the inline SVG was replaced with the lucide RefreshCwIcon
-		   sized inline via `class="size-5"`. */
+		/* SubmitButton child-renders the actual <button>, so the selector must
+		   be global for the primary palette, hover translate-y, and layered
+		   shadows to reach it. The lucide icon stays sized inline to avoid
+		   another descendant override across the scoped-style boundary. */
 		:global(.start-button) {
 			display: inline-flex;
 			align-items: center;
@@ -846,11 +843,10 @@ function formatNumber(n: number): string {
 			flex-wrap: wrap;
 		}
 
-		/* Cancel button — destructive variant. Hoisted to :global so
-		   SubmitButton's child-rendered <button> inherits the red palette
-		   + hover-darken effect. The `.cancel-button svg` descendant rule
-		   is dropped; the lucide XIcon is sized inline via
-		   `class="size-[18px]"`. */
+		/* SubmitButton child-renders the actual <button>, so the destructive
+		   palette and hover-darken treatment need a global selector. The lucide
+		   icon stays sized inline to avoid another descendant override across
+		   the scoped-style boundary. */
 		:global(.cancel-button) {
 			display: inline-flex;
 			align-items: center;
@@ -877,11 +873,10 @@ function formatNumber(n: number): string {
 			cursor: not-allowed;
 		}
 
-		/* Continue button — hoisted to :global so SubmitButton's
-		   child-rendered <button> inherits the primary palette, hover
-		   translate-y, and dual shadow (drop + inset highlight). The
-		   `.continue-button svg` descendant rule is dropped because the
-		   lucide ArrowRightIcon is sized explicitly via `class="size-[18px]"`. */
+		/* SubmitButton child-renders the actual <button>, so the primary
+		   palette, hover translate-y, and dual shadow need a global selector.
+		   The lucide icon stays sized inline to avoid another descendant
+		   override across the scoped-style boundary. */
 		:global(.continue-button) {
 			display: inline-flex;
 			align-items: center;

--- a/src/routes/wrapped/+layout.svelte
+++ b/src/routes/wrapped/+layout.svelte
@@ -27,7 +27,6 @@ function hasLookupSyncMarker(layoutData: LayoutData): boolean {
 	return Boolean(lookupData.lookupSyncTriggered ?? lookupData.lookupSyncStarted);
 }
 
-/** Minimum time to show loading overlay for consistent UX */
 const MIN_LOADING_DISPLAY_MS = 300;
 const FAILED_LIVE_SYNC_MESSAGE =
 	"Couldn't refresh your viewing history from Plex. Showing your most recent data.";
@@ -36,21 +35,16 @@ let isLoading = $state(untrack(() => data.syncStatus?.inProgress ?? false));
 
 let loadingStartTime = $state(Date.now());
 
-/** Whether sync completion has been handled (prevents double-handling) */
 let syncCompletionHandled = $state(false);
 
 const initialLookupSyncMarker = untrack(() => hasLookupSyncMarker(data));
 
 let lookupSyncFeedbackPending = $state(initialLookupSyncMarker);
 
-/** Prevents repeatedly re-arming the same server-provided lookup marker */
 let lookupSyncMarkerSeen = $state(initialLookupSyncMarker);
 
 let syncStatusStore = $state<SyncStatusStore | null>(null);
 
-/**
- * Hide loading overlay with minimum display time guarantee
- */
 async function hideLoadingWithMinDelay(): Promise<void> {
 	const elapsed = Date.now() - loadingStartTime;
 	if (elapsed < MIN_LOADING_DISPLAY_MS) {
@@ -69,7 +63,6 @@ function consumeLookupSyncMarker(event: SyncTerminalEventType): boolean {
 async function handleSyncComplete(event: SyncTerminalEventType): Promise<void> {
 	lookupSyncFeedbackPending = false;
 
-	// Prevent double handling
 	if (syncCompletionHandled) return;
 	syncCompletionHandled = true;
 	if (!isLoading) {

--- a/src/routes/wrapped/+layout.svelte
+++ b/src/routes/wrapped/+layout.svelte
@@ -38,23 +38,13 @@ function hasLookupSyncMarker(layoutData: LayoutData): boolean {
 	return Boolean(lookupData.lookupSyncTriggered ?? lookupData.lookupSyncStarted);
 }
 
-// ==========================================================================
-// Constants
-// ==========================================================================
-
 /** Minimum time to show loading overlay for consistent UX */
 const MIN_LOADING_DISPLAY_MS = 300;
 const FAILED_LIVE_SYNC_MESSAGE =
 	"Couldn't refresh your viewing history from Plex. Showing your most recent data.";
 
-// ==========================================================================
-// Loading State
-// ==========================================================================
-
-/** Whether the loading overlay is visible */
 let isLoading = $state(untrack(() => data.syncStatus?.inProgress ?? false));
 
-/** Timestamp when loading started (for minimum display time calculation) */
 let loadingStartTime = $state(Date.now());
 
 /** Whether sync completion has been handled (prevents double-handling) */
@@ -62,17 +52,11 @@ let syncCompletionHandled = $state(false);
 
 const initialLookupSyncMarker = untrack(() => hasLookupSyncMarker(data));
 
-/** Whether the current page load came from a landing-page lookup sync trigger */
 let lookupSyncFeedbackPending = $state(initialLookupSyncMarker);
 
 /** Prevents repeatedly re-arming the same server-provided lookup marker */
 let lookupSyncMarkerSeen = $state(initialLookupSyncMarker);
 
-// ==========================================================================
-// Sync Status Store
-// ==========================================================================
-
-/** Sync status store instance */
 let syncStatusStore = $state<SyncStatusStore | null>(null);
 
 /**
@@ -86,12 +70,6 @@ async function hideLoadingWithMinDelay(): Promise<void> {
 	isLoading = false;
 }
 
-/**
- * Handle sync completion:
- * 1. Keep overlay visible
- * 2. Refresh data
- * 3. Hide overlay with minimum delay
- */
 function consumeLookupSyncMarker(event: SyncTerminalEventType): boolean {
 	if (!lookupSyncFeedbackPending) return false;
 	if (event !== 'failed') return false;
@@ -111,13 +89,11 @@ async function handleSyncComplete(event: SyncTerminalEventType): Promise<void> {
 	}
 
 	try {
-		// Refresh data while overlay is still visible
 		await invalidateAll();
 	} finally {
 		if (event === 'failed') {
 			toast.error(FAILED_LIVE_SYNC_MESSAGE);
 		}
-		// Hide overlay after data refresh (with minimum delay)
 		await hideLoadingWithMinDelay();
 		syncCompletionHandled = false;
 	}
@@ -137,13 +113,9 @@ $effect(() => {
 	}
 });
 
-// Create sync status store with reactive access to data.syncStatus
-// Using $effect ensures:
-// 1. Proper reactive access to data.syncStatus (fixes Svelte 5 warnings)
-// 2. Browser-only execution (SSR safety)
-// 3. Automatic cleanup on unmount or when data changes
+// Keep the SSE store in an effect so it tracks fresh load data, never runs
+// during SSR, and disconnects whenever the layout data changes.
 $effect(() => {
-	// Access data.syncStatus inside effect for proper reactivity
 	const syncStatus = data.syncStatus;
 
 	if (!browser || !syncStatus) {
@@ -151,13 +123,11 @@ $effect(() => {
 		return;
 	}
 
-	// Reset state for fresh effect run unless sync completion is coordinating invalidation
 	if (!syncCompletionHandled) {
 		loadingStartTime = Date.now();
 		isLoading = syncStatus.inProgress;
 	}
 
-	// Create store with initial server data
 	const store = createSyncStatusStore(
 		{
 			inProgress: syncStatus.inProgress,
@@ -170,7 +140,6 @@ $effect(() => {
 	);
 	syncStatusStore = store;
 
-	// Cleanup SSE connection when effect re-runs or component unmounts
 	return () => {
 		store.disconnect();
 	};

--- a/src/routes/wrapped/+layout.svelte
+++ b/src/routes/wrapped/+layout.svelte
@@ -10,17 +10,6 @@ import { createSyncStatusStore, type SyncStatusStore } from '$lib/stores/sync-st
 import type { SyncTerminalEventType } from '$lib/sync/types';
 import type { LayoutData } from './$types';
 
-/**
- * Wrapped Layout
- *
- * Provides the wrapped theme data and real-time sync status to nested routes.
- * The actual theme application is handled by the root layout,
- * which reads the merged wrappedTheme data from this layout's server load.
- *
- * Shows a loading overlay during sync to prevent jarring content transitions.
- * When sync completes, data is refreshed and overlay fades out smoothly.
- */
-
 interface Props {
 	children: Snippet;
 	data: LayoutData;
@@ -145,7 +134,6 @@ $effect(() => {
 	};
 });
 
-// Use reactive store values if available, otherwise fall back to server data
 const inProgress = $derived(syncStatusStore?.inProgress ?? data.syncStatus?.inProgress ?? false);
 const progress = $derived(syncStatusStore?.progress ?? data.syncStatus?.progress ?? null);
 

--- a/src/routes/wrapped/[year=year]/+page.svelte
+++ b/src/routes/wrapped/[year=year]/+page.svelte
@@ -51,7 +51,7 @@ afterNavigate(() => {
 	routerReady = true;
 });
 
-// Reflect slide index back into the hash without creating history entries.
+// Use replaceState so slide navigation does not pollute the browser Back stack.
 $effect(() => {
 	if (!browser || !routerReady) return;
 	const next = `#slide=${currentSlideIndex}`;

--- a/src/routes/wrapped/[year=year]/+page.svelte
+++ b/src/routes/wrapped/[year=year]/+page.svelte
@@ -13,15 +13,6 @@ import {
 } from '$lib/components/wrapped';
 import type { PageProps } from './$types';
 
-/**
- * Server-wide Wrapped Page
- *
- * Displays the server-wide Year in Review statistics.
- * Supports both Story Mode (full-screen slides) and Scroll Mode.
- *
- * @module routes/wrapped/[year=year]
- */
-
 let { data }: PageProps = $props();
 
 const messagingContext = $derived(createServerContext(data.serverName));
@@ -44,7 +35,6 @@ function readInitialSlideIndex(): number {
 	return Math.min(Math.max(parsed, 0), max);
 }
 
-/** Current slide index for mode switching (preserves position) */
 let currentSlideIndex = $state(readInitialSlideIndex());
 
 let showSummary = $state(false);

--- a/src/routes/wrapped/[year=year]/+page.svelte
+++ b/src/routes/wrapped/[year=year]/+page.svelte
@@ -24,14 +24,8 @@ import type { PageProps } from './$types';
 
 let { data }: PageProps = $props();
 
-// Create messaging context for server-wide wrapped (reactive to data changes)
 const messagingContext = $derived(createServerContext(data.serverName));
 
-// ==========================================================================
-// State
-// ==========================================================================
-
-/** Current viewing mode */
 type ViewMode = 'story' | 'scroll';
 let viewMode = $state<ViewMode>('story');
 
@@ -53,13 +47,10 @@ function readInitialSlideIndex(): number {
 /** Current slide index for mode switching (preserves position) */
 let currentSlideIndex = $state(readInitialSlideIndex());
 
-/** Whether to show the summary page */
 let showSummary = $state(false);
 
-/** Whether to show the share modal */
 let showShareModal = $state(false);
 
-/** Key for forcing StoryMode remount on restart */
 let storyKey = $state(0);
 
 // SvelteKit's replaceState throws "replaceState() called before router was
@@ -81,35 +72,19 @@ $effect(() => {
 	}
 });
 
-// ==========================================================================
-// Event Handlers
-// ==========================================================================
-
-/**
- * Handle mode change from ModeToggle
- */
 function handleModeChange(newMode: ViewMode): void {
 	viewMode = newMode;
 }
 
-/**
- * Handle scroll mode requesting switch (preserves position)
- */
 function handleScrollModeSwitch(slideIndex: number): void {
 	currentSlideIndex = slideIndex;
 	viewMode = 'story';
 }
 
-/**
- * Handle story mode completion - show summary page
- */
 function handleComplete(): void {
 	showSummary = true;
 }
 
-/**
- * Handle close/exit action
- */
 function handleClose(): void {
 	let sameOrigin = false;
 	if (document.referrer) {
@@ -126,17 +101,12 @@ function handleClose(): void {
 	}
 }
 
-/**
- * Handle restart - return to slideshow from summary
- */
 function handleRestart(): void {
 	showSummary = false;
 	viewMode = 'story';
 	currentSlideIndex = 0;
-	// Clear the URL hash before the StoryMode remount. Otherwise the freshly
-	// mounted StoryMode reads the stale `#slide=N` (from the user reaching the
-	// summary) via readInitialSlideIndex and the slideshow restarts at the
-	// last slide instead of slide 0.
+	// Clear the hash before remount so StoryMode does not seed itself from the
+	// stale summary slide index.
 	if (browser && routerReady) {
 		const url = new URL(window.location.href);
 		url.hash = '#slide=0';
@@ -145,9 +115,6 @@ function handleRestart(): void {
 	storyKey++; // Force StoryMode remount
 }
 
-/**
- * Handle return home from summary
- */
 function handleHome(): void {
 	if (data.isAdmin) {
 		goto('/admin');
@@ -158,9 +125,6 @@ function handleHome(): void {
 	}
 }
 
-/**
- * Handle share button click from summary
- */
 function handleShare(): void {
 	showShareModal = true;
 }
@@ -172,24 +136,20 @@ function handleShare(): void {
 </svelte:head>
 
 <div class="wrapped-page">
-	<!-- Logo Watermark -->
 	{#if data.showLogo}
 		<div class="logo-watermark">
 			<Logo size="sm" />
 		</div>
 	{/if}
 
-	<!-- Mode Toggle Button -->
 	<div class="mode-toggle-container">
 		<ModeToggle mode={viewMode} onModeChange={handleModeChange} />
 	</div>
 
-	<!-- Year Navigation -->
 	{#if data.availableYears && data.availableYears.length > 1}
 		<YearNavigation currentYear={data.year} availableYears={data.availableYears} />
 	{/if}
 
-	<!-- Wrapped Content -->
 	{#if showSummary}
 		<SummaryPage
 			stats={data.stats}
@@ -223,7 +183,6 @@ function handleShare(): void {
 		/>
 	{/if}
 
-	<!-- Share Modal (simplified for server-wide - always public) -->
 	<ShareModal
 		bind:open={showShareModal}
 		onOpenChange={(v) => (showShareModal = v)}

--- a/src/routes/wrapped/[year=year]/+page.svelte
+++ b/src/routes/wrapped/[year=year]/+page.svelte
@@ -112,7 +112,7 @@ function handleRestart(): void {
 		url.hash = '#slide=0';
 		replaceState(url, {});
 	}
-	storyKey++; // Force StoryMode remount
+	storyKey++;
 }
 
 function handleHome(): void {

--- a/src/routes/wrapped/[year=year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year=year]/u/[identifier]/+page.server.ts
@@ -108,7 +108,6 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 			});
 			userId = tokenResult.userId;
 
-			// Verify year matches the token's year
 			if (tokenResult.year !== year) {
 				error(404, 'This share link is invalid, expired, or has been revoked.');
 			}

--- a/src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
@@ -118,7 +118,7 @@ function handleRestart(): void {
 		url.hash = '#slide=0';
 		replaceState(url, {});
 	}
-	storyKey++; // Force StoryMode remount
+	storyKey++;
 }
 
 function handleHome(): void {

--- a/src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
@@ -14,22 +14,11 @@ import {
 } from '$lib/components/wrapped';
 import type { PageProps } from './$types';
 
-/**
- * Per-user Wrapped Page
- *
- * Displays the user-specific Year in Review statistics.
- * Supports both Story Mode (full-screen slides) and Scroll Mode.
- *
- * @module routes/wrapped/[year=year]/u/[identifier]
- */
-
 let { data }: PageProps = $props();
 
 const messagingContext = createPersonalContext();
 
-/** Override for optimistic updates (null means use server value) */
 let showLogoOverride = $state<boolean | null>(null);
-/** Effective logo visibility - uses override if pending, otherwise server value */
 let showLogo = $derived(showLogoOverride ?? data.showLogo);
 
 type ViewMode = 'story' | 'scroll';
@@ -50,7 +39,6 @@ function readInitialSlideIndex(): number {
 	return Math.min(Math.max(parsed, 0), max);
 }
 
-/** Current slide index for mode switching (preserves position) */
 let currentSlideIndex = $state(readInitialSlideIndex());
 
 let showSummary = $state(false);

--- a/src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
@@ -25,7 +25,6 @@ import type { PageProps } from './$types';
 
 let { data }: PageProps = $props();
 
-// Create messaging context for personal wrapped
 const messagingContext = createPersonalContext();
 
 /** Override for optimistic updates (null means use server value) */
@@ -33,11 +32,6 @@ let showLogoOverride = $state<boolean | null>(null);
 /** Effective logo visibility - uses override if pending, otherwise server value */
 let showLogo = $derived(showLogoOverride ?? data.showLogo);
 
-// ==========================================================================
-// State
-// ==========================================================================
-
-/** Current viewing mode */
 type ViewMode = 'story' | 'scroll';
 let viewMode = $state<ViewMode>('story');
 
@@ -59,13 +53,10 @@ function readInitialSlideIndex(): number {
 /** Current slide index for mode switching (preserves position) */
 let currentSlideIndex = $state(readInitialSlideIndex());
 
-/** Whether to show the summary page */
 let showSummary = $state(false);
 
-/** Whether to show the share modal */
 let showShareModal = $state(false);
 
-/** Key for forcing StoryMode remount on restart */
 let storyKey = $state(0);
 
 // SvelteKit's replaceState throws "replaceState() called before router was
@@ -87,35 +78,19 @@ $effect(() => {
 	}
 });
 
-// ==========================================================================
-// Event Handlers
-// ==========================================================================
-
-/**
- * Handle mode change from ModeToggle
- */
 function handleModeChange(newMode: ViewMode): void {
 	viewMode = newMode;
 }
 
-/**
- * Handle scroll mode requesting switch (preserves position)
- */
 function handleScrollModeSwitch(slideIndex: number): void {
 	currentSlideIndex = slideIndex;
 	viewMode = 'story';
 }
 
-/**
- * Handle story mode completion - show summary page
- */
 function handleComplete(): void {
 	showSummary = true;
 }
 
-/**
- * Handle close/exit action
- */
 function handleClose(): void {
 	let sameOrigin = false;
 	if (document.referrer) {
@@ -132,17 +107,12 @@ function handleClose(): void {
 	}
 }
 
-/**
- * Handle restart - return to slideshow from summary
- */
 function handleRestart(): void {
 	showSummary = false;
 	viewMode = 'story';
 	currentSlideIndex = 0;
-	// Clear the URL hash before the StoryMode remount. Otherwise the freshly
-	// mounted StoryMode reads the stale `#slide=N` (from the user reaching the
-	// summary) via readInitialSlideIndex and the slideshow restarts at the
-	// last slide instead of slide 0.
+	// Clear the hash before remount so StoryMode does not seed itself from the
+	// stale summary slide index.
 	if (browser && routerReady) {
 		const url = new URL(window.location.href);
 		url.hash = '#slide=0';
@@ -151,9 +121,6 @@ function handleRestart(): void {
 	storyKey++; // Force StoryMode remount
 }
 
-/**
- * Handle return home from summary
- */
 function handleHome(): void {
 	if (data.isAdmin) {
 		goto('/admin');
@@ -164,16 +131,10 @@ function handleHome(): void {
 	}
 }
 
-/**
- * Handle share button click from summary
- */
 function handleShare(): void {
 	showShareModal = true;
 }
 
-/**
- * Handle logo toggle (optimistic update)
- */
 function handleLogoToggle(): void {
 	showLogoOverride = !showLogo;
 }
@@ -185,14 +146,12 @@ function handleLogoToggle(): void {
 </svelte:head>
 
 <div class="wrapped-page">
-	<!-- Logo Watermark -->
 	{#if showLogo}
 		<div class="logo-watermark">
 			<Logo size="sm" />
 		</div>
 	{/if}
 
-	<!-- Controls Container (top right) -->
 	<div class="controls-container">
 		{#if data.canUserControlLogo}
 			<form
@@ -263,12 +222,10 @@ function handleLogoToggle(): void {
 		{/if}
 	</div>
 
-	<!-- User Header -->
 	<div class="user-header" class:with-logo={showLogo}>
 		<h1 class="user-title">{data.username}'s Year in Review</h1>
 	</div>
 
-	<!-- Year Navigation -->
 	{#if data.availableYears && data.availableYears.length > 1}
 		<YearNavigation
 			currentYear={data.year}
@@ -278,7 +235,6 @@ function handleLogoToggle(): void {
 		/>
 	{/if}
 
-	<!-- Wrapped Content -->
 	{#if showSummary}
 		<SummaryPage
 			stats={data.stats}
@@ -329,7 +285,6 @@ function handleLogoToggle(): void {
 		/>
 	{/if}
 
-	<!-- Share Modal -->
 	<ShareModal
 		bind:open={showShareModal}
 		onOpenChange={(v) => (showShareModal = v)}

--- a/src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
@@ -55,7 +55,7 @@ afterNavigate(() => {
 	routerReady = true;
 });
 
-// Reflect slide index back into the hash without creating history entries.
+// Use replaceState so slide navigation does not pollute the browser Back stack.
 $effect(() => {
 	if (!browser || !routerReady) return;
 	const next = `#slide=${currentSlideIndex}`;

--- a/tests/helpers/toast.ts
+++ b/tests/helpers/toast.ts
@@ -33,7 +33,5 @@ export const testToast = {
 	info(message: string, options?: unknown) {
 		recordToast('info', message, options);
 	},
-	dismiss() {
-		// no-op in tests
-	}
+	dismiss() {}
 };

--- a/tests/property/anonymization.property.test.ts
+++ b/tests/property/anonymization.property.test.ts
@@ -23,9 +23,6 @@ const anonymizationModeArbitrary: fc.Arbitrary<AnonymizationModeType> = fc.const
 	AnonymizationMode.HYBRID
 );
 
-/**
- * User display info for testing
- */
 interface TestUserDisplay {
 	userId: number;
 	username: string;
@@ -43,9 +40,11 @@ const userDisplayArbitrary: fc.Arbitrary<TestUserDisplay> = fc.record({
 const uniqueUsersArbitrary: fc.Arbitrary<TestUserDisplay[]> = fc
 	.array(userDisplayArbitrary, { minLength: 1, maxLength: 10 })
 	.map((users) => {
+		// Distinct IDs keep anonymization-order properties from passing only because
+		// duplicated generated users collapse into the same identity.
 		return users.map((user, index) => ({
 			...user,
-			userId: user.userId * 1000 + index // Ensure uniqueness
+			userId: user.userId * 1000 + index
 		}));
 	});
 
@@ -54,7 +53,7 @@ describe('Property 18: Anonymization Mode Display', () => {
 		fc.assert(
 			fc.property(
 				uniqueUsersArbitrary,
-				fc.option(fc.integer({ min: 1, max: 10000 }), { nil: null }), // viewingUserId
+				fc.option(fc.integer({ min: 1, max: 10000 }), { nil: null }),
 				(users, viewingUserId) => {
 					const result = applyAnonymization(users, AnonymizationMode.REAL, viewingUserId);
 
@@ -164,7 +163,7 @@ describe('Property 18: Anonymization Mode Display', () => {
 				(users, randomIndex) => {
 					const viewerIndex = randomIndex % users.length;
 					const viewingUser = users[viewerIndex];
-					if (!viewingUser) return true; // Skip if no user at index
+					if (!viewingUser) return true;
 
 					const viewingUserId = viewingUser.userId;
 					const originalUsername = viewingUser.username;
@@ -229,7 +228,7 @@ describe('Property 18: Anonymization Mode Display', () => {
 				(users, mode, viewingUserId) => {
 					const result = applyAnonymization(users, mode, viewingUserId);
 
-					// UserIds should be in same order
+					// Anonymization can change labels, but it must never reorder identities.
 					return result.every((user, index) => {
 						const original = users[index];
 						return original !== undefined && user.userId === original.userId;

--- a/tests/property/anonymization.property.test.ts
+++ b/tests/property/anonymization.property.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import * as fc from 'fast-check';
 
-// Import the pure functions for testing
 import { applyAnonymization, generateAnonymousIdentifier } from '$lib/server/anonymization/service';
 import { AnonymizationMode, type AnonymizationModeType } from '$lib/server/anonymization/types';
 
@@ -17,10 +16,6 @@ import { AnonymizationMode, type AnonymizationModeType } from '$lib/server/anony
  * These tests verify the formal correctness properties defined in design.md
  * for the anonymization system.
  */
-
-// =============================================================================
-// Arbitraries
-// =============================================================================
 
 const anonymizationModeArbitrary: fc.Arbitrary<AnonymizationModeType> = fc.constantFrom(
 	AnonymizationMode.REAL,
@@ -38,9 +33,6 @@ interface TestUserDisplay {
 	rank: number;
 }
 
-/**
- * Generate a user display object (similar to topViewers items)
- */
 const userDisplayArbitrary: fc.Arbitrary<TestUserDisplay> = fc.record({
 	userId: fc.integer({ min: 1, max: 10000 }),
 	username: fc.string({ minLength: 1, maxLength: 50 }),
@@ -48,29 +40,19 @@ const userDisplayArbitrary: fc.Arbitrary<TestUserDisplay> = fc.record({
 	rank: fc.integer({ min: 1, max: 100 })
 });
 
-/**
- * Generate a non-empty array of users with unique userIds
- */
 const uniqueUsersArbitrary: fc.Arbitrary<TestUserDisplay[]> = fc
 	.array(userDisplayArbitrary, { minLength: 1, maxLength: 10 })
 	.map((users) => {
-		// Ensure unique userIds by adding index to userId
 		return users.map((user, index) => ({
 			...user,
 			userId: user.userId * 1000 + index // Ensure uniqueness
 		}));
 	});
 
-// =============================================================================
 // Property 18: Anonymization Mode Display
-// =============================================================================
 
 // Feature: obzorarr, Property 18: Anonymization Mode Display
 describe('Property 18: Anonymization Mode Display', () => {
-	// -------------------------------------------------------------------------
-	// Real mode displays all usernames as-is
-	// -------------------------------------------------------------------------
-
 	it('real mode displays all usernames as-is', () => {
 		fc.assert(
 			fc.property(
@@ -79,7 +61,6 @@ describe('Property 18: Anonymization Mode Display', () => {
 				(users, viewingUserId) => {
 					const result = applyAnonymization(users, AnonymizationMode.REAL, viewingUserId);
 
-					// All usernames should match original
 					return result.every((user, index) => {
 						const original = users[index];
 						return original !== undefined && user.username === original.username;
@@ -95,7 +76,6 @@ describe('Property 18: Anonymization Mode Display', () => {
 			fc.property(uniqueUsersArbitrary, (users) => {
 				const result = applyAnonymization(users, AnonymizationMode.REAL, null);
 
-				// All properties should be preserved
 				return result.every((user, index) => {
 					const original = users[index];
 					return (
@@ -110,10 +90,6 @@ describe('Property 18: Anonymization Mode Display', () => {
 		);
 	});
 
-	// -------------------------------------------------------------------------
-	// Anonymous mode replaces all usernames
-	// -------------------------------------------------------------------------
-
 	it('anonymous mode replaces all usernames with identifiers', () => {
 		fc.assert(
 			fc.property(
@@ -122,7 +98,6 @@ describe('Property 18: Anonymization Mode Display', () => {
 				(users, viewingUserId) => {
 					const result = applyAnonymization(users, AnonymizationMode.ANONYMOUS, viewingUserId);
 
-					// All usernames should be anonymous identifiers
 					return result.every((user, index) => {
 						const expected = generateAnonymousIdentifier(index);
 						return user.username === expected;
@@ -145,28 +120,23 @@ describe('Property 18: Anonymization Mode Display', () => {
 		);
 	});
 
-	// -------------------------------------------------------------------------
 	// Hybrid mode shows viewing user's name only
-	// -------------------------------------------------------------------------
 
 	it('hybrid mode shows viewing user their name, anonymizes others', () => {
 		fc.assert(
 			fc.property(
 				uniqueUsersArbitrary.filter((users) => users.length >= 2),
 				(users) => {
-					// Pick the first user as the viewing user
 					const viewingUserId = users[0]!.userId;
 					const originalUsername = users[0]!.username;
 
 					const result = applyAnonymization(users, AnonymizationMode.HYBRID, viewingUserId);
 
-					// Viewing user should see their own name
 					const viewingUserResult = result[0];
 					if (!viewingUserResult || viewingUserResult.username !== originalUsername) {
 						return false;
 					}
 
-					// Others should be anonymized
 					return result.slice(1).every((user, index) => {
 						const expectedAnonymous = generateAnonymousIdentifier(index + 1);
 						return user.username === expectedAnonymous;
@@ -195,7 +165,6 @@ describe('Property 18: Anonymization Mode Display', () => {
 				uniqueUsersArbitrary.filter((users) => users.length >= 3),
 				fc.integer({ min: 0, max: 9 }),
 				(users, randomIndex) => {
-					// Pick a random user as the viewing user
 					const viewerIndex = randomIndex % users.length;
 					const viewingUser = users[viewerIndex];
 					if (!viewingUser) return true; // Skip if no user at index
@@ -205,13 +174,11 @@ describe('Property 18: Anonymization Mode Display', () => {
 
 					const result = applyAnonymization(users, AnonymizationMode.HYBRID, viewingUserId);
 
-					// The viewing user should see their own name
 					const viewerResult = result[viewerIndex];
 					if (!viewerResult || viewerResult.username !== originalUsername) {
 						return false;
 					}
 
-					// All other users should be anonymized
 					return result.every((user, index) => {
 						if (index === viewerIndex) {
 							return user.username === originalUsername;
@@ -224,10 +191,6 @@ describe('Property 18: Anonymization Mode Display', () => {
 		);
 	});
 
-	// -------------------------------------------------------------------------
-	// General Properties
-	// -------------------------------------------------------------------------
-
 	it('anonymization is deterministic for same input', () => {
 		fc.assert(
 			fc.property(
@@ -238,7 +201,6 @@ describe('Property 18: Anonymization Mode Display', () => {
 					const result1 = applyAnonymization(users, mode, viewingUserId);
 					const result2 = applyAnonymization(users, mode, viewingUserId);
 
-					// Results should be identical
 					return JSON.stringify(result1) === JSON.stringify(result2);
 				}
 			),
@@ -320,10 +282,6 @@ describe('Property 18: Anonymization Mode Display', () => {
 	});
 });
 
-// =============================================================================
-// Additional Unit Tests
-// =============================================================================
-
 describe('Anonymous Identifier Generation', () => {
 	it('generates correct format for index 0', () => {
 		expect(generateAnonymousIdentifier(0)).toBe('User #1');
@@ -381,7 +339,6 @@ describe('Anonymization Edge Cases', () => {
 		];
 		const result = applyAnonymization(users, AnonymizationMode.HYBRID, 999);
 
-		// All should be anonymized since viewer is not in list
 		expect(result[0]?.username).toBe('User #1');
 		expect(result[1]?.username).toBe('User #2');
 	});

--- a/tests/property/anonymization.property.test.ts
+++ b/tests/property/anonymization.property.test.ts
@@ -109,14 +109,11 @@ describe('Property 18: Anonymization Mode Display', () => {
 			fc.property(uniqueUsersArbitrary, (users) => {
 				const result = applyAnonymization(users, AnonymizationMode.ANONYMOUS, null);
 
-				// All usernames should match "User #N" pattern
 				return result.every((user, index) => user.username === `User #${index + 1}`);
 			}),
 			{ numRuns: 100 }
 		);
 	});
-
-	// Hybrid mode shows viewing user's name only
 
 	it('hybrid mode shows viewing user their name, anonymizes others', () => {
 		fc.assert(
@@ -148,7 +145,6 @@ describe('Property 18: Anonymization Mode Display', () => {
 			fc.property(uniqueUsersArbitrary, (users) => {
 				const result = applyAnonymization(users, AnonymizationMode.HYBRID, null);
 
-				// All usernames should be anonymous (fallback behavior)
 				return result.every((user, index) => user.username === generateAnonymousIdentifier(index));
 			}),
 			{ numRuns: 100 }

--- a/tests/property/anonymization.property.test.ts
+++ b/tests/property/anonymization.property.test.ts
@@ -49,9 +49,6 @@ const uniqueUsersArbitrary: fc.Arbitrary<TestUserDisplay[]> = fc
 		}));
 	});
 
-// Property 18: Anonymization Mode Display
-
-// Feature: obzorarr, Property 18: Anonymization Mode Display
 describe('Property 18: Anonymization Mode Display', () => {
 	it('real mode displays all usernames as-is', () => {
 		fc.assert(

--- a/tests/property/auth.property.test.ts
+++ b/tests/property/auth.property.test.ts
@@ -6,13 +6,9 @@ import * as fc from 'fast-check';
 import * as schema from '$lib/server/db/schema';
 import { sessions, users } from '$lib/server/db/schema';
 
-// Note: We can't import from membership.ts directly because it uses $env/static/private
-
 /**
- * Determine the user's role based on ownership
- *
- * This is the same pure function from membership.ts, duplicated here
- * for testing without environment dependencies.
+ * Duplicated instead of imported because membership.ts pulls in
+ * `$env/static/private`, which would make these properties environment-bound.
  */
 function determineRole(isOwner: boolean): { isAdmin: boolean } {
 	return { isAdmin: isOwner };
@@ -265,7 +261,7 @@ describe('Property 2: Non-Member Access Denial', () => {
 });
 
 describe('Property 3: Session Invalidation', () => {
-	// Use a unique counter to ensure unique plexIds across property test iterations
+	// Property runs share the same in-memory DB; generated plexIds must not collide.
 	let plexIdCounter = 0;
 
 	function getUniquePlexId(): number {

--- a/tests/property/auth.property.test.ts
+++ b/tests/property/auth.property.test.ts
@@ -7,7 +7,6 @@ import * as schema from '$lib/server/db/schema';
 import { sessions, users } from '$lib/server/db/schema';
 
 // Note: We can't import from membership.ts directly because it uses $env/static/private
-// Instead, we test the pure function logic here
 
 /**
  * Determine the user's role based on ownership
@@ -36,21 +35,15 @@ function determineRole(isOwner: boolean): { isAdmin: boolean } {
  * Validates: Requirements 1.3, 1.4, 1.5, 1.7
  */
 
-// =============================================================================
-// Test Database Setup
-// =============================================================================
-
 /**
  * Create an in-memory test database with schema
  */
 function createTestDatabase() {
 	const sqlite = new Database(':memory:', { strict: true });
 
-	// Enable pragmas for testing
 	sqlite.exec('PRAGMA journal_mode = WAL');
 	sqlite.exec('PRAGMA foreign_keys = ON');
 
-	// Create tables directly
 	sqlite.exec(`
 		CREATE TABLE IF NOT EXISTS users (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -78,13 +71,6 @@ function createTestDatabase() {
 	return drizzle(sqlite, { schema });
 }
 
-// =============================================================================
-// Session Test Helpers
-// =============================================================================
-
-/**
- * Create a test session in the database
- */
 async function createTestSession(
 	db: ReturnType<typeof createTestDatabase>,
 	params: {
@@ -108,9 +94,6 @@ async function createTestSession(
 	return sessionId;
 }
 
-/**
- * Validate a session (test implementation)
- */
 async function validateTestSession(
 	db: ReturnType<typeof createTestDatabase>,
 	sessionId: string
@@ -153,9 +136,6 @@ async function invalidateTestSession(
 	await db.delete(sessions).where(eq(sessions.id, sessionId));
 }
 
-/**
- * Create a test user in the database
- */
 async function createTestUser(
 	db: ReturnType<typeof createTestDatabase>,
 	params: {
@@ -180,9 +160,7 @@ async function createTestUser(
 	return inserted.id;
 }
 
-// =============================================================================
 // Property 1: Role Assignment Correctness
-// =============================================================================
 
 // Feature: obzorarr, Property 1: Role Assignment Correctness
 describe('Property 1: Role Assignment Correctness', () => {
@@ -191,7 +169,6 @@ describe('Property 1: Role Assignment Correctness', () => {
 			fc.property(fc.boolean(), (isOwner) => {
 				const result = determineRole(isOwner);
 
-				// Admin should be true iff isOwner is true
 				return result.isAdmin === isOwner;
 			}),
 			{ numRuns: 100 }
@@ -230,7 +207,6 @@ describe('Property 1: Role Assignment Correctness', () => {
 				const result1 = determineRole(isOwner);
 				const result2 = determineRole(isOwner);
 
-				// Same input should always produce same output
 				return result1.isAdmin === result2.isAdmin;
 			}),
 			{ numRuns: 100 }
@@ -238,9 +214,7 @@ describe('Property 1: Role Assignment Correctness', () => {
 	});
 });
 
-// =============================================================================
 // Property 2: Non-Member Access Denial
-// =============================================================================
 
 // Feature: obzorarr, Property 2: Non-Member Access Denial
 describe('Property 2: Non-Member Access Denial', () => {
@@ -265,7 +239,6 @@ describe('Property 2: Non-Member Access Denial', () => {
 	it('non-members are always denied access', () => {
 		fc.assert(
 			fc.property(fc.boolean(), (_isOwner) => {
-				// Non-member scenario
 				const membership: MembershipResult = {
 					isMember: false,
 					isOwner: false // Can't be owner if not a member
@@ -280,7 +253,6 @@ describe('Property 2: Non-Member Access Denial', () => {
 	it('members are always granted access', () => {
 		fc.assert(
 			fc.property(fc.boolean(), (isOwner) => {
-				// Member scenario
 				const membership: MembershipResult = {
 					isMember: true,
 					isOwner
@@ -300,11 +272,9 @@ describe('Property 2: Non-Member Access Denial', () => {
 				(isMember, isOwner) => {
 					const membership: MembershipResult = {
 						isMember,
-						// Owner status is only valid if member
 						isOwner: isMember ? isOwner : false
 					};
 
-					// Access should match membership status exactly
 					return shouldGrantAccess(membership) === membership.isMember;
 				}
 			),
@@ -313,9 +283,7 @@ describe('Property 2: Non-Member Access Denial', () => {
 	});
 });
 
-// =============================================================================
 // Property 3: Session Invalidation
-// =============================================================================
 
 // Feature: obzorarr, Property 3: Session Invalidation
 describe('Property 3: Session Invalidation', () => {
@@ -335,30 +303,24 @@ describe('Property 3: Session Invalidation', () => {
 					isAdmin: fc.boolean()
 				}),
 				async ({ username, plexToken, isAdmin }) => {
-					// Create fresh database for each iteration
 					const db = createTestDatabase();
 					const plexId = getUniquePlexId();
 
-					// Create user
 					const userId = await createTestUser(db, { plexId, username, isAdmin });
 
-					// Create session
 					const sessionId = await createTestSession(db, {
 						userId,
 						plexToken,
 						isAdmin
 					});
 
-					// Verify session is valid before logout
 					const beforeLogout = await validateTestSession(db, sessionId);
 					if (!beforeLogout) {
 						return false; // Session should be valid initially
 					}
 
-					// Invalidate session (logout)
 					await invalidateTestSession(db, sessionId);
 
-					// Verify session is now invalid
 					const afterLogout = await validateTestSession(db, sessionId);
 
 					return afterLogout === null;
@@ -390,11 +352,9 @@ describe('Property 3: Session Invalidation', () => {
 					checkCount: fc.integer({ min: 1, max: 5 })
 				}),
 				async ({ username, plexToken, isAdmin, checkCount }) => {
-					// Create fresh database for each iteration
 					const db = createTestDatabase();
 					const plexId = getUniquePlexId();
 
-					// Create user and session
 					const userId = await createTestUser(db, { plexId, username, isAdmin });
 					const sessionId = await createTestSession(db, {
 						userId,
@@ -402,10 +362,8 @@ describe('Property 3: Session Invalidation', () => {
 						isAdmin
 					});
 
-					// Invalidate session
 					await invalidateTestSession(db, sessionId);
 
-					// Check multiple times - should always be invalid
 					for (let i = 0; i < checkCount; i++) {
 						const result = await validateTestSession(db, sessionId);
 						if (result !== null) {
@@ -429,14 +387,11 @@ describe('Property 3: Session Invalidation', () => {
 					isAdmin: fc.boolean()
 				}),
 				async ({ username, plexToken, isAdmin }) => {
-					// Create fresh database for each iteration
 					const db = createTestDatabase();
 					const plexId = getUniquePlexId();
 
-					// Create user
 					const userId = await createTestUser(db, { plexId, username, isAdmin });
 
-					// Create session that already expired (negative duration)
 					const sessionId = await createTestSession(db, {
 						userId,
 						plexToken,
@@ -454,10 +409,6 @@ describe('Property 3: Session Invalidation', () => {
 		);
 	});
 });
-
-// =============================================================================
-// Additional Unit Tests
-// =============================================================================
 
 describe('Session Management', () => {
 	it('creates valid sessions', async () => {

--- a/tests/property/auth.property.test.ts
+++ b/tests/property/auth.property.test.ts
@@ -160,9 +160,6 @@ async function createTestUser(
 	return inserted.id;
 }
 
-// Property 1: Role Assignment Correctness
-
-// Feature: obzorarr, Property 1: Role Assignment Correctness
 describe('Property 1: Role Assignment Correctness', () => {
 	it('assigns admin privileges if and only if user is server owner', () => {
 		fc.assert(
@@ -177,26 +174,20 @@ describe('Property 1: Role Assignment Correctness', () => {
 
 	it('server owner always gets admin role', () => {
 		fc.assert(
-			fc.property(
-				fc.constantFrom(true), // Always owner
-				(isOwner) => {
-					const result = determineRole(isOwner);
-					return result.isAdmin === true;
-				}
-			),
+			fc.property(fc.constantFrom(true), (isOwner) => {
+				const result = determineRole(isOwner);
+				return result.isAdmin === true;
+			}),
 			{ numRuns: 100 }
 		);
 	});
 
 	it('non-owner members never get admin role', () => {
 		fc.assert(
-			fc.property(
-				fc.constantFrom(false), // Never owner
-				(isOwner) => {
-					const result = determineRole(isOwner);
-					return result.isAdmin === false;
-				}
-			),
+			fc.property(fc.constantFrom(false), (isOwner) => {
+				const result = determineRole(isOwner);
+				return result.isAdmin === false;
+			}),
 			{ numRuns: 100 }
 		);
 	});
@@ -214,9 +205,6 @@ describe('Property 1: Role Assignment Correctness', () => {
 	});
 });
 
-// Property 2: Non-Member Access Denial
-
-// Feature: obzorarr, Property 2: Non-Member Access Denial
 describe('Property 2: Non-Member Access Denial', () => {
 	/**
 	 * This property tests that non-members are denied access.
@@ -266,26 +254,19 @@ describe('Property 2: Non-Member Access Denial', () => {
 
 	it('access decision is based solely on membership status', () => {
 		fc.assert(
-			fc.property(
-				fc.boolean(), // isMember
-				fc.boolean(), // isOwner (ignored for access decision)
-				(isMember, isOwner) => {
-					const membership: MembershipResult = {
-						isMember,
-						isOwner: isMember ? isOwner : false
-					};
+			fc.property(fc.boolean(), fc.boolean(), (isMember, isOwner) => {
+				const membership: MembershipResult = {
+					isMember,
+					isOwner: isMember ? isOwner : false
+				};
 
-					return shouldGrantAccess(membership) === membership.isMember;
-				}
-			),
+				return shouldGrantAccess(membership) === membership.isMember;
+			}),
 			{ numRuns: 100 }
 		);
 	});
 });
 
-// Property 3: Session Invalidation
-
-// Feature: obzorarr, Property 3: Session Invalidation
 describe('Property 3: Session Invalidation', () => {
 	// Use a unique counter to ensure unique plexIds across property test iterations
 	let plexIdCounter = 0;
@@ -316,7 +297,7 @@ describe('Property 3: Session Invalidation', () => {
 
 					const beforeLogout = await validateTestSession(db, sessionId);
 					if (!beforeLogout) {
-						return false; // Session should be valid initially
+						return false;
 					}
 
 					await invalidateTestSession(db, sessionId);
@@ -334,7 +315,6 @@ describe('Property 3: Session Invalidation', () => {
 		const db = createTestDatabase();
 		await fc.assert(
 			fc.asyncProperty(fc.uuid(), async (sessionId) => {
-				// Should not throw even if session doesn't exist
 				await invalidateTestSession(db, sessionId);
 				return true;
 			}),
@@ -367,7 +347,7 @@ describe('Property 3: Session Invalidation', () => {
 					for (let i = 0; i < checkCount; i++) {
 						const result = await validateTestSession(db, sessionId);
 						if (result !== null) {
-							return false; // Session should never be valid after invalidation
+							return false;
 						}
 					}
 
@@ -396,10 +376,9 @@ describe('Property 3: Session Invalidation', () => {
 						userId,
 						plexToken,
 						isAdmin,
-						durationMs: -1000 // Already expired
+						durationMs: -1000
 					});
 
-					// Verify session is invalid due to expiration
 					const result = await validateTestSession(db, sessionId);
 
 					return result === null;

--- a/tests/property/auth.property.test.ts
+++ b/tests/property/auth.property.test.ts
@@ -35,9 +35,6 @@ function determineRole(isOwner: boolean): { isAdmin: boolean } {
  * Validates: Requirements 1.3, 1.4, 1.5, 1.7
  */
 
-/**
- * Create an in-memory test database with schema
- */
 function createTestDatabase() {
 	const sqlite = new Database(':memory:', { strict: true });
 

--- a/tests/property/auth.property.test.ts
+++ b/tests/property/auth.property.test.ts
@@ -119,9 +119,6 @@ async function validateTestSession(
 	};
 }
 
-/**
- * Invalidate a session (test implementation)
- */
 async function invalidateTestSession(
 	db: ReturnType<typeof createTestDatabase>,
 	sessionId: string
@@ -200,12 +197,8 @@ describe('Property 1: Role Assignment Correctness', () => {
 
 describe('Property 2: Non-Member Access Denial', () => {
 	/**
-	 * This property tests that non-members are denied access.
-	 *
-	 * In our implementation, this is handled by requireServerMembership()
-	 * which throws NotServerMemberError when isMember is false.
-	 *
-	 * We test the conceptual property here using a pure function approach.
+	 * Pure model of the membership invariant: a user outside the configured Plex
+	 * server must never be admitted, regardless of the route implementation.
 	 */
 
 	interface MembershipResult {
@@ -222,7 +215,7 @@ describe('Property 2: Non-Member Access Denial', () => {
 			fc.property(fc.boolean(), (_isOwner) => {
 				const membership: MembershipResult = {
 					isMember: false,
-					isOwner: false // Can't be owner if not a member
+					isOwner: false
 				};
 
 				return shouldGrantAccess(membership) === false;

--- a/tests/property/historical.property.test.ts
+++ b/tests/property/historical.property.test.ts
@@ -18,13 +18,6 @@ import { drizzle } from 'drizzle-orm/bun-sqlite';
 import * as fc from 'fast-check';
 import * as schema from '$lib/server/db/schema';
 
-/**
- * Create an in-memory test database with schema
- *
- * Note: We deliberately do NOT create a foreign key between
- * play_history.account_id and users.plex_id to ensure historical
- * data preservation (Requirements 13.1, 13.3).
- */
 function createTestDatabase() {
 	const sqlite = new Database(':memory:', { strict: true });
 
@@ -43,8 +36,8 @@ function createTestDatabase() {
 		)
 	`);
 
-	// Create play_history table WITHOUT foreign key to users
-	// This is intentional for historical data preservation
+	// Historical rows must survive after a Plex account disappears, so this
+	// property fixture intentionally mirrors the production table's loose link.
 	sqlite.exec(`
 		CREATE TABLE IF NOT EXISTS play_history (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -110,26 +103,20 @@ async function getAllUsersWatchTime(
 	return watchTimeMap;
 }
 
-/**
- * Arbitrary for generating play history records
- */
 const playHistoryArbitrary = fc.record({
 	historyKey: fc.uuid(),
 	ratingKey: fc.string({ minLength: 1, maxLength: 20 }),
 	title: fc.string({ minLength: 1, maxLength: 100 }),
 	type: fc.constantFrom('movie', 'episode'),
-	viewedAt: fc.integer({ min: 1704067200, max: 1735689599 }), // 2024 year range
+	viewedAt: fc.integer({ min: 1704067200, max: 1735689599 }),
 	accountId: fc.integer({ min: 1, max: 10000 }),
 	librarySectionId: fc.integer({ min: 1, max: 100 }),
 	thumb: fc.option(fc.webUrl(), { nil: null }),
-	duration: fc.integer({ min: 60, max: 14400 }), // 1 min to 4 hours in seconds
+	duration: fc.integer({ min: 60, max: 14400 }),
 	grandparentTitle: fc.option(fc.string({ minLength: 1, maxLength: 50 }), { nil: null }),
 	parentTitle: fc.option(fc.string({ minLength: 1, maxLength: 50 }), { nil: null })
 });
 
-/**
- * Arbitrary for generating unique play history records (unique historyKeys)
- */
 const uniquePlayHistoryArrayArbitrary = fc
 	.array(playHistoryArbitrary, { minLength: 1, maxLength: 50 })
 	.map((records) => {
@@ -139,9 +126,6 @@ const uniquePlayHistoryArrayArbitrary = fc
 		}));
 	});
 
-/**
- * Arbitrary for generating user records
- */
 const userArbitrary = fc.record({
 	plexId: fc.integer({ min: 1, max: 10000 }),
 	username: fc.string({ minLength: 1, maxLength: 50 }),
@@ -184,13 +168,13 @@ describe('Property 23: Historical Data Preservation', () => {
 
 					const uniqueUsers = userRecords.map((user, index) => ({
 						...user,
-						plexId: 100000 + index // Ensure plexIds don't overlap with accountIds
+						// Force a non-match so the fallback path, not the direct join path, is tested.
+						plexId: 100000 + index
 					}));
 
 					await db.insert(schema.users).values(uniqueUsers);
 
-					// Insert play history with accountIds that DON'T match any users.plexId
-					// (accountIds are in range 1-10000, plexIds are 100000+)
+					// These rows model orphaned Plex history that should still count in stats.
 					await db
 						.insert(schema.playHistory)
 						.values(historyRecords)
@@ -390,7 +374,7 @@ describe('Historical User Data Edge Cases', () => {
 			title: 'Test Movie',
 			type: 'movie',
 			viewedAt: 1704067200,
-			accountId: 12345, // Same as plexId
+			accountId: 12345,
 			librarySectionId: 1,
 			duration: 7200
 		});
@@ -493,7 +477,7 @@ describe('Historical User Data Edge Cases', () => {
 		const yearFilter = createYearFilter(2024);
 		const watchTimeMap = await getAllUsersWatchTime(db, yearFilter);
 
-		// Build top viewers with fallback (simulating engine.ts behavior)
+		// Mirror the engine fallback so orphaned account IDs still produce display names.
 		const topViewers: Array<{ accountId: number; username: string; minutes: number }> = [];
 		for (const [accountId, minutes] of watchTimeMap.entries()) {
 			const username = userMap.get(accountId) ?? `User ${accountId}`;

--- a/tests/property/historical.property.test.ts
+++ b/tests/property/historical.property.test.ts
@@ -18,10 +18,6 @@ import { drizzle } from 'drizzle-orm/bun-sqlite';
 import * as fc from 'fast-check';
 import * as schema from '$lib/server/db/schema';
 
-// =============================================================================
-// Test Database Setup
-// =============================================================================
-
 /**
  * Create an in-memory test database with schema
  *
@@ -32,10 +28,8 @@ import * as schema from '$lib/server/db/schema';
 function createTestDatabase() {
 	const sqlite = new Database(':memory:', { strict: true });
 
-	// Enable WAL mode
 	sqlite.exec('PRAGMA journal_mode = WAL');
 
-	// Create users table
 	sqlite.exec(`
 		CREATE TABLE IF NOT EXISTS users (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -75,29 +69,18 @@ function createTestDatabase() {
 	return drizzle(sqlite, { schema });
 }
 
-// =============================================================================
-// Test Types
-// =============================================================================
-
 interface YearFilter {
 	year: number;
 	startTimestamp: number;
 	endTimestamp: number;
 }
 
-/**
- * Create a year filter for a given year
- */
 function createYearFilter(year: number): YearFilter {
 	const startTimestamp = Math.floor(new Date(Date.UTC(year, 0, 1, 0, 0, 0)).getTime() / 1000);
 	const endTimestamp = Math.floor(new Date(Date.UTC(year, 11, 31, 23, 59, 59)).getTime() / 1000);
 	return { year, startTimestamp, endTimestamp };
 }
 
-/**
- * Get all users' total watch times for a year from the database
- * (Simplified version for testing - mirrors the real implementation)
- */
 async function getAllUsersWatchTime(
 	db: ReturnType<typeof createTestDatabase>,
 	yearFilter: YearFilter
@@ -127,10 +110,6 @@ async function getAllUsersWatchTime(
 	return watchTimeMap;
 }
 
-// =============================================================================
-// Arbitraries
-// =============================================================================
-
 /**
  * Arbitrary for generating play history records
  */
@@ -154,7 +133,6 @@ const playHistoryArbitrary = fc.record({
 const uniquePlayHistoryArrayArbitrary = fc
 	.array(playHistoryArbitrary, { minLength: 1, maxLength: 50 })
 	.map((records) => {
-		// Ensure unique historyKeys by appending index
 		return records.map((record, index) => ({
 			...record,
 			historyKey: `${record.historyKey}-${index}`
@@ -172,9 +150,7 @@ const userArbitrary = fc.record({
 	isAdmin: fc.boolean()
 });
 
-// =============================================================================
 // Property 23: Historical Data Preservation
-// =============================================================================
 
 // Feature: obzorarr, Property 23: Historical Data Preservation
 describe('Property 23: Historical Data Preservation', () => {
@@ -183,19 +159,15 @@ describe('Property 23: Historical Data Preservation', () => {
 			fc.asyncProperty(uniquePlayHistoryArrayArbitrary, async (records) => {
 				const db = createTestDatabase();
 
-				// Insert play history records with NO corresponding users
 				await db
 					.insert(schema.playHistory)
 					.values(records)
 					.onConflictDoNothing({ target: schema.playHistory.historyKey });
 
-				// Query back the records - they should exist
 				const storedRecords = await db.select().from(schema.playHistory);
 
-				// All records should be stored successfully
 				expect(storedRecords.length).toBe(records.length);
 
-				// Verify the users table is empty (no FK constraint violation)
 				const storedUsers = await db.select().from(schema.users);
 				expect(storedUsers.length).toBe(0);
 
@@ -213,13 +185,11 @@ describe('Property 23: Historical Data Preservation', () => {
 				async (historyRecords, userRecords) => {
 					const db = createTestDatabase();
 
-					// Make user plexIds unique
 					const uniqueUsers = userRecords.map((user, index) => ({
 						...user,
 						plexId: 100000 + index // Ensure plexIds don't overlap with accountIds
 					}));
 
-					// Insert users first
 					await db.insert(schema.users).values(uniqueUsers);
 
 					// Insert play history with accountIds that DON'T match any users.plexId
@@ -229,14 +199,12 @@ describe('Property 23: Historical Data Preservation', () => {
 						.values(historyRecords)
 						.onConflictDoNothing({ target: schema.playHistory.historyKey });
 
-					// Both should exist independently
 					const storedHistory = await db.select().from(schema.playHistory);
 					const storedUsers = await db.select().from(schema.users);
 
 					expect(storedHistory.length).toBe(historyRecords.length);
 					expect(storedUsers.length).toBe(uniqueUsers.length);
 
-					// Verify no overlap between accountIds and plexIds
 					const accountIds = new Set(storedHistory.map((h) => h.accountId));
 					const plexIds = new Set(storedUsers.map((u) => u.plexId));
 
@@ -256,25 +224,20 @@ describe('Property 23: Historical Data Preservation', () => {
 			fc.asyncProperty(uniquePlayHistoryArrayArbitrary, async (records) => {
 				const db = createTestDatabase();
 
-				// Insert play history records (NO users)
 				await db
 					.insert(schema.playHistory)
 					.values(records)
 					.onConflictDoNothing({ target: schema.playHistory.historyKey });
 
-				// Get all unique accountIds from records
 				const expectedAccountIds = new Set(records.map((r) => r.accountId));
 
-				// Call getAllUsersWatchTime
 				const yearFilter = createYearFilter(2024);
 				const watchTimeMap = await getAllUsersWatchTime(db, yearFilter);
 
-				// Verify all accountIds are present in the result
 				for (const accountId of expectedAccountIds) {
 					expect(watchTimeMap.has(accountId)).toBe(true);
 				}
 
-				// Verify the map size matches unique accountIds
 				expect(watchTimeMap.size).toBe(expectedAccountIds.size);
 
 				return true;
@@ -288,21 +251,17 @@ describe('Property 23: Historical Data Preservation', () => {
 			fc.asyncProperty(uniquePlayHistoryArrayArbitrary, async (records) => {
 				const db = createTestDatabase();
 
-				// Insert records
 				await db
 					.insert(schema.playHistory)
 					.values(records)
 					.onConflictDoNothing({ target: schema.playHistory.historyKey });
 
-				// Calculate expected total watch time
 				const expectedTotalSeconds = records.reduce((sum, r) => sum + (r.duration ?? 0), 0);
 				const expectedTotalMinutes = expectedTotalSeconds / 60;
 
-				// Get watch times from database
 				const yearFilter = createYearFilter(2024);
 				const watchTimeMap = await getAllUsersWatchTime(db, yearFilter);
 
-				// Sum all watch times
 				let actualTotalMinutes = 0;
 				for (const minutes of watchTimeMap.values()) {
 					actualTotalMinutes += minutes;
@@ -330,7 +289,6 @@ describe('Property 23: Historical Data Preservation', () => {
 					const recordsWithUsers = historyRecords.slice(0, halfIndex);
 					const _recordsWithoutUsers = historyRecords.slice(halfIndex);
 
-					// Create users with specific plexIds matching some accountIds
 					const usersToInsert = recordsWithUsers
 						.slice(0, Math.min(3, recordsWithUsers.length))
 						.map((record, _index) => ({
@@ -341,7 +299,6 @@ describe('Property 23: Historical Data Preservation', () => {
 							isAdmin: false
 						}));
 
-					// Ensure unique plexIds
 					const uniqueUsers = usersToInsert.filter(
 						(user, index, self) => self.findIndex((u) => u.plexId === user.plexId) === index
 					);
@@ -350,7 +307,6 @@ describe('Property 23: Historical Data Preservation', () => {
 						await db.insert(schema.users).values(uniqueUsers);
 					}
 
-					// Insert ALL play history records
 					await db
 						.insert(schema.playHistory)
 						.values(historyRecords)
@@ -368,11 +324,9 @@ describe('Property 23: Historical Data Preservation', () => {
 							)
 						);
 
-					// Calculate total plays and watch time
 					const totalPlays = allRecords.length;
 					const totalWatchTimeSeconds = allRecords.reduce((sum, r) => sum + (r.duration ?? 0), 0);
 
-					// Expected values from input records
 					const expectedPlays = historyRecords.length;
 					const expectedWatchTimeSeconds = historyRecords.reduce(
 						(sum, r) => sum + (r.duration ?? 0),
@@ -395,7 +349,6 @@ describe('Property 23: Historical Data Preservation', () => {
 			fc.asyncProperty(uniquePlayHistoryArrayArbitrary, async (records) => {
 				const db = createTestDatabase();
 
-				// Insert play history (no users)
 				await db
 					.insert(schema.playHistory)
 					.values(records)
@@ -406,7 +359,6 @@ describe('Property 23: Historical Data Preservation', () => {
 				const watchTimeMap = await getAllUsersWatchTime(db, yearFilter);
 				const userCountFromHistory = watchTimeMap.size;
 
-				// Count users in users table
 				const usersResult = await db.select().from(schema.users);
 				const userCountFromTable = usersResult.length;
 
@@ -414,7 +366,6 @@ describe('Property 23: Historical Data Preservation', () => {
 				expect(userCountFromTable).toBe(0);
 				expect(userCountFromHistory).toBeGreaterThan(0);
 
-				// The user count from history should match unique accountIds
 				const uniqueAccountIds = new Set(records.map((r) => r.accountId));
 				expect(userCountFromHistory).toBe(uniqueAccountIds.size);
 
@@ -425,15 +376,10 @@ describe('Property 23: Historical Data Preservation', () => {
 	});
 });
 
-// =============================================================================
-// Unit Tests for Historical User Handling Edge Cases
-// =============================================================================
-
 describe('Historical User Data Edge Cases', () => {
 	it('play history persists when user entry is deleted', async () => {
 		const db = createTestDatabase();
 
-		// Create a user
 		await db.insert(schema.users).values({
 			plexId: 12345,
 			username: 'TestUser',
@@ -441,7 +387,6 @@ describe('Historical User Data Edge Cases', () => {
 			isAdmin: false
 		});
 
-		// Create play history for this user
 		await db.insert(schema.playHistory).values({
 			historyKey: 'test-history-1',
 			ratingKey: 'rating-1',
@@ -453,16 +398,13 @@ describe('Historical User Data Edge Cases', () => {
 			duration: 7200
 		});
 
-		// Verify both exist
 		let users = await db.select().from(schema.users);
 		let history = await db.select().from(schema.playHistory);
 		expect(users.length).toBe(1);
 		expect(history.length).toBe(1);
 
-		// Delete the user
 		await db.delete(schema.users).where(sql`plex_id = 12345`);
 
-		// Verify user is deleted but history remains
 		users = await db.select().from(schema.users);
 		history = await db.select().from(schema.playHistory);
 		expect(users.length).toBe(0);
@@ -475,7 +417,6 @@ describe('Historical User Data Edge Cases', () => {
 
 		const plexId = 54321;
 
-		// Create historical play history (user not in users table)
 		await db.insert(schema.playHistory).values({
 			historyKey: 'historical-watch-1',
 			ratingKey: 'rating-1',
@@ -487,7 +428,6 @@ describe('Historical User Data Edge Cases', () => {
 			duration: 7200
 		});
 
-		// Verify no user exists
 		const users = await db.select().from(schema.users);
 		expect(users.length).toBe(0);
 
@@ -513,7 +453,6 @@ describe('Historical User Data Edge Cases', () => {
 	it('topViewers fallback shows User {accountId} for accounts not in users table', async () => {
 		const db = createTestDatabase();
 
-		// Insert user for accountId 1
 		await db.insert(schema.users).values({
 			plexId: 1,
 			username: 'ActiveUser',
@@ -544,22 +483,17 @@ describe('Historical User Data Edge Cases', () => {
 			}
 		]);
 
-		// Get all users from users table
 		const usersResult = await db.select().from(schema.users);
-		// Build userMap with dual-key lookup (matching engine.ts behavior)
 		const userMap = new Map<number, string>();
 		for (const user of usersResult) {
-			// Register by accountId if set
 			if (user.accountId !== null) {
 				userMap.set(user.accountId, user.username);
 			}
-			// Also register by plexId for backward compatibility
 			if (!userMap.has(user.plexId)) {
 				userMap.set(user.plexId, user.username);
 			}
 		}
 
-		// Get watch times by accountId
 		const yearFilter = createYearFilter(2024);
 		const watchTimeMap = await getAllUsersWatchTime(db, yearFilter);
 
@@ -570,7 +504,6 @@ describe('Historical User Data Edge Cases', () => {
 			topViewers.push({ accountId, username, minutes });
 		}
 
-		// Sort by minutes descending
 		topViewers.sort((a, b) => b.minutes - a.minutes);
 
 		// Verify fallback username for removed user

--- a/tests/property/historical.property.test.ts
+++ b/tests/property/historical.property.test.ts
@@ -248,7 +248,6 @@ describe('Property 23: Historical Data Preservation', () => {
 					actualTotalMinutes += minutes;
 				}
 
-				// Total should match (allow for small floating point differences)
 				expect(Math.abs(actualTotalMinutes - expectedTotalMinutes)).toBeLessThan(0.001);
 
 				return true;
@@ -265,7 +264,6 @@ describe('Property 23: Historical Data Preservation', () => {
 				async (historyRecords, _userRecords) => {
 					const db = createTestDatabase();
 
-					// Split history records: some with matching users, some without
 					const halfIndex = Math.floor(historyRecords.length / 2);
 					const recordsWithUsers = historyRecords.slice(0, halfIndex);
 					const _recordsWithoutUsers = historyRecords.slice(halfIndex);
@@ -293,7 +291,6 @@ describe('Property 23: Historical Data Preservation', () => {
 						.values(historyRecords)
 						.onConflictDoNothing({ target: schema.playHistory.historyKey });
 
-					// Simulate server stats query (queries play_history directly, not joined with users)
 					const yearFilter = createYearFilter(2024);
 					const allRecords = await db
 						.select()
@@ -314,7 +311,6 @@ describe('Property 23: Historical Data Preservation', () => {
 						0
 					);
 
-					// Server stats should include ALL records, not just those with users
 					expect(totalPlays).toBe(expectedPlays);
 					expect(totalWatchTimeSeconds).toBe(expectedWatchTimeSeconds);
 
@@ -335,7 +331,6 @@ describe('Property 23: Historical Data Preservation', () => {
 					.values(records)
 					.onConflictDoNothing({ target: schema.playHistory.historyKey });
 
-				// Count unique accountIds from play_history
 				const yearFilter = createYearFilter(2024);
 				const watchTimeMap = await getAllUsersWatchTime(db, yearFilter);
 				const userCountFromHistory = watchTimeMap.size;
@@ -343,7 +338,6 @@ describe('Property 23: Historical Data Preservation', () => {
 				const usersResult = await db.select().from(schema.users);
 				const userCountFromTable = usersResult.length;
 
-				// These should be different - play_history has users, users table is empty
 				expect(userCountFromTable).toBe(0);
 				expect(userCountFromHistory).toBeGreaterThan(0);
 
@@ -412,7 +406,6 @@ describe('Historical User Data Edge Cases', () => {
 		const users = await db.select().from(schema.users);
 		expect(users.length).toBe(0);
 
-		// Simulate re-authentication (user rejoins Plex server)
 		await db.insert(schema.users).values({
 			plexId: plexId,
 			username: 'ReturningUser',
@@ -420,13 +413,11 @@ describe('Historical User Data Edge Cases', () => {
 			isAdmin: false
 		});
 
-		// Now we can query play history for this user by matching plexId to accountId
 		const userHistory = await db
 			.select()
 			.from(schema.playHistory)
 			.where(sql`account_id = ${plexId}`);
 
-		// User's historical data should be accessible
 		expect(userHistory.length).toBe(1);
 		expect(userHistory[0]?.title).toBe('Old Movie');
 	});

--- a/tests/property/historical.property.test.ts
+++ b/tests/property/historical.property.test.ts
@@ -150,9 +150,6 @@ const userArbitrary = fc.record({
 	isAdmin: fc.boolean()
 });
 
-// Property 23: Historical Data Preservation
-
-// Feature: obzorarr, Property 23: Historical Data Preservation
 describe('Property 23: Historical Data Preservation', () => {
 	it('play history records can be inserted without corresponding users entry', async () => {
 		await fc.assert(
@@ -459,7 +456,6 @@ describe('Historical User Data Edge Cases', () => {
 			isAdmin: false
 		});
 
-		// Insert play history for accountId 1 (in users) and accountId 999 (not in users)
 		await db.insert(schema.playHistory).values([
 			{
 				historyKey: 'active-user-watch',
@@ -506,11 +502,10 @@ describe('Historical User Data Edge Cases', () => {
 
 		topViewers.sort((a, b) => b.minutes - a.minutes);
 
-		// Verify fallback username for removed user
 		expect(topViewers.length).toBe(2);
 		expect(topViewers[0]?.accountId).toBe(999);
-		expect(topViewers[0]?.username).toBe('User 999'); // Fallback for accounts not in plex_accounts or users
+		expect(topViewers[0]?.username).toBe('User 999');
 		expect(topViewers[1]?.accountId).toBe(1);
-		expect(topViewers[1]?.username).toBe('ActiveUser'); // Real name from users table
+		expect(topViewers[1]?.username).toBe('ActiveUser');
 	});
 });

--- a/tests/property/plex.property.test.ts
+++ b/tests/property/plex.property.test.ts
@@ -33,7 +33,7 @@ import {
  */
 function expectedApiCalls(totalRecords: number, pageSize: number): number {
 	if (totalRecords === 0) {
-		return 1; // Need 1 request to discover totalSize = 0
+		return 1;
 	}
 	return Math.ceil(totalRecords / pageSize);
 }
@@ -83,16 +83,13 @@ function createMockPageFetcher(
 	};
 }
 
-// Property 4: Pagination Completeness
-
-// Feature: obzorarr, Property 4: Pagination Completeness
 describe('Property 4: Pagination Completeness', () => {
 	describe('Page count calculation', () => {
 		it('calculateExpectedPages returns ceil(N/P) for any N and P', () => {
 			fc.assert(
 				fc.property(
-					fc.integer({ min: 0, max: 10000 }), // totalRecords N
-					fc.integer({ min: 1, max: 500 }), // pageSize P
+					fc.integer({ min: 0, max: 10000 }),
+					fc.integer({ min: 1, max: 500 }),
 					(totalRecords, pageSize) => {
 						const expected = totalRecords === 0 ? 0 : Math.ceil(totalRecords / pageSize);
 						const actual = calculateExpectedPages(totalRecords, pageSize);
@@ -108,8 +105,8 @@ describe('Property 4: Pagination Completeness', () => {
 		it('fetches expected number of pages for any N records and page size P', async () => {
 			await fc.assert(
 				fc.asyncProperty(
-					fc.integer({ min: 0, max: 1000 }), // totalRecords N (smaller for async perf)
-					fc.integer({ min: 1, max: 100 }), // pageSize P
+					fc.integer({ min: 0, max: 1000 }),
+					fc.integer({ min: 1, max: 100 }),
 					async (totalRecords, pageSize) => {
 						const allItems = generateTestItems(totalRecords);
 						const { fetcher, getPagesFetched } = createMockPageFetcher(allItems, pageSize);
@@ -134,8 +131,8 @@ describe('Property 4: Pagination Completeness', () => {
 		it('retrieves exactly N records with no loss', async () => {
 			await fc.assert(
 				fc.asyncProperty(
-					fc.integer({ min: 0, max: 1000 }), // totalRecords N
-					fc.integer({ min: 1, max: 100 }), // pageSize P
+					fc.integer({ min: 0, max: 1000 }),
+					fc.integer({ min: 1, max: 100 }),
 					async (totalRecords, pageSize) => {
 						const allItems = generateTestItems(totalRecords);
 						const { fetcher } = createMockPageFetcher(allItems, pageSize);
@@ -155,8 +152,8 @@ describe('Property 4: Pagination Completeness', () => {
 		it('retrieves items in correct order with no duplicates', async () => {
 			await fc.assert(
 				fc.asyncProperty(
-					fc.integer({ min: 1, max: 500 }), // totalRecords N (at least 1 for this test)
-					fc.integer({ min: 1, max: 50 }), // pageSize P
+					fc.integer({ min: 1, max: 500 }),
+					fc.integer({ min: 1, max: 50 }),
 					async (totalRecords, pageSize) => {
 						const allItems = generateTestItems(totalRecords);
 						const { fetcher } = createMockPageFetcher(allItems, pageSize);
@@ -166,7 +163,6 @@ describe('Property 4: Pagination Completeness', () => {
 							collectedItems.push(...items);
 						}
 
-						// Verify order is preserved
 						const idsInOrder = collectedItems.every((item, index) => item.id === index + 1);
 
 						const uniqueIds = new Set(collectedItems.map((item) => item.id));
@@ -268,7 +264,7 @@ describe('Property 4: Pagination Completeness', () => {
 
 		it('handles records exactly divisible by page size (multiple pages)', async () => {
 			const pageSize = 10;
-			const totalRecords = 30; // Exactly 3 pages
+			const totalRecords = 30;
 			const allItems = generateTestItems(totalRecords);
 			const { fetcher, getPagesFetched } = createMockPageFetcher(allItems, pageSize);
 
@@ -283,7 +279,7 @@ describe('Property 4: Pagination Completeness', () => {
 
 		it('handles records not divisible by page size (partial last page)', async () => {
 			const pageSize = 10;
-			const totalRecords = 25; // 2 full pages + 5 items
+			const totalRecords = 25;
 			const allItems = generateTestItems(totalRecords);
 			const { fetcher, getPagesFetched } = createMockPageFetcher(allItems, pageSize);
 
@@ -293,7 +289,7 @@ describe('Property 4: Pagination Completeness', () => {
 			}
 
 			expect(collectedItems.length).toBe(totalRecords);
-			expect(getPagesFetched()).toBe(3); // ceil(25/10) = 3
+			expect(getPagesFetched()).toBe(3);
 		});
 
 		it('throws error for invalid page size (zero)', () => {
@@ -315,7 +311,7 @@ describe('Property 4: Pagination Completeness', () => {
 			const result = await fetchAllPaginatedWithStats(fetcher, pageSize);
 
 			expect(result.items.length).toBe(totalRecords);
-			expect(result.pagesFetched).toBe(50); // ceil(5000/100) = 50
+			expect(result.pagesFetched).toBe(50);
 			expect(result.totalSize).toBe(totalRecords);
 		});
 	});

--- a/tests/property/plex.property.test.ts
+++ b/tests/property/plex.property.test.ts
@@ -38,9 +38,6 @@ function expectedApiCalls(totalRecords: number, pageSize: number): number {
 	return Math.ceil(totalRecords / pageSize);
 }
 
-/**
- * Simple item type for testing
- */
 interface TestItem {
 	id: number;
 	value: string;

--- a/tests/property/plex.property.test.ts
+++ b/tests/property/plex.property.test.ts
@@ -22,14 +22,8 @@ import {
  */
 
 /**
- * Calculate expected API calls for pagination
- *
- * For N > 0: exactly ceil(N/P) pages
- * For N = 0: exactly 1 page (needed to discover that totalSize is 0)
- *
- * This differs from calculateExpectedPages which returns the mathematical
- * ceil(N/P) = 0 for N=0. In real-world pagination, you need at least 1
- * request to discover the total size.
+ * Empty pagination still needs one request: the client cannot know `totalSize`
+ * is zero until Plex returns the first page.
  */
 function expectedApiCalls(totalRecords: number, pageSize: number): number {
 	if (totalRecords === 0) {

--- a/tests/property/plex.property.test.ts
+++ b/tests/property/plex.property.test.ts
@@ -21,10 +21,6 @@ import {
  * all combinations of total records and page sizes, ensuring no data loss.
  */
 
-// =============================================================================
-// Test Helpers
-// =============================================================================
-
 /**
  * Calculate expected API calls for pagination
  *
@@ -50,9 +46,6 @@ interface TestItem {
 	value: string;
 }
 
-/**
- * Generate test items with unique IDs
- */
 function generateTestItems(count: number): TestItem[] {
 	return Array.from({ length: count }, (_, i) => ({
 		id: i + 1,
@@ -60,12 +53,6 @@ function generateTestItems(count: number): TestItem[] {
 	}));
 }
 
-/**
- * Create a mock page fetcher that simulates paginated API responses
- *
- * This tracks the number of page fetches and returns items based on
- * the offset and page size parameters.
- */
 function createMockPageFetcher(
 	allItems: TestItem[],
 	_pageSize: number
@@ -78,7 +65,6 @@ function createMockPageFetcher(
 	): Promise<PageResult<TestItem>> => {
 		pagesFetched++;
 
-		// Calculate items for this page
 		const startIndex = offset;
 		const endIndex = Math.min(offset + requestedPageSize, allItems.length);
 		const items = allItems.slice(startIndex, endIndex);
@@ -97,9 +83,7 @@ function createMockPageFetcher(
 	};
 }
 
-// =============================================================================
 // Property 4: Pagination Completeness
-// =============================================================================
 
 // Feature: obzorarr, Property 4: Pagination Completeness
 describe('Property 4: Pagination Completeness', () => {
@@ -130,13 +114,11 @@ describe('Property 4: Pagination Completeness', () => {
 						const allItems = generateTestItems(totalRecords);
 						const { fetcher, getPagesFetched } = createMockPageFetcher(allItems, pageSize);
 
-						// Consume all pages from the generator
 						const collectedItems: TestItem[] = [];
 						for await (const { items } of paginateAll(fetcher, pageSize)) {
 							collectedItems.push(...items);
 						}
 
-						// Verify page count
 						// For N > 0: ceil(N/P) pages
 						// For N = 0: 1 page (to discover totalSize = 0)
 						const expected = expectedApiCalls(totalRecords, pageSize);
@@ -158,13 +140,11 @@ describe('Property 4: Pagination Completeness', () => {
 						const allItems = generateTestItems(totalRecords);
 						const { fetcher } = createMockPageFetcher(allItems, pageSize);
 
-						// Collect all items from pagination
 						const collectedItems: TestItem[] = [];
 						for await (const { items } of paginateAll(fetcher, pageSize)) {
 							collectedItems.push(...items);
 						}
 
-						// Verify all items retrieved
 						return collectedItems.length === totalRecords;
 					}
 				),
@@ -181,7 +161,6 @@ describe('Property 4: Pagination Completeness', () => {
 						const allItems = generateTestItems(totalRecords);
 						const { fetcher } = createMockPageFetcher(allItems, pageSize);
 
-						// Collect all items
 						const collectedItems: TestItem[] = [];
 						for await (const { items } of paginateAll(fetcher, pageSize)) {
 							collectedItems.push(...items);
@@ -190,7 +169,6 @@ describe('Property 4: Pagination Completeness', () => {
 						// Verify order is preserved
 						const idsInOrder = collectedItems.every((item, index) => item.id === index + 1);
 
-						// Verify no duplicates (all IDs are unique)
 						const uniqueIds = new Set(collectedItems.map((item) => item.id));
 						const noDuplicates = uniqueIds.size === collectedItems.length;
 
@@ -254,9 +232,7 @@ describe('Property 4: Pagination Completeness', () => {
 			}
 
 			// With zero records, we should still make one fetch to discover totalSize=0
-			// But then exit immediately
 			expect(collectedItems.length).toBe(0);
-			// The implementation fetches once to get totalSize, then exits
 			expect(getPagesFetched()).toBe(1);
 		});
 
@@ -345,7 +321,6 @@ describe('Property 4: Pagination Completeness', () => {
 	});
 });
 
-// Additional unit tests for completeness
 describe('Pagination utility functions', () => {
 	describe('calculateExpectedPages', () => {
 		it('returns 0 for zero records', () => {

--- a/tests/property/plex.property.test.ts
+++ b/tests/property/plex.property.test.ts
@@ -113,8 +113,6 @@ describe('Property 4: Pagination Completeness', () => {
 							collectedItems.push(...items);
 						}
 
-						// For N > 0: ceil(N/P) pages
-						// For N = 0: 1 page (to discover totalSize = 0)
 						const expected = expectedApiCalls(totalRecords, pageSize);
 						const actualPages = getPagesFetched();
 
@@ -185,7 +183,6 @@ describe('Property 4: Pagination Completeness', () => {
 
 						const result = await fetchAllPaginatedWithStats(fetcher, pageSize);
 
-						// For N > 0: ceil(N/P) pages; For N = 0: 1 page
 						const expected = expectedApiCalls(totalRecords, pageSize);
 						return result.pagesFetched === expected;
 					}
@@ -224,7 +221,6 @@ describe('Property 4: Pagination Completeness', () => {
 				collectedItems.push(...items);
 			}
 
-			// With zero records, we should still make one fetch to discover totalSize=0
 			expect(collectedItems.length).toBe(0);
 			expect(getPagesFetched()).toBe(1);
 		});

--- a/tests/property/serialization.property.test.ts
+++ b/tests/property/serialization.property.test.ts
@@ -214,15 +214,13 @@ const rewatchItemArbitrary: fc.Arbitrary<RewatchItem> = fc.record({
 	rewatchCount: fc.integer({ min: 2, max: 100 })
 });
 
-/**
- * Generate a valid MarathonDay
- * Uses integer-based date generation to avoid Invalid Date errors during shrinking
- */
+// Limit generated days to 1-28 so fast-check shrinking cannot produce an
+// invalid calendar date for shorter months.
 const marathonDayArbitrary: fc.Arbitrary<MarathonDay> = fc
 	.record({
 		year: fc.integer({ min: 2020, max: 2030 }),
 		month: fc.integer({ min: 1, max: 12 }),
-		day: fc.integer({ min: 1, max: 28 }), // Use 28 to avoid invalid dates
+		day: fc.integer({ min: 1, max: 28 }),
 		minutes: fc.float({ min: 0, max: 1440, noNaN: true }),
 		plays: fc.integer({ min: 1, max: 100 }),
 		items: fc.array(
@@ -240,16 +238,14 @@ const marathonDayArbitrary: fc.Arbitrary<MarathonDay> = fc
 		items: data.items
 	}));
 
-/**
- * Generate a valid WatchStreak
- * Uses integer-based date generation to avoid Invalid Date errors during shrinking
- */
+// Same 1-28 day bound as marathon days: these are date-shape fixtures, not
+// calendar-validity tests.
 const watchStreakArbitrary: fc.Arbitrary<WatchStreak> = fc
 	.record({
 		longestStreak: fc.integer({ min: 0, max: 365 }),
 		year: fc.integer({ min: 2020, max: 2030 }),
 		startMonth: fc.integer({ min: 1, max: 12 }),
-		startDay: fc.integer({ min: 1, max: 28 }), // Use 28 to avoid invalid dates
+		startDay: fc.integer({ min: 1, max: 28 }),
 		endMonth: fc.integer({ min: 1, max: 12 }),
 		endDay: fc.integer({ min: 1, max: 28 })
 	})
@@ -269,10 +265,8 @@ const yearComparisonArbitrary: fc.Arbitrary<YearComparison> = fc.record({
 	percentChange: fc.float({ min: -100, max: 1000, noNaN: true })
 });
 
-/**
- * Generate a valid UserStats object
- * Note: Property order must match UserStatsSchema for JSON round-trip comparison
- */
+// Property order must match UserStatsSchema so round-trip diffs identify schema
+// drift instead of fixture ordering noise.
 const userStatsArbitrary: fc.Arbitrary<UserStats> = fc.record({
 	userId: fc.integer({ min: 1, max: 1000000 }),
 	year: fc.integer({ min: 2000, max: 2100 }),
@@ -297,10 +291,8 @@ const userStatsArbitrary: fc.Arbitrary<UserStats> = fc.record({
 	lastWatch: fc.option(watchRecordArbitrary, { nil: null })
 });
 
-/**
- * Generate a valid ServerStats object
- * Note: Property order must match ServerStatsSchema for JSON round-trip comparison
- */
+// Property order must match ServerStatsSchema for the same round-trip drift check
+// as the user-stats arbitrary above.
 const serverStatsArbitrary: fc.Arbitrary<ServerStats> = fc.record({
 	year: fc.integer({ min: 2000, max: 2100 }),
 	totalUsers: fc.integer({ min: 0, max: 10000 }),
@@ -333,10 +325,6 @@ const serverStatsArbitrary: fc.Arbitrary<ServerStats> = fc.record({
 	lastWatch: fc.option(watchRecordArbitrary, { nil: null })
 });
 
-/**
- * Deep equality check for stats objects
- * Handles floating point comparison with tolerance
- */
 function statsAreEqual(a: UserStats | ServerStats, b: UserStats | ServerStats): boolean {
 	const aJson = JSON.stringify(a);
 	const bJson = JSON.stringify(b);

--- a/tests/property/serialization.property.test.ts
+++ b/tests/property/serialization.property.test.ts
@@ -32,13 +32,6 @@ import type {
  * then deserializing SHALL produce an object equivalent to the original.
  */
 
-// =============================================================================
-// Arbitraries (generators for random test data)
-// =============================================================================
-
-/**
- * Generate a valid RankedItem
- */
 const rankedItemArbitrary: fc.Arbitrary<RankedItem> = fc.record({
 	rank: fc.integer({ min: 1, max: 1000 }),
 	title: fc.string({ minLength: 1, maxLength: 200 }),
@@ -46,9 +39,6 @@ const rankedItemArbitrary: fc.Arbitrary<RankedItem> = fc.record({
 	thumb: fc.option(fc.webUrl(), { nil: null })
 });
 
-/**
- * Generate a valid BingeSession
- */
 const bingeSessionArbitrary: fc.Arbitrary<BingeSession> = fc
 	.record({
 		startTime: fc.integer({ min: 1577836800, max: 1893456000 }), // 2020-2030
@@ -58,13 +48,9 @@ const bingeSessionArbitrary: fc.Arbitrary<BingeSession> = fc
 	})
 	.map((session) => ({
 		...session,
-		// Ensure endTime >= startTime
 		endTime: Math.max(session.startTime, session.endTime)
 	}));
 
-/**
- * Generate a valid WatchRecord
- */
 const watchRecordArbitrary: fc.Arbitrary<WatchRecord> = fc.record({
 	title: fc.string({ minLength: 1, maxLength: 200 }),
 	viewedAt: fc.integer({ min: 1577836800, max: 1893456000 }), // 2020-2030
@@ -72,9 +58,6 @@ const watchRecordArbitrary: fc.Arbitrary<WatchRecord> = fc.record({
 	type: fc.constantFrom('movie', 'episode', 'track') as fc.Arbitrary<'movie' | 'episode' | 'track'>
 });
 
-/**
- * Generate a valid MonthlyDistribution object
- */
 const monthlyDistributionArbitrary = fc.record({
 	minutes: fc
 		.tuple(
@@ -110,9 +93,6 @@ const monthlyDistributionArbitrary = fc.record({
 		.map((tuple) => [...tuple])
 });
 
-/**
- * Generate a valid HourlyDistribution object
- */
 const hourlyDistributionArbitrary = fc.record({
 	minutes: fc
 		.tuple(
@@ -172,9 +152,6 @@ const hourlyDistributionArbitrary = fc.record({
 		.map((tuple) => [...tuple])
 });
 
-/**
- * Generate a valid WeekdayDistribution (7 days)
- */
 const weekdayDistributionArbitrary: fc.Arbitrary<WeekdayDistribution> = fc.record({
 	minutes: fc
 		.tuple(
@@ -200,9 +177,6 @@ const weekdayDistributionArbitrary: fc.Arbitrary<WeekdayDistribution> = fc.recor
 		.map((tuple) => [...tuple])
 });
 
-/**
- * Generate a valid ContentTypeBreakdown
- */
 const contentTypeBreakdownArbitrary: fc.Arbitrary<ContentTypeBreakdown> = fc.record({
 	movies: fc.record({
 		count: fc.integer({ min: 0, max: 10000 }),
@@ -218,18 +192,12 @@ const contentTypeBreakdownArbitrary: fc.Arbitrary<ContentTypeBreakdown> = fc.rec
 	})
 });
 
-/**
- * Generate a valid DecadeDistributionItem
- */
 const decadeDistributionItemArbitrary: fc.Arbitrary<DecadeDistributionItem> = fc.record({
 	decade: fc.constantFrom('1950s', '1960s', '1970s', '1980s', '1990s', '2000s', '2010s', '2020s'),
 	count: fc.integer({ min: 0, max: 10000 }),
 	minutes: fc.float({ min: 0, max: 1000000, noNaN: true })
 });
 
-/**
- * Generate a valid SeriesCompletionItem
- */
 const seriesCompletionItemArbitrary: fc.Arbitrary<SeriesCompletionItem> = fc.record({
 	show: fc.string({ minLength: 1, maxLength: 200 }),
 	thumb: fc.option(fc.string({ minLength: 1, maxLength: 500 }), { nil: null }),
@@ -239,9 +207,6 @@ const seriesCompletionItemArbitrary: fc.Arbitrary<SeriesCompletionItem> = fc.rec
 	percentComplete: fc.float({ min: 0, max: 100, noNaN: true })
 });
 
-/**
- * Generate a valid RewatchItem
- */
 const rewatchItemArbitrary: fc.Arbitrary<RewatchItem> = fc.record({
 	title: fc.string({ minLength: 1, maxLength: 200 }),
 	thumb: fc.option(fc.string({ minLength: 1, maxLength: 500 }), { nil: null }),
@@ -298,9 +263,6 @@ const watchStreakArbitrary: fc.Arbitrary<WatchStreak> = fc
 		};
 	});
 
-/**
- * Generate a valid YearComparison
- */
 const yearComparisonArbitrary: fc.Arbitrary<YearComparison> = fc.record({
 	thisYear: fc.float({ min: 0, max: 10000000, noNaN: true }),
 	lastYear: fc.float({ min: 0, max: 10000000, noNaN: true }),
@@ -371,10 +333,6 @@ const serverStatsArbitrary: fc.Arbitrary<ServerStats> = fc.record({
 	lastWatch: fc.option(watchRecordArbitrary, { nil: null })
 });
 
-// =============================================================================
-// Helper functions
-// =============================================================================
-
 /**
  * Deep equality check for stats objects
  * Handles floating point comparison with tolerance
@@ -385,23 +343,16 @@ function statsAreEqual(a: UserStats | ServerStats, b: UserStats | ServerStats): 
 	return aJson === bJson;
 }
 
-// =============================================================================
-// Property Tests
-// =============================================================================
-
 // Feature: obzorarr, Property 21: Statistics Serialization Round-Trip
 describe('Property 21: Statistics Serialization Round-Trip', () => {
 	describe('UserStats round-trip', () => {
 		it('serialize then deserialize produces equivalent UserStats', () => {
 			fc.assert(
 				fc.property(userStatsArbitrary, (originalStats) => {
-					// Serialize to JSON
 					const json = serializeStats(originalStats);
 
-					// Deserialize back to object
 					const parsedStats = parseUserStats(json);
 
-					// Verify equality
 					return statsAreEqual(originalStats, parsedStats);
 				}),
 				{ numRuns: 100 }
@@ -421,15 +372,12 @@ describe('Property 21: Statistics Serialization Round-Trip', () => {
 		it('double round-trip produces equivalent UserStats', () => {
 			fc.assert(
 				fc.property(userStatsArbitrary, (originalStats) => {
-					// First round-trip
 					const json1 = serializeStats(originalStats);
 					const parsed1 = parseUserStats(json1);
 
-					// Second round-trip
 					const json2 = serializeStats(parsed1);
 					const parsed2 = parseUserStats(json2);
 
-					// Both should be equivalent to original
 					return statsAreEqual(originalStats, parsed1) && statsAreEqual(parsed1, parsed2);
 				}),
 				{ numRuns: 100 }
@@ -441,13 +389,10 @@ describe('Property 21: Statistics Serialization Round-Trip', () => {
 		it('serialize then deserialize produces equivalent ServerStats', () => {
 			fc.assert(
 				fc.property(serverStatsArbitrary, (originalStats) => {
-					// Serialize to JSON
 					const json = serializeStats(originalStats);
 
-					// Deserialize back to object
 					const parsedStats = parseServerStats(json);
 
-					// Verify equality
 					return statsAreEqual(originalStats, parsedStats);
 				}),
 				{ numRuns: 100 }
@@ -467,15 +412,12 @@ describe('Property 21: Statistics Serialization Round-Trip', () => {
 		it('double round-trip produces equivalent ServerStats', () => {
 			fc.assert(
 				fc.property(serverStatsArbitrary, (originalStats) => {
-					// First round-trip
 					const json1 = serializeStats(originalStats);
 					const parsed1 = parseServerStats(json1);
 
-					// Second round-trip
 					const json2 = serializeStats(parsed1);
 					const parsed2 = parseServerStats(json2);
 
-					// Both should be equivalent to original
 					return statsAreEqual(originalStats, parsed1) && statsAreEqual(parsed1, parsed2);
 				}),
 				{ numRuns: 100 }
@@ -510,7 +452,6 @@ describe('Property 21: Statistics Serialization Round-Trip', () => {
 	});
 });
 
-// Additional unit tests for edge cases
 // Note: Property order must match schema order for JSON round-trip comparison
 describe('Serialization edge cases', () => {
 	it('handles UserStats with empty arrays', () => {

--- a/tests/property/serialization.property.test.ts
+++ b/tests/property/serialization.property.test.ts
@@ -449,7 +449,7 @@ describe('Property 21: Statistics Serialization Round-Trip', () => {
 	});
 });
 
-// Note: Property order must match schema order for JSON round-trip comparison
+// Keep fixture key order aligned with the schema so round-trip diffs stay meaningful.
 describe('Serialization edge cases', () => {
 	it('handles UserStats with empty arrays', () => {
 		const stats: UserStats = {
@@ -617,7 +617,7 @@ describe('Serialization edge cases', () => {
 			topMovies: [],
 			topShows: [],
 			topGenres: [],
-			watchTimeByMonth: [1, 2, 3], // Wrong length - should be 12
+			watchTimeByMonth: [1, 2, 3],
 			watchTimeByHour: [
 				1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
 			],

--- a/tests/property/serialization.property.test.ts
+++ b/tests/property/serialization.property.test.ts
@@ -343,7 +343,6 @@ function statsAreEqual(a: UserStats | ServerStats, b: UserStats | ServerStats): 
 	return aJson === bJson;
 }
 
-// Feature: obzorarr, Property 21: Statistics Serialization Round-Trip
 describe('Property 21: Statistics Serialization Round-Trip', () => {
 	describe('UserStats round-trip', () => {
 		it('serialize then deserialize produces equivalent UserStats', () => {

--- a/tests/property/serialization.property.test.ts
+++ b/tests/property/serialization.property.test.ts
@@ -41,7 +41,7 @@ const rankedItemArbitrary: fc.Arbitrary<RankedItem> = fc.record({
 
 const bingeSessionArbitrary: fc.Arbitrary<BingeSession> = fc
 	.record({
-		startTime: fc.integer({ min: 1577836800, max: 1893456000 }), // 2020-2030
+		startTime: fc.integer({ min: 1577836800, max: 1893456000 }),
 		endTime: fc.integer({ min: 1577836800, max: 1893456000 }),
 		plays: fc.integer({ min: 1, max: 100 }),
 		totalMinutes: fc.float({ min: 0, max: 10000, noNaN: true })
@@ -53,7 +53,7 @@ const bingeSessionArbitrary: fc.Arbitrary<BingeSession> = fc
 
 const watchRecordArbitrary: fc.Arbitrary<WatchRecord> = fc.record({
 	title: fc.string({ minLength: 1, maxLength: 200 }),
-	viewedAt: fc.integer({ min: 1577836800, max: 1893456000 }), // 2020-2030
+	viewedAt: fc.integer({ min: 1577836800, max: 1893456000 }),
 	thumb: fc.option(fc.webUrl(), { nil: null }),
 	type: fc.constantFrom('movie', 'episode', 'track') as fc.Arbitrary<'movie' | 'episode' | 'track'>
 });
@@ -429,7 +429,6 @@ describe('Property 21: Statistics Serialization Round-Trip', () => {
 			fc.assert(
 				fc.property(userStatsArbitrary, (stats) => {
 					const json = serializeStats(stats);
-					// Should not throw
 					const parsed = JSON.parse(json);
 					return typeof parsed === 'object' && parsed !== null;
 				}),
@@ -441,7 +440,6 @@ describe('Property 21: Statistics Serialization Round-Trip', () => {
 			fc.assert(
 				fc.property(serverStatsArbitrary, (stats) => {
 					const json = serializeStats(stats);
-					// Should not throw
 					const parsed = JSON.parse(json);
 					return typeof parsed === 'object' && parsed !== null;
 				}),

--- a/tests/property/sharing.property.test.ts
+++ b/tests/property/sharing.property.test.ts
@@ -295,11 +295,8 @@ describe('Property 17: Permission Enforcement', () => {
 	function isPermissionAllowed(ctx: PermissionContext): boolean {
 		if (ctx.isAdmin) return true;
 
-		// Users without control permission cannot change anything
 		if (!ctx.canUserControl) return false;
 
-		// Users with control can only set public or private-oauth
-		// They cannot enable private-link unless already in that mode
 		if (
 			ctx.requestedMode === ShareMode.PRIVATE_LINK &&
 			ctx.currentMode !== ShareMode.PRIVATE_LINK
@@ -438,7 +435,6 @@ describe('Property 17: Permission Enforcement', () => {
 	it('user settings cannot exceed admin-granted permissions', () => {
 		fc.assert(
 			fc.property(shareModeArbitrary, (currentMode) => {
-				// User without control cannot change from current mode
 				const ctxNoControl: PermissionContext = {
 					isAdmin: false,
 					canUserControl: false,
@@ -448,7 +444,6 @@ describe('Property 17: Permission Enforcement', () => {
 
 				const denied = !isPermissionAllowed(ctxNoControl);
 
-				// User with control cannot exceed to private-link
 				const ctxWithControl: PermissionContext = {
 					isAdmin: false,
 					canUserControl: true,

--- a/tests/property/sharing.property.test.ts
+++ b/tests/property/sharing.property.test.ts
@@ -118,7 +118,7 @@ describe('Property 15: Share Mode Access Control', () => {
 					shareMode: ShareMode.PRIVATE_OAUTH,
 					shareToken,
 					validToken: null,
-					isAuthenticated: false, // Not authenticated
+					isAuthenticated: false,
 					isServerMember: false,
 					isOwner: false
 				};
@@ -153,7 +153,7 @@ describe('Property 15: Share Mode Access Control', () => {
 		fc.assert(
 			fc.property(
 				fc.uuid(),
-				fc.uuid().filter((t) => t !== ''), // wrongToken
+				fc.uuid().filter((t) => t !== ''),
 				(validToken, wrongToken) => {
 					if (validToken === wrongToken) return true;
 

--- a/tests/property/sharing.property.test.ts
+++ b/tests/property/sharing.property.test.ts
@@ -20,16 +20,13 @@ const shareModeArbitrary: fc.Arbitrary<ShareModeType> = fc.constantFrom(
 	ShareMode.PRIVATE_LINK
 );
 
-// Property 15: Share Mode Access Control
-
-// Feature: obzorarr, Property 15: Share Mode Access Control
 describe('Property 15: Share Mode Access Control', () => {
 	it('public mode allows all requests', () => {
 		fc.assert(
 			fc.property(
-				fc.boolean(), // isAuthenticated
-				fc.boolean(), // isServerMember
-				fc.option(fc.uuid(), { nil: undefined }), // shareToken
+				fc.boolean(),
+				fc.boolean(),
+				fc.option(fc.uuid(), { nil: undefined }),
 				(isAuthenticated, isServerMember, shareToken) => {
 					const context: AccessCheckContext = {
 						shareMode: ShareMode.PUBLIC,
@@ -50,50 +47,42 @@ describe('Property 15: Share Mode Access Control', () => {
 
 	it('private-oauth mode only allows authenticated server members', () => {
 		fc.assert(
-			fc.property(
-				fc.boolean(), // isAuthenticated
-				fc.boolean(), // isServerMember
-				(isAuthenticated, isServerMember) => {
-					const context: AccessCheckContext = {
-						shareMode: ShareMode.PRIVATE_OAUTH,
-						shareToken: undefined,
-						validToken: null,
-						isAuthenticated,
-						isServerMember,
-						isOwner: false
-					};
+			fc.property(fc.boolean(), fc.boolean(), (isAuthenticated, isServerMember) => {
+				const context: AccessCheckContext = {
+					shareMode: ShareMode.PRIVATE_OAUTH,
+					shareToken: undefined,
+					validToken: null,
+					isAuthenticated,
+					isServerMember,
+					isOwner: false
+				};
 
-					const result = checkAccess(context);
-					const shouldAllow = isAuthenticated && isServerMember;
+				const result = checkAccess(context);
+				const shouldAllow = isAuthenticated && isServerMember;
 
-					return result.allowed === shouldAllow;
-				}
-			),
+				return result.allowed === shouldAllow;
+			}),
 			{ numRuns: 100 }
 		);
 	});
 
 	it('private-link mode only allows valid share tokens', () => {
 		fc.assert(
-			fc.property(
-				fc.uuid(), // validToken (stored in DB)
-				fc.option(fc.uuid(), { nil: undefined }), // shareToken (from URL)
-				(validToken, shareToken) => {
-					const context: AccessCheckContext = {
-						shareMode: ShareMode.PRIVATE_LINK,
-						shareToken,
-						validToken,
-						isAuthenticated: false, // Not required for private-link
-						isServerMember: false,
-						isOwner: false
-					};
+			fc.property(fc.uuid(), fc.option(fc.uuid(), { nil: undefined }), (validToken, shareToken) => {
+				const context: AccessCheckContext = {
+					shareMode: ShareMode.PRIVATE_LINK,
+					shareToken,
+					validToken,
+					isAuthenticated: false,
+					isServerMember: false,
+					isOwner: false
+				};
 
-					const result = checkAccess(context);
-					const shouldAllow = shareToken === validToken;
+				const result = checkAccess(context);
+				const shouldAllow = shareToken === validToken;
 
-					return result.allowed === shouldAllow;
-				}
-			),
+				return result.allowed === shouldAllow;
+			}),
 			{ numRuns: 100 }
 		);
 	});
@@ -102,8 +91,8 @@ describe('Property 15: Share Mode Access Control', () => {
 		fc.assert(
 			fc.property(
 				shareModeArbitrary,
-				fc.boolean(), // isAuthenticated
-				fc.option(fc.uuid(), { nil: undefined }), // shareToken
+				fc.boolean(),
+				fc.option(fc.uuid(), { nil: undefined }),
 				(shareMode, isAuthenticated, shareToken) => {
 					const context: AccessCheckContext = {
 						shareMode,
@@ -111,7 +100,7 @@ describe('Property 15: Share Mode Access Control', () => {
 						validToken: 'some-valid-token',
 						isAuthenticated,
 						isServerMember: isAuthenticated,
-						isOwner: true // Key: owner is always true
+						isOwner: true
 					};
 
 					const result = checkAccess(context);
@@ -146,7 +135,7 @@ describe('Property 15: Share Mode Access Control', () => {
 			fc.property(fc.uuid(), (validToken) => {
 				const context: AccessCheckContext = {
 					shareMode: ShareMode.PRIVATE_LINK,
-					shareToken: undefined, // No token provided
+					shareToken: undefined,
 					validToken,
 					isAuthenticated: true,
 					isServerMember: true,
@@ -163,7 +152,7 @@ describe('Property 15: Share Mode Access Control', () => {
 	it('wrong token is denied for private-link', () => {
 		fc.assert(
 			fc.property(
-				fc.uuid(), // validToken
+				fc.uuid(),
 				fc.uuid().filter((t) => t !== ''), // wrongToken
 				(validToken, wrongToken) => {
 					if (validToken === wrongToken) return true;
@@ -220,9 +209,6 @@ describe('Property 15: Share Mode Access Control', () => {
 	});
 });
 
-// Property 16: Share Token Uniqueness
-
-// Feature: obzorarr, Property 16: Share Token Uniqueness
 describe('Property 16: Share Token Uniqueness', () => {
 	it('generated tokens are valid UUID v4 format', () => {
 		fc.assert(
@@ -236,16 +222,13 @@ describe('Property 16: Share Token Uniqueness', () => {
 
 	it('generated tokens are unique', () => {
 		fc.assert(
-			fc.property(
-				fc.integer({ min: 10, max: 100 }), // Number of tokens to generate
-				(count) => {
-					const tokens = new Set<string>();
-					for (let i = 0; i < count; i++) {
-						tokens.add(generateShareToken());
-					}
-					return tokens.size === count;
+			fc.property(fc.integer({ min: 10, max: 100 }), (count) => {
+				const tokens = new Set<string>();
+				for (let i = 0; i < count; i++) {
+					tokens.add(generateShareToken());
 				}
-			),
+				return tokens.size === count;
+			}),
 			{ numRuns: 100 }
 		);
 	});
@@ -257,7 +240,7 @@ describe('Property 16: Share Token Uniqueness', () => {
 				const token2 = generateShareToken();
 				return token1 !== token2;
 			}),
-			{ numRuns: 1000 } // Extra iterations for uniqueness
+			{ numRuns: 1000 }
 		);
 	});
 
@@ -288,16 +271,12 @@ describe('Property 16: Share Token Uniqueness', () => {
 	});
 
 	it('token generation is idempotent format', () => {
-		// Each call produces a new unique token
 		const tokens = Array.from({ length: 100 }, () => generateShareToken());
 		const uniqueTokens = new Set(tokens);
 		expect(uniqueTokens.size).toBe(100);
 	});
 });
 
-// Property 17: Permission Enforcement
-
-// Feature: obzorarr, Property 17: Permission Enforcement
 describe('Property 17: Permission Enforcement', () => {
 	/**
 	 * Permission levels hierarchy:
@@ -336,7 +315,7 @@ describe('Property 17: Permission Enforcement', () => {
 			fc.property(shareModeArbitrary, shareModeArbitrary, (currentMode, requestedMode) => {
 				const ctx: PermissionContext = {
 					isAdmin: true,
-					canUserControl: false, // Doesn't matter for admin
+					canUserControl: false,
 					currentMode,
 					requestedMode
 				};
@@ -385,19 +364,16 @@ describe('Property 17: Permission Enforcement', () => {
 
 	it('users with canUserControl cannot enable private-link', () => {
 		fc.assert(
-			fc.property(
-				fc.constantFrom(ShareMode.PUBLIC, ShareMode.PRIVATE_OAUTH), // Current mode not private-link
-				() => {
-					const ctx: PermissionContext = {
-						isAdmin: false,
-						canUserControl: true,
-						currentMode: ShareMode.PUBLIC,
-						requestedMode: ShareMode.PRIVATE_LINK
-					};
+			fc.property(fc.constantFrom(ShareMode.PUBLIC, ShareMode.PRIVATE_OAUTH), () => {
+				const ctx: PermissionContext = {
+					isAdmin: false,
+					canUserControl: true,
+					currentMode: ShareMode.PUBLIC,
+					requestedMode: ShareMode.PRIVATE_LINK
+				};
 
-					return isPermissionAllowed(ctx) === false;
-				}
-			),
+				return isPermissionAllowed(ctx) === false;
+			}),
 			{ numRuns: 100 }
 		);
 	});
@@ -416,10 +392,10 @@ describe('Property 17: Permission Enforcement', () => {
 	it('permission enforcement is deterministic', () => {
 		fc.assert(
 			fc.property(
-				fc.boolean(), // isAdmin
-				fc.boolean(), // canUserControl
-				shareModeArbitrary, // currentMode
-				shareModeArbitrary, // requestedMode
+				fc.boolean(),
+				fc.boolean(),
+				shareModeArbitrary,
+				shareModeArbitrary,
 				(isAdmin, canUserControl, currentMode, requestedMode) => {
 					const ctx: PermissionContext = {
 						isAdmin,
@@ -441,7 +417,7 @@ describe('Property 17: Permission Enforcement', () => {
 	it('admin permissions override canUserControl', () => {
 		fc.assert(
 			fc.property(
-				fc.boolean(), // canUserControl
+				fc.boolean(),
 				shareModeArbitrary,
 				shareModeArbitrary,
 				(canUserControl, currentMode, requestedMode) => {
@@ -467,7 +443,7 @@ describe('Property 17: Permission Enforcement', () => {
 					isAdmin: false,
 					canUserControl: false,
 					currentMode,
-					requestedMode: ShareMode.PUBLIC // Any requested mode
+					requestedMode: ShareMode.PUBLIC
 				};
 
 				const denied = !isPermissionAllowed(ctxNoControl);
@@ -503,14 +479,14 @@ describe('Share Token Generation', () => {
 
 	it('validates correct UUID format', () => {
 		expect(isValidTokenFormat('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
-		expect(isValidTokenFormat('550E8400-E29B-41D4-A716-446655440000')).toBe(true); // Case insensitive
+		expect(isValidTokenFormat('550E8400-E29B-41D4-A716-446655440000')).toBe(true);
 	});
 
 	it('rejects invalid UUID formats', () => {
 		expect(isValidTokenFormat('')).toBe(false);
 		expect(isValidTokenFormat('not-a-uuid')).toBe(false);
-		expect(isValidTokenFormat('550e8400-e29b-41d4-a716')).toBe(false); // Too short
-		expect(isValidTokenFormat('550e8400-e29b-51d4-a716-446655440000')).toBe(false); // Wrong version
+		expect(isValidTokenFormat('550e8400-e29b-41d4-a716')).toBe(false);
+		expect(isValidTokenFormat('550e8400-e29b-51d4-a716-446655440000')).toBe(false);
 	});
 });
 

--- a/tests/property/sharing.property.test.ts
+++ b/tests/property/sharing.property.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import * as fc from 'fast-check';
 
-// Import the pure functions for testing
 import { checkAccess } from '$lib/server/sharing/access-control';
 import { generateShareToken, isValidTokenFormat } from '$lib/server/sharing/service';
 import { type AccessCheckContext, ShareMode, type ShareModeType } from '$lib/server/sharing/types';
@@ -15,19 +14,13 @@ import { type AccessCheckContext, ShareMode, type ShareModeType } from '$lib/ser
  * for the sharing system.
  */
 
-// =============================================================================
-// Arbitraries
-// =============================================================================
-
 const shareModeArbitrary: fc.Arbitrary<ShareModeType> = fc.constantFrom(
 	ShareMode.PUBLIC,
 	ShareMode.PRIVATE_OAUTH,
 	ShareMode.PRIVATE_LINK
 );
 
-// =============================================================================
 // Property 15: Share Mode Access Control
-// =============================================================================
 
 // Feature: obzorarr, Property 15: Share Mode Access Control
 describe('Property 15: Share Mode Access Control', () => {
@@ -173,7 +166,6 @@ describe('Property 15: Share Mode Access Control', () => {
 				fc.uuid(), // validToken
 				fc.uuid().filter((t) => t !== ''), // wrongToken
 				(validToken, wrongToken) => {
-					// Skip if tokens happen to match
 					if (validToken === wrongToken) return true;
 
 					const context: AccessCheckContext = {
@@ -214,13 +206,10 @@ describe('Property 15: Share Mode Access Control', () => {
 
 					const result = checkAccess(context);
 
-					// Result must have allowed boolean
 					if (typeof result.allowed !== 'boolean') return false;
 
-					// If allowed, must have reason
 					if (result.allowed && !result.reason) return false;
 
-					// If denied, must have denialReason (unless edge case)
 					if (!result.allowed && !result.denialReason) return false;
 
 					return true;
@@ -231,9 +220,7 @@ describe('Property 15: Share Mode Access Control', () => {
 	});
 });
 
-// =============================================================================
 // Property 16: Share Token Uniqueness
-// =============================================================================
 
 // Feature: obzorarr, Property 16: Share Token Uniqueness
 describe('Property 16: Share Token Uniqueness', () => {
@@ -256,7 +243,6 @@ describe('Property 16: Share Token Uniqueness', () => {
 					for (let i = 0; i < count; i++) {
 						tokens.add(generateShareToken());
 					}
-					// All tokens should be unique
 					return tokens.size === count;
 				}
 			),
@@ -278,7 +264,6 @@ describe('Property 16: Share Token Uniqueness', () => {
 	it('token format validation accepts valid UUID v4 tokens', () => {
 		fc.assert(
 			fc.property(fc.constant(null), () => {
-				// Our generated tokens should always pass validation
 				const token = generateShareToken();
 				return isValidTokenFormat(token);
 			}),
@@ -310,9 +295,7 @@ describe('Property 16: Share Token Uniqueness', () => {
 	});
 });
 
-// =============================================================================
 // Property 17: Permission Enforcement
-// =============================================================================
 
 // Feature: obzorarr, Property 17: Permission Enforcement
 describe('Property 17: Permission Enforcement', () => {
@@ -331,7 +314,6 @@ describe('Property 17: Permission Enforcement', () => {
 	}
 
 	function isPermissionAllowed(ctx: PermissionContext): boolean {
-		// Admins can do anything
 		if (ctx.isAdmin) return true;
 
 		// Users without control permission cannot change anything
@@ -470,7 +452,6 @@ describe('Property 17: Permission Enforcement', () => {
 						requestedMode
 					};
 
-					// Admin should always be allowed, regardless of canUserControl
 					return isPermissionAllowed(ctx) === true;
 				}
 			),
@@ -489,7 +470,6 @@ describe('Property 17: Permission Enforcement', () => {
 					requestedMode: ShareMode.PUBLIC // Any requested mode
 				};
 
-				// User should be denied
 				const denied = !isPermissionAllowed(ctxNoControl);
 
 				// User with control cannot exceed to private-link
@@ -508,10 +488,6 @@ describe('Property 17: Permission Enforcement', () => {
 		);
 	});
 });
-
-// =============================================================================
-// Additional Unit Tests
-// =============================================================================
 
 describe('Share Token Generation', () => {
 	it('generates UUID v4 format tokens', () => {

--- a/tests/property/slides.property.test.ts
+++ b/tests/property/slides.property.test.ts
@@ -40,7 +40,6 @@ const slideTypeArbitrary: fc.Arbitrary<SlideType> = fc.constantFrom(
 	'first-last'
 );
 
-// Generate a shuffled order of all default slides
 const slideOrderArbitrary: fc.Arbitrary<SlideType[]> = fc
 	.shuffledSubarray([...DEFAULT_SLIDE_ORDER] as SlideType[], {
 		minLength: DEFAULT_SLIDE_ORDER.length,
@@ -53,9 +52,6 @@ const slidesToDisableArbitrary: fc.Arbitrary<SlideType[]> = fc.subarray(
 	{ minLength: 1, maxLength: DEFAULT_SLIDE_ORDER.length - 1 }
 );
 
-// Property 19: Slide Order Persistence
-
-// Feature: obzorarr, Property 19: Slide Order Persistence
 describe('Property 19: Slide Order Persistence', () => {
 	beforeEach(async () => {
 		await resetToDefaultConfig();
@@ -64,17 +60,14 @@ describe('Property 19: Slide Order Persistence', () => {
 	it('after save and reload, slide order matches saved order', async () => {
 		await fc.assert(
 			fc.asyncProperty(slideOrderArbitrary, async (newOrder) => {
-				// Save the new order
 				await reorderSlides(newOrder);
 
 				const loadedConfigs = await getAllSlideConfigs();
 
-				// Extract order from loaded configs
 				const loadedOrder = loadedConfigs
 					.sort((a, b) => a.sortOrder - b.sortOrder)
 					.map((c) => c.slideType);
 
-				// Verify order matches
 				if (loadedOrder.length !== newOrder.length) return false;
 
 				for (let i = 0; i < newOrder.length; i++) {
@@ -109,7 +102,6 @@ describe('Property 19: Slide Order Persistence', () => {
 	it('order persistence is idempotent', async () => {
 		await fc.assert(
 			fc.asyncProperty(slideOrderArbitrary, async (newOrder) => {
-				// Save order twice
 				await reorderSlides(newOrder);
 				await reorderSlides(newOrder);
 
@@ -147,9 +139,6 @@ describe('Property 19: Slide Order Persistence', () => {
 	});
 });
 
-// Property 20: Disabled Slide Exclusion
-
-// Feature: obzorarr, Property 20: Disabled Slide Exclusion
 describe('Property 20: Disabled Slide Exclusion', () => {
 	beforeEach(async () => {
 		await resetToDefaultConfig();
@@ -217,7 +206,6 @@ describe('Property 20: Disabled Slide Exclusion', () => {
 	it('disabled slide maintains its sortOrder', async () => {
 		await fc.assert(
 			fc.asyncProperty(slideTypeArbitrary, async (slideType) => {
-				// Get original order
 				const originalConfigs = await getAllSlideConfigs();
 				const original = originalConfigs.find((c) => c.slideType === slideType);
 				if (!original) return false;
@@ -238,7 +226,6 @@ describe('Property 20: Disabled Slide Exclusion', () => {
 	it('enabled slides preserve relative order when some are disabled', async () => {
 		await fc.assert(
 			fc.asyncProperty(slidesToDisableArbitrary, async (slidesToDisable) => {
-				// Get original enabled order
 				const originalEnabled = await getEnabledSlides();
 				const originalOrder = originalEnabled.map((s) => s.slideType);
 
@@ -249,10 +236,8 @@ describe('Property 20: Disabled Slide Exclusion', () => {
 				const newEnabled = await getEnabledSlides();
 				const newOrder = newEnabled.map((s) => s.slideType);
 
-				// Filter original order to exclude disabled slides
 				const expectedOrder = originalOrder.filter((type) => !slidesToDisable.includes(type));
 
-				// Verify order is preserved
 				return (
 					newOrder.length === expectedOrder.length &&
 					newOrder.every((type, i) => type === expectedOrder[i])
@@ -330,7 +315,7 @@ describe('Slide Configuration Service', () => {
 	});
 
 	it('enabled slides are in sorted order', async () => {
-		// Reorder slides - must include ALL slide types to avoid sortOrder collisions
+		// Include every slide type so duplicate sortOrder values cannot mask ordering bugs.
 		const newOrder: SlideType[] = [
 			'binge',
 			'total-time',

--- a/tests/property/slides.property.test.ts
+++ b/tests/property/slides.property.test.ts
@@ -21,10 +21,6 @@ import {
  * for the slide configuration system.
  */
 
-// =============================================================================
-// Arbitraries
-// =============================================================================
-
 const slideTypeArbitrary: fc.Arbitrary<SlideType> = fc.constantFrom(
 	'total-time',
 	'top-movies',
@@ -52,15 +48,12 @@ const slideOrderArbitrary: fc.Arbitrary<SlideType[]> = fc
 	})
 	.map((arr) => arr as SlideType[]);
 
-// Generate a subset of slides to disable
 const slidesToDisableArbitrary: fc.Arbitrary<SlideType[]> = fc.subarray(
 	[...DEFAULT_SLIDE_ORDER] as SlideType[],
 	{ minLength: 1, maxLength: DEFAULT_SLIDE_ORDER.length - 1 }
 );
 
-// =============================================================================
 // Property 19: Slide Order Persistence
-// =============================================================================
 
 // Feature: obzorarr, Property 19: Slide Order Persistence
 describe('Property 19: Slide Order Persistence', () => {
@@ -74,7 +67,6 @@ describe('Property 19: Slide Order Persistence', () => {
 				// Save the new order
 				await reorderSlides(newOrder);
 
-				// Reload from database
 				const loadedConfigs = await getAllSlideConfigs();
 
 				// Extract order from loaded configs
@@ -121,7 +113,6 @@ describe('Property 19: Slide Order Persistence', () => {
 				await reorderSlides(newOrder);
 				await reorderSlides(newOrder);
 
-				// Load and verify
 				const configs = await getAllSlideConfigs();
 				const loadedOrder = [...configs]
 					.sort((a, b) => a.sortOrder - b.sortOrder)
@@ -142,13 +133,10 @@ describe('Property 19: Slide Order Persistence', () => {
 				slideOrderArbitrary,
 				slideTypeArbitrary,
 				async (newOrder, slideToDisable) => {
-					// Disable a specific slide
 					await updateSlideConfig(slideToDisable, { enabled: false });
 
-					// Reorder slides
 					await reorderSlides(newOrder);
 
-					// Verify the disabled slide is still disabled
 					const config = await getSlideConfigByType(slideToDisable);
 
 					return config !== null && config.enabled === false;
@@ -159,9 +147,7 @@ describe('Property 19: Slide Order Persistence', () => {
 	});
 });
 
-// =============================================================================
 // Property 20: Disabled Slide Exclusion
-// =============================================================================
 
 // Feature: obzorarr, Property 20: Disabled Slide Exclusion
 describe('Property 20: Disabled Slide Exclusion', () => {
@@ -172,19 +158,15 @@ describe('Property 20: Disabled Slide Exclusion', () => {
 	it('disabled slides are not included in enabled slides list', async () => {
 		await fc.assert(
 			fc.asyncProperty(slidesToDisableArbitrary, async (slidesToDisable) => {
-				// Reset before each iteration to ensure clean state
 				await resetToDefaultConfig();
 
-				// Disable selected slides
 				for (const slideType of slidesToDisable) {
 					await updateSlideConfig(slideType, { enabled: false });
 				}
 
-				// Get enabled slides
 				const enabledSlides = await getEnabledSlides();
 				const enabledTypes = enabledSlides.map((s) => s.slideType);
 
-				// Verify none of the disabled slides appear
 				for (const disabledType of slidesToDisable) {
 					if (enabledTypes.includes(disabledType)) {
 						return false;
@@ -200,10 +182,8 @@ describe('Property 20: Disabled Slide Exclusion', () => {
 	it('enabled slides count equals total minus disabled count', async () => {
 		await fc.assert(
 			fc.asyncProperty(slidesToDisableArbitrary, async (slidesToDisable) => {
-				// Reset before each iteration to ensure clean state
 				await resetToDefaultConfig();
 
-				// Disable selected slides
 				for (const slideType of slidesToDisable) {
 					await updateSlideConfig(slideType, { enabled: false });
 				}
@@ -222,7 +202,6 @@ describe('Property 20: Disabled Slide Exclusion', () => {
 	it('re-enabling a slide includes it in enabled list', async () => {
 		await fc.assert(
 			fc.asyncProperty(slideTypeArbitrary, async (slideType) => {
-				// Disable then re-enable
 				await updateSlideConfig(slideType, { enabled: false });
 				await updateSlideConfig(slideType, { enabled: true });
 
@@ -245,10 +224,8 @@ describe('Property 20: Disabled Slide Exclusion', () => {
 
 				const originalSortOrder = original.sortOrder;
 
-				// Disable
 				await updateSlideConfig(slideType, { enabled: false });
 
-				// Get updated config
 				const updatedConfigs = await getAllSlideConfigs();
 				const updated = updatedConfigs.find((c) => c.slideType === slideType);
 
@@ -265,12 +242,10 @@ describe('Property 20: Disabled Slide Exclusion', () => {
 				const originalEnabled = await getEnabledSlides();
 				const originalOrder = originalEnabled.map((s) => s.slideType);
 
-				// Disable slides
 				for (const slideType of slidesToDisable) {
 					await updateSlideConfig(slideType, { enabled: false });
 				}
 
-				// Get new enabled slides
 				const newEnabled = await getEnabledSlides();
 				const newOrder = newEnabled.map((s) => s.slideType);
 
@@ -290,24 +265,17 @@ describe('Property 20: Disabled Slide Exclusion', () => {
 	it('toggle correctly switches enabled state', async () => {
 		await fc.assert(
 			fc.asyncProperty(slideTypeArbitrary, async (slideType) => {
-				// Get initial state
 				const initial = await getSlideConfigByType(slideType);
 				if (!initial) return false;
 
-				// Toggle
 				const toggled = await toggleSlide(slideType);
 
-				// Verify state changed
 				return toggled.enabled === !initial.enabled;
 			}),
 			{ numRuns: 100 }
 		);
 	});
 });
-
-// =============================================================================
-// Additional Unit Tests
-// =============================================================================
 
 describe('Slide Configuration Service', () => {
 	beforeEach(async () => {
@@ -383,14 +351,11 @@ describe('Slide Configuration Service', () => {
 		];
 		await reorderSlides(newOrder);
 
-		// Disable some
 		await updateSlideConfig('binge', { enabled: false });
 		await updateSlideConfig('percentile', { enabled: false });
 
-		// Get enabled slides
 		const enabled = await getEnabledSlides();
 
-		// Verify they are in ascending sortOrder
 		for (let i = 1; i < enabled.length; i++) {
 			const prev = enabled[i - 1];
 			const curr = enabled[i];
@@ -415,7 +380,6 @@ describe('Slide Order Edge Cases', () => {
 
 		const afterConfigs = await getAllSlideConfigs();
 
-		// Verify nothing changed
 		for (const before of beforeConfigs) {
 			const after = afterConfigs.find((c) => c.slideType === before.slideType);
 			expect(after?.sortOrder).toBe(before.sortOrder);

--- a/tests/property/stats.property.test.ts
+++ b/tests/property/stats.property.test.ts
@@ -33,11 +33,11 @@ const playHistoryRecordArbitrary: fc.Arbitrary<PlayHistoryRecord> = fc.record({
 	ratingKey: fc.string({ minLength: 1, maxLength: 20 }),
 	title: fc.string({ minLength: 1, maxLength: 200 }),
 	type: fc.constantFrom('movie', 'episode'),
-	viewedAt: fc.integer({ min: 1704067200, max: 1735689599 }), // 2024 year range
+	viewedAt: fc.integer({ min: 1704067200, max: 1735689599 }),
 	accountId: fc.integer({ min: 1, max: 1000 }),
 	librarySectionId: fc.integer({ min: 1, max: 100 }),
 	thumb: fc.option(fc.webUrl(), { nil: null }),
-	duration: fc.option(fc.integer({ min: 0, max: 14400 }), { nil: null }), // Up to 4 hours in seconds
+	duration: fc.option(fc.integer({ min: 0, max: 14400 }), { nil: null }),
 	grandparentTitle: fc.option(fc.string({ minLength: 1, maxLength: 100 }), { nil: null }),
 	grandparentRatingKey: fc.option(fc.string({ minLength: 1, maxLength: 20 }), { nil: null }),
 	grandparentThumb: fc.option(fc.webUrl(), { nil: null }),
@@ -68,17 +68,17 @@ const episodeRecordArbitrary: fc.Arbitrary<PlayHistoryRecord> = fc
 		id: fc.integer({ min: 1, max: 1000000 }),
 		historyKey: fc.uuid(),
 		ratingKey: fc.string({ minLength: 1, maxLength: 20 }),
-		title: fc.string({ minLength: 1, maxLength: 100 }), // Episode title
+		title: fc.string({ minLength: 1, maxLength: 100 }),
 		type: fc.constant('episode' as const),
 		viewedAt: fc.integer({ min: 1704067200, max: 1735689599 }),
 		accountId: fc.integer({ min: 1, max: 1000 }),
 		librarySectionId: fc.integer({ min: 1, max: 100 }),
 		thumb: fc.option(fc.webUrl(), { nil: null }),
 		duration: fc.option(fc.integer({ min: 0, max: 14400 }), { nil: null }),
-		grandparentTitle: fc.string({ minLength: 1, maxLength: 100 }), // Show name
+		grandparentTitle: fc.string({ minLength: 1, maxLength: 100 }),
 		grandparentRatingKey: fc.option(fc.string({ minLength: 1, maxLength: 20 }), { nil: null }),
 		grandparentThumb: fc.option(fc.webUrl(), { nil: null }),
-		parentTitle: fc.option(fc.string({ minLength: 1, maxLength: 50 }), { nil: null }), // Season
+		parentTitle: fc.option(fc.string({ minLength: 1, maxLength: 50 }), { nil: null }),
 		genres: fc.option(
 			fc
 				.array(fc.constantFrom('Action', 'Comedy', 'Drama', 'Sci-Fi', 'Horror'), {
@@ -518,7 +518,7 @@ describe('Property 14: Binge Session Detection', () => {
 			fc.property(
 				fc.integer({ min: 2, max: 10 }),
 				fc.integer({ min: 1704067200, max: 1735000000 }),
-				fc.integer({ min: 60, max: 1800 }), // Duration 1-30 min
+				fc.integer({ min: 60, max: 1800 }),
 				(numRecords, startTime, duration) => {
 					const records: PlayHistoryRecord[] = [];
 					for (let i = 0; i < numRecords; i++) {
@@ -528,7 +528,7 @@ describe('Property 14: Binge Session Detection', () => {
 							ratingKey: `rating-${i}`,
 							title: `Title ${i}`,
 							type: 'movie',
-							viewedAt: startTime + i * 15 * 60, // 15 min gaps
+							viewedAt: startTime + i * 15 * 60,
 							accountId: 1,
 							librarySectionId: 1,
 							thumb: null,

--- a/tests/property/stats.property.test.ts
+++ b/tests/property/stats.property.test.ts
@@ -232,7 +232,6 @@ describe('Property 10: Ranking Correctness', () => {
 					const prev = rankings[i - 1];
 					const curr = rankings[i];
 					if (!prev || !curr) continue;
-					// If counts are equal, titles should be in alphabetical order
 					if (prev.count === curr.count) {
 						if (prev.title.localeCompare(curr.title) > 0) return false;
 					}

--- a/tests/property/stats.property.test.ts
+++ b/tests/property/stats.property.test.ts
@@ -27,13 +27,6 @@ import {
 	getYearStartTimestamp
 } from '$lib/server/stats/utils';
 
-// =============================================================================
-// Arbitraries
-// =============================================================================
-
-/**
- * Generate a valid play history record for testing
- */
 const playHistoryRecordArbitrary: fc.Arbitrary<PlayHistoryRecord> = fc.record({
 	id: fc.integer({ min: 1, max: 1000000 }),
 	historyKey: fc.uuid(),
@@ -61,9 +54,6 @@ const playHistoryRecordArbitrary: fc.Arbitrary<PlayHistoryRecord> = fc.record({
 	releaseYear: fc.option(fc.integer({ min: 1900, max: new Date().getFullYear() }), { nil: null })
 });
 
-/**
- * Generate a movie record specifically
- */
 const movieRecordArbitrary: fc.Arbitrary<PlayHistoryRecord> = playHistoryRecordArbitrary.map(
 	(record) => ({
 		...record,
@@ -73,9 +63,6 @@ const movieRecordArbitrary: fc.Arbitrary<PlayHistoryRecord> = playHistoryRecordA
 	})
 );
 
-/**
- * Generate an episode record specifically
- */
 const episodeRecordArbitrary: fc.Arbitrary<PlayHistoryRecord> = fc
 	.record({
 		id: fc.integer({ min: 1, max: 1000000 }),
@@ -105,9 +92,7 @@ const episodeRecordArbitrary: fc.Arbitrary<PlayHistoryRecord> = fc
 	})
 	.map((record) => record as PlayHistoryRecord);
 
-// =============================================================================
 // Property 8: Year Date Range Filtering
-// =============================================================================
 
 describe('Property 8: Year Date Range Filtering', () => {
 	it('year boundaries are correctly calculated', () => {
@@ -119,7 +104,6 @@ describe('Property 8: Year Date Range Filtering', () => {
 				const startDate = new Date(startTimestamp * 1000);
 				const endDate = new Date(endTimestamp * 1000);
 
-				// Start should be Jan 1 00:00:00
 				const isCorrectStart =
 					startDate.getUTCFullYear() === year &&
 					startDate.getUTCMonth() === 0 &&
@@ -128,7 +112,6 @@ describe('Property 8: Year Date Range Filtering', () => {
 					startDate.getUTCMinutes() === 0 &&
 					startDate.getUTCSeconds() === 0;
 
-				// End should be Dec 31 23:59:59
 				const isCorrectEnd =
 					endDate.getUTCFullYear() === year &&
 					endDate.getUTCMonth() === 11 &&
@@ -160,9 +143,7 @@ describe('Property 8: Year Date Range Filtering', () => {
 	});
 });
 
-// =============================================================================
 // Property 9: Watch Time Aggregation
-// =============================================================================
 
 describe('Property 9: Watch Time Aggregation', () => {
 	it('total watch time equals sum of durations', () => {
@@ -175,7 +156,6 @@ describe('Property 9: Watch Time Aggregation', () => {
 
 					const result = calculateWatchTime(records);
 
-					// Allow for small floating point differences
 					return Math.abs(result.totalWatchTimeMinutes - expectedMinutes) < 0.001;
 				}
 			),
@@ -201,11 +181,9 @@ describe('Property 9: Watch Time Aggregation', () => {
 			fc.property(
 				fc.array(playHistoryRecordArbitrary, { minLength: 1, maxLength: 50 }),
 				(records) => {
-					// Force all durations to null
 					const nullDurationRecords = records.map((r) => ({ ...r, duration: null }));
 					const result = calculateWatchTime(nullDurationRecords);
 
-					// Total time should be 0, but plays should equal record count
 					return result.totalWatchTimeMinutes === 0 && result.totalPlays === records.length;
 				}
 			),
@@ -214,9 +192,7 @@ describe('Property 9: Watch Time Aggregation', () => {
 	});
 });
 
-// =============================================================================
 // Property 10: Ranking Correctness
-// =============================================================================
 
 describe('Property 10: Ranking Correctness', () => {
 	it('movie rankings are ordered by count descending', () => {
@@ -290,9 +266,7 @@ describe('Property 10: Ranking Correctness', () => {
 	});
 });
 
-// =============================================================================
 // Property 11: Monthly Distribution Completeness
-// =============================================================================
 
 describe('Property 11: Monthly Distribution Completeness', () => {
 	it('monthly distribution sum equals total watch time', () => {
@@ -356,9 +330,7 @@ describe('Property 11: Monthly Distribution Completeness', () => {
 	});
 });
 
-// =============================================================================
 // Property 12: Hourly Distribution Completeness
-// =============================================================================
 
 describe('Property 12: Hourly Distribution Completeness', () => {
 	it('hourly distribution sum equals total watch time', () => {
@@ -422,9 +394,7 @@ describe('Property 12: Hourly Distribution Completeness', () => {
 	});
 });
 
-// =============================================================================
 // Property 13: Percentile Calculation
-// =============================================================================
 
 describe('Property 13: Percentile Calculation', () => {
 	it('percentile equals (users with less watch time) / N * 100', () => {
@@ -479,7 +449,6 @@ describe('Property 13: Percentile Calculation', () => {
 					// (everyone except themselves has less)
 					const expected = ((watchTimes.length - 1) / watchTimes.length) * 100;
 
-					// Allow for ties affecting the result
 					return (
 						percentile >= expected - 0.001 ||
 						watchTimes.filter((t) => t === maxWatchTime).length > 1
@@ -491,9 +460,7 @@ describe('Property 13: Percentile Calculation', () => {
 	});
 });
 
-// =============================================================================
 // Property 14: Binge Session Detection
-// =============================================================================
 
 describe('Property 14: Binge Session Detection', () => {
 	it('longest binge has maximum totalMinutes among all sessions', () => {
@@ -510,7 +477,6 @@ describe('Property 14: Binge Session Detection', () => {
 						return longestBinge === null;
 					}
 
-					// Longest binge should have maximum totalMinutes
 					const maxMinutes = Math.max(...allBinges.map((b) => b.totalMinutes));
 					return longestBinge !== null && Math.abs(longestBinge.totalMinutes - maxMinutes) < 0.001;
 				}
@@ -562,14 +528,12 @@ describe('Property 14: Binge Session Detection', () => {
 	});
 
 	it('consecutive plays within threshold form a single session', () => {
-		// Create records with small gaps (all within threshold)
 		fc.assert(
 			fc.property(
 				fc.integer({ min: 2, max: 10 }),
 				fc.integer({ min: 1704067200, max: 1735000000 }),
 				fc.integer({ min: 60, max: 1800 }), // Duration 1-30 min
 				(numRecords, startTime, duration) => {
-					// Create records with 15 minute gaps (within 30 min threshold)
 					const records: PlayHistoryRecord[] = [];
 					for (let i = 0; i < numRecords; i++) {
 						records.push({
@@ -594,7 +558,6 @@ describe('Property 14: Binge Session Detection', () => {
 
 					const sessions = detectAllBingeSessions(records);
 
-					// Should be exactly one session containing all records
 					return sessions.length === 1 && sessions[0]?.plays === numRecords;
 				}
 			),
@@ -603,7 +566,6 @@ describe('Property 14: Binge Session Detection', () => {
 	});
 
 	it('large gaps create separate sessions', () => {
-		// Create two groups of records with a large gap between them
 		const records: PlayHistoryRecord[] = [
 			{
 				id: 1,
@@ -645,14 +607,9 @@ describe('Property 14: Binge Session Detection', () => {
 
 		const sessions = detectAllBingeSessions(records);
 
-		// Should be two separate sessions
 		expect(sessions.length).toBe(2);
 	});
 });
-
-// =============================================================================
-// Edge Cases
-// =============================================================================
 
 describe('Edge Cases', () => {
 	it('handles empty arrays for all calculators', () => {

--- a/tests/property/stats.property.test.ts
+++ b/tests/property/stats.property.test.ts
@@ -92,8 +92,6 @@ const episodeRecordArbitrary: fc.Arbitrary<PlayHistoryRecord> = fc
 	})
 	.map((record) => record as PlayHistoryRecord);
 
-// Property 8: Year Date Range Filtering
-
 describe('Property 8: Year Date Range Filtering', () => {
 	it('year boundaries are correctly calculated', () => {
 		fc.assert(
@@ -143,8 +141,6 @@ describe('Property 8: Year Date Range Filtering', () => {
 	});
 });
 
-// Property 9: Watch Time Aggregation
-
 describe('Property 9: Watch Time Aggregation', () => {
 	it('total watch time equals sum of durations', () => {
 		fc.assert(
@@ -191,8 +187,6 @@ describe('Property 9: Watch Time Aggregation', () => {
 		);
 	});
 });
-
-// Property 10: Ranking Correctness
 
 describe('Property 10: Ranking Correctness', () => {
 	it('movie rankings are ordered by count descending', () => {
@@ -266,8 +260,6 @@ describe('Property 10: Ranking Correctness', () => {
 	});
 });
 
-// Property 11: Monthly Distribution Completeness
-
 describe('Property 11: Monthly Distribution Completeness', () => {
 	it('monthly distribution sum equals total watch time', () => {
 		fc.assert(
@@ -330,8 +322,6 @@ describe('Property 11: Monthly Distribution Completeness', () => {
 	});
 });
 
-// Property 12: Hourly Distribution Completeness
-
 describe('Property 12: Hourly Distribution Completeness', () => {
 	it('hourly distribution sum equals total watch time', () => {
 		fc.assert(
@@ -393,8 +383,6 @@ describe('Property 12: Hourly Distribution Completeness', () => {
 		);
 	});
 });
-
-// Property 13: Percentile Calculation
 
 describe('Property 13: Percentile Calculation', () => {
 	it('percentile equals (users with less watch time) / N * 100', () => {
@@ -459,8 +447,6 @@ describe('Property 13: Percentile Calculation', () => {
 		);
 	});
 });
-
-// Property 14: Binge Session Detection
 
 describe('Property 14: Binge Session Detection', () => {
 	it('longest binge has maximum totalMinutes among all sessions', () => {

--- a/tests/property/sync.property.test.ts
+++ b/tests/property/sync.property.test.ts
@@ -121,6 +121,8 @@ function mapPlexRecordToDbInsert(record: TestPlexRecord) {
 		accountId: record.accountID,
 		librarySectionId: parseInt(record.librarySectionID, 10),
 		thumb: record.thumb ?? null,
+		// Mirror sync.service's seconds contract so the properties fail if Plex
+		// millisecond durations ever drift into persisted watch-time inputs.
 		duration: record.duration !== undefined ? Math.floor(record.duration / 1000) : null,
 		grandparentTitle: record.grandparentTitle ?? null,
 		parentTitle: record.parentTitle ?? null

--- a/tests/property/sync.property.test.ts
+++ b/tests/property/sync.property.test.ts
@@ -32,21 +32,15 @@ function getYearStartTimestamp(year: number): number {
  * Validates: Requirements 2.3, 2.4, 2.5
  */
 
-// =============================================================================
-// Test Database Setup
-// =============================================================================
-
 /**
  * Create an in-memory test database with schema
  */
 function createTestDatabase() {
 	const sqlite = new Database(':memory:', { strict: true });
 
-	// Enable WAL mode and foreign keys
 	sqlite.exec('PRAGMA journal_mode = WAL');
 	sqlite.exec('PRAGMA foreign_keys = ON');
 
-	// Create tables
 	sqlite.exec(`
 		CREATE TABLE IF NOT EXISTS play_history (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -83,13 +77,6 @@ function createTestDatabase() {
 	return drizzle(sqlite, { schema });
 }
 
-// =============================================================================
-// Test Types
-// =============================================================================
-
-/**
- * Test record type matching the generated arbitrary
- */
 interface TestPlexRecord {
 	historyKey: string;
 	ratingKey: string;
@@ -104,10 +91,6 @@ interface TestPlexRecord {
 	parentTitle: string | undefined;
 }
 
-// =============================================================================
-// Arbitraries
-// =============================================================================
-
 /**
  * Arbitrary for generating valid Plex history metadata
  */
@@ -118,7 +101,6 @@ const plexHistoryArbitrary: fc.Arbitrary<TestPlexRecord> = fc.record({
 	type: fc.constantFrom('movie', 'episode', 'track') as fc.Arbitrary<'movie' | 'episode' | 'track'>,
 	viewedAt: fc.integer({ min: 1577836800, max: 1893456000 }), // 2020-01-01 to 2030-01-01
 	accountID: fc.integer({ min: 1, max: 1000000 }),
-	// Generate numeric string for librarySectionID
 	librarySectionID: fc.integer({ min: 1, max: 99999 }).map((n) => String(n)),
 	thumb: fc.option(fc.webUrl(), { nil: undefined }),
 	duration: fc.option(fc.integer({ min: 0, max: 10000000 }), { nil: undefined }),
@@ -132,16 +114,11 @@ const plexHistoryArbitrary: fc.Arbitrary<TestPlexRecord> = fc.record({
 const uniquePlexHistoryArrayArbitrary = fc
 	.array(plexHistoryArbitrary, { minLength: 1, maxLength: 50 })
 	.map((records) => {
-		// Ensure unique historyKeys by appending index
 		return records.map((record, index) => ({
 			...record,
 			historyKey: `${record.historyKey}-${index}-${Date.now()}`
 		}));
 	});
-
-// =============================================================================
-// Helper Functions
-// =============================================================================
 
 /**
  * Convert Plex record to database insert format
@@ -171,17 +148,14 @@ async function insertRecordsAndCreateSync(
 ): Promise<{ syncId: number; maxViewedAt: number; insertedCount: number }> {
 	const dbRecords = records.map(mapPlexRecordToDbInsert);
 
-	// Insert all records
 	const insertResult = await db
 		.insert(schema.playHistory)
 		.values(dbRecords)
 		.onConflictDoNothing({ target: schema.playHistory.historyKey })
 		.returning({ id: schema.playHistory.id });
 
-	// Calculate max viewedAt
 	const maxViewedAt = Math.max(...records.map((r) => r.viewedAt));
 
-	// Create sync status record
 	const syncResult = await db
 		.insert(schema.syncStatus)
 		.values({
@@ -205,9 +179,7 @@ async function insertRecordsAndCreateSync(
 	};
 }
 
-// =============================================================================
 // Property 5: History Record Field Completeness
-// =============================================================================
 
 // Feature: obzorarr, Property 5: History Record Field Completeness
 describe('Property 5: History Record Field Completeness', () => {
@@ -216,19 +188,15 @@ describe('Property 5: History Record Field Completeness', () => {
 			fc.asyncProperty(uniquePlexHistoryArrayArbitrary, async (records) => {
 				const db = createTestDatabase();
 
-				// Insert records
 				const dbRecords = records.map(mapPlexRecordToDbInsert);
 				await db
 					.insert(schema.playHistory)
 					.values(dbRecords)
 					.onConflictDoNothing({ target: schema.playHistory.historyKey });
 
-				// Query back all records
 				const storedRecords = await db.select().from(schema.playHistory);
 
-				// Verify all required fields are present and non-null
 				for (const stored of storedRecords) {
-					// Required fields must be defined and non-null
 					expect(stored.historyKey).toBeDefined();
 					expect(stored.historyKey).not.toBeNull();
 					expect(stored.ratingKey).toBeDefined();
@@ -244,7 +212,6 @@ describe('Property 5: History Record Field Completeness', () => {
 					expect(stored.librarySectionId).toBeDefined();
 					expect(stored.librarySectionId).not.toBeNull();
 
-					// Type checks
 					expect(typeof stored.historyKey).toBe('string');
 					expect(typeof stored.ratingKey).toBe('string');
 					expect(typeof stored.title).toBe('string');
@@ -265,17 +232,14 @@ describe('Property 5: History Record Field Completeness', () => {
 			fc.asyncProperty(uniquePlexHistoryArrayArbitrary, async (records) => {
 				const db = createTestDatabase();
 
-				// Insert records
 				const dbRecords = records.map(mapPlexRecordToDbInsert);
 				await db
 					.insert(schema.playHistory)
 					.values(dbRecords)
 					.onConflictDoNothing({ target: schema.playHistory.historyKey });
 
-				// Query back all records
 				const storedRecords = await db.select().from(schema.playHistory);
 
-				// Check for unique historyKeys
 				const historyKeys = storedRecords.map((r) => r.historyKey);
 				const uniqueKeys = new Set(historyKeys);
 
@@ -290,17 +254,14 @@ describe('Property 5: History Record Field Completeness', () => {
 			fc.asyncProperty(uniquePlexHistoryArrayArbitrary, async (records) => {
 				const db = createTestDatabase();
 
-				// Insert records
 				const dbRecords = records.map(mapPlexRecordToDbInsert);
 				await db
 					.insert(schema.playHistory)
 					.values(dbRecords)
 					.onConflictDoNothing({ target: schema.playHistory.historyKey });
 
-				// Query back all records
 				const storedRecords = await db.select().from(schema.playHistory);
 
-				// All types should be valid
 				const validTypes = ['movie', 'episode', 'track'];
 				for (const stored of storedRecords) {
 					expect(validTypes).toContain(stored.type);
@@ -313,9 +274,7 @@ describe('Property 5: History Record Field Completeness', () => {
 	});
 });
 
-// =============================================================================
 // Property 6: Sync Timestamp Tracking
-// =============================================================================
 
 // Feature: obzorarr, Property 6: Sync Timestamp Tracking
 describe('Property 6: Sync Timestamp Tracking', () => {
@@ -324,10 +283,8 @@ describe('Property 6: Sync Timestamp Tracking', () => {
 			fc.asyncProperty(uniquePlexHistoryArrayArbitrary, async (records) => {
 				const db = createTestDatabase();
 
-				// Insert records and create sync
 				const { syncId, maxViewedAt } = await insertRecordsAndCreateSync(db, records);
 
-				// Query the sync status
 				const syncResult = await db
 					.select()
 					.from(schema.syncStatus)
@@ -338,7 +295,6 @@ describe('Property 6: Sync Timestamp Tracking', () => {
 				expect(sync).toBeDefined();
 				expect(sync?.lastViewedAt).toBe(maxViewedAt);
 
-				// Calculate expected max from records
 				const expectedMax = Math.max(...records.map((r) => r.viewedAt));
 				expect(sync?.lastViewedAt).toBe(expectedMax);
 
@@ -353,7 +309,6 @@ describe('Property 6: Sync Timestamp Tracking', () => {
 			fc.asyncProperty(uniquePlexHistoryArrayArbitrary, async (records) => {
 				const db = createTestDatabase();
 
-				// Insert records and create sync
 				const { maxViewedAt } = await insertRecordsAndCreateSync(db, records);
 
 				// Verify it's a valid Unix timestamp (2020-01-01 to 2030-01-01)
@@ -384,10 +339,8 @@ describe('Property 6: Sync Timestamp Tracking', () => {
 				async (records) => {
 					const db = createTestDatabase();
 
-					// Calculate expected max viewedAt
 					const expectedMaxViewedAt = Math.max(...records.map((r) => r.viewedAt));
 
-					// Insert sync with this max
 					const syncResult = await db
 						.insert(schema.syncStatus)
 						.values({
@@ -408,9 +361,7 @@ describe('Property 6: Sync Timestamp Tracking', () => {
 	});
 });
 
-// =============================================================================
 // Property 7: Incremental Sync Filtering
-// =============================================================================
 
 // Feature: obzorarr, Property 7: Incremental Sync Filtering
 describe('Property 7: Incremental Sync Filtering', () => {
@@ -422,7 +373,6 @@ describe('Property 7: Incremental Sync Filtering', () => {
 						fc.record({
 							recordsProcessed: fc.integer({ min: 0, max: 10000 }),
 							lastViewedAt: fc.integer({ min: 1600000000, max: 1700000000 }),
-							// Use integer seconds to ensure distinct timestamps
 							completedAtSeconds: fc.integer({
 								min: Math.floor(new Date('2020-01-01').getTime() / 1000),
 								max: Math.floor(new Date('2025-01-01').getTime() / 1000)
@@ -430,7 +380,6 @@ describe('Property 7: Incremental Sync Filtering', () => {
 						}),
 						{ minLength: 2, maxLength: 10 }
 					)
-					// Ensure unique completedAtSeconds values
 					.map((syncs) => {
 						const seen = new Set<number>();
 						return syncs.filter((s) => {
@@ -439,12 +388,10 @@ describe('Property 7: Incremental Sync Filtering', () => {
 							return true;
 						});
 					})
-					// Filter out empty arrays after deduplication
 					.filter((syncs) => syncs.length >= 2),
 				async (syncs) => {
 					const db = createTestDatabase();
 
-					// Insert multiple completed syncs
 					for (const sync of syncs) {
 						const completedAt = new Date(sync.completedAtSeconds * 1000);
 						await db.insert(schema.syncStatus).values({
@@ -456,7 +403,6 @@ describe('Property 7: Incremental Sync Filtering', () => {
 						});
 					}
 
-					// Query the most recent completed sync
 					const result = await db
 						.select()
 						.from(schema.syncStatus)
@@ -467,14 +413,12 @@ describe('Property 7: Incremental Sync Filtering', () => {
 					const mostRecent = result[0];
 					if (!mostRecent) return false;
 
-					// Find expected most recent from our data
 					const sortedSyncs = [...syncs].sort(
 						(a, b) => b.completedAtSeconds - a.completedAtSeconds
 					);
 					const expected = sortedSyncs[0];
 					if (!expected) return false;
 
-					// The most recent sync should have the expected lastViewedAt
 					return mostRecent.lastViewedAt === expected.lastViewedAt;
 				}
 			),
@@ -483,8 +427,8 @@ describe('Property 7: Incremental Sync Filtering', () => {
 	});
 
 	it('incremental sync should use lastViewedAt from previous sync as minViewedAt filter', async () => {
-		// This test verifies the logic that the sync service uses
-		// by simulating what would happen during incremental sync
+		// The sync service applies this indirectly; model the incremental filter so
+		// the stored watermark cannot regress between sync runs.
 		await fc.assert(
 			fc.asyncProperty(
 				fc.integer({ min: 1600000000, max: 1700000000 }), // firstSyncLastViewedAt
@@ -492,7 +436,6 @@ describe('Property 7: Incremental Sync Filtering', () => {
 				async (firstSyncLastViewedAt, _offset) => {
 					const db = createTestDatabase();
 
-					// Create first sync with known lastViewedAt
 					await db.insert(schema.syncStatus).values({
 						startedAt: new Date(),
 						completedAt: new Date(),
@@ -529,7 +472,6 @@ describe('Property 7: Incremental Sync Filtering', () => {
 				async (status: string) => {
 					const db = createTestDatabase();
 
-					// Create a sync with the given status
 					await db.insert(schema.syncStatus).values({
 						startedAt: new Date(),
 						completedAt: status !== 'running' ? new Date() : null,
@@ -537,7 +479,6 @@ describe('Property 7: Incremental Sync Filtering', () => {
 						status
 					});
 
-					// Check if running sync is detected
 					const runningResult = await db
 						.select()
 						.from(schema.syncStatus)
@@ -554,10 +495,6 @@ describe('Property 7: Incremental Sync Filtering', () => {
 		);
 	});
 });
-
-// =============================================================================
-// Unit Tests for Helper Functions
-// =============================================================================
 
 describe('getYearStartTimestamp', () => {
 	it('returns correct timestamp for Jan 1 00:00:00 UTC', () => {
@@ -625,7 +562,6 @@ describe('Duplicate historyKey handling', () => {
 			parentTitle: null
 		};
 
-		// Insert first time
 		const result1 = await db
 			.insert(schema.playHistory)
 			.values(record)
@@ -634,7 +570,6 @@ describe('Duplicate historyKey handling', () => {
 
 		expect(result1.length).toBe(1);
 
-		// Insert same record again - should be skipped
 		const result2 = await db
 			.insert(schema.playHistory)
 			.values(record)
@@ -643,7 +578,6 @@ describe('Duplicate historyKey handling', () => {
 
 		expect(result2.length).toBe(0);
 
-		// Verify only one record exists
 		const allRecords = await db.select().from(schema.playHistory);
 		expect(allRecords.length).toBe(1);
 	});

--- a/tests/property/sync.property.test.ts
+++ b/tests/property/sync.property.test.ts
@@ -93,7 +93,7 @@ const plexHistoryArbitrary: fc.Arbitrary<TestPlexRecord> = fc.record({
 	ratingKey: fc.string({ minLength: 1, maxLength: 50 }),
 	title: fc.string({ minLength: 1, maxLength: 200 }),
 	type: fc.constantFrom('movie', 'episode', 'track') as fc.Arbitrary<'movie' | 'episode' | 'track'>,
-	viewedAt: fc.integer({ min: 1577836800, max: 1893456000 }), // 2020-01-01 to 2030-01-01
+	viewedAt: fc.integer({ min: 1577836800, max: 1893456000 }),
 	accountID: fc.integer({ min: 1, max: 1000000 }),
 	librarySectionID: fc.integer({ min: 1, max: 99999 }).map((n) => String(n)),
 	thumb: fc.option(fc.webUrl(), { nil: undefined }),
@@ -290,7 +290,6 @@ describe('Property 6: Sync Timestamp Tracking', () => {
 
 				const { maxViewedAt } = await insertRecordsAndCreateSync(db, records);
 
-				// Verify it's a valid Unix timestamp (2020-01-01 to 2030-01-01)
 				expect(maxViewedAt).toBeGreaterThanOrEqual(1577836800);
 				expect(maxViewedAt).toBeLessThanOrEqual(1893456000);
 
@@ -371,7 +370,7 @@ describe('Property 7: Incremental Sync Filtering', () => {
 					for (const sync of syncs) {
 						const completedAt = new Date(sync.completedAtSeconds * 1000);
 						await db.insert(schema.syncStatus).values({
-							startedAt: new Date(completedAt.getTime() - 60000), // 1 minute before
+							startedAt: new Date(completedAt.getTime() - 60000),
 							completedAt,
 							recordsProcessed: sync.recordsProcessed,
 							lastViewedAt: sync.lastViewedAt,
@@ -407,8 +406,8 @@ describe('Property 7: Incremental Sync Filtering', () => {
 		// the stored watermark cannot regress between sync runs.
 		await fc.assert(
 			fc.asyncProperty(
-				fc.integer({ min: 1600000000, max: 1700000000 }), // firstSyncLastViewedAt
-				fc.integer({ min: 0, max: 100000 }), // offset to add for new records
+				fc.integer({ min: 1600000000, max: 1700000000 }),
+				fc.integer({ min: 0, max: 100000 }),
 				async (firstSyncLastViewedAt, _offset) => {
 					const db = createTestDatabase();
 
@@ -420,7 +419,6 @@ describe('Property 7: Incremental Sync Filtering', () => {
 						status: 'completed'
 					});
 
-					// Query last successful sync (simulating what sync service does)
 					const lastSync = await db
 						.select()
 						.from(schema.syncStatus)
@@ -431,7 +429,6 @@ describe('Property 7: Incremental Sync Filtering', () => {
 					const previous = lastSync[0];
 					if (!previous) return false;
 
-					// The minViewedAt for next sync should be the lastViewedAt from previous
 					const minViewedAtForNextSync = previous.lastViewedAt;
 
 					return minViewedAtForNextSync === firstSyncLastViewedAt;
@@ -463,7 +460,6 @@ describe('Property 7: Incremental Sync Filtering', () => {
 
 					const isRunning = runningResult.length > 0;
 
-					// Should only be running if status is 'running'
 					return isRunning === (status === 'running');
 				}
 			),
@@ -474,7 +470,6 @@ describe('Property 7: Incremental Sync Filtering', () => {
 
 describe('getYearStartTimestamp', () => {
 	it('returns correct timestamp for Jan 1 00:00:00 UTC', () => {
-		// 2024-01-01 00:00:00 UTC
 		const ts2024 = getYearStartTimestamp(2024);
 		const date2024 = new Date(ts2024 * 1000);
 		expect(date2024.getUTCFullYear()).toBe(2024);

--- a/tests/property/sync.property.test.ts
+++ b/tests/property/sync.property.test.ts
@@ -179,9 +179,6 @@ async function insertRecordsAndCreateSync(
 	};
 }
 
-// Property 5: History Record Field Completeness
-
-// Feature: obzorarr, Property 5: History Record Field Completeness
 describe('Property 5: History Record Field Completeness', () => {
 	it('all stored records contain required fields: historyKey, ratingKey, title, type, viewedAt, accountId, librarySectionId', async () => {
 		await fc.assert(
@@ -274,9 +271,6 @@ describe('Property 5: History Record Field Completeness', () => {
 	});
 });
 
-// Property 6: Sync Timestamp Tracking
-
-// Feature: obzorarr, Property 6: Sync Timestamp Tracking
 describe('Property 6: Sync Timestamp Tracking', () => {
 	it('completed sync lastViewedAt equals maximum viewedAt from synced records', async () => {
 		await fc.assert(
@@ -361,9 +355,6 @@ describe('Property 6: Sync Timestamp Tracking', () => {
 	});
 });
 
-// Property 7: Incremental Sync Filtering
-
-// Feature: obzorarr, Property 7: Incremental Sync Filtering
 describe('Property 7: Incremental Sync Filtering', () => {
 	it('getLastSuccessfulSync returns the most recent completed sync', async () => {
 		await fc.assert(

--- a/tests/property/sync.property.test.ts
+++ b/tests/property/sync.property.test.ts
@@ -32,9 +32,6 @@ function getYearStartTimestamp(year: number): number {
  * Validates: Requirements 2.3, 2.4, 2.5
  */
 
-/**
- * Create an in-memory test database with schema
- */
 function createTestDatabase() {
 	const sqlite = new Database(':memory:', { strict: true });
 
@@ -91,9 +88,6 @@ interface TestPlexRecord {
 	parentTitle: string | undefined;
 }
 
-/**
- * Arbitrary for generating valid Plex history metadata
- */
 const plexHistoryArbitrary: fc.Arbitrary<TestPlexRecord> = fc.record({
 	historyKey: fc.string({ minLength: 1, maxLength: 50 }),
 	ratingKey: fc.string({ minLength: 1, maxLength: 50 }),
@@ -108,9 +102,6 @@ const plexHistoryArbitrary: fc.Arbitrary<TestPlexRecord> = fc.record({
 	parentTitle: fc.option(fc.string({ minLength: 0, maxLength: 100 }), { nil: undefined })
 });
 
-/**
- * Arbitrary for generating unique Plex history records (unique historyKeys)
- */
 const uniquePlexHistoryArrayArbitrary = fc
 	.array(plexHistoryArbitrary, { minLength: 1, maxLength: 50 })
 	.map((records) => {
@@ -120,9 +111,6 @@ const uniquePlexHistoryArrayArbitrary = fc
 		}));
 	});
 
-/**
- * Convert Plex record to database insert format
- */
 function mapPlexRecordToDbInsert(record: TestPlexRecord) {
 	return {
 		historyKey: record.historyKey,
@@ -139,9 +127,6 @@ function mapPlexRecordToDbInsert(record: TestPlexRecord) {
 	};
 }
 
-/**
- * Insert records and create sync status, returning the max viewedAt
- */
 async function insertRecordsAndCreateSync(
 	db: ReturnType<typeof createTestDatabase>,
 	records: TestPlexRecord[]

--- a/tests/property/sync.property.test.ts
+++ b/tests/property/sync.property.test.ts
@@ -478,7 +478,7 @@ describe('getYearStartTimestamp', () => {
 		const ts2024 = getYearStartTimestamp(2024);
 		const date2024 = new Date(ts2024 * 1000);
 		expect(date2024.getUTCFullYear()).toBe(2024);
-		expect(date2024.getUTCMonth()).toBe(0); // January
+		expect(date2024.getUTCMonth()).toBe(0);
 		expect(date2024.getUTCDate()).toBe(1);
 		expect(date2024.getUTCHours()).toBe(0);
 		expect(date2024.getUTCMinutes()).toBe(0);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,14 +1,6 @@
-/**
- * Test setup file for Obzorarr
- *
- * This file is preloaded before all tests run.
- * Use it for global test configuration, mocks, and utilities.
- */
-
 import { mock } from 'bun:test';
 import { testToast } from './helpers/toast';
 
-// Ensure tests run in a clean environment
 process.env.NODE_ENV = 'test';
 
 // Set a test database path to avoid conflicts with development database
@@ -53,7 +45,6 @@ mock.module('$lib/services/toast', () => ({
 // Using dynamic import ensures the environment is properly configured first.
 const { sqlite } = await import('$lib/server/db/client');
 
-// Create all necessary tables for testing
 sqlite.exec(`
 	-- Users table
 	CREATE TABLE IF NOT EXISTS users (

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,10 +3,9 @@ import { testToast } from './helpers/toast';
 
 process.env.NODE_ENV = 'test';
 
-// Set a test database path to avoid conflicts with development database
+// Tests must never touch the development SQLite file.
 process.env.DATABASE_PATH = ':memory:';
 
-// Mock SvelteKit's $env/dynamic/private module for tests
 mock.module('$env/dynamic/private', () => ({
 	env: {
 		PLEX_SERVER_URL: 'https://test-plex-server:32400',
@@ -18,7 +17,6 @@ mock.module('$env/dynamic/private', () => ({
 	}
 }));
 
-// Mock SvelteKit's $env/static/private module for tests
 mock.module('$env/static/private', () => ({
 	PLEX_SERVER_URL: 'https://test-plex-server:32400',
 	PLEX_TOKEN: 'test-plex-token'
@@ -39,10 +37,7 @@ mock.module('$lib/services/toast', () => ({
 	toast: testToast
 }));
 
-// Import database client DYNAMICALLY after setting environment variables
-// NOTE: Static imports are hoisted and execute BEFORE the code above,
-// which would cause the db client to read DATABASE_PATH before we set it.
-// Using dynamic import ensures the environment is properly configured first.
+// Static imports would let the DB client read DATABASE_PATH before the test override.
 const { sqlite } = await import('$lib/server/db/client');
 
 sqlite.exec(`

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -41,7 +41,6 @@ mock.module('$lib/services/toast', () => ({
 const { sqlite } = await import('$lib/server/db/client');
 
 sqlite.exec(`
-	-- Users table
 	CREATE TABLE IF NOT EXISTS users (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		plex_id INTEGER UNIQUE NOT NULL,
@@ -53,7 +52,6 @@ sqlite.exec(`
 		created_at INTEGER
 	);
 
-	-- Play history table
 	CREATE TABLE IF NOT EXISTS play_history (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		history_key TEXT UNIQUE NOT NULL,
@@ -73,7 +71,6 @@ sqlite.exec(`
 		release_year INTEGER
 	);
 
-	-- Sync status table
 	CREATE TABLE IF NOT EXISTS sync_status (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		started_at INTEGER NOT NULL,
@@ -84,7 +81,6 @@ sqlite.exec(`
 		error TEXT
 	);
 
-	-- Cached stats table
 	CREATE TABLE IF NOT EXISTS cached_stats (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		user_id INTEGER,
@@ -94,7 +90,6 @@ sqlite.exec(`
 		calculated_at INTEGER
 	);
 
-	-- Share settings table
 	CREATE TABLE IF NOT EXISTS share_settings (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		user_id INTEGER NOT NULL,
@@ -106,7 +101,6 @@ sqlite.exec(`
 		show_logo INTEGER
 	);
 
-	-- Custom slides table
 	CREATE TABLE IF NOT EXISTS custom_slides (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		title TEXT NOT NULL,
@@ -116,7 +110,6 @@ sqlite.exec(`
 		year INTEGER
 	);
 
-	-- Slide configuration table
 	CREATE TABLE IF NOT EXISTS slide_config (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		slide_type TEXT NOT NULL,
@@ -124,14 +117,12 @@ sqlite.exec(`
 		sort_order INTEGER NOT NULL
 	);
 
-	-- App settings table
 	CREATE TABLE IF NOT EXISTS app_settings (
 		key TEXT PRIMARY KEY,
 		value TEXT NOT NULL,
 		updated_at INTEGER NOT NULL DEFAULT (cast((julianday('now') - 2440587.5)*86400000 as integer))
 	);
 
-	-- Sessions table
 	CREATE TABLE IF NOT EXISTS sessions (
 		id TEXT PRIMARY KEY,
 		user_id INTEGER NOT NULL,
@@ -140,7 +131,6 @@ sqlite.exec(`
 		expires_at INTEGER NOT NULL
 	);
 
-	-- PIN transactions table
 	CREATE TABLE IF NOT EXISTS pin_transactions (
 		state TEXT PRIMARY KEY NOT NULL,
 		pin_id INTEGER NOT NULL,
@@ -151,7 +141,6 @@ sqlite.exec(`
 	CREATE INDEX IF NOT EXISTS idx_pin_transactions_expires_at
 		ON pin_transactions (expires_at);
 
-	-- Logs table
 	CREATE TABLE IF NOT EXISTS logs (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		level TEXT NOT NULL,
@@ -161,7 +150,6 @@ sqlite.exec(`
 		timestamp INTEGER NOT NULL
 	);
 
-	-- Metadata cache table
 	CREATE TABLE IF NOT EXISTS metadata_cache (
 		rating_key TEXT PRIMARY KEY,
 		duration INTEGER,
@@ -171,7 +159,6 @@ sqlite.exec(`
 		fetch_failed INTEGER DEFAULT 0
 	);
 
-	-- Plex accounts table
 	CREATE TABLE IF NOT EXISTS plex_accounts (
 		account_id INTEGER PRIMARY KEY,
 		plex_id INTEGER NOT NULL,

--- a/tests/unit/admin/appearance-actions.test.ts
+++ b/tests/unit/admin/appearance-actions.test.ts
@@ -145,7 +145,7 @@ describe('appearance nested route — updateUITheme', () => {
 		// toast — onUpdated branches on form.valid). Pin valid===false + the message.
 		expect(result.data.form.valid).toBe(false);
 		expect(result.data.form.message).toBe('Invalid theme selection');
-		expect(await getUITheme()).toBe('modern-minimal'); // unchanged DB default, not a persisted write
+		expect(await getUITheme()).toBe('modern-minimal');
 	});
 });
 
@@ -226,7 +226,7 @@ describe('appearance nested route — updateWrappedTheme', () => {
 		// failure instead of a false 'Saved'.
 		expect(result.data.form.valid).toBe(false);
 		expect(result.data.form.message).toBe('Invalid theme selection');
-		expect(await getWrappedTheme()).toBe('modern-minimal'); // unchanged DB default, not a persisted write
+		expect(await getWrappedTheme()).toBe('modern-minimal');
 	});
 });
 
@@ -314,6 +314,6 @@ describe('appearance nested route — updateWrappedLogoMode', () => {
 		// failure instead of a false 'Saved'.
 		expect(result.data.form.valid).toBe(false);
 		expect(result.data.form.message).toBe('Invalid logo mode');
-		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.ALWAYS_SHOW); // unchanged DB default
+		expect(await getWrappedLogoMode()).toBe(WrappedLogoMode.ALWAYS_SHOW);
 	});
 });

--- a/tests/unit/admin/connections-actions.test.ts
+++ b/tests/unit/admin/connections-actions.test.ts
@@ -323,11 +323,9 @@ describe('connections nested route — updateApiConfig (OCC + schema)', () => {
 			const result = await run(request);
 			// The result must be a success object (not a failure ActionResult).
 			expect(result).toMatchObject({ success: true });
-			// It must carry a fresh apiConfigVersion string.
 			const version = (result as { apiConfigVersion?: string }).apiConfigVersion;
 			expect(typeof version).toBe('string');
 			expect(version!.length).toBeGreaterThan(0);
-			// The returned version must be parseable as an ISO date.
 			expect(Number.isNaN(Date.parse(version!))).toBe(false);
 		});
 	});
@@ -335,7 +333,6 @@ describe('connections nested route — updateApiConfig (OCC + schema)', () => {
 	// C2: submitting a value for a locked field yields the informational note
 	it('includes locked-field note in success message when a locked field is submitted (C2)', async () => {
 		// The test harness has PLEX_SERVER_URL locked via the mock env.
-		// Submit plexServerUrl (the locked field) alongside a valid apiConfigVersion.
 		// The action should succeed (setApiConfigAtomic ignores locked fields) and
 		// include the informational note in the message.
 		const result = await run(

--- a/tests/unit/admin/connections-actions.test.ts
+++ b/tests/unit/admin/connections-actions.test.ts
@@ -260,7 +260,6 @@ describe('connections nested route — updateApiConfig (OCC + schema)', () => {
 		}
 	});
 
-	// H5: bad openaiBaseUrl returns fieldErrors.openaiBaseUrl (not just a generic error)
 	it('returns fieldErrors.openaiBaseUrl for an invalid base URL (H5)', async () => {
 		const result = await run(
 			makeRequest('updateApiConfig', {

--- a/tests/unit/admin/connections-actions.test.ts
+++ b/tests/unit/admin/connections-actions.test.ts
@@ -63,7 +63,7 @@ describe('connections nested route — updateApiConfig (OCC + schema)', () => {
 		const formData = new FormData();
 		formData.set('plexServerUrl', 'http://plex.local:32400');
 		formData.set('plexToken', 'token');
-		// apiConfigVersion intentionally absent
+		// Omitted on purpose; blank and absent versions must both enter the OCC path.
 		const request = new Request('http://localhost/admin/settings/connections?/updateApiConfig', {
 			method: 'POST',
 			body: formData
@@ -202,16 +202,13 @@ describe('connections nested route — updateApiConfig (OCC + schema)', () => {
 			const formData = new FormData();
 			formData.set('openaiModel', 'gpt-4o-mini');
 			formData.set('apiConfigVersion', new Date(Date.now() + 60_000).toISOString());
-			// plexServerUrl intentionally absent
 			const request = new Request('http://localhost/admin/settings/connections?/updateApiConfig', {
 				method: 'POST',
 				body: formData
 			});
 
 			const result = await run(request);
-			// Whatever the outcome, it must NOT be the blank-URL required-field 400.
 			expect(result).not.toMatchObject({ data: { error: 'Plex server URL is required' } });
-			// And the stored Plex URL is preserved.
 			expect((await getApiConfigWithSources()).plex.serverUrl.value).toBe(
 				'http://plex.local:32400'
 			);
@@ -306,10 +303,8 @@ describe('connections nested route — updateApiConfig (OCC + schema)', () => {
 		expect(await getAppSetting(AppSettingsKey.OPENAI_BASE_URL)).toBeNull();
 	});
 
-	// A2: successful save returns a fresh apiConfigVersion
 	it('returns a fresh apiConfigVersion on success (A2)', async () => {
 		await withUnlockedPlex(async () => {
-			// Seed a valid Plex URL so the save can succeed.
 			await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'https://plex.local:32400');
 
 			const formData = new FormData();
@@ -321,7 +316,6 @@ describe('connections nested route — updateApiConfig (OCC + schema)', () => {
 			});
 
 			const result = await run(request);
-			// The result must be a success object (not a failure ActionResult).
 			expect(result).toMatchObject({ success: true });
 			const version = (result as { apiConfigVersion?: string }).apiConfigVersion;
 			expect(typeof version).toBe('string');
@@ -330,11 +324,9 @@ describe('connections nested route — updateApiConfig (OCC + schema)', () => {
 		});
 	});
 
-	// C2: submitting a value for a locked field yields the informational note
 	it('includes locked-field note in success message when a locked field is submitted (C2)', async () => {
-		// The test harness has PLEX_SERVER_URL locked via the mock env.
-		// The action should succeed (setApiConfigAtomic ignores locked fields) and
-		// include the informational note in the message.
+		// The harness locks PLEX_SERVER_URL via ENV; the action should ignore the
+		// submitted value but tell the operator why it was ignored.
 		const result = await run(
 			makeRequest('updateApiConfig', {
 				plexServerUrl: 'https://plex.local:32400',

--- a/tests/unit/admin/csrf-action.test.ts
+++ b/tests/unit/admin/csrf-action.test.ts
@@ -74,7 +74,6 @@ describe('admin updateCsrfOrigin action', () => {
 		expect(result.data.attemptedOrigin).toBe('http://tampered.example.com:5173');
 		expect(result.data.requestOrigin).toBe(ORIGIN);
 		expect(typeof result.data.csrfMismatchMessage).toBe('string');
-		// Critically, no DB write should have happened.
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
 	});
 
@@ -250,7 +249,6 @@ describe('admin updateCsrfOrigin action', () => {
 		await runUpdate(createRequest({ csrfOrigin: ORIGIN }));
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
 
-		// Stale tab tries to overwrite with the epoch timestamp.
 		const result = (await runUpdate(
 			createRequest({
 				csrfOrigin: 'http://other.example.com:5173',
@@ -276,7 +274,6 @@ describe('admin updateCsrfOrigin action', () => {
 
 		expect(result.status).toBe(409);
 		expect(result.data).toMatchObject({ conflict: true });
-		// Row left intact.
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
 	});
 });

--- a/tests/unit/admin/csrf-action.test.ts
+++ b/tests/unit/admin/csrf-action.test.ts
@@ -245,7 +245,6 @@ describe('admin updateCsrfOrigin action', () => {
 	});
 
 	it('rejects updateCsrfOrigin with stale settingsVersion as 409 conflict', async () => {
-		// First write succeeds and advances the row's updatedAt.
 		await runUpdate(createRequest({ csrfOrigin: ORIGIN }));
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
 

--- a/tests/unit/admin/occ-helpers.test.ts
+++ b/tests/unit/admin/occ-helpers.test.ts
@@ -66,7 +66,6 @@ describe('externalOccCheck', () => {
 	it('returns ok when submitted version is fresh (>= current row updatedAt)', async () => {
 		await setAppSetting(AppSettingsKey.UI_THEME, 'modern-minimal');
 
-		// Future timestamp wins.
 		const futureVersion = new Date(Date.now() + 60_000).toISOString();
 		const result = await externalOccCheck(futureVersion, UI_THEME_SETTINGS_KEYS);
 

--- a/tests/unit/admin/occ-helpers.test.ts
+++ b/tests/unit/admin/occ-helpers.test.ts
@@ -114,7 +114,6 @@ describe('inlineOccCheck', () => {
 	});
 
 	it('returns conflict when submitted version is stale', async () => {
-		// Seed one of the LOG_SETTINGS_KEYS rows so max(updatedAt) > 0.
 		await setAppSetting('log_retention_days' as never, '14');
 
 		const result = await inlineOccCheck(new Date(0).toISOString(), LOG_SETTINGS_KEYS);

--- a/tests/unit/admin/privacy-actions.test.ts
+++ b/tests/unit/admin/privacy-actions.test.ts
@@ -269,7 +269,6 @@ describe('privacy nested route — updateUserDefaults', () => {
 			status: 409,
 			data: { conflict: true, error: 'Settings changed in another tab. Please reload.' }
 		});
-		// Stale save did not overwrite the fresh value.
 		expect(await getGlobalDefaultShareMode()).toBe('public');
 	});
 

--- a/tests/unit/admin/public-landing-lookup.test.ts
+++ b/tests/unit/admin/public-landing-lookup.test.ts
@@ -46,7 +46,6 @@ describe('PUBLIC_LANDING_LOOKUP setting', () => {
 		});
 
 		it('does NOT seed when onboarding is not complete', async () => {
-			// no ONBOARDING_COMPLETED row
 			await ensurePublicLandingLookupDefault();
 			expect(await getAppSetting(AppSettingsKey.PUBLIC_LANDING_LOOKUP)).toBeNull();
 
@@ -86,7 +85,6 @@ describe('PUBLIC_LANDING_LOOKUP setting', () => {
 describe('shared sharing-option copy module', () => {
 	const assertWellFormed = (options: OptionCopy[]) => {
 		const values = options.map((o) => o.value);
-		// exactly one entry per value
 		expect(new Set(values).size).toBe(values.length);
 		for (const opt of options) {
 			expect(opt.label.trim().length).toBeGreaterThan(0);
@@ -167,23 +165,18 @@ describe('shared sharing-option copy module', () => {
 			for (const preset of PRIVACY_PRESETS) {
 				const v = preset.values;
 
-				// anonymizationMode
 				expect(anonymizationValues.has(v.anonymizationMode)).toBe(true);
 				expect(serverAnonymization.has(v.anonymizationMode)).toBe(true);
 
-				// defaultShareMode (per-user, all three modes)
 				expect(shareModeValues.has(v.defaultShareMode)).toBe(true);
 				expect(serverShareModes.has(v.defaultShareMode)).toBe(true);
 
-				// serverWrappedShareMode (public | private-oauth only)
 				expect(serverWrappedValues.has(v.serverWrappedShareMode)).toBe(true);
 				expect(serverShareModes.has(v.serverWrappedShareMode)).toBe(true);
 
-				// logoMode
 				expect(logoValues.has(v.logoMode)).toBe(true);
 				expect(serverLogoModes.has(v.logoMode)).toBe(true);
 
-				// booleans
 				expect(typeof v.publicLandingLookup).toBe('boolean');
 				expect(typeof v.allowUserControl).toBe('boolean');
 			}

--- a/tests/unit/admin/security-actions.test.ts
+++ b/tests/unit/admin/security-actions.test.ts
@@ -106,7 +106,6 @@ describe('security nested route — updateCsrfOrigin (OCC + set + clear)', () =>
 		expect(result.status).toBe(409);
 		expect(result.data.requireConfirmation).toBe(true);
 		expect(typeof result.data.csrfMismatchMessage).toBe('string');
-		// No write happened.
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
 	});
 
@@ -138,7 +137,6 @@ describe('security nested route — updateCsrfOrigin (OCC + set + clear)', () =>
 		const result = await run(csrfRequest({ csrfOrigin: '', settingsVersion: futureVersion }));
 		expect(result).toMatchObject({ status: 400 });
 		expect((result as { data: { error: string } }).data.error).toMatch(/Cannot clear CSRF origin/);
-		// Stored origin untouched.
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBe(ORIGIN);
 	});
 

--- a/tests/unit/admin/settings.service.test.ts
+++ b/tests/unit/admin/settings.service.test.ts
@@ -61,10 +61,6 @@ import { resetSharedTestDb } from '../../helpers/db';
 describe('Admin Settings Service', () => {
 	beforeEach(resetSharedTestDb);
 
-	// =========================================================================
-	// App Settings CRUD
-	// =========================================================================
-
 	describe('App Settings CRUD', () => {
 		describe('getAppSetting', () => {
 			it('returns null when setting does not exist', async () => {
@@ -167,10 +163,6 @@ describe('Admin Settings Service', () => {
 			});
 		});
 	});
-
-	// =========================================================================
-	// Specific Settings Helpers
-	// =========================================================================
 
 	describe('Theme Settings', () => {
 		describe('getCurrentTheme', () => {
@@ -501,13 +493,10 @@ describe('Admin Settings Service', () => {
 		});
 	});
 
-	// =========================================================================
 	// Cache Management
-	// =========================================================================
 
 	describe('Cache Management', () => {
 		beforeEach(async () => {
-			// Insert test cached stats
 			await db.insert(cachedStats).values([
 				{ userId: 1, year: 2023, statsType: 'user', statsJson: '{}' },
 				{ userId: 1, year: 2024, statsType: 'user', statsJson: '{}' },
@@ -695,10 +684,6 @@ describe('Admin Settings Service', () => {
 			});
 		});
 	});
-
-	// =========================================================================
-	// API Configuration
-	// =========================================================================
 
 	describe('API Configuration', () => {
 		describe('getApiConfigWithSources', () => {
@@ -917,7 +902,6 @@ describe('Admin Settings Service', () => {
 				expect(cleared).toContain('PLEX_SERVER_URL');
 				expect(cleared).toContain('PLEX_TOKEN');
 
-				// Verify DB values are actually deleted
 				const dbUrl = await getAppSetting(AppSettingsKey.PLEX_SERVER_URL);
 				const dbToken = await getAppSetting(AppSettingsKey.PLEX_TOKEN);
 				expect(dbUrl).toBeNull();
@@ -934,7 +918,6 @@ describe('Admin Settings Service', () => {
 				expect(cleared).not.toContain('OPENAI_MODEL');
 				expect(cleared).not.toContain('OPENAI_BASE_URL');
 
-				// Verify DB values are preserved
 				const model = await getAppSetting(AppSettingsKey.OPENAI_MODEL);
 				const baseUrl = await getAppSetting(AppSettingsKey.OPENAI_BASE_URL);
 				expect(model).toBe('custom-model');
@@ -951,7 +934,6 @@ describe('Admin Settings Service', () => {
 			});
 
 			it('returns empty array when no conflicts exist', async () => {
-				// No DB settings set, so nothing to clear
 				const cleared = await clearConflictingDbSettings();
 
 				expect(cleared).toEqual([]);
@@ -1363,7 +1345,6 @@ describe('Admin Settings Service', () => {
 				AppSettingsKey.API_CONFIG_VERSION
 			]);
 
-			// Allow at least 1ms for updatedAt comparison to be meaningful.
 			await new Promise((r) => setTimeout(r, 5));
 
 			// Tab A submits the version it loaded and clears OPENAI_BASE_URL only.

--- a/tests/unit/admin/settings.service.test.ts
+++ b/tests/unit/admin/settings.service.test.ts
@@ -142,7 +142,6 @@ describe('Admin Settings Service', () => {
 			});
 
 			it('does nothing for non-existent setting', async () => {
-				// Should not throw
 				await deleteAppSetting(AppSettingsKey.CURRENT_THEME);
 			});
 		});
@@ -493,8 +492,6 @@ describe('Admin Settings Service', () => {
 		});
 	});
 
-	// Cache Management
-
 	describe('Cache Management', () => {
 		beforeEach(async () => {
 			await db.insert(cachedStats).values([
@@ -690,7 +687,6 @@ describe('Admin Settings Service', () => {
 			it('returns env values when env vars are configured', async () => {
 				const config = await getApiConfigWithSources();
 
-				// Plex values come from env (test setup mocks PLEX_SERVER_URL and PLEX_TOKEN)
 				expect(config.plex.serverUrl.value).toBe('https://test-plex-server:32400');
 				expect(config.plex.serverUrl.source).toBe('env');
 				expect(config.plex.serverUrl.isLocked).toBe(true);
@@ -698,7 +694,6 @@ describe('Admin Settings Service', () => {
 				expect(config.plex.token.source).toBe('env');
 				expect(config.plex.token.isLocked).toBe(true);
 
-				// OpenAI env vars are empty in test setup, so defaults are used
 				expect(config.openai.baseUrl.value).toBe('https://api.openai.com/v1');
 				expect(config.openai.baseUrl.source).toBe('default');
 				expect(config.openai.baseUrl.isLocked).toBe(false);
@@ -708,13 +703,11 @@ describe('Admin Settings Service', () => {
 			});
 
 			it('prioritizes DB values over defaults (when ENV not set)', async () => {
-				// OpenAI env vars are empty in test setup, so DB values should take priority
 				await setAppSetting(AppSettingsKey.OPENAI_MODEL, 'gpt-4');
 				await setAppSetting(AppSettingsKey.OPENAI_BASE_URL, 'http://custom-api:8080/v1');
 
 				const config = await getApiConfigWithSources();
 
-				// OpenAI settings should come from DB since ENV is not set
 				expect(config.openai.model.value).toBe('gpt-4');
 				expect(config.openai.model.source).toBe('db');
 				expect(config.openai.model.isLocked).toBe(false);
@@ -724,13 +717,11 @@ describe('Admin Settings Service', () => {
 			});
 
 			it('prioritizes ENV values over DB values', async () => {
-				// Plex env vars ARE set in test setup, so ENV should win even if DB has values
 				await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://db-plex:32400');
 				await setAppSetting(AppSettingsKey.PLEX_TOKEN, 'db-token-value');
 
 				const config = await getApiConfigWithSources();
 
-				// Plex settings should come from ENV (test setup mocks these)
 				expect(config.plex.serverUrl.value).toBe('https://test-plex-server:32400');
 				expect(config.plex.serverUrl.source).toBe('env');
 				expect(config.plex.serverUrl.isLocked).toBe(true);
@@ -742,7 +733,6 @@ describe('Admin Settings Service', () => {
 
 		describe('hasPlexEnvConfig', () => {
 			it('returns true when Plex env vars are set', () => {
-				// Test setup mocks PLEX_SERVER_URL and PLEX_TOKEN with values
 				const hasConfig = hasPlexEnvConfig();
 				expect(hasConfig).toBe(true);
 			});
@@ -801,7 +791,6 @@ describe('Admin Settings Service', () => {
 
 		describe('hasOpenAIEnvConfig', () => {
 			it('returns false when no OpenAI env vars set', () => {
-				// Test setup mocks env vars as empty strings
 				const hasConfig = hasOpenAIEnvConfig();
 				expect(hasConfig).toBe(false);
 			});
@@ -893,7 +882,6 @@ describe('Admin Settings Service', () => {
 
 		describe('clearConflictingDbSettings', () => {
 			it('clears DB settings when ENV values exist', async () => {
-				// Plex env vars ARE set in test setup, so these DB values should be cleared
 				await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://db-url:32400');
 				await setAppSetting(AppSettingsKey.PLEX_TOKEN, 'db-token');
 
@@ -909,7 +897,6 @@ describe('Admin Settings Service', () => {
 			});
 
 			it('preserves DB settings when no ENV values exist', async () => {
-				// OpenAI env vars are empty in test setup, so DB values should be preserved
 				await setAppSetting(AppSettingsKey.OPENAI_MODEL, 'custom-model');
 				await setAppSetting(AppSettingsKey.OPENAI_BASE_URL, 'http://custom-api:8080/v1');
 
@@ -925,7 +912,6 @@ describe('Admin Settings Service', () => {
 			});
 
 			it('returns correct labels for cleared settings', async () => {
-				// Set only one DB value that conflicts with ENV
 				await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://db-url:32400');
 
 				const cleared = await clearConflictingDbSettings();
@@ -992,7 +978,6 @@ describe('Admin Settings Service', () => {
 
 		describe('isPlexConfigured', () => {
 			it('returns true when both serverUrl and token are configured', async () => {
-				// Test setup mocks PLEX_SERVER_URL and PLEX_TOKEN via env
 				const configured = await isPlexConfigured();
 				expect(configured).toBe(true);
 			});
@@ -1050,7 +1035,6 @@ describe('Admin Settings Service', () => {
 	describe('CSRF Configuration', () => {
 		describe('getCsrfConfigWithSource', () => {
 			it('returns default values when no config exists', async () => {
-				// ENV ORIGIN is empty in test setup
 				const config = await getCsrfConfigWithSource();
 				expect(config.origin.value).toBe('');
 				expect(config.origin.source).toBe('default');

--- a/tests/unit/admin/settings.service.test.ts
+++ b/tests/unit/admin/settings.service.test.ts
@@ -51,13 +51,6 @@ import { appSettings, cachedStats, playHistory } from '$lib/server/db/schema';
 import { createYearFilter } from '$lib/server/stats/utils';
 import { resetSharedTestDb } from '../../helpers/db';
 
-/**
- * Unit tests for Admin Settings Service
- *
- * Tests app settings management and cache operations.
- * Uses in-memory SQLite from test setup.
- */
-
 describe('Admin Settings Service', () => {
 	beforeEach(resetSharedTestDb);
 

--- a/tests/unit/admin/system-actions.test.ts
+++ b/tests/unit/admin/system-actions.test.ts
@@ -94,7 +94,6 @@ describe('system nested route — updateLogSettings (Superforms + inline OCC)', 
 			status: 409,
 			data: { conflict: true }
 		});
-		// First write's values still in place.
 		expect(await getLogRetentionDays()).toBe(14);
 		expect(await getLogMaxCount()).toBe(2000);
 	});
@@ -163,7 +162,7 @@ describe('system nested route — updateLogSettings (Superforms + inline OCC)', 
 		expect(trueResult).toMatchObject({ success: true });
 		expect(await isDebugEnabled()).toBe(true);
 
-		// Seed the row updatedAt so the next write must use a fresh version
+		// The second write must use the row version created by the first save.
 		await setAppSetting('log_debug_enabled' as never, 'true');
 		const falseResult = await run(
 			makeRequest({

--- a/tests/unit/admin/system-actions.test.ts
+++ b/tests/unit/admin/system-actions.test.ts
@@ -68,13 +68,11 @@ describe('system nested route — updateLogSettings (Superforms + inline OCC)', 
 				error: 'Settings changed in another tab. Please reload.'
 			}
 		});
-		// Defaults preserved
 		expect(await getLogRetentionDays()).toBe(7);
 		expect(await getLogMaxCount()).toBe(50000);
 	});
 
 	it('rejects stale settingsVersion as 409 conflict', async () => {
-		// Seed the row by writing once.
 		await run(
 			makeRequest({
 				retentionDays: '14',
@@ -84,7 +82,6 @@ describe('system nested route — updateLogSettings (Superforms + inline OCC)', 
 			})
 		);
 
-		// Second write uses the original (stale) epoch.
 		const result = await run(
 			makeRequest({
 				retentionDays: '21',
@@ -112,7 +109,6 @@ describe('system nested route — updateLogSettings (Superforms + inline OCC)', 
 			})
 		);
 		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid input' } });
-		// Confirm no partial write.
 		expect(await getLogRetentionDays()).toBe(7);
 		expect(await getLogMaxCount()).toBe(50000);
 	});
@@ -139,7 +135,6 @@ describe('system nested route — updateLogSettings (Superforms + inline OCC)', 
 				settingsVersion: new Date(0).toISOString()
 			})
 		);
-		// Future timestamp wins OCC against any current row updatedAt.
 		const result = await run(
 			makeRequest({
 				retentionDays: '21',

--- a/tests/unit/admin/system-actions.test.ts
+++ b/tests/unit/admin/system-actions.test.ts
@@ -60,7 +60,6 @@ describe('system nested route — updateLogSettings (Superforms + inline OCC)', 
 				settingsVersion: ''
 			})
 		);
-		// Superforms wraps fail() with { form, conflict: true, error: '...' }
 		expect(result).toMatchObject({
 			status: 409,
 			data: {

--- a/tests/unit/admin/users.service.test.ts
+++ b/tests/unit/admin/users.service.test.ts
@@ -222,7 +222,7 @@ describe('admin users service', () => {
 			});
 
 			const [row] = await getAllUsersWithStats(2025);
-			expect(row?.shareMode).toBe(ShareMode.PUBLIC); // raw stored value preserved
+			expect(row?.shareMode).toBe(ShareMode.PUBLIC);
 			expect(row?.effectiveShareMode).toBe(ShareMode.PRIVATE_OAUTH);
 			expect(row?.effectiveLabel).toBe('OAuth');
 			expect(row?.effectiveClass).toBe('oauth');

--- a/tests/unit/auth/identity.test.ts
+++ b/tests/unit/auth/identity.test.ts
@@ -80,7 +80,7 @@ describe('dev-users module', () => {
 	const mockSharedUsers = [
 		{ id: 1001, username: 'SharedUser1', email: 'user1@example.com', thumb: 'thumb1' },
 		{ id: 1002, username: 'SharedUser2', email: 'user2@example.com', thumb: 'thumb2' },
-		{ id: 1003, username: 'SharedUser3' } // No email/thumb
+		{ id: 1003, username: 'SharedUser3' }
 	];
 	function setupFetchMock(sharedUsers = mockSharedUsers) {
 		fetchMock = spyOn(globalThis, 'fetch').mockImplementation(((url: URL | RequestInfo) => {
@@ -119,7 +119,7 @@ describe('dev-users module', () => {
 			await getServerUsers();
 			expect(mockGetPlexUserInfo).toHaveBeenCalledTimes(1);
 			const result2 = await getServerUsers();
-			expect(mockGetPlexUserInfo).toHaveBeenCalledTimes(1); // Still 1
+			expect(mockGetPlexUserInfo).toHaveBeenCalledTimes(1);
 			expect(result2.owner.username).toBe('ServerOwner');
 		});
 		it('handles empty shared users list', async () => {

--- a/tests/unit/db/client.test.ts
+++ b/tests/unit/db/client.test.ts
@@ -1,8 +1,6 @@
 /**
- * Unit tests for Database Client Module
- *
- * Tests module-level initialization code in db/client.ts. These use subprocesses
- * because db/client executes on import and the main test process preloads it.
+ * db/client performs import-time initialization, so these cases run in
+ * subprocesses instead of re-importing it inside the preloaded Bun test process.
  */
 
 import { describe, expect, it } from 'bun:test';

--- a/tests/unit/funfacts/ai.test.ts
+++ b/tests/unit/funfacts/ai.test.ts
@@ -21,10 +21,6 @@ import { resetSharedTestDb } from '../../helpers/db';
  * Uses mocked fetch for API calls.
  */
 
-// =============================================================================
-// Test Helpers
-// =============================================================================
-
 function createMockUserStats(overrides: Partial<UserStats> = {}): UserStats {
 	return {
 		userId: 1,
@@ -112,7 +108,6 @@ function createValidAIResponse() {
 	};
 }
 
-// Store original fetch
 let originalFetch: typeof fetch;
 
 describe('Fun Facts AI', () => {
@@ -124,10 +119,6 @@ describe('Fun Facts AI', () => {
 	afterEach(() => {
 		globalThis.fetch = originalFetch;
 	});
-
-	// =========================================================================
-	// Configuration Tests
-	// =========================================================================
 
 	describe('getFunFactsConfig', () => {
 		it('returns defaults when no settings exist', async () => {
@@ -157,11 +148,9 @@ describe('Fun Facts AI', () => {
 		});
 
 		it('aiEnabled is true only when API key exists', async () => {
-			// No API key
 			let config = await getFunFactsConfig();
 			expect(config.aiEnabled).toBe(false);
 
-			// With API key
 			await db.insert(appSettings).values({
 				key: AppSettingsKey.OPENAI_API_KEY,
 				value: 'sk-test'
@@ -188,10 +177,6 @@ describe('Fun Facts AI', () => {
 		});
 	});
 
-	// =========================================================================
-	// generateWithAI Tests
-	// =========================================================================
-
 	describe('generateWithAI', () => {
 		it('throws AIGenerationError when API key not configured', async () => {
 			const stats = createMockUserStats();
@@ -213,7 +198,6 @@ describe('Fun Facts AI', () => {
 			let capturedUrl: string | null = null;
 
 			globalThis.fetch = mock(async (input: RequestInfo | URL) => {
-				// Extract URL from input (could be string, URL, or Request)
 				if (typeof input === 'string') {
 					capturedUrl = input;
 				} else if (input instanceof URL) {
@@ -269,7 +253,6 @@ describe('Fun Facts AI', () => {
 				expect((error as AIGenerationError).message).toContain('400');
 			}
 
-			// Should NOT retry 4xx errors
 			expect(callCount).toBe(1);
 		});
 
@@ -430,38 +413,31 @@ describe('Fun Facts AI', () => {
 		});
 	});
 
-	// =========================================================================
 	// generateFunFacts Tests (AI/Template Fallback)
-	// =========================================================================
 
 	describe('generateFunFacts', () => {
 		it('uses templates when AI is not configured', async () => {
 			const stats = createMockUserStats();
 
-			// No API key configured
 			const facts = await generateFunFacts(stats, { count: 3 });
 
 			expect(facts).toHaveLength(3);
-			// All facts should be from templates (no AI call made)
 		});
 
 		it('falls back to templates when AI fails', async () => {
 			const stats = createMockUserStats();
 
-			// Configure API key
 			await db.insert(appSettings).values({
 				key: AppSettingsKey.OPENAI_API_KEY,
 				value: 'sk-test'
 			});
 
-			// Mock fetch to fail
 			globalThis.fetch = mock(async () => {
 				throw new Error('Network error');
 			}) as unknown as typeof fetch;
 
 			const facts = await generateFunFacts(stats, { count: 3 });
 
-			// Should fall back to templates
 			expect(facts).toHaveLength(3);
 			expect(facts[0]?.fact).toBeTruthy();
 		});
@@ -495,7 +471,6 @@ describe('Fun Facts AI', () => {
 				value: 'sk-test'
 			});
 
-			// Mock should not be called
 			let fetchCalled = false;
 			globalThis.fetch = mock(async () => {
 				fetchCalled = true;
@@ -544,13 +519,8 @@ describe('Fun Facts AI', () => {
 
 			expect(facts).toHaveLength(3);
 			expect(facts[0]?.fact).toBe('Only one fact'); // AI fact first
-			// Remaining 2 facts should be from templates
 		});
 	});
-
-	// =========================================================================
-	// Template Applicability Edge Cases
-	// =========================================================================
 
 	describe('Template Applicability Edge Cases', () => {
 		it('rejects template when required stat is empty string', async () => {
@@ -559,7 +529,6 @@ describe('Fun Facts AI', () => {
 			});
 			const context = buildGenerationContext(stats);
 
-			// Context should have empty string for topMovie
 			expect(context.topMovie).toBe('');
 
 			// Generate facts should still work (templates requiring topMovie excluded)
@@ -568,7 +537,6 @@ describe('Fun Facts AI', () => {
 		});
 
 		it('night-owl template requires peakHour >= 21', async () => {
-			// Peak hour at 10 PM (22)
 			const nightOwlStats = createMockUserStats({
 				watchTimeByHour: {
 					minutes: Array(24)
@@ -581,13 +549,11 @@ describe('Fun Facts AI', () => {
 			const context = buildGenerationContext(nightOwlStats);
 			expect(context.peakHour).toBe(22);
 
-			// Facts might include night-owl template
 			const facts = await generateFunFacts(nightOwlStats, { count: 10 });
 			expect(facts.length).toBeGreaterThan(0);
 		});
 
 		it('night-owl template is excluded when peakHour < 21', async () => {
-			// Peak hour at 8 PM (20) - should exclude night-owl
 			const notNightOwlStats = createMockUserStats({
 				watchTimeByHour: {
 					minutes: Array(24)
@@ -600,11 +566,9 @@ describe('Fun Facts AI', () => {
 			const context = buildGenerationContext(notNightOwlStats);
 			expect(context.peakHour).toBe(20);
 
-			// Generate facts - night-owl template should be excluded
 			const facts = await generateFunFacts(notNightOwlStats, { count: 20 });
 			expect(facts.length).toBeGreaterThan(0);
 
-			// Verify night-owl specific content is not present
 			const hasNightOwl = facts.some(
 				(f) =>
 					f.fact.toLowerCase().includes('night owl') || f.fact.toLowerCase().includes('9:00 pm')
@@ -613,7 +577,6 @@ describe('Fun Facts AI', () => {
 		});
 
 		it('night-owl template is included at boundary peakHour = 21', async () => {
-			// Peak hour at 9 PM (21) - boundary, should include night-owl
 			const boundaryStats = createMockUserStats({
 				watchTimeByHour: {
 					minutes: Array(24)
@@ -626,13 +589,11 @@ describe('Fun Facts AI', () => {
 			const context = buildGenerationContext(boundaryStats);
 			expect(context.peakHour).toBe(21);
 
-			// Generate many facts to increase chance of hitting night-owl
 			const facts = await generateFunFacts(boundaryStats, { count: 20 });
 			expect(facts.length).toBeGreaterThan(0);
 		});
 
 		it('early-bird template requires peakHour <= 9', async () => {
-			// Peak hour at 6 AM
 			const earlyBirdStats = createMockUserStats({
 				watchTimeByHour: {
 					minutes: Array(24)
@@ -645,13 +606,11 @@ describe('Fun Facts AI', () => {
 			const context = buildGenerationContext(earlyBirdStats);
 			expect(context.peakHour).toBe(6);
 
-			// Facts might include early-bird template
 			const facts = await generateFunFacts(earlyBirdStats, { count: 10 });
 			expect(facts.length).toBeGreaterThan(0);
 		});
 
 		it('early-bird template is excluded when peakHour > 9', async () => {
-			// Peak hour at 10 AM - should exclude early-bird
 			const notEarlyBirdStats = createMockUserStats({
 				watchTimeByHour: {
 					minutes: Array(24)
@@ -664,15 +623,10 @@ describe('Fun Facts AI', () => {
 			const context = buildGenerationContext(notEarlyBirdStats);
 			expect(context.peakHour).toBe(10);
 
-			// Generate facts - early-bird template should be excluded
 			const facts = await generateFunFacts(notEarlyBirdStats, { count: 20 });
 			expect(facts.length).toBeGreaterThan(0);
 		});
 	});
-
-	// =========================================================================
-	// Timeout Handling Tests
-	// =========================================================================
 
 	describe('Timeout Handling', () => {
 		it('retries on AbortError (timeout)', async () => {
@@ -683,7 +637,6 @@ describe('Fun Facts AI', () => {
 			globalThis.fetch = mock(async () => {
 				callCount++;
 				if (callCount === 1) {
-					// Simulate AbortError (timeout)
 					const error = new Error('The operation was aborted');
 					error.name = 'AbortError';
 					throw error;
@@ -732,12 +685,10 @@ describe('Fun Facts AI', () => {
 			globalThis.fetch = mock(async () => {
 				callCount++;
 				if (callCount <= 2) {
-					// First 2 calls timeout
 					const error = new Error('The operation was aborted');
 					error.name = 'AbortError';
 					throw error;
 				}
-				// Third call succeeds
 				return new Response(JSON.stringify(createValidAIResponse()), {
 					status: 200,
 					headers: { 'Content-Type': 'application/json' }

--- a/tests/unit/funfacts/ai.test.ts
+++ b/tests/unit/funfacts/ai.test.ts
@@ -267,7 +267,7 @@ describe('Fun Facts AI', () => {
 
 			const facts = await generateWithAI(stats, config, 3);
 
-			expect(callCount).toBe(3); // Initial + 2 retries
+			expect(callCount).toBe(3);
 			expect(facts).toHaveLength(3);
 		});
 
@@ -310,7 +310,7 @@ describe('Fun Facts AI', () => {
 				expect(error).toBeInstanceOf(AIGenerationError);
 			}
 
-			expect(callCount).toBe(3); // Initial + 2 retries
+			expect(callCount).toBe(3);
 		});
 
 		it('retries on network error', async () => {
@@ -405,8 +405,6 @@ describe('Fun Facts AI', () => {
 			}
 		});
 	});
-
-	// generateFunFacts Tests (AI/Template Fallback)
 
 	describe('generateFunFacts', () => {
 		it('uses templates when AI is not configured', async () => {
@@ -640,7 +638,7 @@ describe('Fun Facts AI', () => {
 
 			const facts = await generateWithAI(stats, config, 3);
 
-			expect(callCount).toBe(2); // Initial + 1 retry after timeout
+			expect(callCount).toBe(2);
 			expect(facts).toHaveLength(3);
 		});
 
@@ -664,7 +662,7 @@ describe('Fun Facts AI', () => {
 				expect((error as AIGenerationError).message).toContain('timed out');
 			}
 
-			expect(callCount).toBe(2); // Initial + 1 retry
+			expect(callCount).toBe(2);
 		});
 
 		it('recovers from timeout then succeeds on retry', async () => {

--- a/tests/unit/funfacts/ai.test.ts
+++ b/tests/unit/funfacts/ai.test.ts
@@ -531,7 +531,6 @@ describe('Fun Facts AI', () => {
 
 			expect(context.topMovie).toBe('');
 
-			// Generate facts should still work (templates requiring topMovie excluded)
 			const facts = await generateFunFacts(stats, { count: 3 });
 			expect(facts).toHaveLength(3);
 		});

--- a/tests/unit/funfacts/ai.test.ts
+++ b/tests/unit/funfacts/ai.test.ts
@@ -14,18 +14,11 @@ import {
 import type { UserStats } from '$lib/server/stats/types';
 import { resetSharedTestDb } from '../../helpers/db';
 
-/**
- * Unit tests for Fun Facts AI Generation
- *
- * Tests AI configuration, API calls, response parsing, and retry logic.
- * Uses mocked fetch for API calls.
- */
-
 function createMockUserStats(overrides: Partial<UserStats> = {}): UserStats {
 	return {
 		userId: 1,
 		year: 2024,
-		totalWatchTimeMinutes: 6000, // 100 hours
+		totalWatchTimeMinutes: 6000,
 		totalPlays: 200,
 		topMovies: [
 			{ rank: 1, title: 'The Matrix', count: 5, thumb: null },
@@ -460,7 +453,7 @@ describe('Fun Facts AI', () => {
 			const facts = await generateFunFacts(stats, { count: 3, preferAI: true });
 
 			expect(facts).toHaveLength(3);
-			expect(facts[0]?.fact).toBe('You watched 100 hours'); // AI response
+			expect(facts[0]?.fact).toBe('You watched 100 hours');
 		});
 
 		it('uses templates when preferAI is false', async () => {
@@ -494,7 +487,6 @@ describe('Fun Facts AI', () => {
 				value: 'sk-test'
 			});
 
-			// AI returns only 1 fact
 			globalThis.fetch = mock(async () => {
 				return new Response(
 					JSON.stringify({
@@ -518,7 +510,7 @@ describe('Fun Facts AI', () => {
 			const facts = await generateFunFacts(stats, { count: 3 });
 
 			expect(facts).toHaveLength(3);
-			expect(facts[0]?.fact).toBe('Only one fact'); // AI fact first
+			expect(facts[0]?.fact).toBe('Only one fact');
 		});
 	});
 
@@ -659,7 +651,6 @@ describe('Fun Facts AI', () => {
 			let callCount = 0;
 			globalThis.fetch = mock(async () => {
 				callCount++;
-				// Always throw AbortError
 				const error = new Error('The operation was aborted');
 				error.name = 'AbortError';
 				throw error;

--- a/tests/unit/funfacts/prompts.test.ts
+++ b/tests/unit/funfacts/prompts.test.ts
@@ -155,8 +155,8 @@ describe('AI Prompts', () => {
 
 			expect(prompt).toContain('100 hours');
 			expect(prompt).toContain('200');
-			expect(prompt).toContain('50'); // uniqueMovies
-			expect(prompt).toContain('20'); // uniqueShows
+			expect(prompt).toContain('50');
+			expect(prompt).toContain('20');
 		});
 
 		it('includes count in prompt', () => {

--- a/tests/unit/funfacts/prompts.test.ts
+++ b/tests/unit/funfacts/prompts.test.ts
@@ -9,13 +9,6 @@ import {
 } from '$lib/server/funfacts/ai/prompts';
 import type { AIPersona, FactGenerationContext } from '$lib/server/funfacts/types';
 
-/**
- * Unit tests for AI Prompts Module
- *
- * Tests the prompt building functions used for AI-generated fun facts.
- * Covers persona selection, system/user prompt construction, and edge cases.
- */
-
 function createMockContext(overrides: Partial<FactGenerationContext> = {}): FactGenerationContext {
 	return {
 		hours: 100,

--- a/tests/unit/funfacts/prompts.test.ts
+++ b/tests/unit/funfacts/prompts.test.ts
@@ -350,7 +350,6 @@ describe('AI Prompts', () => {
 			const context = createMockContext({ topMovie: '' });
 			const prompt = buildUserPrompt(context, 3);
 
-			// Empty string is falsy, so topMovie section is excluded
 			expect(prompt).not.toContain('Top movie:');
 		});
 
@@ -398,7 +397,6 @@ describe('AI Prompts', () => {
 			const context = createMockContext();
 			const result = buildEnhancedPrompt(context, 3, 'random');
 
-			// Should contain one of the persona descriptions
 			const hasPersona =
 				result.system.includes('witty entertainment columnist') ||
 				result.system.includes('encouraging friend') ||

--- a/tests/unit/funfacts/prompts.test.ts
+++ b/tests/unit/funfacts/prompts.test.ts
@@ -324,9 +324,7 @@ describe('AI Prompts', () => {
 			});
 			const prompt = buildUserPrompt(context, 3);
 
-			// Header shows because counts are truthy
 			expect(prompt).toContain('For Reference');
-			// But individual items don't show because they're < 1
 			expect(prompt).not.toContain('Game of Thrones');
 			expect(prompt).not.toContain('Friends');
 			expect(prompt).not.toContain('Star Wars');

--- a/tests/unit/funfacts/service.test.ts
+++ b/tests/unit/funfacts/service.test.ts
@@ -124,15 +124,15 @@ describe('buildGenerationContext', () => {
 		const stats = createMockUserStats();
 		const context = buildGenerationContext(stats);
 
-		expect(context.hours).toBe(100); // 6000 / 60
-		expect(context.days).toBe(4.2); // 100 / 24 rounded to 1 decimal
+		expect(context.hours).toBe(100);
+		expect(context.days).toBe(4.2);
 		expect(context.plays).toBe(200);
 		expect(context.topMovie).toBe('The Matrix');
 		expect(context.topMovieCount).toBe(5);
 		expect(context.topShow).toBe('Breaking Bad');
 		expect(context.topShowCount).toBe(50);
 		expect(context.percentile).toBe(85);
-		expect(context.bingeHours).toBe(5); // 300 / 60
+		expect(context.bingeHours).toBe(5);
 		expect(context.bingePlays).toBe(6);
 		expect(context.firstWatchTitle).toBe('New Year Movie');
 		expect(context.lastWatchTitle).toBe('Year End Show');
@@ -145,7 +145,7 @@ describe('buildGenerationContext', () => {
 		const context = buildGenerationContext(stats);
 
 		expect(context.percentile).toBe(50);
-		expect(context.hours).toBe(1000); // 60000 / 60
+		expect(context.hours).toBe(1000);
 	});
 
 	it('handles missing optional fields', () => {
@@ -170,7 +170,7 @@ describe('buildGenerationContext', () => {
 
 	it('calculates peak hour correctly', () => {
 		const minutes = Array(24).fill(0);
-		minutes[22] = 1000; // 10 PM peak
+		minutes[22] = 1000;
 		const stats = createMockUserStats({
 			watchTimeByHour: { minutes, plays: Array(24).fill(1) }
 		});
@@ -181,7 +181,7 @@ describe('buildGenerationContext', () => {
 
 	it('calculates peak month correctly', () => {
 		const minutes = Array(12).fill(0);
-		minutes[6] = 5000; // July peak (0-indexed)
+		minutes[6] = 5000;
 		const stats = createMockUserStats({
 			watchTimeByMonth: { minutes, plays: Array(12).fill(1) }
 		});
@@ -257,10 +257,8 @@ describe('isTemplateApplicable', () => {
 			minThresholds: { peakHour: 21 }
 		};
 
-		// peakHour is 22, so should be applicable
 		expect(isTemplateApplicable(template, mockContext)).toBe(true);
 
-		// peakHour is 18, so should not be applicable
 		expect(isTemplateApplicable(template, { ...mockContext, peakHour: 18 })).toBe(false);
 	});
 
@@ -272,10 +270,8 @@ describe('isTemplateApplicable', () => {
 			requiredStats: ['peakHour']
 		};
 
-		// peakHour is 22, so should not be applicable
 		expect(isTemplateApplicable(template, mockContext)).toBe(false);
 
-		// peakHour is 7, so should be applicable
 		expect(isTemplateApplicable(template, { ...mockContext, peakHour: 7 })).toBe(true);
 	});
 
@@ -336,7 +332,7 @@ describe('interpolateTemplate', () => {
 
 	it('formats peak month correctly', () => {
 		const result = interpolateTemplate('{peakMonthName}', mockContext);
-		expect(result).toBe('July'); // Month 6 (0-indexed)
+		expect(result).toBe('July');
 	});
 
 	it('preserves unknown placeholders', () => {
@@ -476,7 +472,6 @@ describe('generateFromTemplates', () => {
 		const result = generateFromTemplates(context, { count: 5 });
 
 		for (const fact of result) {
-			// Should not contain {placeholder} patterns
 			expect(fact.fact).not.toMatch(/\{[a-zA-Z]+\}/);
 			if (fact.comparison) {
 				expect(fact.comparison).not.toMatch(/\{[a-zA-Z]+\}/);
@@ -815,7 +810,7 @@ describe('generateWithAI', () => {
 			openaiApiKey: 'sk-test',
 			openaiBaseUrl: 'https://api.openai.com/v1',
 			openaiModel: 'gpt-5-mini',
-			maxAIRetries: 0, // No retries for this test
+			maxAIRetries: 0,
 			aiTimeoutMs: 10000,
 			aiPersona: 'witty' as const
 		};

--- a/tests/unit/funfacts/service.test.ts
+++ b/tests/unit/funfacts/service.test.ts
@@ -497,7 +497,6 @@ describe('generateFromTemplates', () => {
 
 		const timeEquivIds = TIME_EQUIVALENCY_TEMPLATES.map((t) => t.id);
 
-		// Generate without time-equivalency templates
 		const result = generateFromTemplates(context, {
 			count: 3,
 			excludeIds: timeEquivIds

--- a/tests/unit/funfacts/service.test.ts
+++ b/tests/unit/funfacts/service.test.ts
@@ -1,10 +1,3 @@
-/**
- * Unit tests for Fun Facts Service
- *
- * Tests context building, template applicability, interpolation,
- * and random selection functions.
- */
-
 import { afterAll, afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { AppSettingsKey } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
@@ -42,7 +35,7 @@ function createMockUserStats(overrides: Partial<UserStats> = {}): UserStats {
 	return {
 		userId: 1,
 		year: 2024,
-		totalWatchTimeMinutes: 6000, // 100 hours
+		totalWatchTimeMinutes: 6000,
 		totalPlays: 200,
 		topMovies: [
 			{ rank: 1, title: 'The Matrix', count: 5, thumb: null },

--- a/tests/unit/funfacts/service.test.ts
+++ b/tests/unit/funfacts/service.test.ts
@@ -38,10 +38,6 @@ import { getALL_TEMPLATES, getTemplatesForCategory } from '$lib/server/funfacts/
 import type { ServerStats, UserStats } from '$lib/server/stats/types';
 import { resetSharedTestDb } from '../../helpers/db';
 
-// =============================================================================
-// Test Helpers
-// =============================================================================
-
 function createMockUserStats(overrides: Partial<UserStats> = {}): UserStats {
 	return {
 		userId: 1,
@@ -130,10 +126,6 @@ function createMockServerStats(overrides: Partial<ServerStats> = {}): ServerStat
 	};
 }
 
-// =============================================================================
-// Context Building Tests
-// =============================================================================
-
 describe('buildGenerationContext', () => {
 	it('builds context correctly from user stats', () => {
 		const stats = createMockUserStats();
@@ -205,10 +197,6 @@ describe('buildGenerationContext', () => {
 		expect(context.peakMonth).toBe(6);
 	});
 });
-
-// =============================================================================
-// Template Applicability Tests
-// =============================================================================
 
 describe('isTemplateApplicable', () => {
 	const mockContext: FactGenerationContext = {
@@ -311,10 +299,6 @@ describe('isTemplateApplicable', () => {
 	});
 });
 
-// =============================================================================
-// Template Interpolation Tests
-// =============================================================================
-
 describe('interpolateTemplate', () => {
 	const mockContext: FactGenerationContext = {
 		hours: 100,
@@ -374,10 +358,6 @@ describe('interpolateTemplate', () => {
 	});
 });
 
-// =============================================================================
-// Template Generation Tests
-// =============================================================================
-
 describe('generateFromTemplate', () => {
 	const mockContext: FactGenerationContext = {
 		hours: 100,
@@ -432,10 +412,6 @@ describe('generateFromTemplate', () => {
 	});
 });
 
-// =============================================================================
-// Random Selection Tests
-// =============================================================================
-
 describe('selectRandomTemplates', () => {
 	const templates: FactTemplate[] = [
 		{ id: 'a', category: 'time-equivalency', factTemplate: 'A', requiredStats: [] },
@@ -481,10 +457,6 @@ describe('selectRandomTemplates', () => {
 	});
 });
 
-// =============================================================================
-// Full Generation Tests
-// =============================================================================
-
 describe('generateFromTemplates', () => {
 	it('generates requested number of facts', () => {
 		const stats = createMockUserStats();
@@ -523,7 +495,6 @@ describe('generateFromTemplates', () => {
 		const stats = createMockUserStats();
 		const context = buildGenerationContext(stats);
 
-		// Get all IDs from time-equivalency category
 		const timeEquivIds = TIME_EQUIVALENCY_TEMPLATES.map((t) => t.id);
 
 		// Generate without time-equivalency templates
@@ -557,10 +528,6 @@ describe('generateFromTemplates', () => {
 		expect(result[0]?.fact).toContain('active viewer');
 	});
 });
-
-// =============================================================================
-// Template Constants Tests
-// =============================================================================
 
 describe('Template constants and registry index', () => {
 	const expectedCategories = [
@@ -641,10 +608,6 @@ describe('Template constants and registry index', () => {
 	});
 });
 
-// =============================================================================
-// Configuration Tests
-// =============================================================================
-
 describe('getFunFactsConfig', () => {
 	beforeEach(async () => {
 		await resetSharedTestDb();
@@ -720,10 +683,6 @@ describe('isAIAvailable', () => {
 		expect(available).toBe(true);
 	});
 });
-
-// =============================================================================
-// AI Generation Tests
-// =============================================================================
 
 describe('generateWithAI', () => {
 	let fetchMock: ReturnType<typeof spyOn>;
@@ -896,10 +855,6 @@ describe('generateWithAI', () => {
 	});
 });
 
-// =============================================================================
-// Main generateFunFacts Tests
-// =============================================================================
-
 describe('generateFunFacts', () => {
 	let fetchMock: ReturnType<typeof spyOn>;
 
@@ -918,7 +873,6 @@ describe('generateFunFacts', () => {
 		const facts = await generateFunFacts(stats, { count: 3 });
 
 		expect(facts).toHaveLength(3);
-		// Template facts should have string facts
 		for (const fact of facts) {
 			expect(typeof fact.fact).toBe('string');
 			expect(fact.fact.length).toBeGreaterThan(0);
@@ -977,7 +931,6 @@ describe('generateFunFacts', () => {
 		const stats = createMockUserStats();
 		const facts = await generateFunFacts(stats, { count: 3 });
 
-		// Should have fallen back to templates
 		expect(facts).toHaveLength(3);
 	});
 
@@ -1007,7 +960,6 @@ describe('generateFunFacts', () => {
 		const stats = createMockUserStats();
 		const facts = await generateFunFacts(stats, { count: 3 });
 
-		// Should have 3 facts total (1 AI + 2 templates)
 		expect(facts).toHaveLength(3);
 		expect(facts[0]?.fact).toBe('Only one AI fact');
 	});

--- a/tests/unit/funfacts/service.test.ts
+++ b/tests/unit/funfacts/service.test.ts
@@ -242,7 +242,7 @@ describe('isTemplateApplicable', () => {
 			category: 'time-equivalency',
 			factTemplate: 'You watched {hours} hours',
 			requiredStats: ['hours'],
-			minThresholds: { hours: 200 } // Higher than context.hours (100)
+			minThresholds: { hours: 200 }
 		};
 
 		expect(isTemplateApplicable(template, mockContext)).toBe(false);
@@ -490,7 +490,6 @@ describe('generateFromTemplates', () => {
 			excludeIds: timeEquivIds
 		});
 
-		// None should be from time-equivalency category (by verifying they exist in other categories)
 		expect(result.length).toBeGreaterThan(0);
 	});
 
@@ -510,7 +509,6 @@ describe('generateFromTemplates', () => {
 		const context = buildGenerationContext(stats);
 
 		const result = generateFromTemplates(context, { count: 3 });
-		// The year-participant template always applies as a fallback
 		expect(result.length).toBeGreaterThanOrEqual(1);
 		expect(result[0]?.fact).toContain('active viewer');
 	});

--- a/tests/unit/landing-lookup.test.ts
+++ b/tests/unit/landing-lookup.test.ts
@@ -240,8 +240,8 @@ describe('landing username lookup', () => {
 
 	describe('public landing lookup gate', () => {
 		it('rejects the lookup with 403 (no redirect) when the toggle is off', async () => {
-			// Toggle off even though the user would otherwise be publicly reachable —
-			// proves the action guard is independent of the per-user share mode.
+			// The landing toggle is the outer gate; this proves it blocks lookup before
+			// per-user share mode is considered.
 			await setPublicLandingLookupEnabled(false);
 			await setGlobalShareDefaults({
 				defaultShareMode: ShareMode.PUBLIC,
@@ -259,7 +259,6 @@ describe('landing username lookup', () => {
 						requiresAuth: true
 					}
 				});
-				// Guard short-circuits before any live-sync work runs.
 				expect(liveSyncCalls).toHaveLength(0);
 			} finally {
 				warnSpy.mockRestore();
@@ -301,8 +300,8 @@ describe('landing username lookup', () => {
 			};
 
 		it('returns publicLookupEnabled === toggle value regardless of default share mode', async () => {
-			// Toggle on but default non-public: load still reports the toggle value
-			// (sole-gate semantics), and surfaces the sign-in href.
+			// The load contract mirrors only the landing toggle (sole-gate semantics)
+			// and still surfaces the sign-in href.
 			await setPublicLandingLookupEnabled(true);
 			await setGlobalShareDefaults({
 				defaultShareMode: ShareMode.PRIVATE_OAUTH,

--- a/tests/unit/plex/pagination.test.ts
+++ b/tests/unit/plex/pagination.test.ts
@@ -1,9 +1,3 @@
-/**
- * Unit tests for Plex Pagination Module
- *
- * Tests the generic pagination implementation for Plex API.
- */
-
 import { describe, expect, it } from 'bun:test';
 import {
 	calculateExpectedPages,

--- a/tests/unit/plex/pagination.test.ts
+++ b/tests/unit/plex/pagination.test.ts
@@ -14,18 +14,11 @@ import {
 	paginateAll
 } from '$lib/server/plex/pagination';
 
-// =============================================================================
-// Test Helpers
-// =============================================================================
-
 interface TestItem {
 	id: number;
 	name: string;
 }
 
-/**
- * Create a mock page fetcher that returns items from a predefined dataset
- */
 function createMockFetcher(items: TestItem[]): PageFetcher<TestItem> {
 	return async (offset: number, pageSize: number): Promise<PageResult<TestItem>> => {
 		const pageItems = items.slice(offset, offset + pageSize);
@@ -38,19 +31,12 @@ function createMockFetcher(items: TestItem[]): PageFetcher<TestItem> {
 	};
 }
 
-/**
- * Generate test items
- */
 function generateItems(count: number): TestItem[] {
 	return Array.from({ length: count }, (_, i) => ({
 		id: i + 1,
 		name: `Item ${i + 1}`
 	}));
 }
-
-// =============================================================================
-// paginateAll Tests
-// =============================================================================
 
 describe('paginateAll', () => {
 	describe('input validation', () => {
@@ -60,7 +46,6 @@ describe('paginateAll', () => {
 			await expect(async () => {
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
 				for await (const _page of paginateAll(fetcher, 0)) {
-					// Should not reach here
 				}
 			}).toThrow('pageSize must be greater than 0');
 		});
@@ -71,7 +56,6 @@ describe('paginateAll', () => {
 			await expect(async () => {
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
 				for await (const _page of paginateAll(fetcher, -1)) {
-					// Should not reach here
 				}
 			}).toThrow('pageSize must be greater than 0');
 		});
@@ -155,10 +139,6 @@ describe('paginateAll', () => {
 	});
 });
 
-// =============================================================================
-// fetchAllPaginated Tests
-// =============================================================================
-
 describe('fetchAllPaginated', () => {
 	it('collects all items from multiple pages', async () => {
 		const items = generateItems(25);
@@ -210,10 +190,6 @@ describe('fetchAllPaginated', () => {
 	});
 });
 
-// =============================================================================
-// fetchAllPaginatedWithStats Tests
-// =============================================================================
-
 describe('fetchAllPaginatedWithStats', () => {
 	it('throws error when pageSize is 0', async () => {
 		const fetcher = createMockFetcher([]);
@@ -263,10 +239,6 @@ describe('fetchAllPaginatedWithStats', () => {
 		expect(result.pagesFetched).toBe(1);
 	});
 });
-
-// =============================================================================
-// calculateExpectedPages Tests
-// =============================================================================
 
 describe('calculateExpectedPages', () => {
 	it('returns 0 for zero records', () => {

--- a/tests/unit/security/csrf-handle.test.ts
+++ b/tests/unit/security/csrf-handle.test.ts
@@ -99,8 +99,6 @@ describe('csrfHandle (production mode)', () => {
 		});
 
 		it('passes through when onboarding is still in progress', async () => {
-			// ONBOARDING_COMPLETED not set ⇒ onboarding in progress.
-
 			const event = makeEvent({
 				method: 'POST',
 				url: 'https://example.com/onboarding/csrf?/skipCsrf',
@@ -122,7 +120,6 @@ describe('csrfHandle (production mode)', () => {
 			const event = makeEvent({
 				method: 'POST',
 				url: `https://example.com/wrapped/2024/u/${tokenUUID}?/updateShareMode`,
-				// No origin header → missing-origin branch.
 				route: { id: '/wrapped/[year=year]/u/[identifier]' }
 			});
 

--- a/tests/unit/security/csrf-handle.test.ts
+++ b/tests/unit/security/csrf-handle.test.ts
@@ -134,8 +134,9 @@ describe('csrfHandle (production mode)', () => {
 			expect(rows.length).toBeGreaterThan(0);
 
 			const metadata = rows[0]?.metadata ?? '';
+			// Route IDs are logged instead of raw paths so private-link UUIDs never land
+			// in CSRF diagnostics.
 			expect(metadata).toContain('/wrapped/[year=year]/u/[identifier]');
-			// The raw UUID must NOT appear anywhere in the log metadata.
 			expect(metadata).not.toContain(tokenUUID);
 			expect(metadata).not.toContain('"path"');
 		});
@@ -159,6 +160,8 @@ describe('csrfHandle (production mode)', () => {
 			expect(rows.length).toBeGreaterThan(0);
 
 			const metadata = rows[0]?.metadata ?? '';
+			// Route IDs are logged instead of raw paths so private-link UUIDs never land
+			// in CSRF diagnostics.
 			expect(metadata).toContain('/wrapped/[year=year]/u/[identifier]');
 			expect(metadata).not.toContain(tokenUUID);
 		});
@@ -192,7 +195,6 @@ describe('csrfHandle (production mode)', () => {
 
 			const event = makeEvent({
 				method: 'POST',
-				// Admin is loaded on the real origin and repairs the setting.
 				url: 'https://example.com/admin/settings/security?/updateCsrfOrigin',
 				origin: 'https://example.com',
 				route: { id: '/admin/settings/security' }
@@ -254,7 +256,6 @@ describe('csrfHandle (production mode)', () => {
 			const repairResponse = await invoke(repairWithForgedOrigin);
 			expect(repairResponse.status).toBe(200);
 
-			// A different state-changing route gets no exemption.
 			const otherRoute = makeEvent({
 				method: 'POST',
 				url: 'https://example.com/admin/users?/deleteUser',

--- a/tests/unit/security/proxy-handle.test.ts
+++ b/tests/unit/security/proxy-handle.test.ts
@@ -44,9 +44,8 @@ async function invoke(options: InvokeOptions): Promise<InvokeResult> {
 	return { rewrittenUrl: observedUrl };
 }
 
-// Build a request whose headers map can return CR/LF — the WHATWG Headers API
-// strips/rejects these, so we use a fake headers object to exercise the
-// header-injection guard inside proxyHandle.
+// WHATWG Headers strips/rejects CR/LF before proxyHandle sees them, so the
+// injection guard needs a fake headers object that can return raw values.
 async function invokeWithRawHeaders(options: {
 	url: string;
 	headerLookup: (name: string) => string | null;

--- a/tests/unit/sharing/access-control.test.ts
+++ b/tests/unit/sharing/access-control.test.ts
@@ -35,10 +35,6 @@ import { resetSharedTestDb } from '../../helpers/db';
 describe('Sharing Access Control', () => {
 	beforeEach(resetSharedTestDb);
 
-	// =========================================================================
-	// checkAccess - Pure Function Tests
-	// =========================================================================
-
 	describe('checkAccess', () => {
 		describe('owner access', () => {
 			it('allows owner access regardless of share mode', () => {
@@ -207,10 +203,6 @@ describe('Sharing Access Control', () => {
 			});
 		});
 	});
-
-	// =========================================================================
-	// checkWrappedAccess - Integration Tests
-	// =========================================================================
 
 	describe('checkWrappedAccess', () => {
 		const userId = 1;
@@ -466,10 +458,6 @@ describe('Sharing Access Control', () => {
 		});
 	});
 
-	// =========================================================================
-	// checkTokenAccess - Token Validation Tests
-	// =========================================================================
-
 	describe('checkTokenAccess', () => {
 		const userId = 1;
 		const year = 2024;
@@ -706,10 +694,6 @@ describe('Sharing Access Control', () => {
 		});
 	});
 
-	// =========================================================================
-	// Integration: Full Access Flow
-	// =========================================================================
-
 	describe('Integration: Access Flow', () => {
 		const userId = 1;
 		const year = 2024;
@@ -751,7 +735,6 @@ describe('Sharing Access Control', () => {
 			let result = await checkWrappedAccess({ userId, year, shareToken: token });
 			expect(result.accessReason).toBe('valid_token');
 
-			// Change to public
 			await db
 				.update(shareSettings)
 				.set({ mode: ShareMode.PUBLIC })
@@ -770,10 +753,6 @@ describe('Sharing Access Control', () => {
 			}
 		});
 	});
-
-	// =========================================================================
-	// Privacy Level Helpers - Floor Enforcement
-	// =========================================================================
 
 	describe('Privacy Level Helpers', () => {
 		describe('ShareModePrivacyLevel', () => {
@@ -849,10 +828,6 @@ describe('Sharing Access Control', () => {
 		});
 	});
 
-	// =========================================================================
-	// Floor Enforcement in checkWrappedAccess
-	// =========================================================================
-
 	describe('Floor Enforcement', () => {
 		const userId = 1;
 		const year = 2024;
@@ -865,7 +840,6 @@ describe('Sharing Access Control', () => {
 					allowUserControl: true
 				});
 
-				// Create user setting as public (less restrictive than floor)
 				await db.insert(shareSettings).values({
 					userId,
 					year,
@@ -901,7 +875,6 @@ describe('Sharing Access Control', () => {
 
 		describe('when user setting is more restrictive than floor', () => {
 			beforeEach(async () => {
-				// Set global floor to public
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PUBLIC,
 					allowUserControl: true
@@ -958,10 +931,6 @@ describe('Sharing Access Control', () => {
 			});
 		});
 	});
-
-	// =========================================================================
-	// Server-Wide Wrapped Access Control
-	// =========================================================================
 
 	describe('checkServerWrappedAccess', () => {
 		const year = 2024;

--- a/tests/unit/sharing/access-control.test.ts
+++ b/tests/unit/sharing/access-control.test.ts
@@ -23,15 +23,6 @@ import {
 } from '$lib/server/sharing/types';
 import { resetSharedTestDb } from '../../helpers/db';
 
-/**
- * Unit tests for Sharing Access Control
- *
- * Tests access control logic for wrapped pages.
- * Covers pure access check function and high-level route guards.
- *
- * Uses in-memory SQLite from test setup.
- */
-
 describe('Sharing Access Control', () => {
 	beforeEach(resetSharedTestDb);
 
@@ -485,11 +476,12 @@ describe('Sharing Access Control', () => {
 		it('throws InvalidShareTokenError when mode is not private-link', async () => {
 			const token = generateShareToken();
 
-			// Insert token but with PUBLIC mode (simulating mode change after token generation)
+			// Simulate a mode change after token generation; stale private-link tokens
+			// must not authorize once the share is public.
 			await db.insert(shareSettings).values({
 				userId,
 				year,
-				mode: ShareMode.PUBLIC, // Not PRIVATE_LINK
+				mode: ShareMode.PUBLIC,
 				shareToken: token,
 				canUserControl: false
 			});

--- a/tests/unit/sharing/access-control.test.ts
+++ b/tests/unit/sharing/access-control.test.ts
@@ -701,7 +701,6 @@ describe('Sharing Access Control', () => {
 		it('complete flow: admin sets private-link, user shares token', async () => {
 			const token = generateShareToken();
 
-			// Admin creates private-link settings
 			await db.insert(shareSettings).values({
 				userId,
 				year,
@@ -710,11 +709,9 @@ describe('Sharing Access Control', () => {
 				canUserControl: false
 			});
 
-			// Unauthenticated user with token can access via checkTokenAccess
 			const tokenResult = await checkTokenAccess(token);
 			expect(tokenResult.userId).toBe(userId);
 
-			// And via checkWrappedAccess with token
 			const wrappedResult = await checkWrappedAccess({ userId, year, shareToken: token });
 			expect(wrappedResult.accessReason).toBe('valid_token');
 		});
@@ -722,7 +719,6 @@ describe('Sharing Access Control', () => {
 		it('complete flow: mode changed from private-link to public', async () => {
 			const token = generateShareToken();
 
-			// Start with private-link
 			await db.insert(shareSettings).values({
 				userId,
 				year,
@@ -731,7 +727,6 @@ describe('Sharing Access Control', () => {
 				canUserControl: false
 			});
 
-			// Token works
 			let result = await checkWrappedAccess({ userId, year, shareToken: token });
 			expect(result.accessReason).toBe('valid_token');
 
@@ -740,11 +735,9 @@ describe('Sharing Access Control', () => {
 				.set({ mode: ShareMode.PUBLIC })
 				.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)));
 
-			// Now anyone can access (no token needed)
 			result = await checkWrappedAccess({ userId, year });
 			expect(result.accessReason).toBe('public');
 
-			// Old token no longer works via checkTokenAccess
 			try {
 				await checkTokenAccess(token);
 				expect.unreachable('Should have thrown');
@@ -761,7 +754,6 @@ describe('Sharing Access Control', () => {
 				expect(ShareModePrivacyLevel[ShareMode.PRIVATE_LINK]).toBe(1);
 				expect(ShareModePrivacyLevel[ShareMode.PRIVATE_OAUTH]).toBe(2);
 
-				// OAuth is most restrictive
 				expect(ShareModePrivacyLevel[ShareMode.PRIVATE_OAUTH]).toBeGreaterThan(
 					ShareModePrivacyLevel[ShareMode.PRIVATE_LINK]
 				);
@@ -834,7 +826,6 @@ describe('Sharing Access Control', () => {
 
 		describe('when user setting is public but floor is private-oauth', () => {
 			beforeEach(async () => {
-				// Set global floor to private-oauth
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PRIVATE_OAUTH,
 					allowUserControl: true
@@ -850,7 +841,6 @@ describe('Sharing Access Control', () => {
 			});
 
 			it('enforces floor by requiring authentication', async () => {
-				// Unauthenticated should be denied (floor is OAuth)
 				try {
 					await checkWrappedAccess({ userId, year });
 					expect.unreachable('Should have thrown');
@@ -868,7 +858,6 @@ describe('Sharing Access Control', () => {
 			it('returns effective mode (floor) in settings', async () => {
 				const currentUser = { id: 2, plexId: 200, isAdmin: false };
 				const result = await checkWrappedAccess({ userId, year, currentUser });
-				// Effective mode should be the floor, not the user's setting
 				expect(result.settings.mode).toBe(ShareMode.PRIVATE_OAUTH);
 			});
 		});
@@ -880,7 +869,6 @@ describe('Sharing Access Control', () => {
 					allowUserControl: true
 				});
 
-				// Create user setting as private-oauth (more restrictive)
 				await db.insert(shareSettings).values({
 					userId,
 					year,
@@ -891,7 +879,6 @@ describe('Sharing Access Control', () => {
 			});
 
 			it('respects user setting when more restrictive', async () => {
-				// Unauthenticated should be denied (user wants OAuth)
 				try {
 					await checkWrappedAccess({ userId, year });
 					expect.unreachable('Should have thrown');

--- a/tests/unit/sharing/access-control.test.ts
+++ b/tests/unit/sharing/access-control.test.ts
@@ -501,7 +501,7 @@ describe('Sharing Access Control', () => {
 			await db.insert(shareSettings).values({
 				userId,
 				year,
-				mode: ShareMode.PRIVATE_OAUTH, // Not PRIVATE_LINK
+				mode: ShareMode.PRIVATE_OAUTH,
 				shareToken: token,
 				canUserControl: false
 			});
@@ -826,7 +826,7 @@ describe('Sharing Access Control', () => {
 				await db.insert(shareSettings).values({
 					userId,
 					year,
-					mode: ShareMode.PUBLIC, // User wants public
+					mode: ShareMode.PUBLIC,
 					shareToken: null,
 					canUserControl: true
 				});
@@ -864,7 +864,7 @@ describe('Sharing Access Control', () => {
 				await db.insert(shareSettings).values({
 					userId,
 					year,
-					mode: ShareMode.PRIVATE_OAUTH, // More restrictive than floor
+					mode: ShareMode.PRIVATE_OAUTH,
 					shareToken: null,
 					canUserControl: true
 				});

--- a/tests/unit/sharing/presets.test.ts
+++ b/tests/unit/sharing/presets.test.ts
@@ -36,7 +36,6 @@ describe('matchPresetFull (onboarding, 6 fields)', () => {
 
 	it('returns "custom" for an off-map combination', () => {
 		const balanced = byId('balanced').values;
-		// Flip one field so no preset matches.
 		const offMap: PrivacyPresetValues = { ...balanced, logoMode: 'always_show' };
 		expect(matchPresetFull(offMap)).toBe('custom');
 	});

--- a/tests/unit/sharing/presets.test.ts
+++ b/tests/unit/sharing/presets.test.ts
@@ -22,7 +22,6 @@ describe('matchPresetFull (onboarding, 6 fields)', () => {
 
 	it('is stable under key reordering', () => {
 		const balanced = byId('balanced').values;
-		// Rebuild the object with keys in a different insertion order.
 		const reordered: PrivacyPresetValues = {
 			logoMode: balanced.logoMode,
 			allowUserControl: balanced.allowUserControl,
@@ -54,7 +53,7 @@ describe('matchPresetPrivacy (admin, 5 fields, logoMode excluded)', () => {
 		const { logoMode: _logoMode, ...fiveFields } = balanced;
 		// logoMode is NOT part of the admin match, so passing only the five fields
 		// (whatever the persisted logoMode is) still resolves to balanced.
-		expect(balanced.logoMode).not.toBe('always_hide'); // sanity: balanced is user_choice
+		expect(balanced.logoMode).not.toBe('always_hide');
 		expect(matchPresetPrivacy(fiveFields)).toBe('balanced');
 	});
 

--- a/tests/unit/sharing/server-wrapped-route.test.ts
+++ b/tests/unit/sharing/server-wrapped-route.test.ts
@@ -123,7 +123,6 @@ describe('server wrapped route year guard (ISSUE-009, ISSUE-018)', () => {
 	});
 
 	it('returns 404 for an empty past year not in availableYears (ISSUE-009)', async () => {
-		// availableYears = [2026], year 2025 has no data → must 404
 		const currentYear = new Date().getFullYear();
 		const emptyPastYear = currentYear - 1;
 		try {
@@ -175,22 +174,18 @@ describe('server wrapped route year guard (ISSUE-009, ISSUE-018)', () => {
 			await load({
 				params: { year: String(currentYear) },
 				locals: {},
-				parent: makeParent([]), // empty — no data synced yet
+				parent: makeParent([]),
 				url: new URL(`http://localhost/wrapped/${currentYear}`),
 				setHeaders: () => {}
 			} as unknown as Parameters<ServerWrappedLoad>[0]);
-			// If load somehow succeeds, that's also fine for this guard test
 		} catch (err) {
 			expect(isHttpError(err)).toBe(true);
 			if (!isHttpError(err)) throw err;
-			// Must NOT be blocked by the year guard (404 "No data found for this year")
 			expect(err.body.message).not.toBe('No data found for this year');
 		}
 	});
 
 	it('does not 404 for a year present in availableYears', async () => {
-		// A year with actual data should pass the guard and reach access-control.
-		// Expect either success or a non-year-guard error (e.g. 403 from access control).
 		try {
 			await load({
 				params: { year: '2026' },

--- a/tests/unit/sharing/server-wrapped-route.test.ts
+++ b/tests/unit/sharing/server-wrapped-route.test.ts
@@ -2,9 +2,8 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import { isHttpError } from '@sveltejs/kit';
 import { setServerWrappedShareMode } from '$lib/server/sharing/service';
 import { ShareMode } from '$lib/server/sharing/types';
-// Post-US-022: re-pointed to the nested Privacy route. The
-// updateServerWrappedSettings handler is byte-identical between the deleted
-// monolith and the privacy/+page.server.ts copy (commit 853561f).
+// This route-level guard keeps server-wrapped settings behavior pinned after
+// the handler moved out of the deleted monolith into privacy/+page.server.ts.
 import { actions as adminSettingsActions } from '../../../src/routes/admin/settings/privacy/+page.server';
 import { load } from '../../../src/routes/wrapped/[year=year]/+page.server';
 import { resetSharedTestDb } from '../../helpers/db';
@@ -14,7 +13,6 @@ type UpdateServerWrappedSettingsAction = NonNullable<
 	typeof adminSettingsActions.updateServerWrappedSettings
 >;
 
-/** Helper: build a minimal parent() that satisfies the year guard. */
 function makeParent(availableYears: number[]) {
 	return async () => ({
 		availableYears,
@@ -204,7 +202,6 @@ describe('server wrapped route year guard (ISSUE-009, ISSUE-018)', () => {
 		} catch (err) {
 			expect(isHttpError(err)).toBe(true);
 			if (!isHttpError(err)) throw err;
-			// Must NOT be a year-guard 404
 			expect(err.body.message).not.toBe('No data found for this year');
 		}
 	});

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -593,7 +593,6 @@ describe('Sharing Service', () => {
 
 				const settings = await getOrCreateShareSettings({ userId, year });
 
-				// Mode and token should be preserved from database
 				expect(settings.mode).toBe(ShareMode.PRIVATE_LINK);
 				expect(settings.modeSource).toBe(ShareModeSource.EXPLICIT);
 				expect(settings.shareToken).toBe(existingToken);
@@ -676,7 +675,7 @@ describe('Sharing Service', () => {
 					userId,
 					year,
 					{ mode: ShareMode.PRIVATE_OAUTH },
-					true // isAdmin
+					true
 				);
 
 				expect(updated.mode).toBe(ShareMode.PRIVATE_OAUTH);
@@ -688,7 +687,7 @@ describe('Sharing Service', () => {
 					userId,
 					year,
 					{ mode: ShareMode.PRIVATE_LINK },
-					true // isAdmin
+					true
 				);
 
 				expect(updated.mode).toBe(ShareMode.PRIVATE_LINK);
@@ -696,26 +695,15 @@ describe('Sharing Service', () => {
 			});
 
 			it('allows admin to update canUserControl', async () => {
-				const updated = await updateShareSettings(
-					userId,
-					year,
-					{ canUserControl: false },
-					true // isAdmin
-				);
+				const updated = await updateShareSettings(userId, year, { canUserControl: false }, true);
 
 				expect(updated.canUserControl).toBe(false);
 			});
 
 			it('allows user with canUserControl to change to public', async () => {
-				// First set to private-oauth
 				await updateShareSettings(userId, year, { mode: ShareMode.PRIVATE_OAUTH }, true);
 
-				const updated = await updateShareSettings(
-					userId,
-					year,
-					{ mode: ShareMode.PUBLIC },
-					false // not admin
-				);
+				const updated = await updateShareSettings(userId, year, { mode: ShareMode.PUBLIC }, false);
 
 				expect(updated.mode).toBe(ShareMode.PUBLIC);
 			});
@@ -733,7 +721,7 @@ describe('Sharing Service', () => {
 					userId,
 					year,
 					{ mode: ShareMode.PRIVATE_LINK },
-					false // not admin
+					false
 				);
 
 				expect(updated.mode).toBe(ShareMode.PRIVATE_LINK);
@@ -741,7 +729,6 @@ describe('Sharing Service', () => {
 			});
 
 			it('allows user to keep private-link if already set', async () => {
-				// Admin sets private-link
 				await updateShareSettings(userId, year, { mode: ShareMode.PRIVATE_LINK }, true);
 
 				const updated = await updateShareSettings(
@@ -905,7 +892,6 @@ describe('Sharing Service', () => {
 			});
 
 			it('does nothing for non-existent settings', async () => {
-				// Should not throw
 				await deleteShareSettings(userId, year);
 			});
 		});

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -43,10 +43,6 @@ describe('Sharing Service', () => {
 		await resetSharedTestDb();
 	});
 
-	// =========================================================================
-	// Identifier Helpers
-	// =========================================================================
-
 	describe('Identifier Helpers', () => {
 		it('isPureNumericId accepts non-empty digit strings', () => {
 			expect(isPureNumericId('1')).toBe(true);
@@ -65,10 +61,6 @@ describe('Sharing Service', () => {
 			expect(isPureNumericId('1.0')).toBe(false);
 		});
 	});
-
-	// =========================================================================
-	// Global Defaults
-	// =========================================================================
 
 	describe('Global Defaults', () => {
 		describe('getGlobalDefaultShareMode', () => {
@@ -140,13 +132,11 @@ describe('Sharing Service', () => {
 			});
 
 			it('updates existing settings', async () => {
-				// Insert initial values
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PUBLIC,
 					allowUserControl: false
 				});
 
-				// Update values
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PRIVATE_OAUTH,
 					allowUserControl: true
@@ -301,7 +291,6 @@ describe('Sharing Service', () => {
 
 				const explicitToken = generateShareToken();
 				await db.insert(shareSettings).values([
-					// Default-sourced row: should adopt the new default.
 					{
 						userId: 1,
 						year: 2024,
@@ -310,7 +299,6 @@ describe('Sharing Service', () => {
 						shareToken: null,
 						canUserControl: false
 					},
-					// Explicit override: must be preserved verbatim.
 					{
 						userId: 2,
 						year: 2024,
@@ -453,10 +441,6 @@ describe('Sharing Service', () => {
 			});
 		});
 	});
-
-	// =========================================================================
-	// Share Settings CRUD
-	// =========================================================================
 
 	describe('Share Settings CRUD', () => {
 		const userId = 1;
@@ -680,13 +664,11 @@ describe('Sharing Service', () => {
 
 		describe('updateShareSettings', () => {
 			beforeEach(async () => {
-				// Set global defaults (canUserControl is now derived from global setting)
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PUBLIC,
 					allowUserControl: true
 				});
 
-				// Create initial settings
 				await db.insert(shareSettings).values({
 					userId,
 					year,
@@ -735,7 +717,6 @@ describe('Sharing Service', () => {
 				// First set to private-oauth
 				await updateShareSettings(userId, year, { mode: ShareMode.PRIVATE_OAUTH }, true);
 
-				// User changes to public
 				const updated = await updateShareSettings(
 					userId,
 					year,
@@ -770,7 +751,6 @@ describe('Sharing Service', () => {
 				// Admin sets private-link
 				await updateShareSettings(userId, year, { mode: ShareMode.PRIVATE_LINK }, true);
 
-				// User updates something else (mode stays the same)
 				const updated = await updateShareSettings(
 					userId,
 					year,
@@ -803,7 +783,6 @@ describe('Sharing Service', () => {
 				// Set to private-link first
 				await updateShareSettings(userId, year, { mode: ShareMode.PRIVATE_LINK }, true);
 
-				// Switch to public
 				const updated = await updateShareSettings(userId, year, { mode: ShareMode.PUBLIC }, true);
 
 				expect(updated.shareToken).toBeNull();

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -31,13 +31,6 @@ import {
 } from '$lib/server/sharing/types';
 import { resetSharedTestDb } from '../../helpers/db';
 
-/**
- * Unit tests for Sharing Service
- *
- * Tests database operations for share settings management.
- * Uses in-memory SQLite from test setup.
- */
-
 describe('Sharing Service', () => {
 	beforeEach(async () => {
 		await resetSharedTestDb();
@@ -780,7 +773,6 @@ describe('Sharing Service', () => {
 			});
 
 			it('clears token when switching away from private-link', async () => {
-				// Set to private-link first
 				await updateShareSettings(userId, year, { mode: ShareMode.PRIVATE_LINK }, true);
 
 				const updated = await updateShareSettings(userId, year, { mode: ShareMode.PUBLIC }, true);

--- a/tests/unit/sharing/wrapped-identifier-loader.test.ts
+++ b/tests/unit/sharing/wrapped-identifier-loader.test.ts
@@ -158,7 +158,6 @@ describe('wrapped/[year=year]/u/[identifier] loader: cross-year token isolation'
 			defaultShareMode: ShareMode.PRIVATE_LINK,
 			allowUserControl: false
 		});
-		// Main year must already have the token the visitor is presenting.
 		await seedShareSettings({
 			userId: USER_ID,
 			year: ORIGIN_YEAR,
@@ -184,7 +183,6 @@ describe('wrapped/[year=year]/u/[identifier] loader: cross-year token isolation'
 
 		expect(data.yearIdentifiers).toBeDefined();
 		expect(data.yearIdentifiers?.[ORIGIN_YEAR]).toBe(CURRENT_YEAR_TOKEN);
-		// Critical property: other year's identifier is the numeric userId, NOT its token.
 		expect(data.yearIdentifiers?.[OTHER_YEAR]).toBe(USER_ID);
 		expect(data.yearIdentifiers?.[OTHER_YEAR]).not.toBe(OTHER_YEAR_TOKEN_FOR_PRESEED);
 	});
@@ -201,7 +199,6 @@ describe('wrapped/[year=year]/u/[identifier] loader: cross-year token isolation'
 		});
 
 		expect(data.yearIdentifiers?.[OTHER_YEAR]).toBe(USER_ID);
-		// No share_settings row was created for OTHER_YEAR as a side effect.
 		const rows = await db
 			.select()
 			.from(shareSettings)
@@ -855,7 +852,6 @@ describe('wrapped/[year=year]/u/[identifier] loader: ISSUE-001 uniform-404 anti-
 	const EXISTING_ID = 2;
 	const NON_EXISTENT_ID = 4242;
 	const YEAR = 2024;
-	// Reuse the module-level fixture UUIDs rather than minting new literals.
 	const PRIVATE_LINK_TOKEN = CURRENT_YEAR_TOKEN;
 	const VALID_LINK_TOKEN = OTHER_YEAR_TOKEN_FOR_PRESEED;
 
@@ -878,14 +874,12 @@ describe('wrapped/[year=year]/u/[identifier] loader: ISSUE-001 uniform-404 anti-
 	}
 
 	it('returns a byte-identical 404 for anon private-oauth, anon private-link-no-token, and non-existent id', async () => {
-		// Case A: existing user, private-oauth (was 403 before the uniform-404 fix).
 		await setGlobalShareDefaults({
 			defaultShareMode: ShareMode.PRIVATE_OAUTH,
 			allowUserControl: false
 		});
 		const privateOauth = await captureAnonFailure(String(EXISTING_ID));
 
-		// Case B: existing user, private-link without a token in the URL.
 		await setGlobalShareDefaults({
 			defaultShareMode: ShareMode.PRIVATE_LINK,
 			allowUserControl: false
@@ -967,9 +961,7 @@ describe('wrapped/[year=year]/u/[identifier] loader: ISSUE-001 uniform-404 anti-
 			allowUserControl: false
 		});
 
-		// Real, existing user whose personal wrapped is members-only (private-oauth).
 		const realMembersOnly = await captureAnonFailure(String(EXISTING_ID));
-		// Garbage, non-numeric identifier that is neither a valid token nor an id.
 		const garbage = await captureAnonFailure('definitely-not-a-real-identifier');
 
 		expect(realMembersOnly.status).toBe(404);

--- a/tests/unit/sharing/wrapped-identifier-loader.test.ts
+++ b/tests/unit/sharing/wrapped-identifier-loader.test.ts
@@ -898,7 +898,6 @@ describe('wrapped/[year=year]/u/[identifier] loader: ISSUE-001 uniform-404 anti-
 		});
 		const privateLinkNoToken = await captureAnonFailure(String(EXISTING_ID));
 
-		// Case C: non-existent numeric id.
 		const nonExistent = await captureAnonFailure(String(NON_EXISTENT_ID));
 
 		expect(privateOauth.status).toBe(404);

--- a/tests/unit/slides/config.service.test.ts
+++ b/tests/unit/slides/config.service.test.ts
@@ -52,11 +52,9 @@ describe('Slide Config Service', () => {
 		});
 
 		it('does not duplicate existing slides', async () => {
-			// First initialization
 			await initializeDefaultSlideConfig();
 			const firstCount = (await getAllSlideConfigs()).length;
 
-			// Second initialization
 			await initializeDefaultSlideConfig();
 			const secondCount = (await getAllSlideConfigs()).length;
 
@@ -71,7 +69,6 @@ describe('Slide Config Service', () => {
 				sortOrder: 0
 			});
 
-			// Run initialization (should migrate)
 			await initializeDefaultSlideConfig();
 
 			const config = await getSlideConfigByType('total-time');
@@ -82,7 +79,6 @@ describe('Slide Config Service', () => {
 			// First initialization with migration
 			await initializeDefaultSlideConfig();
 
-			// Disable a slide
 			await updateSlideConfig('total-time', { enabled: false });
 
 			// Second initialization (should not override user's choice)
@@ -220,7 +216,6 @@ describe('Slide Config Service', () => {
 		});
 
 		it('throws NOT_FOUND for non-existent slide', async () => {
-			// Delete all configs first
 			await db.delete(slideConfig);
 
 			let error: SlideError | null = null;
@@ -300,7 +295,6 @@ describe('Slide Config Service', () => {
 		});
 
 		it('toggles enabled slide to disabled', async () => {
-			// Ensure it's enabled first
 			const original = await getSlideConfigByType('total-time');
 			expect(original?.enabled).toBe(true);
 
@@ -309,7 +303,6 @@ describe('Slide Config Service', () => {
 		});
 
 		it('toggles disabled slide to enabled', async () => {
-			// First disable it
 			await updateSlideConfig('total-time', { enabled: false });
 
 			const toggled = await toggleSlide('total-time');
@@ -336,11 +329,9 @@ describe('Slide Config Service', () => {
 
 	describe('resetToDefaultConfig', () => {
 		it('clears and reinitializes all configs', async () => {
-			// Initialize and modify
 			await initializeDefaultSlideConfig();
 			await updateSlideConfig('total-time', { enabled: false, sortOrder: 99 });
 
-			// Reset
 			await resetToDefaultConfig();
 
 			const config = await getSlideConfigByType('total-time');

--- a/tests/unit/slides/config.service.test.ts
+++ b/tests/unit/slides/config.service.test.ts
@@ -70,12 +70,10 @@ describe('Slide Config Service', () => {
 		});
 
 		it('does not re-migrate on subsequent runs', async () => {
-			// First initialization with migration
 			await initializeDefaultSlideConfig();
 
 			await updateSlideConfig('total-time', { enabled: false });
 
-			// Second initialization (should not override user's choice)
 			await initializeDefaultSlideConfig();
 
 			const config = await getSlideConfigByType('total-time');
@@ -275,9 +273,7 @@ describe('Slide Config Service', () => {
 			const newOrder = ['genres', 'total-time'] as const;
 			const result = await reorderSlides([...newOrder]);
 
-			// Should return all configs sorted by sortOrder
 			expect(result.length).toBeGreaterThan(0);
-			// First two should be in our specified order
 			expect(result[0]?.slideType).toBe('genres');
 			expect(result[1]?.slideType).toBe('total-time');
 		});

--- a/tests/unit/slides/config.service.test.ts
+++ b/tests/unit/slides/config.service.test.ts
@@ -1,9 +1,3 @@
-/**
- * Unit tests for Slide Configuration Service
- *
- * Tests slide config initialization, updates, and error handling.
- */
-
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { eq } from 'drizzle-orm';
 import { DEFAULT_SLIDE_ORDER } from '$lib/components/slides/types';

--- a/tests/unit/slides/config.service.test.ts
+++ b/tests/unit/slides/config.service.test.ts
@@ -326,7 +326,7 @@ describe('Slide Config Service', () => {
 
 			const config = await getSlideConfigByType('total-time');
 			expect(config?.enabled).toBe(true);
-			expect(config?.sortOrder).toBe(0); // Should be back at default position
+			expect(config?.sortOrder).toBe(0);
 		});
 	});
 });

--- a/tests/unit/slides/config.service.test.ts
+++ b/tests/unit/slides/config.service.test.ts
@@ -62,7 +62,7 @@ describe('Slide Config Service', () => {
 		});
 
 		it('migrates disabled slides to enabled on first run', async () => {
-			// Insert a disabled slide manually (simulating bug where slides were created disabled)
+			// Reproduces the historical bug where newly-created rows were disabled by default.
 			await db.insert(slideConfig).values({
 				slideType: 'total-time',
 				enabled: false,

--- a/tests/unit/stats/calculators.test.ts
+++ b/tests/unit/stats/calculators.test.ts
@@ -347,9 +347,9 @@ describe('Distribution Calculators', () => {
 
 			const result = calculateMonthlyDistribution(records);
 
-			expect(result.minutes[0]).toBe(60); // January
-			expect(result.minutes[6]).toBe(30); // July
-			expect(result.minutes.reduce((a, b) => a + b, 0)).toBe(90); // Total
+			expect(result.minutes[0]).toBe(60);
+			expect(result.minutes[6]).toBe(30);
+			expect(result.minutes.reduce((a, b) => a + b, 0)).toBe(90);
 		});
 
 		it('returns 12 buckets for empty array', () => {
@@ -362,31 +362,31 @@ describe('Distribution Calculators', () => {
 
 		it('counts plays per month', () => {
 			const records = [
-				createRecord({ viewedAt: 1704067200, duration: 3600 }), // Jan 2024
-				createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704153600, duration: 1800 }), // Jan 2024 (next day)
-				createRecord({ id: 3, historyKey: 'key-3', viewedAt: 1719792000, duration: 1800 }) // July 2024
+				createRecord({ viewedAt: 1704067200, duration: 3600 }),
+				createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704153600, duration: 1800 }),
+				createRecord({ id: 3, historyKey: 'key-3', viewedAt: 1719792000, duration: 1800 })
 			];
 
 			const result = calculateMonthlyDistribution(records);
 
-			expect(result.plays[0]).toBe(2); // January - 2 plays
-			expect(result.plays[6]).toBe(1); // July - 1 play
-			expect(result.plays.reduce((a, b) => a + b, 0)).toBe(3); // Total plays
+			expect(result.plays[0]).toBe(2);
+			expect(result.plays[6]).toBe(1);
+			expect(result.plays.reduce((a, b) => a + b, 0)).toBe(3);
 		});
 	});
 
 	describe('calculateHourlyDistribution', () => {
 		it('distributes watch time to correct hours', () => {
 			const records = [
-				createRecord({ viewedAt: 1704067200, duration: 3600 }), // 00:00 UTC
-				createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704110400, duration: 1800 }) // 12:00 UTC
+				createRecord({ viewedAt: 1704067200, duration: 3600 }),
+				createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704110400, duration: 1800 })
 			];
 
 			const result = calculateHourlyDistribution(records);
 
-			expect(result.minutes[0]).toBe(60); // Midnight
-			expect(result.minutes[12]).toBe(30); // Noon
-			expect(result.minutes.reduce((a, b) => a + b, 0)).toBe(90); // Total
+			expect(result.minutes[0]).toBe(60);
+			expect(result.minutes[12]).toBe(30);
+			expect(result.minutes.reduce((a, b) => a + b, 0)).toBe(90);
 		});
 
 		it('returns 24 buckets for empty array', () => {
@@ -399,16 +399,16 @@ describe('Distribution Calculators', () => {
 
 		it('counts plays per hour', () => {
 			const records = [
-				createRecord({ viewedAt: 1704067200, duration: 3600 }), // 00:00 UTC
-				createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704067260, duration: 1800 }), // 00:01 UTC (same hour)
-				createRecord({ id: 3, historyKey: 'key-3', viewedAt: 1704110400, duration: 1800 }) // 12:00 UTC
+				createRecord({ viewedAt: 1704067200, duration: 3600 }),
+				createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704067260, duration: 1800 }),
+				createRecord({ id: 3, historyKey: 'key-3', viewedAt: 1704110400, duration: 1800 })
 			];
 
 			const result = calculateHourlyDistribution(records);
 
-			expect(result.plays[0]).toBe(2); // Midnight - 2 plays
-			expect(result.plays[12]).toBe(1); // Noon - 1 play
-			expect(result.plays.reduce((a, b) => a + b, 0)).toBe(3); // Total plays
+			expect(result.plays[0]).toBe(2);
+			expect(result.plays[12]).toBe(1);
+			expect(result.plays.reduce((a, b) => a + b, 0)).toBe(3);
 		});
 	});
 });
@@ -446,22 +446,22 @@ describe('Percentile Calculator', () => {
 describe('Binge Detector', () => {
 	it('detects binge session with small gaps', () => {
 		const records = [
-			createRecord({ viewedAt: 1704067200, duration: 3600 }), // 00:00
-			createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704068000, duration: 3600 }), // 00:13 (13 min gap)
-			createRecord({ id: 3, historyKey: 'key-3', viewedAt: 1704069000, duration: 3600 }) // 00:30 (16 min gap)
+			createRecord({ viewedAt: 1704067200, duration: 3600 }),
+			createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704068000, duration: 3600 }),
+			createRecord({ id: 3, historyKey: 'key-3', viewedAt: 1704069000, duration: 3600 })
 		];
 
 		const result = detectLongestBinge(records);
 
 		expect(result).not.toBeNull();
 		expect(result?.plays).toBe(3);
-		expect(result?.totalMinutes).toBe(180); // 3 hours
+		expect(result?.totalMinutes).toBe(180);
 	});
 
 	it('splits into separate sessions for large gaps', () => {
 		const records = [
-			createRecord({ viewedAt: 1704067200, duration: 3600 }), // 00:00
-			createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704074400, duration: 3600 }) // 02:00 (2 hour gap)
+			createRecord({ viewedAt: 1704067200, duration: 3600 }),
+			createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704074400, duration: 3600 })
 		];
 
 		const sessions = detectAllBingeSessions(records);
@@ -473,9 +473,9 @@ describe('Binge Detector', () => {
 
 	it('returns the session with max duration', () => {
 		const records = [
-			createRecord({ viewedAt: 1704067200, duration: 1800 }), // 30 min
-			createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704068000, duration: 1800 }), // 30 min
-			createRecord({ id: 3, historyKey: 'key-3', viewedAt: 1704074400, duration: 7200 }) // 2 hours
+			createRecord({ viewedAt: 1704067200, duration: 1800 }),
+			createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704068000, duration: 1800 }),
+			createRecord({ id: 3, historyKey: 'key-3', viewedAt: 1704074400, duration: 7200 })
 		];
 
 		const longest = detectLongestBinge(records);

--- a/tests/unit/stats/calculators.test.ts
+++ b/tests/unit/stats/calculators.test.ts
@@ -24,7 +24,6 @@ import {
 
 import { createPlayHistoryRecord } from '../../helpers/factories';
 
-// Alias for cleaner test code
 const createRecord = createPlayHistoryRecord;
 
 describe('Utils', () => {
@@ -58,22 +57,16 @@ describe('Utils', () => {
 
 	describe('getMonthFromTimestamp', () => {
 		it('returns correct month (0-indexed)', () => {
-			// Jan 1, 2024
 			expect(getMonthFromTimestamp(1704067200)).toBe(0);
-			// July 1, 2024
 			expect(getMonthFromTimestamp(1719792000)).toBe(6);
-			// Dec 31, 2024
 			expect(getMonthFromTimestamp(1735603199)).toBe(11);
 		});
 	});
 
 	describe('getHourFromTimestamp', () => {
 		it('returns correct hour (0-23)', () => {
-			// Jan 1, 2024 00:00 UTC
 			expect(getHourFromTimestamp(1704067200)).toBe(0);
-			// Jan 1, 2024 12:00 UTC
 			expect(getHourFromTimestamp(1704110400)).toBe(12);
-			// Jan 1, 2024 23:00 UTC
 			expect(getHourFromTimestamp(1704150000)).toBe(23);
 		});
 	});
@@ -422,7 +415,6 @@ describe('Distribution Calculators', () => {
 
 describe('Percentile Calculator', () => {
 	it('calculates percentile correctly', () => {
-		// User with 100 min, others have 50, 75, 150
 		// 2 users have less than 100, so percentile = 2/4 * 100 = 50
 		const percentile = calculatePercentileRank(100, [50, 75, 100, 150]);
 		expect(percentile).toBe(50);
@@ -445,7 +437,6 @@ describe('Percentile Calculator', () => {
 	});
 
 	it('handles ties correctly', () => {
-		// Two users with same watch time
 		const percentile = calculatePercentileRank(50, [50, 50, 100]);
 		// 0 users have less than 50, so 0%
 		expect(percentile).toBe(0);
@@ -482,17 +473,13 @@ describe('Binge Detector', () => {
 
 	it('returns the session with max duration', () => {
 		const records = [
-			// First session: 2 short movies
 			createRecord({ viewedAt: 1704067200, duration: 1800 }), // 30 min
 			createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1704068000, duration: 1800 }), // 30 min
-			// Gap of 2 hours
-			// Second session: 1 long movie
 			createRecord({ id: 3, historyKey: 'key-3', viewedAt: 1704074400, duration: 7200 }) // 2 hours
 		];
 
 		const longest = detectLongestBinge(records);
 
-		// Second session has more total time (2 hours vs 1 hour)
 		expect(longest?.totalMinutes).toBe(120);
 		expect(longest?.plays).toBe(1);
 	});

--- a/tests/unit/stats/calculators.test.ts
+++ b/tests/unit/stats/calculators.test.ts
@@ -415,7 +415,6 @@ describe('Distribution Calculators', () => {
 
 describe('Percentile Calculator', () => {
 	it('calculates percentile correctly', () => {
-		// 2 users have less than 100, so percentile = 2/4 * 100 = 50
 		const percentile = calculatePercentileRank(100, [50, 75, 100, 150]);
 		expect(percentile).toBe(50);
 	});
@@ -427,7 +426,6 @@ describe('Percentile Calculator', () => {
 
 	it('returns high percentile for top watcher', () => {
 		const percentile = calculatePercentileRank(100, [10, 50, 100]);
-		// 2 out of 3 have less, so 66.67%
 		expect(Math.round(percentile * 100) / 100).toBeCloseTo(66.67, 1);
 	});
 
@@ -438,7 +436,6 @@ describe('Percentile Calculator', () => {
 
 	it('handles ties correctly', () => {
 		const percentile = calculatePercentileRank(50, [50, 50, 100]);
-		// 0 users have less than 50, so 0%
 		expect(percentile).toBe(0);
 	});
 });

--- a/tests/unit/stats/calculators.test.ts
+++ b/tests/unit/stats/calculators.test.ts
@@ -75,14 +75,14 @@ describe('Utils', () => {
 describe('Watch Time Calculator', () => {
 	it('calculates total watch time correctly', () => {
 		const records = [
-			createRecord({ duration: 3600 }), // 1 hour
-			createRecord({ id: 2, historyKey: 'key-2', duration: 1800 }), // 30 min
-			createRecord({ id: 3, historyKey: 'key-3', duration: 900 }) // 15 min
+			createRecord({ duration: 3600 }),
+			createRecord({ id: 2, historyKey: 'key-2', duration: 1800 }),
+			createRecord({ id: 3, historyKey: 'key-3', duration: 900 })
 		];
 
 		const result = calculateWatchTime(records);
 
-		expect(result.totalWatchTimeMinutes).toBe(105); // 60 + 30 + 15
+		expect(result.totalWatchTimeMinutes).toBe(105);
 		expect(result.totalPlays).toBe(3);
 	});
 
@@ -341,8 +341,8 @@ describe('Distribution Calculators', () => {
 	describe('calculateMonthlyDistribution', () => {
 		it('distributes watch time to correct months', () => {
 			const records = [
-				createRecord({ viewedAt: 1704067200, duration: 3600 }), // Jan 2024
-				createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1719792000, duration: 1800 }) // July 2024
+				createRecord({ viewedAt: 1704067200, duration: 3600 }),
+				createRecord({ id: 2, historyKey: 'key-2', viewedAt: 1719792000, duration: 1800 })
 			];
 
 			const result = calculateMonthlyDistribution(records);
@@ -501,7 +501,7 @@ describe('Binge Detector', () => {
 
 		const result = detectLongestBinge(records);
 
-		expect(result?.totalMinutes).toBe(60); // Only the non-null duration counts
+		expect(result?.totalMinutes).toBe(60);
 	});
 
 	it('gap threshold is 30 minutes', () => {

--- a/tests/unit/sync/scheduler.test.ts
+++ b/tests/unit/sync/scheduler.test.ts
@@ -59,13 +59,11 @@ describe('updateSchedulerCron preserves run-state — ISSUE-012 regression guard
 	});
 
 	it('does NOT activate an INACTIVE scheduler when only the cron is updated', () => {
-		// Scheduler is inactive (never set up)
 		const before = getSchedulerStatus();
 		expect(before.isRunning).toBe(false);
 		expect(before.isPaused).toBe(false);
 		expect(before.cronExpression).toBeNull();
 
-		// Updating the cron must not flip it to active
 		updateSchedulerCron('0 6 * * *');
 
 		const after = getSchedulerStatus();
@@ -83,7 +81,6 @@ describe('updateSchedulerCron preserves run-state — ISSUE-012 regression guard
 		const after = getSchedulerStatus();
 		expect(after.isPaused).toBe(true);
 		expect(after.isRunning).toBe(false);
-		// The new expression should be applied
 		expect(after.cronExpression).toBe('0 3 * * *');
 	});
 

--- a/tests/unit/sync/service.test.ts
+++ b/tests/unit/sync/service.test.ts
@@ -88,7 +88,7 @@ describe('startSync service behavior', () => {
 		expect(row?.status).toBe('cancelled');
 		expect(row?.completedAt).not.toBeNull();
 		expect(row?.error).toBeNull();
-		// lastViewedAt should be persisted even for cancelled syncs (null when aborted before any pages)
+		// Aborting before the first page must not invent a sync watermark.
 		expect(row?.lastViewedAt).toBeNull();
 	});
 

--- a/tests/unit/utils/submit-action.test.ts
+++ b/tests/unit/utils/submit-action.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 
-// Mock $app/forms before importing the helper that depends on it.
+// The helper binds `$app/forms` at module load, so the test double must be in
+// place before the import.
 mock.module('$app/forms', () => ({
 	deserialize: (text: string) => {
 		const parsed = JSON.parse(text);

--- a/tests/unit/utils/submit-action.test.ts
+++ b/tests/unit/utils/submit-action.test.ts
@@ -46,9 +46,7 @@ describe('submitAction', () => {
 		globalThis.fetch = originalFetch;
 	});
 
-	beforeEach(() => {
-		// reset
-	});
+	beforeEach(() => {});
 
 	it('sends POST with x-sveltekit-action header', async () => {
 		let capturedInit: RequestInit | undefined;


### PR DESCRIPTION
## Summary

This PR audits comments across the codebase and removes or rewrites comments that repeat what the surrounding code already states.

Key points:

- Removes redundant comments from Svelte components, route handlers, server services, shared utilities, and tests.
- Keeps or clarifies comments that document non-obvious rationale, behavioral invariants, compatibility constraints, or security-sensitive decisions.
- Reduces maintenance noise without intending to change runtime behavior.

## Validation

- `bun run check:biome`
- `bun run check`
- `bun run test`

## Notes for reviewers

The diff is intentionally broad because the cleanup covers comments throughout the repository. Review focus should be on ensuring preserved comments still explain important context and that removed comments were truly redundant.
