### PR TITLE
fix: remediate 2026-06-07 dogfood findings (rev2 plan)

### DIFF
--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -318,6 +318,12 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 			pollIntervalId = timers.setInterval(async () => {
 				try {
 					if (finished) return;
+					// Capture the popup state at tick start. A completed login is always
+					// preferred over a cancel, so we only act on "closed" AFTER confirming
+					// the poll did not return a completed login — otherwise a user who
+					// authorizes and then closes the popup before the next poll lands would
+					// see a false "cancelled" over a successful sign-in (ISSUE-015).
+					const popupClosed = authWindow?.closed ?? false;
 					const pollResponse = await fetch('/auth/plex', {
 						method: 'POST',
 						headers: { 'Content-Type': 'application/json' },
@@ -355,6 +361,15 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 							if (cancelled || succeeded || timedOut || pinExpired) return;
 							opts.onError(err instanceof Error ? err.message : 'Login failed');
 						}
+						return;
+					}
+
+					// Still pending: if the user closed the popup, treat it as an explicit
+					// cancel so the landing page can surface feedback (ISSUE-015).
+					if (popupClosed) {
+						cleanup();
+						opts.onError('Sign-in cancelled. You can try again.');
+						return;
 					}
 				} catch (err) {
 					if (cancelled || succeeded || timedOut || pinExpired || callbackInProgress) return;

--- a/src/lib/components/slides/messaging-context.ts
+++ b/src/lib/components/slides/messaging-context.ts
@@ -7,38 +7,32 @@ export function getSubject(ctx: SlideMessagingContext): string {
 	if (!ctx.isServerWrapped) {
 		return 'You';
 	}
-	return ctx.serverName ?? 'We';
+	return ctx.serverName ? `${ctx.serverName} Community` : 'We';
 }
 
 export function getPossessive(ctx: SlideMessagingContext): string {
 	if (!ctx.isServerWrapped) {
 		return 'Your';
 	}
-	if (ctx.serverName) {
-		return `${ctx.serverName}'s`;
-	}
-	return 'Our';
+	// Use noun-modifier form ("PARENTI Community Top Movies") to avoid
+	// person-like possessive phrasing ("PARENTI's Top Movies") on server Wrapped.
+	return ctx.serverName ? `${ctx.serverName} Community` : 'Our';
 }
 
-export function getHaveVerb(ctx: SlideMessagingContext): string {
-	if (!ctx.isServerWrapped) {
-		return 'have';
-	}
-	return ctx.serverName ? 'has' : 'have';
+// Both personal and server-wide (community) Wrapped use plural verbs — server
+// context is framed as a collective ("the {serverName} community ... watch"), not
+// a single person (ISSUE-009) — so these are context-independent. The `_ctx`
+// param is kept for a uniform helper API alongside getSubject/getPossessive.
+export function getHaveVerb(_ctx: SlideMessagingContext): string {
+	return 'have';
 }
 
-export function getAreVerb(ctx: SlideMessagingContext): string {
-	if (!ctx.isServerWrapped) {
-		return 'are';
-	}
-	return ctx.serverName ? 'is' : 'are';
+export function getAreVerb(_ctx: SlideMessagingContext): string {
+	return 'are';
 }
 
-export function getWatchVerb(ctx: SlideMessagingContext): string {
-	if (!ctx.isServerWrapped) {
-		return 'watch';
-	}
-	return ctx.serverName ? 'watches' : 'watch';
+export function getWatchVerb(_ctx: SlideMessagingContext): string {
+	return 'watch';
 }
 
 export function createPersonalContext(): SlideMessagingContext {

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -996,6 +996,29 @@ export function isAuthoritativeEnvValue(value: string): boolean {
 	return Boolean(value) && !isPlaceholderSentinel(value);
 }
 
+/**
+ * Plex-specific authority check for the SERVER URL (ISSUE-002).
+ *
+ * The shared `isPlaceholderSentinel` treats `http://localhost:32400`
+ * unconditionally as a placeholder because it is the `.env.example` default —
+ * correct when the token is ALSO a placeholder, so a bare template copy never
+ * locks the connections UI (the onboarding-strands guard the L1043-1050 comment
+ * protects). But a genuine localhost Plex deployment supplied via ENV pairs that
+ * URL with a REAL token (`.env.example` ships localhost with the placeholder
+ * token `your-plex-token-here`). So localhost is authoritative ONLY when the
+ * paired `PLEX_TOKEN` is itself authoritative. Any non-localhost URL falls back
+ * to the shared value-only check. This predicate is used solely by the Plex
+ * branch of config resolution; `isPlaceholderSentinel`/`isAuthoritativeEnvValue`
+ * stay value-only so OpenAI/CSRF semantics are unaffected.
+ */
+export function isAuthoritativePlexServerUrl(serverUrl: string, token: string): boolean {
+	if (isAuthoritativeEnvValue(serverUrl)) return true;
+	if (serverUrl.trim() === 'http://localhost:32400' && isAuthoritativeEnvValue(token)) {
+		return true;
+	}
+	return false;
+}
+
 function resolveConfigValue(
 	dbSettings: Record<string, string>,
 	dbKey: string,
@@ -1012,6 +1035,28 @@ function resolveConfigValue(
 	return { value: defaultValue, source: 'default', isLocked: false };
 }
 
+/**
+ * Plex SERVER URL resolution (ISSUE-002). Identical to `resolveConfigValue`
+ * except it uses the token-aware `isAuthoritativePlexServerUrl` so a real
+ * localhost deployment supplied via ENV (localhost URL + real token) locks
+ * the field, while a bare `.env.example` copy (localhost URL + placeholder
+ * token) still falls through to the onboarding-written DB row.
+ */
+function resolvePlexServerUrlValue(
+	dbSettings: Record<string, string>,
+	envUrl: string,
+	envToken: string
+): ConfigValue<string> {
+	if (isAuthoritativePlexServerUrl(envUrl, envToken)) {
+		return { value: envUrl, source: 'env', isLocked: true };
+	}
+	const dbValue = dbSettings[AppSettingsKey.PLEX_SERVER_URL];
+	if (dbValue) {
+		return { value: dbValue, source: 'db', isLocked: false };
+	}
+	return { value: '', source: 'default', isLocked: false };
+}
+
 export async function getApiConfigWithSources(): Promise<ApiConfigWithSources> {
 	const dbSettings = await getAllAppSettings();
 	const plexEnv = getPlexEnvConfig();
@@ -1019,7 +1064,7 @@ export async function getApiConfigWithSources(): Promise<ApiConfigWithSources> {
 
 	return {
 		plex: {
-			serverUrl: resolveConfigValue(dbSettings, AppSettingsKey.PLEX_SERVER_URL, plexEnv.serverUrl),
+			serverUrl: resolvePlexServerUrlValue(dbSettings, plexEnv.serverUrl, plexEnv.token),
 			token: resolveConfigValue(dbSettings, AppSettingsKey.PLEX_TOKEN, plexEnv.token)
 		},
 		openai: {
@@ -1145,33 +1190,69 @@ export async function clearConflictingDbSettings(): Promise<string[]> {
 	const csrfEnvOrigin = env.ORIGIN ?? '';
 	const trustProxyEnv = (env.TRUST_PROXY ?? '').trim();
 
-	const envToDbMapping: Array<{ envValue: string; dbKey: AppSettingsKeyType; label: string }> = [
+	// `authoritative` mirrors exactly what config resolution would treat as
+	// env-locked, so a DB row is only cleared when its env value actually wins.
+	// PLEX_SERVER_URL uses the token-aware Plex predicate (ISSUE-002) so a real
+	// localhost deployment (localhost URL + real token) clears the stale
+	// onboarding row, while a bare .env.example copy does not.
+	const envToDbMapping: Array<{
+		envValue: string;
+		dbKey: AppSettingsKeyType;
+		label: string;
+		authoritative: boolean;
+	}> = [
 		{
 			envValue: plexEnv.serverUrl,
 			dbKey: AppSettingsKey.PLEX_SERVER_URL,
-			label: 'PLEX_SERVER_URL'
+			label: 'PLEX_SERVER_URL',
+			authoritative: isAuthoritativePlexServerUrl(plexEnv.serverUrl, plexEnv.token)
 		},
-		{ envValue: plexEnv.token, dbKey: AppSettingsKey.PLEX_TOKEN, label: 'PLEX_TOKEN' },
-		{ envValue: openaiEnv.apiKey, dbKey: AppSettingsKey.OPENAI_API_KEY, label: 'OPENAI_API_KEY' },
+		{
+			envValue: plexEnv.token,
+			dbKey: AppSettingsKey.PLEX_TOKEN,
+			label: 'PLEX_TOKEN',
+			authoritative: isAuthoritativeEnvValue(plexEnv.token)
+		},
+		{
+			envValue: openaiEnv.apiKey,
+			dbKey: AppSettingsKey.OPENAI_API_KEY,
+			label: 'OPENAI_API_KEY',
+			authoritative: isAuthoritativeEnvValue(openaiEnv.apiKey)
+		},
 		{
 			envValue: openaiEnv.baseUrl,
 			dbKey: AppSettingsKey.OPENAI_BASE_URL,
-			label: 'OPENAI_BASE_URL'
+			label: 'OPENAI_BASE_URL',
+			authoritative: isAuthoritativeEnvValue(openaiEnv.baseUrl)
 		},
-		{ envValue: openaiEnv.model, dbKey: AppSettingsKey.OPENAI_MODEL, label: 'OPENAI_MODEL' },
-		{ envValue: csrfEnvOrigin, dbKey: AppSettingsKey.CSRF_ORIGIN, label: 'CSRF_ORIGIN' },
-		{ envValue: trustProxyEnv, dbKey: AppSettingsKey.TRUST_PROXY, label: 'TRUST_PROXY' }
+		{
+			envValue: openaiEnv.model,
+			dbKey: AppSettingsKey.OPENAI_MODEL,
+			label: 'OPENAI_MODEL',
+			authoritative: isAuthoritativeEnvValue(openaiEnv.model)
+		},
+		{
+			envValue: csrfEnvOrigin,
+			dbKey: AppSettingsKey.CSRF_ORIGIN,
+			label: 'CSRF_ORIGIN',
+			authoritative: isAuthoritativeEnvValue(csrfEnvOrigin)
+		},
+		{
+			envValue: trustProxyEnv,
+			dbKey: AppSettingsKey.TRUST_PROXY,
+			label: 'TRUST_PROXY',
+			authoritative: isAuthoritativeEnvValue(trustProxyEnv)
+		}
 	];
 
 	const dbSettings = await getAllAppSettings();
 
-	for (const { envValue, dbKey, label } of envToDbMapping) {
-		// Only an env value that resolveConfigValue would actually treat as
-		// authoritative (non-empty AND not a placeholder sentinel) may clear a
-		// conflicting DB row. Otherwise a shipped .env.example placeholder like
-		// `http://localhost:32400` would delete a real admin-configured value and
-		// resolveConfigValue would then fall through to the empty default.
-		if (envValue && !isPlaceholderSentinel(envValue) && dbSettings[dbKey]) {
+	for (const { dbKey, label, authoritative } of envToDbMapping) {
+		// Only an env value that config resolution would actually treat as
+		// authoritative may clear a conflicting DB row. Otherwise a shipped
+		// .env.example placeholder like `http://localhost:32400` would delete a
+		// real admin-configured value and resolution would fall through to empty.
+		if (authoritative && dbSettings[dbKey]) {
 			await deleteAppSetting(dbKey);
 			clearedSettings.push(label);
 		}
@@ -1181,7 +1262,7 @@ export async function clearConflictingDbSettings(): Promise<string[]> {
 	// have been derived from a different PLEX_SERVER_URL/PLEX_TOKEN (e.g. the env
 	// changed between restarts). Drop the cache so the next call to
 	// getConfiguredServerMachineId() re-fetches /identity against the current config.
-	const plexServerUrlAuthoritative = isAuthoritativeEnvValue(plexEnv.serverUrl);
+	const plexServerUrlAuthoritative = isAuthoritativePlexServerUrl(plexEnv.serverUrl, plexEnv.token);
 	const plexTokenAuthoritative = isAuthoritativeEnvValue(plexEnv.token);
 	if (
 		(plexServerUrlAuthoritative || plexTokenAuthoritative) &&

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -1010,12 +1010,19 @@ export function isAuthoritativeEnvValue(value: string): boolean {
  * to the shared value-only check. This predicate is used solely by the Plex
  * branch of config resolution; `isPlaceholderSentinel`/`isAuthoritativeEnvValue`
  * stay value-only so OpenAI/CSRF semantics are unaffected.
+ *
+ * The localhost comparison is canonicalized (trim + strip trailing slashes) so a
+ * near-bare template copy with a cosmetic variant of the `.env.example` default
+ * (e.g. `http://localhost:32400/`) is still recognized as the localhost
+ * sentinel rather than slipping past `isPlaceholderSentinel` and env-locking the
+ * connections UI with a placeholder token.
  */
 export function isAuthoritativePlexServerUrl(serverUrl: string, token: string): boolean {
-	if (isAuthoritativeEnvValue(serverUrl)) return true;
-	if (serverUrl.trim() === 'http://localhost:32400' && isAuthoritativeEnvValue(token)) {
-		return true;
+	const canonicalUrl = serverUrl.trim().replace(/\/+$/, '');
+	if (canonicalUrl === 'http://localhost:32400') {
+		return isAuthoritativeEnvValue(token);
 	}
+	if (isAuthoritativeEnvValue(serverUrl)) return true;
 	return false;
 }
 

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -277,8 +277,11 @@ export async function getShareSettings(
 		return null;
 	}
 
-	const globalDefault = await getGlobalDefaultShareMode();
-	const settings = toShareSettings(record, globalDefault);
+	const [globalDefault, globalAllowUserControl] = await Promise.all([
+		getGlobalDefaultShareMode(),
+		getGlobalAllowUserControl()
+	]);
+	const settings = toShareSettings(record, globalDefault, globalAllowUserControl);
 
 	if (settings.mode !== ShareMode.PRIVATE_LINK || settings.shareToken) {
 		return settings;
@@ -321,10 +324,18 @@ export async function getShareSettingsReadOnly(
 		return null;
 	}
 
-	return toShareSettings(record, await getGlobalDefaultShareMode());
+	const [globalDefault, globalAllowUserControl] = await Promise.all([
+		getGlobalDefaultShareMode(),
+		getGlobalAllowUserControl()
+	]);
+	return toShareSettings(record, globalDefault, globalAllowUserControl);
 }
 
-function toShareSettings(record: ShareSettingsRecord, globalDefault: ShareModeType): ShareSettings {
+function toShareSettings(
+	record: ShareSettingsRecord,
+	globalDefault: ShareModeType,
+	globalAllowUserControl: boolean
+): ShareSettings {
 	const parsedMode = ShareModeSchema.safeParse(record.mode);
 	const storedMode = parsedMode.success ? parsedMode.data : globalDefault;
 	const modeSource = normalizeShareModeSource(record.modeSource);
@@ -335,6 +346,15 @@ function toShareSettings(record: ShareSettingsRecord, globalDefault: ShareModeTy
 	// a token after the effective mode was widened (e.g. global default changed).
 	const shareToken = mode === ShareMode.PRIVATE_LINK ? record.shareToken : null;
 
+	// ISSUE-003: effective per-user control is the AND of the per-row flag and the
+	// LIVE global "allow user control" setting — mirroring how `mode` already folds
+	// in `globalDefault` above. The per-row `canUserControl` is only seeded at
+	// row-creation, so reading it raw lets a user who predates an admin toggling
+	// global control OFF keep editing indefinitely (policy bypass). Folding the
+	// global flag in here — the single centralization point already on every read
+	// path — closes the bypass without a stale read in any caller.
+	const canUserControl = (record.canUserControl ?? false) && globalAllowUserControl;
+
 	return {
 		userId: record.userId,
 		year: record.year,
@@ -342,7 +362,7 @@ function toShareSettings(record: ShareSettingsRecord, globalDefault: ShareModeTy
 		storedMode,
 		modeSource,
 		shareToken,
-		canUserControl: record.canUserControl ?? false
+		canUserControl
 	};
 }
 
@@ -381,7 +401,7 @@ export async function getOrCreateShareSettings(
 		throw new ShareError('Failed to create share settings', 'CREATE_FAILED');
 	}
 
-	return toShareSettings(record, defaultMode);
+	return toShareSettings(record, defaultMode, allowUserControl);
 }
 
 export async function updateShareSettings(
@@ -556,7 +576,11 @@ export async function getShareSettingsByToken(token: string): Promise<ShareSetti
 		return null;
 	}
 
-	return toShareSettings(record, await getGlobalDefaultShareMode());
+	const [globalDefault, globalAllowUserControl] = await Promise.all([
+		getGlobalDefaultShareMode(),
+		getGlobalAllowUserControl()
+	]);
+	return toShareSettings(record, globalDefault, globalAllowUserControl);
 }
 
 export async function deleteShareSettings(userId: number, year: number): Promise<void> {
@@ -567,9 +591,12 @@ export async function deleteShareSettings(userId: number, year: number): Promise
 
 export async function getAllUserShareSettings(userId: number): Promise<ShareSettings[]> {
 	const results = await db.select().from(shareSettings).where(eq(shareSettings.userId, userId));
-	const globalDefault = await getGlobalDefaultShareMode();
+	const [globalDefault, globalAllowUserControl] = await Promise.all([
+		getGlobalDefaultShareMode(),
+		getGlobalAllowUserControl()
+	]);
 
-	return results.map((record) => toShareSettings(record, globalDefault));
+	return results.map((record) => toShareSettings(record, globalDefault, globalAllowUserControl));
 }
 
 export async function updateUserLogoPreference(

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -3,7 +3,11 @@ import { goto } from '$app/navigation';
 import { page } from '$app/stores';
 
 const status = $derived($page.status);
-const message = $derived($page.error?.message ?? '');
+const rawMessage = $derived($page.error?.message ?? '');
+// Suppress bare generic messages that SvelteKit emits for unmatched routes so
+// the friendly status-based copy is used instead.
+const GENERIC_MESSAGES = new Set(['Not found', 'Not Found']);
+const message = $derived(GENERIC_MESSAGES.has(rawMessage) ? '' : rawMessage);
 
 const title = $derived.by(() => {
 	if (status === 404) return 'Page not found';

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -289,30 +289,36 @@ function handleCsrfWarningDismissed() {
 					<span class="user-role">Administrator</span>
 				</div>
 			</div>
-			<AlertDialog.Root>
-				<AlertDialog.Trigger>
-					{#snippet child({ props })}
-						<button type="button" class="logout-button" {...props}>
-							<LogOut class="logout-icon" />
-							<span>Logout</span>
-						</button>
-					{/snippet}
-				</AlertDialog.Trigger>
-				<AlertDialog.Content>
-					<AlertDialog.Header>
-						<AlertDialog.Title>Sign out?</AlertDialog.Title>
-						<AlertDialog.Description>
-							You will be returned to the sign-in page.
-						</AlertDialog.Description>
-					</AlertDialog.Header>
-					<AlertDialog.Footer>
-						<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
-						<form method="POST" action="/auth/logout" use:enhance style="display: contents;">
-							<AlertDialog.Action type="submit">Sign out</AlertDialog.Action>
-						</form>
-					</AlertDialog.Footer>
-				</AlertDialog.Content>
-			</AlertDialog.Root>
+			<form id="admin-logout-form" method="POST" action="/auth/logout" use:enhance>
+				<AlertDialog.Root>
+					<AlertDialog.Trigger>
+						{#snippet child({ props })}
+							<button type="button" class="logout-button" {...props}>
+								<LogOut class="logout-icon" />
+								<span>Logout</span>
+							</button>
+						{/snippet}
+					</AlertDialog.Trigger>
+					<AlertDialog.Content>
+						<AlertDialog.Header>
+							<AlertDialog.Title>Sign out?</AlertDialog.Title>
+							<AlertDialog.Description>
+								You will be returned to the sign-in page.
+							</AlertDialog.Description>
+						</AlertDialog.Header>
+						<AlertDialog.Footer>
+							<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+							<AlertDialog.Action type="submit" form="admin-logout-form">Sign out</AlertDialog.Action>
+						</AlertDialog.Footer>
+					</AlertDialog.Content>
+				</AlertDialog.Root>
+				<noscript>
+					<button type="submit" class="logout-button">
+						<LogOut class="logout-icon" />
+						<span>Logout</span>
+					</button>
+				</noscript>
+			</form>
 			<div
 				class="text-[10px] text-muted-foreground/50 font-mono tracking-wider text-center leading-none select-all"
 				title={data.appVersion.kind}

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -18,6 +18,7 @@ import { goto, invalidateAll } from '$app/navigation';
 import { page } from '$app/stores';
 import Logo from '$lib/components/Logo.svelte';
 import CsrfWarningBanner from '$lib/components/security/CsrfWarningBanner.svelte';
+import * as AlertDialog from '$lib/components/ui/alert-dialog';
 import type { LayoutData } from './$types';
 
 interface Props {
@@ -288,12 +289,30 @@ function handleCsrfWarningDismissed() {
 					<span class="user-role">Administrator</span>
 				</div>
 			</div>
-			<form method="POST" action="/auth/logout" use:enhance>
-				<button type="submit" class="logout-button">
-					<LogOut class="logout-icon" />
-					<span>Logout</span>
-				</button>
-			</form>
+			<AlertDialog.Root>
+				<AlertDialog.Trigger>
+					{#snippet child({ props })}
+						<button type="button" class="logout-button" {...props}>
+							<LogOut class="logout-icon" />
+							<span>Logout</span>
+						</button>
+					{/snippet}
+				</AlertDialog.Trigger>
+				<AlertDialog.Content>
+					<AlertDialog.Header>
+						<AlertDialog.Title>Sign out?</AlertDialog.Title>
+						<AlertDialog.Description>
+							You will be returned to the sign-in page.
+						</AlertDialog.Description>
+					</AlertDialog.Header>
+					<AlertDialog.Footer>
+						<AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+						<form method="POST" action="/auth/logout" use:enhance style="display: contents;">
+							<AlertDialog.Action type="submit">Sign out</AlertDialog.Action>
+						</form>
+					</AlertDialog.Footer>
+				</AlertDialog.Content>
+			</AlertDialog.Root>
 			<div
 				class="text-[10px] text-muted-foreground/50 font-mono tracking-wider text-center leading-none select-all"
 				title={data.appVersion.kind}

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -79,8 +79,8 @@ function handleAdminNavigation(event: MouseEvent) {
 const statsConfig = $derived([
 	{
 		value: data.userCount,
-		label: 'Total Users',
-		sub: `${data.syncedViewerCount.toLocaleString()} synced viewers`,
+		label: 'Registered Users',
+		sub: `${data.syncedViewerCount.toLocaleString()} distinct Plex viewers in history`,
 		icon: Users,
 		color: 'blue',
 		gradient: 'from-blue-500/20 to-blue-600/5'

--- a/src/routes/admin/slides/+page.server.ts
+++ b/src/routes/admin/slides/+page.server.ts
@@ -3,6 +3,7 @@ import type { SlideType } from '$lib/components/slides/types';
 import {
 	FunFactFrequency,
 	type FunFactFrequencyType,
+	getApiConfigWithSources,
 	getFunFactFrequency,
 	setFunFactFrequency
 } from '$lib/server/admin/settings.service';
@@ -35,11 +36,12 @@ import type { Actions, PageServerLoad } from './$types';
 export const load: PageServerLoad = async () => {
 	await initializeDefaultSlideConfig();
 
-	const [configs, customSlides, funFactFrequency, availableYears] = await Promise.all([
+	const [configs, customSlides, funFactFrequency, availableYears, apiConfig] = await Promise.all([
 		getAllSlideConfigs(),
 		getAllCustomSlides(),
 		getFunFactFrequency(),
-		getAvailableYears()
+		getAvailableYears(),
+		getApiConfigWithSources()
 	]);
 
 	const customSlidesWithPreview = customSlides.map((slide) => ({
@@ -47,11 +49,19 @@ export const load: PageServerLoad = async () => {
 		renderedHtml: renderMarkdownSync(slide.content)
 	}));
 
+	// ISSUE-012: signal whether AI fun facts will actually run. The effective
+	// OpenAI key (env-over-DB via resolveConfigValue) being non-empty means the
+	// AI generator is used; empty means the built-in template fallback. Surfaced
+	// as a badge on the Fun Fact Frequency section so the admin can tell which
+	// path is in effect. No secret is rendered — only the boolean.
+	const aiFunFactsActive = Boolean(apiConfig.openai.apiKey.value.trim());
+
 	return {
 		configs,
 		customSlides: customSlidesWithPreview,
 		funFactFrequency,
-		availableYears
+		availableYears,
+		aiFunFactsActive
 	};
 };
 

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import Pencil from '@lucide/svelte/icons/pencil';
 import Plus from '@lucide/svelte/icons/plus';
+import SparklesIcon from '@lucide/svelte/icons/sparkles';
 import Trash2 from '@lucide/svelte/icons/trash-2';
 import { untrack } from 'svelte';
 import { enhance } from '$app/forms';
@@ -460,6 +461,22 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			Control how many fun facts appear interspersed throughout the wrapped presentation.
 		</p>
 
+		<!-- ISSUE-012: tell the admin whether fun facts are AI-generated (OpenAI key
+		     in effect) or falling back to the built-in template generator. -->
+		{#if data.aiFunFactsActive}
+			<p class="ai-status ai-status-active" role="status">
+				<SparklesIcon class="ai-status-icon" aria-hidden="true" />
+				AI fun facts active — generated with your configured OpenAI key.
+			</p>
+		{:else}
+			<p class="ai-status ai-status-fallback" role="status">
+				<SparklesIcon class="ai-status-icon" aria-hidden="true" />
+				Template fallback — no OpenAI key configured, so fun facts use the built-in
+				generator. Add a key in
+				<a href="/admin/settings/connections">Settings → Connections</a> to enable AI fun facts.
+			</p>
+		{/if}
+
 		<form
 			method="POST"
 			action="?/setFunFactFrequency"
@@ -807,6 +824,42 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			color: oklch(var(--muted-foreground));
 			font-size: 0.875rem;
 			margin: 0 0 1rem;
+		}
+
+		/* ISSUE-012: AI-vs-template status badge for the fun-fact section. */
+		.ai-status {
+			display: flex;
+			align-items: center;
+			gap: 0.5rem;
+			margin: 0 0 1rem;
+			padding: 0.625rem 0.75rem;
+			font-size: 0.8125rem;
+			line-height: 1.4;
+			border-radius: 8px;
+			border: 1px solid transparent;
+		}
+
+		.ai-status :global(.ai-status-icon) {
+			flex-shrink: 0;
+			width: 1rem;
+			height: 1rem;
+		}
+
+		.ai-status-active {
+			color: oklch(var(--foreground));
+			background: oklch(0.72 0.16 152 / 0.12);
+			border-color: oklch(0.72 0.16 152 / 0.32);
+		}
+
+		.ai-status-fallback {
+			color: oklch(var(--foreground));
+			background: oklch(0.79 0.1606 79.6 / 0.1);
+			border-color: oklch(0.79 0.1606 79.6 / 0.3);
+		}
+
+		.ai-status-fallback a {
+			color: inherit;
+			text-decoration: underline;
 		}
 
 		.slide-list {

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -118,8 +118,12 @@ export const actions: Actions = requireAdminActions({
 			const result = await startBackgroundSync(backfillYear);
 
 			if (!result.started) {
-				return fail(400, {
-					error: result.error ?? 'Failed to start sync',
+				// ISSUE-005: the only !started path is an in-progress sync, which is a
+				// conflict (409), not a bad request (400). The client surfaces the
+				// message; the status code lets a concurrent double-trigger be told
+				// apart from a validation failure.
+				return fail(409, {
+					error: result.error ?? 'A sync is already in progress',
 					selectedYear: backfillYear ?? null
 				});
 			}

--- a/src/routes/admin/wrapped/+page.server.ts
+++ b/src/routes/admin/wrapped/+page.server.ts
@@ -1,16 +1,27 @@
+import { getAvailableYears } from '$lib/server/admin/users.service';
 import { getOwnerWrappedHref } from '$lib/server/sharing/service';
 import type { PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, url }) => {
+	const availableYears = await getAvailableYears();
 	const currentYear = new Date().getFullYear();
-	const wrappedHref = await getOwnerWrappedHref(locals.user!.id, currentYear);
+
+	const yearParam = url.searchParams.get('year');
+	const parsedYear = yearParam ? parseInt(yearParam, 10) : Number.NaN;
+	const year =
+		Number.isInteger(parsedYear) && parsedYear >= 2000 && parsedYear <= 2100
+			? parsedYear
+			: currentYear;
+
+	const wrappedHref = await getOwnerWrappedHref(locals.user!.id, year);
 
 	return {
 		adminUser: {
 			id: locals.user!.id,
 			username: locals.user!.username
 		},
-		currentYear,
+		year,
+		availableYears,
 		wrappedHref
 	};
 };

--- a/src/routes/admin/wrapped/+page.server.ts
+++ b/src/routes/admin/wrapped/+page.server.ts
@@ -23,7 +23,14 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			? currentYear
 			: (availableYears[0] ?? currentYear);
 
-	const wrappedHref = await getOwnerWrappedHref(locals.user!.id, year);
+	// Only mint/look up the owner's share href once there's at least one year of
+	// data. With no available years, `year` falls back to currentYear and calling
+	// getOwnerWrappedHref would lazily INSERT a shareSettings row for a year that
+	// isn't actually 'available' (getOrCreateShareSettings creates by default) —
+	// the no-data case must not create share state. The card is hidden client-side
+	// when wrappedHref is null.
+	const wrappedHref =
+		availableYears.length > 0 ? await getOwnerWrappedHref(locals.user!.id, year) : null;
 
 	return {
 		adminUser: {

--- a/src/routes/admin/wrapped/+page.server.ts
+++ b/src/routes/admin/wrapped/+page.server.ts
@@ -8,10 +8,20 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 
 	const yearParam = url.searchParams.get('year');
 	const parsedYear = yearParam ? parseInt(yearParam, 10) : Number.NaN;
-	const year =
+	const requestedYear =
 		Number.isInteger(parsedYear) && parsedYear >= 2000 && parsedYear <= 2100
 			? parsedYear
 			: currentYear;
+
+	// Reconcile the requested year against the DB-derived set of available years so
+	// the title, <select>, and wrappedHref stay consistent (and we don't lazily mint a
+	// shareSettings row for a non-available year). Mirrors the includes() guard in
+	// src/routes/wrapped/[year=year]/+page.server.ts.
+	const year = availableYears.includes(requestedYear)
+		? requestedYear
+		: availableYears.includes(currentYear)
+			? currentYear
+			: (availableYears[0] ?? currentYear);
 
 	const wrappedHref = await getOwnerWrappedHref(locals.user!.id, year);
 

--- a/src/routes/admin/wrapped/+page.svelte
+++ b/src/routes/admin/wrapped/+page.svelte
@@ -47,10 +47,25 @@ function handleConfigNavigation(event: MouseEvent): void {
 				<span>Year in Review</span>
 			</div>
 			<h1 class="hero-title">
-				<span class="year-display">{data.currentYear}</span>
+				<span class="year-display">{data.year}</span>
 				<span class="title-text">Wrapped</span>
 			</h1>
 			<p class="hero-subtitle">Discover viewing journeys and manage the wrapped experience</p>
+			{#if data.availableYears.length > 0}
+				<form method="GET" class="year-form">
+					<select
+						name="year"
+						class="year-selector"
+						disabled={data.availableYears.length === 1}
+						onchange={(e) => e.currentTarget.form?.requestSubmit()}
+					>
+						{#each data.availableYears as yr}
+							<option value={yr} selected={yr === data.year}>{yr}</option>
+						{/each}
+					</select>
+					<noscript><button type="submit" class="year-submit">Go</button></noscript>
+				</form>
+			{/if}
 		</div>
 		<div class="hero-decoration">
 			<div class="floating-ring ring-1"></div>
@@ -76,7 +91,7 @@ function handleConfigNavigation(event: MouseEvent): void {
 					<div class="card-text">
 						<h2 class="card-title">My Wrapped</h2>
 						<p class="card-description">
-							Your personal viewing journey and stats for {data.currentYear}
+							Your personal viewing journey and stats for {data.year}
 						</p>
 					</div>
 					<div class="card-cta">
@@ -87,7 +102,7 @@ function handleConfigNavigation(event: MouseEvent): void {
 				<div class="card-accent"></div>
 			</a>
 
-			<a href="/wrapped/{data.currentYear}" class="showcase-card server">
+			<a href="/wrapped/{data.year}" class="showcase-card server">
 				<div class="card-glow"></div>
 				<div class="card-shimmer"></div>
 				<div class="card-content">
@@ -158,6 +173,32 @@ function handleConfigNavigation(event: MouseEvent): void {
 			margin: 0 auto;
 			padding: 1.5rem 2rem 3rem;
 			overflow: hidden;
+		}
+
+		.year-form {
+			display: contents;
+		}
+
+		.year-selector {
+			padding: 0.5rem 0.75rem;
+			background: oklch(var(--input));
+			border: 1px solid oklch(var(--border));
+			border-radius: var(--radius);
+			color: oklch(var(--foreground));
+			font-size: 0.875rem;
+			cursor: pointer;
+			margin-top: 1rem;
+		}
+
+		.year-selector:focus {
+			outline: none;
+			border-color: oklch(var(--ring));
+			box-shadow: 0 0 0 2px oklch(var(--ring) / 0.2);
+		}
+
+		.year-selector:disabled {
+			cursor: default;
+			opacity: 0.75;
 		}
 
 		.ambient-glow {

--- a/src/routes/admin/wrapped/+page.svelte
+++ b/src/routes/admin/wrapped/+page.svelte
@@ -56,6 +56,7 @@ function handleConfigNavigation(event: MouseEvent): void {
 					<select
 						name="year"
 						class="year-selector"
+						aria-label="Select wrapped year"
 						disabled={data.availableYears.length === 1}
 						onchange={(e) => e.currentTarget.form?.requestSubmit()}
 					>
@@ -81,26 +82,28 @@ function handleConfigNavigation(event: MouseEvent): void {
 		</div>
 
 		<div class="wrapped-cards">
-			<a href={data.wrappedHref} class="showcase-card personal">
-				<div class="card-glow"></div>
-				<div class="card-shimmer"></div>
-				<div class="card-content">
-					<div class="card-icon-wrap">
-						<Star class="card-icon" />
+			{#if data.wrappedHref}
+				<a href={data.wrappedHref} class="showcase-card personal">
+					<div class="card-glow"></div>
+					<div class="card-shimmer"></div>
+					<div class="card-content">
+						<div class="card-icon-wrap">
+							<Star class="card-icon" />
+						</div>
+						<div class="card-text">
+							<h2 class="card-title">My Wrapped</h2>
+							<p class="card-description">
+								Your personal viewing journey and stats for {data.year}
+							</p>
+						</div>
+						<div class="card-cta">
+							<span class="cta-text">View your story</span>
+							<ArrowRight class="cta-arrow" />
+						</div>
 					</div>
-					<div class="card-text">
-						<h2 class="card-title">My Wrapped</h2>
-						<p class="card-description">
-							Your personal viewing journey and stats for {data.year}
-						</p>
-					</div>
-					<div class="card-cta">
-						<span class="cta-text">View your story</span>
-						<ArrowRight class="cta-arrow" />
-					</div>
-				</div>
-				<div class="card-accent"></div>
-			</a>
+					<div class="card-accent"></div>
+				</a>
+			{/if}
 
 			<a href="/wrapped/{data.year}" class="showcase-card server">
 				<div class="card-glow"></div>

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -290,6 +290,11 @@ $effect(() => {
 	// styles and detaches the filling animation, releasing the stale layer so the
 	// first click expands reliably.
 	controls?.finished?.then(() => controls.stop?.()).catch(() => {});
+
+	// Stop the active animation if the effect reruns (carousel advances) or the
+	// component unmounts before `controls.finished` resolves, so the filling
+	// composited layer is always released and never outlives this run.
+	return () => controls?.stop?.();
 });
 
 const defaultColors = { primary: '#3b82f6', accent: '#60a5fa', bg: '#0f172a' };

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -271,7 +271,7 @@ $effect(() => {
 	const xOffset = animationDirection === 'forward' ? 30 : -30;
 
 	// biome-ignore lint/suspicious/noExplicitAny: Motion's animate function has complex overloads
-	(animate as any)(
+	const controls = (animate as any)(
 		contentRef,
 		{
 			opacity: [0, 1],
@@ -279,6 +279,17 @@ $effect(() => {
 		},
 		{ duration: 0.3, easing: [0.22, 1, 0.36, 1] }
 	);
+
+	// Motion runs this entrance via a WAAPI animation with `fill: "both"`, which
+	// keeps a *filling* composited layer on contentRef after it finishes. While
+	// that layer is held, DOM inserted into this subtree later (e.g. the Advanced
+	// Options panel toggled open by `{#if advancedPrivacyOpen}`) does not repaint
+	// on the first state change — the click flips the rune but the panel only
+	// becomes visible on the next interaction, the two-click bug (ISSUE-016).
+	// Stopping the animation once finished bakes the final values as plain inline
+	// styles and detaches the filling animation, releasing the stale layer so the
+	// first click expands reliably.
+	controls?.finished?.then(() => controls.stop?.()).catch(() => {});
 });
 
 const defaultColors = { primary: '#3b82f6', accent: '#60a5fa', bg: '#0f172a' };

--- a/tests/unit/admin/connections-actions.test.ts
+++ b/tests/unit/admin/connections-actions.test.ts
@@ -352,6 +352,14 @@ describe('connections nested route — updateApiConfig (OCC + schema)', () => {
 		expect(result).toMatchObject({ success: true });
 		const message = (result as { message?: string }).message ?? '';
 		expect(message).toContain('Some fields are controlled by environment variables');
+
+		// ISSUE-002 security property: the submitted value must be DROPPED, not just
+		// flagged. The env-locked value still wins and the attacker-supplied URL is
+		// never persisted — disabling the input is cosmetic; this is the real block.
+		const after = await getApiConfigWithSources();
+		expect(after.plex.serverUrl.value).toBe('https://test-plex-server:32400');
+		expect(after.plex.serverUrl.value).not.toBe('https://plex.local:32400');
+		expect(after.plex.serverUrl.isLocked).toBe(true);
 	});
 });
 

--- a/tests/unit/admin/settings.service.test.ts
+++ b/tests/unit/admin/settings.service.test.ts
@@ -29,6 +29,7 @@ import {
 	getWrappedTheme,
 	hasOpenAIEnvConfig,
 	hasPlexEnvConfig,
+	isAuthoritativePlexServerUrl,
 	isCsrfWarningDismissed,
 	isPlaceholderSentinel,
 	isPlexConfigured,
@@ -721,6 +722,68 @@ describe('Admin Settings Service', () => {
 				expect(config.plex.token.value).toBe('test-plex-token');
 				expect(config.plex.token.source).toBe('env');
 				expect(config.plex.token.isLocked).toBe(true);
+			});
+
+			it('locks a real localhost Plex deployment supplied via ENV (ISSUE-002)', async () => {
+				const dynamicEnv = env as Record<string, string | undefined>;
+				const prevUrl = dynamicEnv.PLEX_SERVER_URL;
+				const prevToken = dynamicEnv.PLEX_TOKEN;
+				// Real localhost deployment: the .env.example localhost URL paired with a
+				// REAL (non-placeholder) token. Onboarding may have written matching DB
+				// rows, but ENV must win and lock both fields.
+				dynamicEnv.PLEX_SERVER_URL = 'http://localhost:32400';
+				dynamicEnv.PLEX_TOKEN = 'a-real-plex-token-value';
+				await setAppSetting(AppSettingsKey.PLEX_SERVER_URL, 'http://localhost:32400');
+				await setAppSetting(AppSettingsKey.PLEX_TOKEN, 'a-real-plex-token-value');
+
+				try {
+					const config = await getApiConfigWithSources();
+					expect(config.plex.serverUrl.source).toBe('env');
+					expect(config.plex.serverUrl.isLocked).toBe(true);
+					expect(config.plex.token.source).toBe('env');
+					expect(config.plex.token.isLocked).toBe(true);
+				} finally {
+					dynamicEnv.PLEX_SERVER_URL = prevUrl;
+					dynamicEnv.PLEX_TOKEN = prevToken;
+				}
+			});
+
+			it('does NOT lock a bare .env.example localhost copy (placeholder token) (ISSUE-002)', async () => {
+				const dynamicEnv = env as Record<string, string | undefined>;
+				const prevUrl = dynamicEnv.PLEX_SERVER_URL;
+				const prevToken = dynamicEnv.PLEX_TOKEN;
+				// Bare template copy: localhost URL + the shipped placeholder token. The
+				// field must stay editable so onboarding can proceed.
+				dynamicEnv.PLEX_SERVER_URL = 'http://localhost:32400';
+				dynamicEnv.PLEX_TOKEN = 'your-plex-token-here';
+
+				try {
+					const config = await getApiConfigWithSources();
+					expect(config.plex.serverUrl.isLocked).toBe(false);
+					expect(config.plex.serverUrl.source).not.toBe('env');
+					expect(config.plex.token.isLocked).toBe(false);
+				} finally {
+					dynamicEnv.PLEX_SERVER_URL = prevUrl;
+					dynamicEnv.PLEX_TOKEN = prevToken;
+				}
+			});
+		});
+
+		describe('isAuthoritativePlexServerUrl (ISSUE-002)', () => {
+			it('treats a non-localhost real URL as authoritative regardless of token', () => {
+				expect(isAuthoritativePlexServerUrl('https://plex.example.com:32400', '')).toBe(true);
+				expect(isAuthoritativePlexServerUrl('https://plex.example.com:32400', 'tok')).toBe(true);
+			});
+
+			it('treats localhost as authoritative ONLY when paired with a real token', () => {
+				expect(isAuthoritativePlexServerUrl('http://localhost:32400', 'a-real-token')).toBe(true);
+			});
+
+			it('treats a bare .env.example localhost copy as a placeholder (not authoritative)', () => {
+				expect(isAuthoritativePlexServerUrl('http://localhost:32400', 'your-plex-token-here')).toBe(
+					false
+				);
+				expect(isAuthoritativePlexServerUrl('http://localhost:32400', '')).toBe(false);
 			});
 		});
 

--- a/tests/unit/admin/settings.service.test.ts
+++ b/tests/unit/admin/settings.service.test.ts
@@ -785,6 +785,21 @@ describe('Admin Settings Service', () => {
 				);
 				expect(isAuthoritativePlexServerUrl('http://localhost:32400', '')).toBe(false);
 			});
+
+			it('canonicalizes cosmetic localhost variants (trailing slash / whitespace)', () => {
+				// A near-bare template copy with only a cosmetic difference from the
+				// .env.example default must NOT slip past the placeholder check and
+				// env-lock the connections UI with a placeholder token.
+				expect(
+					isAuthoritativePlexServerUrl('http://localhost:32400/', 'your-plex-token-here')
+				).toBe(false);
+				expect(
+					isAuthoritativePlexServerUrl('  http://localhost:32400/  ', 'your-plex-token-here')
+				).toBe(false);
+				// A genuine localhost deployment (real token) still locks regardless of
+				// the cosmetic trailing slash.
+				expect(isAuthoritativePlexServerUrl('http://localhost:32400/', 'a-real-token')).toBe(true);
+			});
 		});
 
 		describe('hasPlexEnvConfig', () => {

--- a/tests/unit/admin/slides-actions.test.ts
+++ b/tests/unit/admin/slides-actions.test.ts
@@ -1,12 +1,17 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import { FunFactFrequency, getFunFactFrequency } from '$lib/server/admin/settings.service';
+import {
+	AppSettingsKey,
+	FunFactFrequency,
+	getFunFactFrequency,
+	setAppSetting
+} from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { customSlides } from '$lib/server/db/schema';
 import {
 	getSlideConfigByType,
 	initializeDefaultSlideConfig
 } from '$lib/server/slides/config.service';
-import { actions } from '../../../src/routes/admin/slides/+page.server';
+import { actions, load } from '../../../src/routes/admin/slides/+page.server';
 import { resetSharedTestDb } from '../../helpers/db';
 
 type SetFunFactFrequencyAction = NonNullable<typeof actions.setFunFactFrequency>;
@@ -362,5 +367,26 @@ describe('admin slides actions', () => {
 			expect((await getSlideConfigByType('genres'))?.sortOrder).toBe(1);
 			expect((await getSlideConfigByType('total-time'))?.sortOrder).toBe(2);
 		});
+	});
+});
+
+describe('slides load — AI fun-fact status flag (ISSUE-012)', () => {
+	beforeEach(async () => {
+		await resetSharedTestDb();
+	});
+
+	function runLoad() {
+		return (load as unknown as () => Promise<{ aiFunFactsActive: boolean }>)();
+	}
+
+	it('reports aiFunFactsActive=false when no OpenAI key is configured', async () => {
+		const data = await runLoad();
+		expect(data.aiFunFactsActive).toBe(false);
+	});
+
+	it('reports aiFunFactsActive=true when an OpenAI key is stored', async () => {
+		await setAppSetting(AppSettingsKey.OPENAI_API_KEY, 'sk-test-key');
+		const data = await runLoad();
+		expect(data.aiFunFactsActive).toBe(true);
 	});
 });

--- a/tests/unit/dashboard/settings-permission.test.ts
+++ b/tests/unit/dashboard/settings-permission.test.ts
@@ -60,11 +60,32 @@ describe('dashboard settings per-user share control', () => {
 		});
 	});
 
-	it('honors an admin-granted user control row even when the global default is false', async () => {
+	it('denies a share-mode change when global allow-user-control is OFF despite a stored true row (ISSUE-003)', async () => {
+		// beforeEach seeds global allowUserControl=false with a stale per-row
+		// canUserControl=true — the exact dogfood bypass. Effective control must be
+		// false: load reports it disabled and the action returns 403 server-side.
 		const data = (await load({ locals, setHeaders: () => {} } as unknown as LoadArgs)) as {
 			shareSettings: { canUserControl: boolean };
 		};
-		expect(data.shareSettings.canUserControl).toBe(true);
+		expect(data.shareSettings.canUserControl).toBe(false);
+
+		const result = await invokeUpdateShareMode(ShareMode.PRIVATE_LINK);
+		expect((result as { status?: number }).status).toBe(403);
+
+		const row = await db
+			.select({ mode: shareSettings.mode })
+			.from(shareSettings)
+			.where(and(eq(shareSettings.userId, USER_ID), eq(shareSettings.year, YEAR)))
+			.limit(1);
+		// Mode is unchanged — the bypass is blocked.
+		expect(row[0]?.mode).toBe(ShareMode.PUBLIC);
+	});
+
+	it('allows a share-mode change when global allow-user-control is ON', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PUBLIC,
+			allowUserControl: true
+		});
 
 		const result = await invokeUpdateShareMode(ShareMode.PRIVATE_LINK);
 		expect((result as { status?: number }).status).toBeUndefined();
@@ -78,6 +99,11 @@ describe('dashboard settings per-user share control', () => {
 	});
 
 	it('returns the refreshed private href and invalidates the previous token on regenerate', async () => {
+		// Regenerate is a user-control action, so the global flag must be ON.
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PUBLIC,
+			allowUserControl: true
+		});
 		const oldToken = '11111111-1111-4111-8111-111111111111';
 		await db
 			.update(shareSettings)

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -795,6 +795,131 @@ describe('startPlexLoginPopup', () => {
 		expect(onError).toHaveBeenCalledTimes(1);
 	});
 
+	it('fires onError with cancel message when popup is closed by user before auth completes', async () => {
+		let resolveIntervalRegistered: () => void = () => {};
+		const intervalRegistered = new Promise<void>((resolve) => {
+			resolveIntervalRegistered = resolve;
+		});
+		const intervalCallbacks: Array<() => Promise<void>> = [];
+		const timers = createTimerMocks((callback) => {
+			intervalCallbacks.push(callback);
+			resolveIntervalRegistered();
+		});
+
+		// Popup starts open, user closes it before auth completes.
+		const popup: MockPopupWindow = { closed: false, close: mock(() => {}) };
+		const browserWindow: MockWindow = {
+			location: { origin: 'https://obzorarr.example', href: 'https://obzorarr.example/' },
+			open: mock(() => popup) as unknown as MockWindow['open']
+		};
+
+		globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+			// PIN fetch (GET /auth/plex) — always succeeds.
+			if (init?.method !== 'POST') {
+				return new Response(
+					JSON.stringify({ pinId: 42, authUrl: 'https://app.plex.tv/auth#?code=ABCD' }),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				);
+			}
+			// Poll response — return pending (no user yet).
+			return new Response(JSON.stringify({}), { status: 202 });
+		}) as unknown as typeof fetch;
+
+		const onSuccess = mock(async () => {});
+		const onError = mock(() => {});
+		const onPopupBlocked = mock(() => {});
+
+		startPlexLoginPopup({
+			context: 'landing',
+			onSuccess,
+			onError,
+			onPopupBlocked,
+			window: browserWindow,
+			timers
+		});
+		await intervalRegistered;
+
+		const poll = intervalCallbacks[0] as () => Promise<void>;
+
+		// First tick: popup is still open — no error yet.
+		await poll();
+		expect(onError).not.toHaveBeenCalled();
+
+		// User closes the popup.
+		popup.closed = true;
+
+		// Second tick: closed popup detected → cancel error fired exactly once.
+		await poll();
+		expect(onError).toHaveBeenCalledTimes(1);
+		expect((onError.mock.calls[0] as string[])[0]).toBe('Sign-in cancelled. You can try again.');
+		expect(onSuccess).not.toHaveBeenCalled();
+		expect(onPopupBlocked).not.toHaveBeenCalled();
+
+		// Further ticks must not fire again (finished guard).
+		await poll();
+		expect(onError).toHaveBeenCalledTimes(1);
+	});
+
+	it('prefers a completed login over a closed-popup cancel (ISSUE-015 race guard)', async () => {
+		let resolveIntervalRegistered: () => void = () => {};
+		const intervalRegistered = new Promise<void>((resolve) => {
+			resolveIntervalRegistered = resolve;
+		});
+		const intervalCallbacks: Array<() => Promise<void>> = [];
+		const timers = createTimerMocks((callback) => {
+			intervalCallbacks.push(callback);
+			resolveIntervalRegistered();
+		});
+
+		// Popup opens normally so the poll interval registers.
+		const popup: MockPopupWindow = { closed: false, close: mock(() => {}) };
+		const browserWindow: MockWindow = {
+			location: { origin: 'https://obzorarr.example', href: 'https://obzorarr.example/' },
+			open: mock(() => popup) as unknown as MockWindow['open']
+		};
+
+		globalThis.fetch = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+			if (init?.method !== 'POST') {
+				return new Response(
+					JSON.stringify({ pinId: 42, authUrl: 'https://app.plex.tv/auth#?code=ABCD' }),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } }
+				);
+			}
+			// The poll lands a completed login on the SAME tick the popup is closed.
+			return new Response(
+				JSON.stringify({
+					user: { id: 1, plexId: 123, username: 'alice', isAdmin: false },
+					redirectTo: '/dashboard'
+				}),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } }
+			);
+		}) as unknown as typeof fetch;
+
+		const onSuccess = mock(async () => {});
+		const onError = mock(() => {});
+		const onPopupBlocked = mock(() => {});
+
+		startPlexLoginPopup({
+			context: 'landing',
+			onSuccess,
+			onError,
+			onPopupBlocked,
+			window: browserWindow,
+			timers
+		});
+		await intervalRegistered;
+
+		// User closed the popup just as authorization completed server-side.
+		popup.closed = true;
+
+		const poll = intervalCallbacks[0] as () => Promise<void>;
+		await poll();
+
+		// Completed login wins — no false "cancelled".
+		expect(onSuccess).toHaveBeenCalledTimes(1);
+		expect(onError).not.toHaveBeenCalled();
+	});
+
 	it('surfaces server message and stops polling on 502 (PlexAuthApiError)', async () => {
 		let resolveIntervalRegistered: () => void = () => {};
 		const intervalRegistered = new Promise<void>((resolve) => {

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -446,6 +446,13 @@ describe('Sharing Service', () => {
 			});
 
 			it('returns settings when they exist', async () => {
+				// ISSUE-003: canUserControl is now the EFFECTIVE value (stored row AND
+				// the live global "allow user control" flag). Enable the global flag so
+				// the stored per-row `true` surfaces as effective `true`.
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: true
+				});
 				await db.insert(shareSettings).values({
 					userId,
 					year,
@@ -624,7 +631,7 @@ describe('Sharing Service', () => {
 				expect(settings2.canUserControl).toBe(false);
 			});
 
-			it('keeps default-sourced mode effective from global defaults without changing control', async () => {
+			it('keeps default-sourced mode effective from global defaults; global off revokes effective control (ISSUE-003)', async () => {
 				await setGlobalShareDefaults({
 					defaultShareMode: ShareMode.PUBLIC,
 					allowUserControl: true
@@ -644,7 +651,12 @@ describe('Sharing Service', () => {
 				expect(updated.mode).toBe(ShareMode.PRIVATE_OAUTH);
 				expect(updated.storedMode).toBe(ShareMode.PUBLIC);
 				expect(updated.modeSource).toBe(ShareModeSource.DEFAULT);
-				expect(updated.canUserControl).toBe(true);
+				// ISSUE-003: effective canUserControl folds in the LIVE global flag, so
+				// toggling "allow user control" OFF immediately revokes effective control
+				// even though the per-row stored flag is unchanged. (The stored row value
+				// is still surfaced raw to the admin /admin/users "Can Control" column,
+				// which reads the DB directly rather than through toShareSettings.)
+				expect(updated.canUserControl).toBe(false);
 			});
 
 			it('throws when createIfMissing is false and settings do not exist', async () => {
@@ -714,6 +726,35 @@ describe('Sharing Service', () => {
 				await expect(
 					updateShareSettings(userId, year, { mode: ShareMode.PRIVATE_OAUTH }, false)
 				).rejects.toBeInstanceOf(PermissionExceededError);
+			});
+
+			it('denies a non-admin when global allow-user-control is OFF despite stored true (ISSUE-003)', async () => {
+				// Stored per-row canUserControl is true (seeded in beforeEach), but the
+				// admin flips the GLOBAL flag off after the row exists — the exact dogfood
+				// bypass. Effective control must be false, so the non-admin is denied.
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: false
+				});
+
+				await expect(
+					updateShareSettings(userId, year, { mode: ShareMode.PRIVATE_OAUTH }, false)
+				).rejects.toBeInstanceOf(PermissionExceededError);
+			});
+
+			it('still lets an admin update share mode when global allow-user-control is OFF (ISSUE-003 admin-unaffected)', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: false
+				});
+
+				const updated = await updateShareSettings(
+					userId,
+					year,
+					{ mode: ShareMode.PRIVATE_OAUTH },
+					true
+				);
+				expect(updated.mode).toBe(ShareMode.PRIVATE_OAUTH);
 			});
 
 			it('allows user with canUserControl to enable private-link', async () => {

--- a/tests/unit/slides/contracts.test.ts
+++ b/tests/unit/slides/contracts.test.ts
@@ -20,11 +20,11 @@ describe('slide messaging context helpers', () => {
 			createServerContext('PARENTI'),
 			true,
 			'PARENTI',
-			'PARENTI',
-			"PARENTI's",
-			'has',
-			'is',
-			'watches'
+			'PARENTI Community',
+			'PARENTI Community',
+			'have',
+			'are',
+			'watch'
 		],
 		['unnamed server', createServerContext(null), true, null, 'We', 'Our', 'have', 'are', 'watch']
 	] as const)('maps %s context to grammar tokens', (_name, ctx, isServerWrapped, serverName, subject, possessive, have, are, watch) => {
@@ -37,10 +37,28 @@ describe('slide messaging context helpers', () => {
 	});
 
 	it.each([
-		[createServerContext('PARENTI'), 'When PARENTI watches'],
+		[createServerContext('PARENTI'), 'When PARENTI Community watch'],
 		[createPersonalContext(), 'When You watch']
 	] as const)('produces grammatical heading %s', (ctx, heading) => {
 		expect(`When ${getSubject(ctx)} ${getWatchVerb(ctx)}`).toBe(heading);
+	});
+
+	it('server context uses community framing, not person-like possessive', () => {
+		const ctx = createServerContext('PARENTI');
+		// Subject must not be bare serverName (community-framed)
+		expect(getSubject(ctx)).not.toBe('PARENTI');
+		expect(getSubject(ctx)).toContain('Community');
+		// Possessive must not use apostrophe-s (no "PARENTI's")
+		expect(getPossessive(ctx)).not.toContain("'s");
+		expect(getPossessive(ctx)).toContain('Community');
+		// Verbs must be plural (community treated as collective, not singular person)
+		expect(getHaveVerb(ctx)).toBe('have');
+		expect(getAreVerb(ctx)).toBe('are');
+		expect(getWatchVerb(ctx)).toBe('watch');
+		// Sanity: personal context is unchanged
+		const personal = createPersonalContext();
+		expect(getSubject(personal)).toBe('You');
+		expect(getPossessive(personal)).toBe('Your');
 	});
 });
 

--- a/tests/unit/sync/schedule-action.test.ts
+++ b/tests/unit/sync/schedule-action.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { AppSettingsKey, getAppSetting } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import { syncStatus } from '$lib/server/db/schema';
 import { setupSyncScheduler, stopSyncScheduler } from '$lib/server/sync/scheduler';
 import { actions } from '../../../src/routes/admin/sync/+page.server';
 import { resetSharedTestDb } from '../../helpers/db';
@@ -59,5 +61,39 @@ describe('sync updateSchedule action (ISSUE-004 / ISSUE-005)', () => {
 	it('rejects an invalid cron with a 400 and echoes the bad value back', async () => {
 		const result = await run('not a cron');
 		expect(result).toMatchObject({ status: 400 });
+	});
+});
+
+describe('sync startSync action conflict (ISSUE-005)', () => {
+	type StartSyncAction = NonNullable<typeof actions.startSync>;
+
+	beforeEach(async () => {
+		await resetSharedTestDb();
+		stopSyncScheduler();
+	});
+
+	afterEach(() => {
+		stopSyncScheduler();
+	});
+
+	function runStartSync() {
+		const request = new Request('http://localhost/admin/sync?/startSync', {
+			method: 'POST',
+			body: new FormData()
+		});
+		const handler = actions.startSync as StartSyncAction;
+		return handler({ request, locals: adminLocals } as Parameters<StartSyncAction>[0]);
+	}
+
+	it('returns 409 (conflict) when a sync is already in progress', async () => {
+		// getRunningSync() looks for a syncStatus row with status='running'.
+		await db.insert(syncStatus).values({
+			startedAt: new Date(Date.now() - 1000),
+			status: 'running',
+			recordsProcessed: 0
+		});
+
+		const result = (await runStartSync()) as { status?: number; data?: { error?: string } };
+		expect(result.status).toBe(409);
 	});
 });

--- a/tests/unit/sync/scheduler.test.ts
+++ b/tests/unit/sync/scheduler.test.ts
@@ -53,6 +53,33 @@ describe('getSchedulerStatus pause/resume', () => {
 	});
 });
 
+describe('croner instance re-arms on resume — ISSUE-001 regression guard', () => {
+	afterEach(() => {
+		stopSyncScheduler();
+	});
+
+	// getSchedulerStatus().isRunning/.nextRun derive purely from the
+	// pausedByOperator flag (green-by-construction), so they cannot tell a working
+	// resume from a broken one. This assertion reaches PAST getSchedulerStatus to
+	// the underlying Cron: isRunning() is the only croner method that consults
+	// _states.paused, so a resume that stopped/killed the instance (the reported
+	// INACTIVE symptom) would leave it false. nextRun() must be a future fire.
+	it('underlying Cron reports isRunning()===true and a future nextRun after setup->pause->resume', () => {
+		const cron = setupSyncScheduler({ cronExpression: '0 0 * * *', startImmediately: true });
+		expect(cron.isRunning()).toBe(true);
+
+		pauseSyncScheduler();
+		expect(cron.isRunning()).toBe(false);
+
+		resumeSyncScheduler();
+		expect(cron.isRunning()).toBe(true);
+
+		const next = cron.nextRun();
+		expect(next).not.toBeNull();
+		expect(next!.getTime()).toBeGreaterThan(Date.now());
+	});
+});
+
 describe('updateSchedulerCron preserves run-state — ISSUE-012 regression guard', () => {
 	afterEach(() => {
 		stopSyncScheduler();


### PR DESCRIPTION
## Summary

Remediates the 2026-06-07 dogfood QA findings (`dogfood-output/report.md`: 20 findings — 0 critical, 0 high, 4 medium, 14 low, 2 info) per the consensus-reviewed plan in `.omc/plans/fix-dogfood-findings.md`.

A mandatory Phase 0 re-verification gate ran first: the report was a pre-remediation snapshot and commit `e32c7ff` landed the same day, so several findings were already fixed on `main`. Every finding was assigned a tri-state outcome (fix-now / already-fixed / keep-or-downgrade) by code-read before any code was written.

No database migrations: every change is logic, UI, copy, or access-control.

## Medium / security fixes

- **ISSUE-002 — ENV-sourced Plex config is now locked in the connections UI.** Added a token-aware `isAuthoritativePlexServerUrl(url, token)`: a genuine localhost deployment supplied via ENV (localhost URL paired with a real token) locks the field, while a bare `.env.example` copy (localhost URL + the shipped placeholder token) stays editable so onboarding can proceed. The shared `isPlaceholderSentinel` / `isAuthoritativeEnvValue` predicates are unchanged, so OpenAI and CSRF resolution are unaffected. The existing connections action test was strengthened to assert the locked-field submit value is dropped server-side, not merely disabled in the UI.
- **ISSUE-003 — the global "Allow users to change share settings = OFF" policy is now enforced.** The live global flag is folded into `toShareSettings` (the single read-path source of truth) as `canUserControl = (per-row flag) AND (global flag)`, closing the bypass where a stale per-row value let a user keep editing after an admin turned the policy off. This restores the global-AND enforcement that a prior change (#95) had removed. The admin "Can Control" column still reflects the stored per-row value because it reads the raw row directly.

## Low / info fixes

- **ISSUE-005** — `startSync` returns HTTP 409 (conflict) instead of 400 when a sync is already in progress.
- **ISSUE-012** — `/admin/slides` shows an AI-vs-template fun-fact status badge derived from whether an OpenAI key is in effect (no secret rendered).
- **ISSUE-009** — server-wide Wrapped headings use community framing instead of person-like possessive phrasing; per-user phrasing and top-contributor anonymization are untouched.
- **ISSUE-014** — bare `Not found` 404s now render the friendly status-based error card.
- **ISSUE-015** — closing the Plex OAuth popup surfaces a "Sign-in cancelled" message in the existing landing alert region; the poll runs first so a completed login always wins over a false cancel.
- **ISSUE-016** — the onboarding Privacy "Advanced Options" accordion expands on the first click (a Motion WAAPI `fill: both` entrance animation had held a composited layer that suppressed the first repaint).
- **ISSUE-017** — admin logout now requires a confirmation dialog; framework-level CSRF is preserved.
- **ISSUE-018** — `/admin/wrapped` gains a year picker matching the `/admin/users` pattern.
- **ISSUE-007** — clarified the dashboard card copy distinguishing registered users from distinct Plex viewers.

## Verified already-fixed (no code change)

ISSUE-001 (scheduler resume — a croner-discriminating regression test was added), ISSUE-004 (regenerate-link button), ISSUE-006 (malformed OpenAI base URL feedback), ISSUE-008 (admin 0h tooltip), ISSUE-011 (invalid-cron a11y).

## Kept / out of scope

ISSUE-010 (third-party Plex.tv console noise), ISSUE-013 (`/api/sync/status/stream` is the member-facing feed with a documented no-PII contract), ISSUE-019 (per-slide configuration is a backlog feature, not a defect), ISSUE-020 (the appearance form already guards double-submit via the superForm submitting state).

## Tests

Added or updated focused coverage for ISSUE-001, 002, 003, 005, 009, 012, 015, including the share-policy bypass and admin-unaffected cases, the Plex env-lock predicate and server-side write-block, and the OAuth-cancel race guard.

## Verification

- `bun run check` — 0 errors, 0 warnings.
- `bun test --env-file=.env.test` — 1913 pass, 0 fail.
- `bun run check:biome` — clean.

## Notes for reviewers

- The ISSUE-003 fix changes the semantics of `ShareSettings.canUserControl` to the effective value (stored AND global); two existing tests that had encoded the prior bypass behavior were updated accordingly.
- Live agent-browser re-tests that require real Plex OAuth (ISSUE-005 concurrent slow-sync overlap; the markdown-preview real-newline false positive) were deferred and are noted in the plan.
