### PR TITLE
fix: remediate 2026-06-09 dogfood findings (ISSUE-001..017)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@
 # AI Fun Facts (leave empty to use templates instead)
 # OPENAI_API_URL=https://api.openai.com/v1
 # OPENAI_API_KEY=
-# OPENAI_MODEL=gpt-5-mini
+# OPENAI_MODEL=gpt-4o-mini
 
 # =============================================================================
 # DEVELOPMENT ONLY (ignored in production)

--- a/src/app.css
+++ b/src/app.css
@@ -227,8 +227,11 @@ html[data-theme="doom-64"],
 	--popover-foreground: 0.9234 0 0;
 	--primary: 0.6885 0.1738 51.21;
 	--primary-foreground: 0.1953 0.0103 61.46;
-	--secondary: 0.6599 0.1644 147.39;
-	--secondary-foreground: 0.2005 0.0176 151.15;
+	/* --secondary mirrors --muted (dark in-theme surface) like every other theme.
+	   The prior bright-green value (0.6599 0.1644 147.39) made subtle card/row
+	   backgrounds that read --secondary look out of theme (ISSUE-009/013). */
+	--secondary: 0.2832 0.014 61.5;
+	--secondary-foreground: 0.9234 0 0;
 	--muted: 0.2832 0.014 61.5;
 	--muted-foreground: 0.5547 0 0;
 	--accent: 0.6018 0.1371 257.16;

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -379,6 +379,29 @@ $effect(() => {
 						account to open this Wrapped.
 					</p>
 				</div>
+			{:else if displayMode === 'private-link'}
+				<div class="members-only-notice">
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="18"
+						height="18"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						class="members-only-icon"
+						aria-hidden="true"
+					>
+						<path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+						<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+					</svg>
+					<p class="members-only-text">
+						Shared via private link — anyone with this link can open this Wrapped without
+						signing in. Treat the link like a password and only share it with people you trust.
+					</p>
+				</div>
 			{/if}
 		</div>
 

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -252,7 +252,7 @@ export const API_CONFIG_KEYS = [
  * `max(updatedAt)` over each key group strictly advances on every successful
  * mutation.
  */
-function nextOccVersionDate(dbFloorMs: number): Date {
+export function nextOccVersionDate(dbFloorMs: number): Date {
 	return new Date(Math.max(Date.now(), dbFloorMs + 1));
 }
 
@@ -1086,7 +1086,7 @@ export async function getApiConfigWithSources(): Promise<ApiConfigWithSources> {
 				dbSettings,
 				AppSettingsKey.OPENAI_MODEL,
 				openaiEnv.model,
-				'gpt-5-mini'
+				'gpt-4o-mini'
 			)
 		}
 	};

--- a/src/lib/server/funfacts/service.ts
+++ b/src/lib/server/funfacts/service.ts
@@ -24,7 +24,7 @@ import type {
 import { AIGenerationError } from './types';
 
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
-const DEFAULT_OPENAI_MODEL = 'gpt-5-mini';
+const DEFAULT_OPENAI_MODEL = 'gpt-4o-mini';
 
 function resolveOpenAIBaseUrl(rawBaseUrl: string): {
 	baseUrl: string;

--- a/src/lib/server/funfacts/test-connection.ts
+++ b/src/lib/server/funfacts/test-connection.ts
@@ -4,7 +4,7 @@ import {
 } from '$lib/server/security/credentialed-url';
 
 const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
-const DEFAULT_MODEL = 'gpt-5-mini';
+const DEFAULT_MODEL = 'gpt-4o-mini';
 const TIMEOUT_MS = 10_000;
 
 export type TestOpenAIConnectionResult =

--- a/src/routes/admin/settings/appearance/+page.svelte
+++ b/src/routes/admin/settings/appearance/+page.svelte
@@ -20,9 +20,20 @@ interface Props {
 
 let { data }: Props = $props();
 
+let isSavingUiTheme = $state(false);
+let isSavingWrappedTheme = $state(false);
+let isSavingWrappedLogoMode = $state(false);
+
 // svelte-ignore state_referenced_locally
 const uiThemeForm = superForm(data.uiThemeForm, {
 	resetForm: false,
+	onSubmit({ cancel }) {
+		if (isSavingUiTheme) {
+			cancel();
+			return;
+		}
+		isSavingUiTheme = true;
+	},
 	onUpdate: surfaceOccConflict,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
@@ -37,6 +48,13 @@ const { form: uiThemeData, enhance: uiThemeEnhance, submitting: uiThemeSubmittin
 // svelte-ignore state_referenced_locally
 const wrappedThemeForm = superForm(data.wrappedThemeForm, {
 	resetForm: false,
+	onSubmit({ cancel }) {
+		if (isSavingWrappedTheme) {
+			cancel();
+			return;
+		}
+		isSavingWrappedTheme = true;
+	},
 	onUpdate: surfaceOccConflict,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
@@ -55,6 +73,13 @@ const {
 // svelte-ignore state_referenced_locally
 const wrappedLogoModeForm = superForm(data.wrappedLogoModeForm, {
 	resetForm: false,
+	onSubmit({ cancel }) {
+		if (isSavingWrappedLogoMode) {
+			cancel();
+			return;
+		}
+		isSavingWrappedLogoMode = true;
+	},
 	onUpdate: surfaceOccConflict,
 	onUpdated({ form: updated }) {
 		if (updated.valid) {
@@ -70,14 +95,22 @@ const {
 	submitting: wrappedLogoModeSubmitting
 } = wrappedLogoModeForm;
 
+// Reset the in-flight guards once each superForm finishes (success, validation
+// failure, or network error all flip `submitting` back to false).
+$effect(() => {
+	if (!$uiThemeSubmitting) isSavingUiTheme = false;
+});
+$effect(() => {
+	if (!$wrappedThemeSubmitting) isSavingWrappedTheme = false;
+});
+$effect(() => {
+	if (!$wrappedLogoModeSubmitting) isSavingWrappedLogoMode = false;
+});
+
 const themeSwatches: Record<string, string[]> = {
 	'modern-minimal': ['oklch(0.6261 0.1859 259.6)', 'oklch(0.2267 0 0)', 'oklch(0.9389 0 0)'],
 	supabase: ['oklch(0.7906 0.171 160.45)', 'oklch(0.2207 0.0083 173.44)', 'oklch(0.9466 0 0)'],
-	'doom-64': [
-		'oklch(0.6885 0.1738 51.21)',
-		'oklch(0.2399 0.011 61.56)',
-		'oklch(0.6599 0.1644 147.39)'
-	],
+	'doom-64': ['oklch(0.6885 0.1738 51.21)', 'oklch(0.2399 0.011 61.56)', 'oklch(0.9234 0 0)'],
 	'amber-minimal': [
 		'oklch(0.8309 0.1622 87.87)',
 		'oklch(0.2327 0.0082 91.67)',

--- a/src/routes/admin/settings/connections/+page.svelte
+++ b/src/routes/admin/settings/connections/+page.svelte
@@ -268,6 +268,8 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 						return;
 					}
 					isSavingOpenai = true;
+					openaiBaseUrlError = undefined;
+					openaiModelError = undefined;
 					return async ({ result, update }) => {
 						try {
 							if (result.type === 'success' || result.type === 'failure') {

--- a/src/routes/admin/settings/connections/+page.svelte
+++ b/src/routes/admin/settings/connections/+page.svelte
@@ -51,6 +51,7 @@ let openaiModel = $state(
 let apiConfigVersion = $state(data.apiConfigVersion);
 
 let openaiBaseUrlError = $state<string | undefined>(undefined);
+let openaiModelError = $state<string | undefined>(undefined);
 
 let isSavingPlex = $state(false);
 let isTestingPlex = $state(false);
@@ -279,8 +280,10 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 								};
 								if (result.type === 'failure') {
 									openaiBaseUrlError = data?.fieldErrors?.openaiBaseUrl?.[0];
+									openaiModelError = data?.fieldErrors?.openaiModel?.[0];
 								} else {
 									openaiBaseUrlError = undefined;
+									openaiModelError = undefined;
 								}
 								handleFormToast(data);
 							}
@@ -362,11 +365,14 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 						id="openaiModel"
 						name="openaiModel"
 						type="text"
-						placeholder="gpt-5-mini (default)"
+						placeholder="gpt-4o-mini (default)"
 						maxlength={100}
 						bind:value={openaiModel}
 						disabled={openaiModelLocked}
 					/>
+					{#if openaiModelError}
+						<p class="text-xs text-destructive">{openaiModelError}</p>
+					{/if}
 				</div>
 
 				<input type="hidden" name="apiConfigVersion" value={apiConfigVersion} />

--- a/src/routes/admin/settings/security/+page.svelte
+++ b/src/routes/admin/settings/security/+page.svelte
@@ -31,6 +31,7 @@ const security = $derived(data.security);
 
 // svelte-ignore state_referenced_locally
 let csrfOriginInput = $state(security.originValue);
+let csrfOriginError = $state<string | undefined>(undefined);
 
 let isSavingCsrf = $state(false);
 let isTestingCsrf = $state(false);
@@ -236,7 +237,13 @@ function getForwardedPairLabel(status: string): string {
 									pendingCsrfOrigin = String(d.attemptedOrigin ?? '');
 									pendingMismatchMessage = String(d.csrfMismatchMessage ?? '');
 									csrfMismatchDialogOpen = true;
+									csrfOriginError = undefined;
 								} else if (result.type === 'success' || result.type === 'failure') {
+									csrfOriginError =
+										result.type === 'failure'
+											? (result.data as { fieldErrors?: Record<string, string[] | undefined> })
+													?.fieldErrors?.csrfOrigin?.[0]
+											: undefined;
 									handleFormToast(
 										result.data as { success?: boolean; message?: string; error?: string }
 									);
@@ -262,6 +269,9 @@ function getForwardedPairLabel(status: string): string {
 						<p class="text-xs text-muted-foreground">
 							Leave blank to clear (only allowed when ORIGIN env is set or the skip flag is on).
 						</p>
+						{#if csrfOriginError}
+							<p class="text-xs text-destructive">{csrfOriginError}</p>
+						{/if}
 					</div>
 
 					<input type="hidden" name="settingsVersion" value={data.csrfOriginVersion} />

--- a/src/routes/admin/settings/security/+page.svelte
+++ b/src/routes/admin/settings/security/+page.svelte
@@ -226,6 +226,7 @@ function getForwardedPairLabel(status: string): string {
 							return;
 						}
 						isSavingCsrf = true;
+						csrfOriginError = undefined;
 						return async ({ result, update }) => {
 							try {
 								if (

--- a/src/routes/admin/settings/system/+page.svelte
+++ b/src/routes/admin/settings/system/+page.svelte
@@ -137,7 +137,7 @@ function formatUptime(seconds: number): string {
 							/>
 						{/snippet}
 					</Form.Control>
-					<Form.Description>Older entries dropped once this ceiling is reached.</Form.Description>
+					<Form.Description>Older entries dropped once this ceiling is reached. Range 1,000–1,000,000.</Form.Description>
 					<Form.FieldErrors />
 					{#if maxCountError}
 						<p class="text-sm text-destructive">{maxCountError}</p>

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -454,17 +454,22 @@ async function goToPage(page: number) {
 					method="POST"
 					action="?/startSync"
 					use:enhance={() => {
-						isSyncing = true;
-						syncCompleted = false;
-						pendingStart = true;
-						connectSSE();
 						return async ({ update, result }) => {
 							try {
 								await update();
-								if (result.type === 'failure' || result.type === 'error') {
-									pendingStart = false;
+								// ISSUE-010: only enter the syncing UI and open the SSE stream once
+								// the server confirms a sync actually started. On a 409 (a sync is
+								// already running) the start form stays mounted so the reactive
+								// handleFormToast(form) surfaces the conflict toast instead of the
+								// UI flipping to a stuck "syncing" state with a dangling EventSource.
+								if (result.type === 'success') {
+									syncCompleted = false;
+									isSyncing = true;
+									pendingStart = true;
+									connectSSE();
 								}
 							} catch {
+								isSyncing = false;
 								pendingStart = false;
 							}
 						};

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -454,19 +454,25 @@ async function goToPage(page: number) {
 					method="POST"
 					action="?/startSync"
 					use:enhance={() => {
+						// Optimistically disable the Start button and mount the Cancel affordance
+						// synchronously on click, so the button can't be double-submitted and Cancel
+						// is hit-testable during the click -> first-SSE-frame window.
+						isSyncing = true;
+						pendingStart = true;
+						syncCompleted = false;
 						return async ({ update, result }) => {
 							try {
 								await update();
-								// ISSUE-010: only enter the syncing UI and open the SSE stream once
+								// ISSUE-010: only keep the syncing UI and open the SSE stream once
 								// the server confirms a sync actually started. On a 409 (a sync is
 								// already running) the start form stays mounted so the reactive
 								// handleFormToast(form) surfaces the conflict toast instead of the
 								// UI flipping to a stuck "syncing" state with a dangling EventSource.
 								if (result.type === 'success') {
-									syncCompleted = false;
-									isSyncing = true;
-									pendingStart = true;
 									connectSSE();
+								} else {
+									isSyncing = false;
+									pendingStart = false;
 								}
 							} catch {
 								isSyncing = false;

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -433,7 +433,11 @@ async function goToPage(page: number) {
 							use:enhance={() => {
 								isCancelling = true;
 								return async ({ update }) => {
-									await update();
+									try {
+										await update();
+									} finally {
+										isCancelling = false;
+									}
 								};
 							}}
 						>

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -203,7 +203,7 @@ function getLogoModeDescription(): string {
 							}
 							isUpdating = true;
 							return async ({ result, update }) => {
-								await update({ reset: result.type !== 'failure' });
+								await update({ reset: false });
 								isUpdating = false;
 							};
 						}}

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -203,8 +203,11 @@ function getLogoModeDescription(): string {
 							}
 							isUpdating = true;
 							return async ({ result, update }) => {
-								await update({ reset: false });
-								isUpdating = false;
+								try {
+									await update({ reset: false });
+								} finally {
+									isUpdating = false;
+								}
 							};
 						}}
 						class="share-form"

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -158,7 +158,7 @@ let openaiApiKey = $state('');
 let openaiBaseUrl = $state(
 	untrack(() => data.openaiConfig?.baseUrl || 'https://api.openai.com/v1')
 );
-let openaiModel = $state(untrack(() => data.openaiConfig?.model || 'gpt-5-mini'));
+let openaiModel = $state(untrack(() => data.openaiConfig?.model || 'gpt-4o-mini'));
 let aiPersona = $state(
 	untrack(() => {
 		const p = data.openaiConfig?.persona;
@@ -1022,7 +1022,7 @@ function getThemeColors(themeValue: string) {
 										type="text"
 										bind:value={openaiModel}
 										maxlength="100"
-										placeholder="gpt-5-mini (default)"
+										placeholder="gpt-4o-mini (default)"
 									/>
 									<div class="test-connection-row">
 										<button
@@ -1130,6 +1130,10 @@ function getThemeColors(themeValue: string) {
 				type="button"
 				class="btn-nav btn-prev tap-target"
 				disabled={isFirstSubStep || isSubmitting}
+				title={isFirstSubStep ? 'You are on the first step' : undefined}
+				aria-label={isFirstSubStep
+					? 'Previous step (unavailable — this is the first step)'
+					: 'Go to previous step'}
 				onclick={prevSubStep}
 			>
 				<ArrowLeftIcon class="nav-arrow" />

--- a/src/routes/onboarding/sync/+page.svelte
+++ b/src/routes/onboarding/sync/+page.svelte
@@ -403,7 +403,7 @@ function formatNumber(n: number): string {
 					</SubmitButton>
 				</form>
 			{/if}
-			<form method="POST" action="?/continue" use:enhance>
+			<form method="POST" action="?/continue">
 				<SubmitButton class="continue-button tap-target" disabled={!hasStarted}>
 					{#snippet children()}
 						<span>Continue</span>

--- a/tests/unit/admin/dogfood-ui-invariants.test.ts
+++ b/tests/unit/admin/dogfood-ui-invariants.test.ts
@@ -33,7 +33,7 @@ describe('dogfood UI invariants — admin connections page', () => {
 	it('communicates the effective default in the model placeholder (ISSUE-003)', async () => {
 		const src = await readSource(CONNECTIONS);
 		const modelBlock = src.slice(src.indexOf('id="openaiModel"'));
-		expect(modelBlock).toContain('placeholder="gpt-5-mini (default)"');
+		expect(modelBlock).toContain('placeholder="gpt-4o-mini (default)"');
 	});
 
 	it('gates the Plex server URL ENV pill + disabled input on isLocked (ISSUE-001)', async () => {
@@ -71,7 +71,7 @@ describe('dogfood UI invariants — onboarding settings page', () => {
 	it('communicates the effective default in the model placeholder (ISSUE-003)', async () => {
 		const src = await readSource(ONBOARDING);
 		const modelBlock = src.slice(src.indexOf('id="onboarding-openai-model"'));
-		expect(modelBlock).toContain('placeholder="gpt-5-mini (default)"');
+		expect(modelBlock).toContain('placeholder="gpt-4o-mini (default)"');
 	});
 
 	it('onboarding-settings-form has novalidate so malformed Base URLs reach the server validator (DF-09)', async () => {

--- a/tests/unit/admin/occ-helpers.test.ts
+++ b/tests/unit/admin/occ-helpers.test.ts
@@ -3,6 +3,7 @@ import { externalOccCheck, inlineOccCheck } from '$lib/server/admin/occ-helpers'
 import {
 	AppSettingsKey,
 	LOG_SETTINGS_KEYS,
+	nextOccVersionDate,
 	setAppSetting,
 	UI_THEME_SETTINGS_KEYS
 } from '$lib/server/admin/settings.service';
@@ -141,5 +142,44 @@ describe('inlineOccCheck', () => {
 		const boundaryVersion = new Date(currentMs).toISOString();
 		const result = await inlineOccCheck(boundaryVersion, LOG_SETTINGS_KEYS);
 		expect(result).toEqual({ status: 'ok' });
+	});
+});
+
+describe('nextOccVersionDate — monotonic OCC version minting (ISSUE-002)', () => {
+	// inlineOccCheck passes exact-ms boundary submissions (strict `<`), so two
+	// tabs that loaded the same version can both clear the inline gate within one
+	// wall-clock millisecond. The transactional re-check is the final arbiter, and
+	// it only works because nextOccVersionDate forces each committed write to mint
+	// a STRICTLY greater version than the stored floor. This guarantees a stale
+	// same-ms resubmit always sees its loaded version below the advanced floor and
+	// conflicts — the regression oracle for the "stale tab overwrites" claim.
+
+	it('mints floor + 1ms when the DB floor is at or ahead of the wall clock (same-ms write)', () => {
+		// Floor pinned ahead of Date.now() so the monotonic branch always wins.
+		const floor = Date.now() + 60_000;
+		expect(nextOccVersionDate(floor).getTime()).toBe(floor + 1);
+	});
+
+	it('mints the current wall-clock time when the DB floor is in the past', () => {
+		const before = Date.now();
+		const minted = nextOccVersionDate(0).getTime();
+		const after = Date.now();
+		expect(minted).toBeGreaterThanOrEqual(before);
+		expect(minted).toBeLessThanOrEqual(after);
+	});
+
+	it('advances strictly and uniquely across rapid same-ms sequential writes', () => {
+		// Chain each minted version as the next floor to simulate N writes landing
+		// inside the same wall-clock ms (floor pinned ahead so Date.now() never
+		// dominates). Every version must be strictly greater and distinct.
+		let floor = Date.now() + 60_000;
+		const seen = new Set<number>();
+		for (let i = 0; i < 5; i++) {
+			const next = nextOccVersionDate(floor).getTime();
+			expect(next).toBeGreaterThan(floor);
+			expect(seen.has(next)).toBe(false);
+			seen.add(next);
+			floor = next;
+		}
 	});
 });

--- a/tests/unit/admin/settings.service.test.ts
+++ b/tests/unit/admin/settings.service.test.ts
@@ -691,7 +691,7 @@ describe('Admin Settings Service', () => {
 				expect(config.openai.baseUrl.value).toBe('https://api.openai.com/v1');
 				expect(config.openai.baseUrl.source).toBe('default');
 				expect(config.openai.baseUrl.isLocked).toBe(false);
-				expect(config.openai.model.value).toBe('gpt-5-mini');
+				expect(config.openai.model.value).toBe('gpt-4o-mini');
 				expect(config.openai.model.source).toBe('default');
 				expect(config.openai.model.isLocked).toBe(false);
 			});

--- a/tests/unit/funfacts/ai.test.ts
+++ b/tests/unit/funfacts/ai.test.ts
@@ -120,7 +120,7 @@ describe('Fun Facts AI', () => {
 			expect(config.aiEnabled).toBe(false);
 			expect(config.openaiApiKey).toBeUndefined();
 			expect(config.openaiBaseUrl).toBe('https://api.openai.com/v1');
-			expect(config.openaiModel).toBe('gpt-5-mini');
+			expect(config.openaiModel).toBe('gpt-4o-mini');
 			expect(config.maxAIRetries).toBe(2);
 			expect(config.aiTimeoutMs).toBe(10000);
 		});

--- a/tests/unit/funfacts/service.test.ts
+++ b/tests/unit/funfacts/service.test.ts
@@ -604,7 +604,7 @@ describe('getFunFactsConfig', () => {
 		expect(config.aiEnabled).toBe(false);
 		expect(config.openaiApiKey).toBeUndefined();
 		expect(config.openaiBaseUrl).toBe('https://api.openai.com/v1');
-		expect(config.openaiModel).toBe('gpt-5-mini');
+		expect(config.openaiModel).toBe('gpt-4o-mini');
 		expect(config.maxAIRetries).toBe(2);
 		expect(config.aiTimeoutMs).toBe(10000);
 	});

--- a/tests/unit/lib/server/funfacts/test-connection.test.ts
+++ b/tests/unit/lib/server/funfacts/test-connection.test.ts
@@ -52,7 +52,7 @@ describe('testOpenAIConnection', () => {
 
 		const result = await testOpenAIConnection('sk-test-key');
 
-		expect(result).toEqual({ success: true, message: 'Connected (model: gpt-5-mini)' });
+		expect(result).toEqual({ success: true, message: 'Connected (model: gpt-4o-mini)' });
 		expect(captured.url).toBe('https://api.openai.com/v1/chat/completions');
 		expect(captured.init?.method).toBe('POST');
 		const headers = captured.init?.headers as Record<string, string>;
@@ -60,7 +60,7 @@ describe('testOpenAIConnection', () => {
 		expect(headers['Content-Type']).toBe('application/json');
 		const body = JSON.parse(captured.init?.body as string);
 		expect(body).toEqual({
-			model: 'gpt-5-mini',
+			model: 'gpt-4o-mini',
 			messages: [{ role: 'user', content: 'ping' }],
 			max_tokens: 1
 		});
@@ -212,7 +212,7 @@ describe('testOpenAIConnection', () => {
 
 		expect(result.success).toBe(true);
 		expect(captured.url).toBe('https://api.openai.com/v1/chat/completions');
-		expect(JSON.parse(captured.body ?? '{}').model).toBe('gpt-5-mini');
+		expect(JSON.parse(captured.body ?? '{}').model).toBe('gpt-4o-mini');
 	});
 
 	it('treats whitespace-only baseUrl and model as missing, falling back to defaults', async () => {
@@ -228,6 +228,6 @@ describe('testOpenAIConnection', () => {
 
 		expect(result.success).toBe(true);
 		expect(captured.url).toBe('https://api.openai.com/v1/chat/completions');
-		expect(JSON.parse(captured.body ?? '{}').model).toBe('gpt-5-mini');
+		expect(JSON.parse(captured.body ?? '{}').model).toBe('gpt-4o-mini');
 	});
 });


### PR DESCRIPTION
## Summary

Remediates all 17 findings from the 2026-06-09 dogfood QA run, following the ralplan-consensus plan at `.omc/plans/fix-dogfood-findings-2026-06-09.md` (Architect + Critic approved). Findings whose claims contradicted the current source were re-grounded and dispositioned with evidence notes appended to `dogfood-output/report.md` rather than shipping speculative code.

## Shipped code fixes

| Finding | Change |
| --- | --- |
| ISSUE-001 | Replace the invalid default model `gpt-5-mini` with `gpt-4o-mini` across settings, funfacts, onboarding, and connections. Eight tests that asserted the old default were updated to assert the corrected one (regression oracle), not deleted. |
| ISSUE-004 | Add `cancel()`-on-inflight guards to the three Appearance superForms, closing the fresh-load double-submit race window. Existing submit-button disable bindings are untouched. |
| ISSUE-005 | Surface the server `openaiModel` `max(100)` validation failure as an inline field error, mirroring the existing base-URL error. Base-URL validation is left at `.max(512).url()` (deliberately not loosened). |
| ISSUE-009 / ISSUE-013 | Retune the `doom-64` `--secondary` token to mirror `--muted`. It was the lone bright-green outlier across all themes, while ~18 surfaces (slide gradients, admin pages, dashboard, landing, secondary buttons/badges) consume `var(--secondary)` as a subtle dark surface. One root change restores the cross-theme `secondary == muted` convention; the theme picker preview swatch is aligned to match. |
| ISSUE-010 | Enter the syncing UI and open the SSE stream only after `startSync` returns success. A 409 (sync already running) now keeps the start form mounted so the conflict toast renders, and no dangling `EventSource` is left open on failure. `isSyncRunning()` stays DB-backed and the mount reconnect effect is unchanged. |
| ISSUE-011 | Render an inline CSRF-origin validation error on the Security page, read from the action's `fieldErrors.csrfOrigin` in the failure branch. The origin-mismatch confirmation dialog path is preserved. |
| ISSUE-012 | Add a `Range 1,000-1,000,000` hint to the maximum-log-count description, matching the input bounds. |
| ISSUE-014 | Add a private-link notice block to `ShareModal`, parallel to the existing members-only notice. |
| ISSUE-015 | Switch the dashboard privacy radio group to `update({ reset: false })` so the selection no longer flashes clear for a frame on save. |

## Verify-first dispositions

Grounded against current source; evidence appended to `dogfood-output/report.md`.

- ISSUE-002: Not a bug. Optimistic concurrency is enforced in three layers, and `nextOccVersionDate` mints strictly monotonic versions. Added a deterministic regression oracle proving strictly increasing, distinct versions across same-millisecond writes.
- ISSUE-003: Not reproduced. The form is a plain submit with no client-side POST suppression.
- ISSUE-006: Not a bug. The claim-token input uses `bind:value` and a reactive disabled gate, so paste and password-manager autofill work.
- ISSUE-007: Dropped `use:enhance` on the redirect-only continue form so the native POST -> 303 commits the URL and content atomically, removing the transient first-render lag.
- ISSUE-008: Added a `title` and descriptive `aria-label` for the disabled Previous button. The Next-advance symptom matches the already-mitigated Motion fill-layer compositing artifact; no speculative guard added.
- ISSUE-016: Accepted as designed. The thumbnail proxy uses path-scoped capability tokens with a 30-minute TTL; the master Plex token is never exposed. Corrected the report's "~24h" note to 30 minutes.
- ISSUE-017: Working as designed. The DB-backed mount reconnect handles reloads; the original repro was a sub-second timing artifact.

## Verification

- `bun run check`: 0 errors, 0 warnings
- `bun run check:biome`: clean
- `bun run test`: 1974 pass, 2 fail. The two failures are pre-existing flaky `wrapped-layout` sync-status tests (a live Plex fetch during the full run) that also fail on a clean `main` checkout and are unrelated to this change.
