### PR TITLE
fix(dogfood 2026-06-14): remediate UX/a11y/contract findings (ISSUE-001..008)

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -229,8 +229,9 @@ const onboardingHandle: Handle = async ({ event, resolve }) => {
 };
 
 // ISSUE-008 — SSE denial contract. Admin stream routes (/admin/logs/stream,
-// /admin/sync/stream) are denied by `authorizationHandle` below with a 303 to '/'
-// (anon) or '/dashboard' (non-admin) BEFORE their endpoint's own requireAdmin 403
+// /admin/sync/stream) are denied by `authorizationHandle` below with a 303
+// (anon: '/?returnTo=<encodedPath>' for a safe path, else '/'; non-admin:
+// '/dashboard') BEFORE their endpoint's own requireAdmin 403
 // ever runs, so the 403 is unreachable for anonymous callers and the observable
 // anon contract for admin streams is this hook 303. /api/sync/status/stream
 // instead returns a 401 JSON from its own handler. The split is intentional and

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -228,6 +228,18 @@ const onboardingHandle: Handle = async ({ event, resolve }) => {
 	return resolve(event);
 };
 
+// ISSUE-008 — SSE denial contract. Admin stream routes (/admin/logs/stream,
+// /admin/sync/stream) are denied by `authorizationHandle` below with a 303 to '/'
+// (anon) or '/dashboard' (non-admin) BEFORE their endpoint's own requireAdmin 403
+// ever runs, so the 403 is unreachable for anonymous callers and the observable
+// anon contract for admin streams is this hook 303. /api/sync/status/stream
+// instead returns a 401 JSON from its own handler. The split is intentional and
+// only matters for document navigation vs. programmatic clients (curl/fetch): a
+// browser `EventSource` cannot consume either a 303 or a 401 — both surface as a
+// generic `onerror` — so the status-code difference is cosmetic for SSE consumers.
+// Admin streams are reached by in-app navigation that benefits from a
+// redirect-to-login; the api endpoint is a programmatic surface where a 401 is
+// cleaner. Do not "unify" these without re-reading this rationale.
 const authorizationHandle: Handle = async ({ event, resolve }) => {
 	if (isAdminRouteId(event.route.id)) {
 		if (!event.locals.user || !event.locals.user.isAdmin) {

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -84,7 +84,7 @@ const statsConfig = $derived([
 		// as three conflicting numbers.
 		value: data.userCount,
 		label: 'Registered Accounts',
-		sub: `${data.syncedViewerCount.toLocaleString()} Plex viewers with synced watch history`,
+		sub: `${data.syncedViewerCount.toLocaleString()} distinct Plex viewers in synced history (not registered accounts)`,
 		icon: Users,
 		color: 'blue',
 		gradient: 'from-blue-500/20 to-blue-600/5'
@@ -124,7 +124,7 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 </script>
 
 <svelte:head>
-	<title>Dashboard - Admin - Obzorarr</title>
+	<title>Dashboard — Admin — Obzorarr</title>
 </svelte:head>
 
 <div class="dashboard">

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -365,6 +365,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 							<input type="hidden" name="slideType" value={item.slideType} />
 							<SubmitButton
 								class={`toggle-button tap-target ${item.enabled ? 'enabled' : ''}`}
+								aria-pressed={item.enabled}
 								aria-label={`${item.enabled ? 'Disable' : 'Enable'} ${SLIDE_NAMES[item.slideType as SlideType] ?? item.slideType} slide`}
 							>
 								{#snippet children()}
@@ -402,6 +403,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 								<input type="hidden" name="id" value={item.id} />
 								<SubmitButton
 									class={`toggle-button tap-target ${item.enabled ? 'enabled' : ''}`}
+									aria-pressed={item.enabled}
 									aria-label={`${item.enabled ? 'Disable' : 'Enable'} ${item.title.trim().length > 0 ? item.title : 'Untitled custom slide'}`}
 								>
 									{#snippet children()}

--- a/src/routes/admin/wrapped/+page.svelte
+++ b/src/routes/admin/wrapped/+page.svelte
@@ -33,7 +33,7 @@ function handleConfigNavigation(event: MouseEvent): void {
 </script>
 
 <svelte:head>
-	<title>Wrapped - Admin - Obzorarr</title>
+	<title>Wrapped — Admin — Obzorarr</title>
 </svelte:head>
 
 <div class="wrapped-hub">

--- a/src/routes/api/sync/status/stream/+server.ts
+++ b/src/routes/api/sync/status/stream/+server.ts
@@ -40,6 +40,13 @@ const POLL_INTERVAL_IDLE_MS = 2000;
 
 export const GET: RequestHandler = async ({ request, locals }) => {
 	// Gate: allow anonymous access only while onboarding is incomplete.
+	// ISSUE-008 — denial contract: this programmatic endpoint returns 401 JSON,
+	// whereas admin stream routes are denied with a 303 by `authorizationHandle`
+	// in hooks.server.ts (see the rationale there). The split is intentional and
+	// cosmetic for SSE consumers — a browser `EventSource` cannot read either a
+	// 401 body or follow a 303, so both surface only as `onerror`; it is observable
+	// only to curl/fetch-style clients, for which a 401 status is the cleaner
+	// contract on an API surface.
 	const onboardingPending = await requiresOnboarding();
 	if (!onboardingPending && !locals.user) {
 		return new Response(JSON.stringify({ message: 'Unauthorized' }), {

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -254,7 +254,10 @@ function getLogoModeDescription(): string {
 								<span class="card-desc">{shareModeDescriptions['private-link']}</span>
 								{#if isBelowFloor('private-link')}
 									<span class="floor-note">
-										Your administrator requires at least {shareModeLabels[data.globalFloor ?? ''] ?? data.globalFloor} privacy.
+										Private links and token regeneration are unavailable while your
+										administrator limits sharing to at least {shareModeLabels[
+											data.globalFloor ?? ''
+										] ?? data.globalFloor} privacy.
 									</span>
 								{/if}
 							</label>

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -702,7 +702,10 @@ function formatServerUrl(url: string | null): string {
 					{:else}
 						<a class="redirect-fallback" href="?auth=redirect">
 							<span class="redirect-fallback-label">Use redirect instead</span>
-							<span class="redirect-fallback-hint">If sign-in doesn't return, use this.</span>
+							<span class="redirect-fallback-hint"
+								>Sign-in opens in a popup by default. If it's blocked, switch to a
+								same-tab redirect.</span
+							>
 						</a>
 					{/if}
 				</div>
@@ -770,7 +773,10 @@ function formatServerUrl(url: string | null): string {
 					{:else}
 						<a class="redirect-fallback" href="?auth=redirect">
 							<span class="redirect-fallback-label">Use redirect instead</span>
-							<span class="redirect-fallback-hint">If sign-in doesn't return, use this.</span>
+							<span class="redirect-fallback-hint"
+								>Sign-in opens in a popup by default. If it's blocked, switch to a
+								same-tab redirect.</span
+							>
 						</a>
 					{/if}
 				</div>

--- a/src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
@@ -149,9 +149,14 @@ function handleLogoToggle(): void {
 
 	<div class="controls-container">
 		{#if data.isOwner && data.canUserControlLogo}
+			<!-- ISSUE-006: post to the opaque canonical href (data.currentUrl is the
+			     owner's slug/token path) instead of the relative page URL, so the
+			     toggleLogo request never carries the internal integer user id. The
+			     form only renders for the owner (isOwner above), so currentUrl is
+			     always the viewer's own canonical href — never another user's token. -->
 			<form
 				method="POST"
-				action="?/toggleLogo"
+				action="{data.currentUrl}?/toggleLogo"
 				use:enhance={() => {
 					handleLogoToggle();
 					return async ({ result, update }) => {

--- a/tests/unit/admin/dogfood-ui-invariants.test.ts
+++ b/tests/unit/admin/dogfood-ui-invariants.test.ts
@@ -18,6 +18,8 @@ const WRAPPED_PAGE = 'src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
 const SHARE_MODAL = 'src/lib/components/wrapped/ShareModal.svelte';
 const SLIDES_PAGE = 'src/routes/admin/slides/+page.svelte';
 const ADMIN_DASHBOARD = 'src/routes/admin/+page.svelte';
+const ADMIN_WRAPPED = 'src/routes/admin/wrapped/+page.svelte';
+const DASHBOARD_SETTINGS = 'src/routes/dashboard/settings/+page.svelte';
 
 describe('dogfood UI invariants — admin connections page', () => {
 	it('caps the OpenAI Base URL input at maxlength=512 (ISSUE-008)', async () => {
@@ -140,8 +142,10 @@ describe('DF-06 source-guard — wrapped page logo toggle gated on isOwner && ca
 		const src = await readSource(WRAPPED_PAGE);
 		// The condition must include BOTH flags joined with &&.
 		// We find the toggleLogo action attribute and walk backwards to its
-		// enclosing {#if} to verify the full gate.
-		const toggleIdx = src.indexOf('action="?/toggleLogo"');
+		// enclosing {#if} to verify the full gate. (ISSUE-006 made the action an
+		// absolute opaque href; we match on the action prefix so this guard is
+		// agnostic to the relative-vs-absolute form.)
+		const toggleIdx = src.indexOf('?/toggleLogo"');
 		expect(toggleIdx).toBeGreaterThan(-1);
 		// The nearest {#if ...} before the toggleLogo form must contain isOwner.
 		const before = src.slice(0, toggleIdx);
@@ -151,6 +155,23 @@ describe('DF-06 source-guard — wrapped page logo toggle gated on isOwner && ca
 		expect(ifBlock).toContain('data.canUserControlLogo');
 		// The two conditions must be ANDed (not ORed).
 		expect(ifBlock).toContain('&&');
+	});
+});
+
+describe('ISSUE-006 source-guard — toggleLogo posts to the opaque canonical href', () => {
+	// ISSUE-006: the toggleLogo form must post to data.currentUrl (the owner's
+	// opaque slug/token path), NOT the relative page URL, so the request never
+	// carries the internal integer user id. The form only renders for the owner
+	// (DF-06 guard above), so currentUrl is always the viewer's own canonical href.
+
+	it('toggle form action is the absolute opaque href {data.currentUrl}?/toggleLogo', async () => {
+		const src = await readSource(WRAPPED_PAGE);
+		expect(src).toContain('action="{data.currentUrl}?/toggleLogo"');
+	});
+
+	it('the relative action="?/toggleLogo" (which would leak /u/{int}) is gone', async () => {
+		const src = await readSource(WRAPPED_PAGE);
+		expect(src).not.toContain('action="?/toggleLogo"');
 	});
 });
 
@@ -243,5 +264,85 @@ describe('DF-16 source-guard — admin dashboard scheduler-cta callout', () => {
 		const syncStatusBlock = src.slice(src.indexOf('const syncStatus = $derived'));
 		const closingParen = syncStatusBlock.indexOf('});');
 		expect(syncStatusBlock.slice(0, closingParen)).toContain("return 'inactive'");
+	});
+});
+
+describe('ISSUE-005 source-guard — admin <title> separator uniformity', () => {
+	// All admin document titles use an em-dash separator. Dashboard and Wrapped
+	// previously used a hyphen; this guard pins the em-dash so the separator
+	// stays consistent across admin pages.
+
+	it('admin dashboard title uses the em-dash separator', async () => {
+		const src = await readSource(ADMIN_DASHBOARD);
+		expect(src).toContain('<title>Dashboard — Admin — Obzorarr</title>');
+		expect(src).not.toContain('<title>Dashboard - Admin - Obzorarr</title>');
+	});
+
+	it('admin wrapped hub title uses the em-dash separator', async () => {
+		const src = await readSource(ADMIN_WRAPPED);
+		expect(src).toContain('<title>Wrapped — Admin — Obzorarr</title>');
+		expect(src).not.toContain('<title>Wrapped - Admin - Obzorarr</title>');
+	});
+});
+
+describe('ISSUE-004 source-guard — admin slides toggles expose aria-pressed', () => {
+	// The built-in and custom slide enable/disable toggles are native SubmitButton
+	// buttons (not the bits-ui Toggle). They must expose aria-pressed bound to the
+	// enabled state so screen readers announce on/off, not just a visual style.
+
+	it('built-in slide toggle SubmitButton sets aria-pressed={item.enabled}', async () => {
+		const src = await readSource(SLIDES_PAGE);
+		const block = src.slice(src.indexOf('action="?/toggleSlide"'));
+		const formEnd = block.indexOf('</form>');
+		expect(block.slice(0, formEnd)).toContain('aria-pressed={item.enabled}');
+	});
+
+	it('custom slide toggle SubmitButton sets aria-pressed={item.enabled}', async () => {
+		const src = await readSource(SLIDES_PAGE);
+		const block = src.slice(src.indexOf('action="?/toggleCustomSlide"'));
+		const formEnd = block.indexOf('</form>');
+		expect(block.slice(0, formEnd)).toContain('aria-pressed={item.enabled}');
+	});
+});
+
+describe('ISSUE-003 source-guard — dashboard registered-accounts clarifying copy', () => {
+	// The "Registered Accounts" stat card subtitle must distinguish registered app
+	// accounts from distinct synced Plex viewers, consistent with the /admin/users
+	// note, so the two counts don't read as a discrepancy.
+
+	it('registered-accounts card subtitle distinguishes viewers from registered accounts', async () => {
+		const src = await readSource(ADMIN_DASHBOARD);
+		const cardBlock = src.slice(src.indexOf("label: 'Registered Accounts'"));
+		const subLine = cardBlock.slice(0, cardBlock.indexOf('icon:'));
+		expect(subLine).toContain('distinct Plex viewers in synced history');
+		expect(subLine).toContain('not registered accounts');
+	});
+});
+
+describe('ISSUE-002 source-guard — Plex login redirect-fallback copy reflects popup default', () => {
+	// The "Use redirect instead" affordance copy must describe popup as the default
+	// with same-tab redirect as the fallback, reconciling copy with behavior
+	// (shouldUseRedirectAuth defaults to popup unless headless/blocked).
+
+	it('redirect-fallback hint states popup is the default with redirect fallback', async () => {
+		const src = await readSource(ONBOARDING_PLEX);
+		expect(src).toContain('Sign-in opens in a popup by default. If it');
+		// The stale vague hint must be gone.
+		expect(src).not.toContain("If sign-in doesn't return, use this.");
+	});
+});
+
+describe('ISSUE-001 source-guard — share-floor private-link unavailable copy', () => {
+	// When the server floor clamps private-link, the Privacy tab must explain that
+	// private links and token regeneration are unavailable (not just the generic
+	// "below floor" note), reusing the .floor-note pattern.
+
+	it('private-link card surfaces unavailable-feature copy under the floor', async () => {
+		const src = await readSource(DASHBOARD_SETTINGS);
+		const block = src.slice(src.indexOf("isBelowFloor('private-link')"));
+		// Walk to the end of the {#if} floor-note for the private-link card.
+		const floorNoteEnd = block.indexOf('</label>');
+		const floorNote = block.slice(0, floorNoteEnd);
+		expect(floorNote).toContain('Private links and token regeneration are unavailable');
 	});
 });

--- a/tests/unit/routes/sse-denial-contract.test.ts
+++ b/tests/unit/routes/sse-denial-contract.test.ts
@@ -12,8 +12,9 @@ import { resetSharedTestDb } from '../../helpers/db';
 // The denial responses for the three streaming endpoints are intentionally
 // split and documented in hooks.server.ts / the api endpoint:
 //   - admin streams (/admin/logs/stream, /admin/sync/stream): denied by the
-//     `authorizationHandle` hook with a 303 to '/' for anonymous callers,
-//     BEFORE the endpoint's own requireAdmin 403 ever runs.
+//     `authorizationHandle` hook with a 303 for anonymous callers (to
+//     '/?returnTo=<encodedPath>' for a safe path, else '/'), BEFORE the
+//     endpoint's own requireAdmin 403 ever runs.
 //   - /api/sync/status/stream: returns 401 JSON from its own handler once
 //     onboarding is complete.
 //

--- a/tests/unit/routes/sse-denial-contract.test.ts
+++ b/tests/unit/routes/sse-denial-contract.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
+import { isAdminRouteId } from '$lib/server/auth/guards';
+import { GET as adminLogsStreamGET } from '../../../src/routes/admin/logs/stream/+server';
+import { GET as adminSyncStreamGET } from '../../../src/routes/admin/sync/stream/+server';
+import { GET as apiSyncStatusStreamGET } from '../../../src/routes/api/sync/status/stream/+server';
+import { resetSharedTestDb } from '../../helpers/db';
+
+// ISSUE-008 — SSE denial contract.
+//
+// The denial responses for the three streaming endpoints are intentionally
+// split and documented in hooks.server.ts / the api endpoint:
+//   - admin streams (/admin/logs/stream, /admin/sync/stream): denied by the
+//     `authorizationHandle` hook with a 303 to '/' for anonymous callers,
+//     BEFORE the endpoint's own requireAdmin 403 ever runs.
+//   - /api/sync/status/stream: returns 401 JSON from its own handler once
+//     onboarding is complete.
+//
+// The split is cosmetic for SSE consumers — a browser EventSource cannot read a
+// 401 body or follow a 303, so both surface only as `onerror`; it is observable
+// only to programmatic (curl/fetch) clients. These tests pin the observable
+// contract so the split stays intentional, not accidental.
+
+const PROJECT_ROOT = join(import.meta.dir, '..', '..', '..');
+
+async function readSource(relPath: string): Promise<string> {
+	return Bun.file(join(PROJECT_ROOT, relPath)).text();
+}
+
+type AnyGet = (args: { request: Request; locals: App.Locals }) => Promise<Response>;
+
+function streamRequest(path: string): Request {
+	return new Request(`http://localhost${path}`, { method: 'GET' });
+}
+
+async function expectStatus(get: AnyGet, locals: App.Locals, path: string): Promise<number> {
+	try {
+		const res = await get({ request: streamRequest(path), locals });
+		return res.status;
+	} catch (err) {
+		// requireAdmin throws a SvelteKit HttpError with a numeric status.
+		return (err as { status?: number }).status ?? 0;
+	}
+}
+
+describe('ISSUE-008 — /api/sync/status/stream anon denial after onboarding', () => {
+	beforeEach(resetSharedTestDb);
+
+	it('returns 401 JSON for an anonymous caller once onboarding is complete', async () => {
+		await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+
+		const res = await apiSyncStatusStreamGET({
+			request: streamRequest('/api/sync/status/stream'),
+			locals: {} as App.Locals
+		} as Parameters<typeof apiSyncStatusStreamGET>[0]);
+
+		expect(res.status).toBe(401);
+		expect(res.headers.get('Content-Type')).toBe('application/json');
+		expect(await res.json()).toMatchObject({ message: 'Unauthorized' });
+	});
+});
+
+describe('ISSUE-008 — admin stream routes are admin-gated (hook 303 governs anon)', () => {
+	// The observable anon denial for these routes is the hook 303; the endpoint
+	// requireAdmin 403 is unreachable for anon because the hook fires first. We
+	// assert (a) the routes are classified as admin routes so the hook governs
+	// them, and (b) the endpoints' own requireAdmin denies non-admin as
+	// defense-in-depth.
+	beforeEach(resetSharedTestDb);
+
+	it('classifies both admin stream route ids as admin routes', () => {
+		expect(isAdminRouteId('/admin/logs/stream')).toBe(true);
+		expect(isAdminRouteId('/admin/sync/stream')).toBe(true);
+	});
+
+	it('admin logs stream endpoint denies an anonymous caller (403 defense-in-depth)', async () => {
+		const status = await expectStatus(
+			adminLogsStreamGET as AnyGet,
+			{} as App.Locals,
+			'/admin/logs/stream'
+		);
+		expect(status).toBe(403);
+	});
+
+	it('admin sync stream endpoint denies an anonymous caller (403 defense-in-depth)', async () => {
+		const status = await expectStatus(
+			adminSyncStreamGET as AnyGet,
+			{} as App.Locals,
+			'/admin/sync/stream'
+		);
+		expect(status).toBe(403);
+	});
+});
+
+describe('ISSUE-008 — denial-contract rationale is documented in source', () => {
+	it('hooks.server.ts authorizationHandle records the 303-vs-401 rationale', async () => {
+		const src = await readSource('src/hooks.server.ts');
+		// The rationale sits in a block comment immediately preceding the handler.
+		const commentIdx = src.indexOf('ISSUE-008 — SSE denial contract');
+		expect(commentIdx).toBeGreaterThan(-1);
+		const handlerIdx = src.indexOf('const authorizationHandle');
+		expect(handlerIdx).toBeGreaterThan(commentIdx);
+		const rationale = src.slice(commentIdx, handlerIdx);
+		expect(rationale).toContain('EventSource');
+		// The admin-stream denial remains a 303 (redirectResponse) inside the handler.
+		const handlerBody = src.slice(handlerIdx, handlerIdx + 1600);
+		expect(handlerBody).toContain('redirectResponse');
+	});
+
+	it('/api/sync/status/stream records the 401-vs-303 rationale near its 401', async () => {
+		const src = await readSource('src/routes/api/sync/status/stream/+server.ts');
+		expect(src).toContain('ISSUE-008');
+		expect(src).toContain('status: 401');
+	});
+});

--- a/tests/unit/sharing/issue-006-admin-cross-user.test.ts
+++ b/tests/unit/sharing/issue-006-admin-cross-user.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { db } from '$lib/server/db/client';
+import { shareSettings, users } from '$lib/server/db/schema';
+import { setGlobalShareDefaults } from '$lib/server/sharing/service';
+import { ShareMode, ShareModeSource } from '$lib/server/sharing/types';
+import { load } from '../../../src/routes/wrapped/[year=year]/u/[identifier]/+page.server';
+import { resetSharedTestDb } from '../../helpers/db';
+
+// ISSUE-006 — the toggleLogo integer-id leak is fixed in the template via an
+// absolute opaque form action (see tests/unit/admin/dogfood-ui-invariants.test.ts).
+// The chosen fix deliberately does NOT add a load-level redirect, because an
+// admin GET of another user's numeric PRIVATE_LINK URL must never 307 onto that
+// user's secret token URL (address-bar/history/Referer leak) nor mint a
+// slug/token as a write-on-GET.
+//
+// This test locks in that safe load behavior: an admin viewing another user's
+// numeric PRIVATE_LINK URL is denied with the byte-identical anti-enumeration
+// 404 (owner/admin must use the token URL), with NO redirect and NO share row
+// minted as a side effect.
+
+type LoadArgs = Parameters<typeof load>[0];
+
+const YEAR = 2026;
+const ADMIN_ID = 1;
+const OTHER_USER_ID = 7;
+const OTHER_USER_TOKEN = '550e8400-e29b-41d4-a716-446655440000';
+
+async function seedUser(userId: number, plexId: number, accountId: number): Promise<void> {
+	await db.insert(users).values({
+		id: userId,
+		plexId,
+		accountId,
+		username: `user-${userId}`
+	});
+}
+
+async function countShareRows(): Promise<number> {
+	return (await db.select().from(shareSettings)).length;
+}
+
+async function invokeLoad(params: {
+	identifier: string;
+	currentUser: App.Locals['user'];
+}): Promise<{ status?: number; redirectLocation?: string; threw: boolean }> {
+	try {
+		await load({
+			params: { year: String(YEAR), identifier: params.identifier },
+			locals: { user: params.currentUser },
+			parent: async () => ({ availableYears: [YEAR] }),
+			setHeaders: () => {}
+		} as unknown as LoadArgs);
+		return { threw: false };
+	} catch (err) {
+		const e = err as { status?: number; location?: string };
+		return { threw: true, status: e.status, redirectLocation: e.location };
+	}
+}
+
+describe('ISSUE-006 — admin viewing another user’s numeric PRIVATE_LINK URL', () => {
+	beforeEach(async () => {
+		await resetSharedTestDb();
+		await seedUser(ADMIN_ID, 100001, 200001);
+		await seedUser(OTHER_USER_ID, 100007, 200007);
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: false
+		});
+		// The other user is PRIVATE_LINK with an EXISTING token (the realistic
+		// state for a private-link user — the token is the link).
+		await db.insert(shareSettings).values({
+			userId: OTHER_USER_ID,
+			year: YEAR,
+			mode: ShareMode.PRIVATE_LINK,
+			modeSource: ShareModeSource.EXPLICIT,
+			shareToken: OTHER_USER_TOKEN,
+			canUserControl: false
+		});
+	});
+
+	it('denies with a 404 (no redirect) and mints no share row', async () => {
+		const rowsBefore = await countShareRows();
+
+		const result = await invokeLoad({
+			identifier: String(OTHER_USER_ID),
+			currentUser: { id: ADMIN_ID, plexId: 100001, username: 'admin', isAdmin: true }
+		});
+
+		// Denied via the anti-enumeration 404 — NOT a 3xx redirect.
+		expect(result.threw).toBe(true);
+		expect(result.status).toBe(404);
+		expect(result.status).not.toBe(307);
+		// No Location header carrying the other user's token URL.
+		expect(result.redirectLocation).toBeUndefined();
+
+		// No share_settings row minted as a GET side effect (ensurePublicSlug /
+		// ensureShareToken must not fire on this denied load).
+		const rowsAfter = await countShareRows();
+		expect(rowsAfter).toBe(rowsBefore);
+
+		// The other user's token is untouched (not regenerated).
+		const otherRow = (await db.select().from(shareSettings)).find(
+			(r) => r.userId === OTHER_USER_ID && r.year === YEAR
+		);
+		expect(otherRow?.shareToken).toBe(OTHER_USER_TOKEN);
+	});
+});


### PR DESCRIPTION
## Summary

Remediates the 2026-06-14 dogfood QA findings (`dogfood-output/report.md`: 1 medium, 7 low, plus 1 security follow-up) with minimal, surgical diffs. No schema, migration, or dependency changes. The app's security posture (anti-enumeration 404 uniformity, owner/admin integer-id gating, `returnTo` open-redirect guard, share-floor enforcement) is preserved unchanged.

Implements the approved plan in `.omc/plans/fix-dogfood-findings.md` (single branch, risk-tiered).

## Changes

| Finding | Severity | Change |
| --- | --- | --- |
| ISSUE-005 | low | Unify admin `<title>` separators to em-dash (Dashboard, Wrapped) |
| ISSUE-004 | low | Add `aria-pressed` to the `/admin/slides` enable/disable toggles so screen readers announce on/off state |
| ISSUE-003 | low | Clarify the dashboard "Registered Accounts" card subtitle (registered accounts vs distinct synced Plex viewers) |
| ISSUE-002 | low | Reconcile the Plex login redirect-fallback copy with behavior (popup is default; redirect is the fallback when the popup is blocked) |
| ISSUE-008 | low | Document the intentional SSE denial-contract split (admin streams 303 via the hook; `/api/sync/status/stream` 401). No behavior change |
| ISSUE-006 | low | Post the wrapped logo toggle to the opaque canonical href instead of the relative page URL, removing the internal integer user id from the request |
| ISSUE-001 | medium | Explain in the dashboard Privacy tab that private links and token regeneration are unavailable while the server floor clamps sharing |
| ISSUE-007 + returnTo | low | Verified already-safe (no code change required) |

## Notable details

### ISSUE-006 (security-adjacent)
The `toggleLogo` form action changes from the relative `?/toggleLogo` to the absolute `{data.currentUrl}?/toggleLogo`. The form renders only for the owner (`{#if data.isOwner && data.canUserControlLogo}`), and `data.currentUrl` is the owner's own same-origin canonical opaque href (slug or token). The internal sequential integer id therefore never appears in the toggle POST.

A `load`-level redirect was deliberately rejected: an admin GET of another user's numeric PRIVATE_LINK URL would have 307-redirected onto that user's secret token URL (leaking it into the admin's address bar/history/Referer) and minted a slug as a write-on-GET. The chosen form-action fix avoids all of that. The actual safe behavior for that admin cross-user case is a 404 (owner/admin must use the token URL) with no redirect and no mint, which is locked in by a new test.

### ISSUE-008
The denial-status split is cosmetic for SSE consumers: a browser `EventSource` cannot consume either a 303 or a 401 (both surface as a generic `onerror`), so the difference is observable only to programmatic clients. The hook's 303 fires before the endpoint's `requireAdmin` 403 for anonymous callers. This rationale is now encoded in code comments; the contract is pinned by tests rather than changed.

### ISSUE-007 + returnTo (verified, no change)
The `returnTo` open-redirect guard (`isSafeReturnPath` / `resolveSafeReturnPath`) is enforced at three layers and already covered by `tests/unit/auth/core.test.ts`. The Plex OAuth-init JSON parse warning is third-party Plex bundled OAuth JS noise (documented in `auth/plex/+server.ts`); no first-party `JSON.parse` on the OAuth path is unguarded.

## Tests

- Update the existing DF-06 source guard to match the new absolute form action.
- Add source guards for ISSUE-001 through ISSUE-006 in `tests/unit/admin/dogfood-ui-invariants.test.ts`.
- New `tests/unit/routes/sse-denial-contract.test.ts`: anon `/api/sync/status/stream` returns 401 JSON post-onboarding; admin stream routes are admin-gated; rationale documented in source.
- New `tests/unit/sharing/issue-006-admin-cross-user.test.ts`: an admin GET of another user's numeric PRIVATE_LINK URL returns 404 with no redirect, no `share_settings` row minted, and the other user's token untouched.

## Verification

- `bun run lint` — clean
- `bun run check` — 0 errors
- `bun run test` — 2065 pass / 0 fail (coverage thresholds enforced)

## Follow-up (out of scope)

- Migrate the pre-existing `console.warn('Failed to generate fun facts:', err)` at `src/routes/wrapped/[year=year]/u/[identifier]/+page.server.ts` to `logger` (convention nit in an otherwise-untouched-by-this-PR function).