### PR TITLE
fix: resolve privacy dogfood findings

### DIFF
--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -115,6 +115,7 @@ let savedPublicLandingLookup = $state({
 // svelte-ignore state_referenced_locally
 const serverWrappedForm = superForm(data.serverWrappedForm, {
 	resetForm: false,
+	invalidateAll: false,
 	onUpdate: guardSettingsUpdate,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
@@ -137,6 +138,7 @@ const {
 // svelte-ignore state_referenced_locally
 const userDefaultsForm = superForm(data.userDefaultsForm, {
 	resetForm: false,
+	invalidateAll: false,
 	onUpdate: guardSettingsUpdate,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
@@ -159,6 +161,7 @@ const {
 // svelte-ignore state_referenced_locally
 const publicLandingLookupForm = superForm(data.publicLandingLookupForm, {
 	resetForm: false,
+	invalidateAll: false,
 	onUpdate: guardSettingsUpdate,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
@@ -273,11 +276,12 @@ function applyPrivacyPreset(preset: PrivacyPreset) {
 	$publicLandingLookupData.publicLandingLookup = preset.values.publicLandingLookup;
 }
 
-// WAI-ARIA APG radio-group keyboard support for the preset selector. Each preset
-// button is a `role="radio"` in a `role="radiogroup"`; native buttons already
-// handle Space/Enter, so we add roving tabindex (one tab stop) + arrow/Home/End
-// navigation here. Refs are indexed by preset position so a keyboard move can both
-// select (APG: moving in a radio group selects) and shift DOM focus.
+// Privacy dogfood requires every preset card to be directly reachable with Tab,
+// so this intentionally deviates from the APG roving-tabindex radio pattern:
+// every card has tabindex=0 while Arrow/Home/End still move focus and select.
+// Native buttons handle Space/Enter, so this handler only owns navigation keys.
+// Refs are indexed by preset position so a keyboard move can both select and
+// shift DOM focus.
 let presetButtons = $state<(HTMLButtonElement | null)[]>([]);
 
 function handlePresetKeydown(event: KeyboardEvent, index: number) {
@@ -428,15 +432,13 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 						type="button"
 						role="radio"
 						aria-checked={selectedPreset === preset.id}
-						tabindex={selectedPreset === preset.id || (selectedPreset === 'custom' && i === 0)
-							? 0
-							: -1}
+						tabindex={0}
 						onclick={() => applyPrivacyPreset(preset)}
 						onkeydown={(event) => handlePresetKeydown(event, i)}
 						class={selectedPreset === preset.id
-							? 'flex flex-col items-start gap-2 rounded-lg border border-primary bg-primary/5 p-4 text-left ring-1 ring-primary transition-colors'
-							: 'flex flex-col items-start gap-2 rounded-lg border border-border p-4 text-left transition-colors hover:bg-muted/50'}
-					>
+						? 'flex flex-col items-start gap-2 rounded-lg border border-primary bg-primary/5 p-4 text-left ring-1 ring-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+						: 'flex flex-col items-start gap-2 rounded-lg border border-border p-4 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'}
+						>
 						<span class="flex items-center gap-2 text-sm font-medium">
 							<PresetIcon class="size-4 text-primary" />
 							{preset.label}

--- a/src/routes/wrapped/+layout.server.ts
+++ b/src/routes/wrapped/+layout.server.ts
@@ -1,24 +1,28 @@
 import { getWrappedTheme } from '$lib/server/admin/settings.service';
 import { getAvailableYears } from '$lib/server/admin/users.service';
+import { requiresOnboarding } from '$lib/server/onboarding';
 import { getSyncStatus } from '$lib/server/sync/live-sync';
 import type { LayoutServerLoad } from './$types';
 
 const LOOKUP_LIVE_SYNC_COOKIE = 'lookup_live_sync';
 
-export const load: LayoutServerLoad = async ({ cookies }) => {
+export const load: LayoutServerLoad = async ({ cookies, locals }) => {
 	const lookupSyncTriggered = cookies.get(LOOKUP_LIVE_SYNC_COOKIE) === '1';
 	if (lookupSyncTriggered) {
 		cookies.delete(LOOKUP_LIVE_SYNC_COOKIE, { path: '/wrapped' });
 	}
 
-	const [wrappedTheme, syncStatus, availableYears] = await Promise.all([
+	const [wrappedTheme, availableYears, onboardingPending] = await Promise.all([
 		getWrappedTheme(),
-		getSyncStatus(),
-		getAvailableYears()
+		getAvailableYears(),
+		requiresOnboarding()
 	]);
+	const syncStatusEnabled = Boolean(locals.user) || onboardingPending;
+	const syncStatus = syncStatusEnabled ? await getSyncStatus() : null;
 
 	return {
 		wrappedTheme,
+		syncStatusEnabled,
 		syncStatus,
 		availableYears,
 		lookupSyncTriggered

--- a/src/routes/wrapped/+layout.svelte
+++ b/src/routes/wrapped/+layout.svelte
@@ -22,6 +22,10 @@ type LayoutDataWithLookupSync = LayoutData & {
 
 let { children, data }: Props = $props();
 
+function canUseSyncStatus(layoutData: LayoutData): boolean {
+	return layoutData.syncStatusEnabled === true && Boolean(layoutData.syncStatus);
+}
+
 function hasLookupSyncMarker(layoutData: LayoutData): boolean {
 	const lookupData = layoutData as LayoutDataWithLookupSync;
 	return Boolean(lookupData.lookupSyncTriggered ?? lookupData.lookupSyncStarted);
@@ -31,13 +35,15 @@ const MIN_LOADING_DISPLAY_MS = 300;
 const FAILED_LIVE_SYNC_MESSAGE =
 	"Couldn't refresh your viewing history from Plex. Showing your most recent data.";
 
-let isLoading = $state(untrack(() => data.syncStatus?.inProgress ?? false));
+let isLoading = $state(
+	untrack(() => (canUseSyncStatus(data) ? (data.syncStatus?.inProgress ?? false) : false))
+);
 
 let loadingStartTime = $state(Date.now());
 
 let syncCompletionHandled = $state(false);
 
-const initialLookupSyncMarker = untrack(() => hasLookupSyncMarker(data));
+const initialLookupSyncMarker = untrack(() => canUseSyncStatus(data) && hasLookupSyncMarker(data));
 
 let lookupSyncFeedbackPending = $state(initialLookupSyncMarker);
 
@@ -82,14 +88,15 @@ async function handleSyncComplete(event: SyncTerminalEventType): Promise<void> {
 }
 
 $effect(() => {
-	const lookupSyncStarted = hasLookupSyncMarker(data);
+	const syncStatusEnabled = canUseSyncStatus(data);
+	const lookupSyncStarted = syncStatusEnabled && hasLookupSyncMarker(data);
 
 	if (lookupSyncStarted && !lookupSyncMarkerSeen) {
 		lookupSyncFeedbackPending = true;
 		lookupSyncMarkerSeen = true;
 	}
 
-	if (!lookupSyncStarted) {
+	if (!lookupSyncStarted || !syncStatusEnabled) {
 		lookupSyncMarkerSeen = false;
 		lookupSyncFeedbackPending = false;
 	}
@@ -98,10 +105,13 @@ $effect(() => {
 // Keep the SSE store in an effect so it tracks fresh load data, never runs
 // during SSR, and disconnects whenever the layout data changes.
 $effect(() => {
-	const syncStatus = data.syncStatus;
+	const syncStatus = data.syncStatusEnabled === true ? data.syncStatus : null;
 
 	if (!browser || !syncStatus) {
 		syncStatusStore = null;
+		if (!syncCompletionHandled) {
+			isLoading = false;
+		}
 		return;
 	}
 
@@ -127,8 +137,16 @@ $effect(() => {
 	};
 });
 
-const inProgress = $derived(syncStatusStore?.inProgress ?? data.syncStatus?.inProgress ?? false);
-const progress = $derived(syncStatusStore?.progress ?? data.syncStatus?.progress ?? null);
+const inProgress = $derived(
+	data.syncStatusEnabled === true
+		? (syncStatusStore?.inProgress ?? data.syncStatus?.inProgress ?? false)
+		: false
+);
+const progress = $derived(
+	data.syncStatusEnabled === true
+		? (syncStatusStore?.progress ?? data.syncStatus?.progress ?? null)
+		: null
+);
 
 // Suppress the sync status region entirely on error pages (403/404/+error.svelte).
 // When $page.error is set, the overlay's role="status" aria-live region must be
@@ -138,7 +156,11 @@ const hasPageError = $derived(Boolean($page.error));
 </script>
 
 {#if !hasPageError}
-	<SyncLoadingOverlay visible={isLoading || inProgress} {progress} syncInProgress={inProgress} />
+	<SyncLoadingOverlay
+		visible={data.syncStatusEnabled === true && (isLoading || inProgress)}
+		{progress}
+		syncInProgress={inProgress}
+	/>
 {/if}
 
 {@render children()}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -24,6 +24,7 @@ const config = {
 				'style-src': ['self', 'unsafe-inline', 'https://fonts.googleapis.com'],
 				'font-src': ['self', 'https://fonts.gstatic.com'],
 				'script-src': ['self'],
+				'script-src-attr': ['unsafe-hashes', 'sha256-7dQwUgLau1NFCCGjfn9FsYptB6ZtWxJin6VohGIu20I='],
 				'connect-src': ['self', 'https://plex.tv'],
 				'frame-ancestors': ['none'],
 				'base-uri': ['self'],

--- a/tests/unit/sharing/wrapped-layout.test.ts
+++ b/tests/unit/sharing/wrapped-layout.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
+import { load } from '../../../src/routes/wrapped/+layout.server';
+import { resetSharedTestDb } from '../../helpers/db';
+import { createTestCookies } from '../../helpers/requests';
+
+type WrappedLayoutLoad = typeof load;
+type LoadArgs = Parameters<WrappedLayoutLoad>[0];
+type WrappedLayoutData = Exclude<Awaited<ReturnType<WrappedLayoutLoad>>, void>;
+
+async function invokeLoad(
+	args: { locals?: LoadArgs['locals']; cookies?: LoadArgs['cookies'] } = {}
+): Promise<WrappedLayoutData> {
+	return (await load({
+		cookies: args.cookies ?? createTestCookies(),
+		locals: args.locals ?? {},
+		url: new URL('http://localhost/wrapped/2026'),
+		params: {},
+		route: { id: '/wrapped' },
+		setHeaders: () => {},
+		getClientAddress: () => '127.0.0.1'
+	} as unknown as LoadArgs)) as WrappedLayoutData;
+}
+
+describe('wrapped layout sync status privacy gate', () => {
+	beforeEach(resetSharedTestDb);
+
+	it('does not expose sync status to anonymous post-onboarding wrapped pages', async () => {
+		await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+
+		const result = await invokeLoad();
+
+		expect(result.syncStatusEnabled).toBe(false);
+		expect(result.syncStatus).toBeNull();
+	});
+
+	it('exposes sync status to authenticated wrapped pages after onboarding', async () => {
+		await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+
+		const result = await invokeLoad({
+			locals: {
+				user: { id: 1, plexId: 100, username: 'admin', isAdmin: true }
+			} as LoadArgs['locals']
+		});
+
+		expect(result.syncStatusEnabled).toBe(true);
+		expect(result.syncStatus).toMatchObject({ inProgress: false, progress: null });
+	});
+
+	it('keeps sync status available to anonymous onboarding flows', async () => {
+		const result = await invokeLoad();
+
+		expect(result.syncStatusEnabled).toBe(true);
+		expect(result.syncStatus).toMatchObject({ inProgress: false, progress: null });
+	});
+
+	it('consumes lookup_live_sync even when anonymous sync status is disabled', async () => {
+		await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+		const cookies = createTestCookies({ lookup_live_sync: '1' });
+
+		const result = await invokeLoad({ cookies });
+
+		expect(result.lookupSyncTriggered).toBe(true);
+		expect(result.syncStatusEnabled).toBe(false);
+		expect(result.syncStatus).toBeNull();
+		expect(cookies.deletes).toEqual([{ name: 'lookup_live_sync', options: { path: '/wrapped' } }]);
+	});
+});


### PR DESCRIPTION
## Summary

This change resolves the privacy dogfood findings with narrow, security-preserving updates:

- Adds a scoped CSP `script-src-attr` hash for Svelte's generated `this.__e=event` handler while keeping `script-src` restricted to `self`.
- Preserves staged privacy preset changes across independent section saves by disabling Superforms invalidation on the three privacy settings forms.
- Makes every privacy preset card directly keyboard-tabbable, preserves native Space/Enter activation, retains arrow/Home/End navigation, and documents the intentional APG roving-tabindex deviation.
- Prevents anonymous post-onboarding Wrapped pages from receiving sync status data, opening the sync-status EventSource, or showing an indefinite sync overlay.
- Adds wrapped layout regression tests for anonymous, authenticated, onboarding, and lookup marker behavior.

## Validation

- `bun run build`
- `bun run check:biome`
- `bun run check`
- `bun run test`
- `prek run --all-files`

All validation passed locally before commit and push.

## Notes

Manual browser and screen-reader smoke testing was not performed in this final pass. Static keyboard/CSP probes, Svelte diagnostics, build, full tests, and hooks passed.
