### PR TITLE
fix(dogfood 2026-06-15): remediate ISSUE-001..015

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -306,6 +306,16 @@ export const handleError: HandleServerError = async ({ error, event }) => {
 		return { message: 'Not found' };
 	}
 
+	// Remaining 4xx HttpErrors (403/422/etc — the 404 is handled above) are caller
+	// mistakes, not server faults, so log them at WARN to keep the ERROR channel
+	// reserved for genuine 5xx/unexpected failures (ISSUE-009). Placed after BOTH
+	// 404 guards so neither 404 path is mis-leveled. SvelteKitError is not an
+	// HttpError, so unmatched-route 404s never reach this branch.
+	if (isHttpError(error) && error.status >= 400 && error.status < 500) {
+		logger.warn(`Client error ${error.status}: ${event.url.pathname}`, 'ClientError', metadata);
+		return { message: error.body.message ?? 'Request error' };
+	}
+
 	logger.error(`Unexpected error: ${error}`, 'ErrorHandler', metadata);
 
 	return {

--- a/src/lib/components/slides/DistributionSlide.svelte
+++ b/src/lib/components/slides/DistributionSlide.svelte
@@ -238,14 +238,14 @@ function formatMinutes(minutes: number): string {
 }
 
 function formatMinutesDetailed(minutes: number): string {
-	if (minutes < 60) return `${Math.round(minutes)} minutes`;
+	if (minutes < 60) return `${Math.round(minutes)}m`;
 	let hours = Math.floor(minutes / 60);
 	let mins = Math.round(minutes % 60);
 	if (mins >= 60) {
 		hours++;
 		mins -= 60;
 	}
-	if (mins === 0) return `${hours} ${hours === 1 ? 'hour' : 'hours'}`;
+	if (mins === 0) return `${hours}h`;
 	return `${hours}h ${mins}m`;
 }
 

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -468,7 +468,12 @@ $effect(() => {
 											<strong>{modeLabels[globalFloor].label}</strong>.
 											{#if isAdmin}
 												Lower the server-wide floor in
-												<a href="/admin/settings/privacy" class="floor-note-link">
+												<a
+													href="/admin/settings/privacy"
+													class="floor-note-link"
+													target="_blank"
+													rel="noopener noreferrer"
+												>
 													Privacy settings
 												</a>
 												to self-share — note this lowers the floor for
@@ -615,6 +620,12 @@ $effect(() => {
 <style>
 	:global(.share-modal) {
 			max-width: 28rem !important;
+			/* ISSUE-003: under the privacy floor the modal grows tall enough that the
+			   "Regenerate share link" action fell below the viewport with no way to
+			   reach it. Cap the height and scroll INSIDE the dialog so every control
+			   (incl. Regenerate) is reachable without dismissing the modal. */
+			max-height: calc(100dvh - 4rem) !important;
+			overflow-y: auto !important;
 		}
 
 		.url-section {

--- a/src/lib/server/admin/users.service.ts
+++ b/src/lib/server/admin/users.service.ts
@@ -1,7 +1,11 @@
 import { and, between, eq, sql } from 'drizzle-orm';
 import { db } from '$lib/server/db/client';
-import { playHistory, shareSettings, users } from '$lib/server/db/schema';
-import { generateShareToken, getGlobalDefaultShareMode } from '$lib/server/sharing/service';
+import { playHistory, plexAccounts, shareSettings, users } from '$lib/server/db/schema';
+import {
+	generateShareToken,
+	getGlobalDefaultShareMode,
+	getOwnerWrappedHref
+} from '$lib/server/sharing/service';
 import {
 	getMoreRestrictiveMode,
 	ShareMode,
@@ -106,12 +110,116 @@ export async function getSyncedViewerCount(): Promise<number> {
 	return result[0]?.count ?? 0;
 }
 
+/**
+ * Bridge a user's Plex.tv id (`plexId`) to the LOCAL Plex `accountId` that
+ * `play_history` is keyed by, using the `plex_accounts` map. Needed because
+ * `users.accountId` is nullable with no backfill yet (ISSUE-007), and a user's
+ * `plexId` (Plex.tv id) is NOT the same number as `play_history.accountId`
+ * (local server id), so stats came back as 0h for accounts that actually had data.
+ *
+ * `plex_accounts.plexId` is NOT unique (managed/home users, multiple servers can
+ * share a Plex.tv id), so the lookup can return several rows. Disambiguate
+ * deterministically: a single match wins; for multiple matches prefer the unique
+ * owner row; if still ambiguous (no owner, or more than one owner) REFUSE and
+ * return null so the caller falls back rather than cross-attributing one viewer's
+ * history to another (P5). Pure, so the three paths are unit-testable without a DB.
+ */
+export function resolvePlexAccountId(
+	plexId: number,
+	rows: { accountId: number; plexId: number; isOwner: boolean | null }[]
+): number | null {
+	const matches = rows.filter((r) => r.plexId === plexId);
+	if (matches.length === 0) return null;
+	if (matches.length === 1) return matches[0]!.accountId;
+	const owners = matches.filter((r) => r.isOwner === true);
+	if (owners.length === 1) return owners[0]!.accountId;
+	return null;
+}
+
+/**
+ * Resolve the LOCAL Plex account id to feed {@link calculateUserStats} for an app
+ * user. Prefers the user's own `accountId`; when null, bridges via `plex_accounts`
+ * ({@link resolvePlexAccountId}); last-resort keeps the legacy `plexId` fallback so
+ * behavior is never worse than before for rows that predate `plex_accounts`.
+ */
+export async function resolveStatsAccountId(user: {
+	accountId: number | null;
+	plexId: number;
+}): Promise<number> {
+	if (user.accountId !== null) return user.accountId;
+	const rows = await db
+		.select({
+			accountId: plexAccounts.accountId,
+			plexId: plexAccounts.plexId,
+			isOwner: plexAccounts.isOwner
+		})
+		.from(plexAccounts)
+		.where(eq(plexAccounts.plexId, user.plexId));
+	return resolvePlexAccountId(user.plexId, rows) ?? user.plexId;
+}
+
+/**
+ * Whether the user has at least one play in `year`, using the bridged local
+ * accountId ({@link resolveStatsAccountId}). Cheap existence check (LIMIT 1).
+ */
+export async function userHasResolvablePlaysForYear(
+	user: { accountId: number | null; plexId: number },
+	year: number
+): Promise<boolean> {
+	const accountId = await resolveStatsAccountId(user);
+	const yearStart = Math.floor(new Date(Date.UTC(year, 0, 1, 0, 0, 0)).getTime() / 1000);
+	const yearEnd = Math.floor(new Date(Date.UTC(year, 11, 31, 23, 59, 59)).getTime() / 1000);
+	const rows = await db
+		.select({ id: playHistory.id })
+		.from(playHistory)
+		.where(
+			and(eq(playHistory.accountId, accountId), between(playHistory.viewedAt, yearStart, yearEnd))
+		)
+		.limit(1);
+	return rows.length > 0;
+}
+
+/**
+ * The owner's Wrapped href for `year`, or null when the user has no resolvable
+ * plays that year. Returning null lets callers render no link, so SvelteKit's
+ * hover-preload (`data-sveltekit-preload-data` in app.html) never fires a request
+ * for an empty personal Wrapped (ISSUE-001). Equally important: by skipping
+ * {@link getOwnerWrappedHref} entirely for a no-data user we avoid lazily minting a
+ * share_settings row on every page load (getOrCreateShareSettings creates on read),
+ * so a 0-play admin no longer accrues share state just by visiting /admin. Mirrors
+ * the existing guard in src/routes/admin/wrapped/+page.server.ts.
+ */
+export async function getOwnerWrappedHrefIfData(
+	userId: number,
+	year: number
+): Promise<string | null> {
+	const userRow = await db
+		.select({ accountId: users.accountId, plexId: users.plexId })
+		.from(users)
+		.where(eq(users.id, userId))
+		.limit(1);
+	const user = userRow[0];
+	if (!user) return null;
+	if (!(await userHasResolvablePlaysForYear(user, year))) return null;
+	return getOwnerWrappedHref(userId, year);
+}
+
 export async function getAllUsersWithStats(year: number): Promise<UserWithStats[]> {
 	const yearStart = Math.floor(new Date(Date.UTC(year, 0, 1, 0, 0, 0)).getTime() / 1000);
 	const yearEnd = Math.floor(new Date(Date.UTC(year, 11, 31, 23, 59, 59)).getTime() / 1000);
 
 	const allUsers = await db.select().from(users);
 	const globalFloor = await getGlobalDefaultShareMode();
+
+	// Bridge null-accountId users to their local play_history accountId via
+	// plex_accounts (ISSUE-007). Loaded once (tiny table) to avoid an N+1 lookup.
+	const plexAccountRows = await db
+		.select({
+			accountId: plexAccounts.accountId,
+			plexId: plexAccounts.plexId,
+			isOwner: plexAccounts.isOwner
+		})
+		.from(plexAccounts);
 
 	const watchTimeByUser = await db
 		.select({
@@ -149,8 +257,11 @@ export async function getAllUsersWithStats(year: number): Promise<UserWithStats[
 	}
 
 	return allUsers.map((user) => {
-		// Legacy rows predate accountId, so plexId remains the compatibility fallback.
-		const stats = (user.accountId !== null ? watchTimeMap.get(user.accountId) : undefined) ??
+		// Prefer the user's own accountId; otherwise bridge plexId -> local accountId
+		// via plex_accounts (ISSUE-007). Legacy rows with neither still fall back to
+		// the plexId lookup, so behavior is never worse than before.
+		const resolvedAccountId = user.accountId ?? resolvePlexAccountId(user.plexId, plexAccountRows);
+		const stats = (resolvedAccountId !== null ? watchTimeMap.get(resolvedAccountId) : undefined) ??
 			watchTimeMap.get(user.plexId) ?? { totalDuration: 0, totalPlays: 0 };
 		const settings = shareSettingsMap.get(user.id);
 		const shareMode = settings?.mode ?? null;

--- a/src/lib/services/toast.ts
+++ b/src/lib/services/toast.ts
@@ -25,6 +25,7 @@ function shouldDebounce(message: string): boolean {
 interface ToastOptions {
 	duration?: number;
 	description?: string;
+	action?: { label: string; onClick: () => void };
 }
 
 export const toast = {
@@ -40,7 +41,8 @@ export const toast = {
 		if (shouldDebounce(message)) return;
 		return sonnerToast.error(message, {
 			duration: options?.duration ?? 7000,
-			description: options?.description
+			description: options?.description,
+			action: options?.action
 		});
 	},
 

--- a/src/lib/utils/occ-form.ts
+++ b/src/lib/utils/occ-form.ts
@@ -1,5 +1,5 @@
 import type { ActionResult } from '@sveltejs/kit';
-import { handleFormToast } from '$lib/utils/form-toast';
+import { toast } from '$lib/services/toast';
 
 /**
  * Sentinel matching the server's `OCC_CONFLICT_CODE`
@@ -43,7 +43,7 @@ export function surfaceOccConflict(event: { result: ActionResult; cancel: () => 
 		const message =
 			(result.data as { error?: string } | undefined)?.error ??
 			'Settings changed in another tab. Please reload.';
-		handleFormToast({ error: message });
+		toast.error(message, { action: { label: 'Reload', onClick: () => window.location.reload() } });
 		event.cancel();
 	}
 }

--- a/src/routes/admin/+layout.server.ts
+++ b/src/routes/admin/+layout.server.ts
@@ -2,17 +2,19 @@ import {
 	getCsrfConfigWithSource,
 	isCsrfWarningDismissed
 } from '$lib/server/admin/settings.service';
-import { getUserFullProfile } from '$lib/server/admin/users.service';
-import { getOwnerWrappedHref } from '$lib/server/sharing/service';
+import { getOwnerWrappedHrefIfData, getUserFullProfile } from '$lib/server/admin/users.service';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
 	const currentYear = new Date().getFullYear();
+	// Owner Wrapped href is null when the admin has no plays this year, so the
+	// dashboard renders no "My Wrapped" link to hover-preload (no recurring 404,
+	// ISSUE-001) and we don't lazily mint share state for a 0-play admin.
 	const [csrfConfig, csrfWarningDismissed, profile, wrappedHref] = await Promise.all([
 		getCsrfConfigWithSource(),
 		isCsrfWarningDismissed(),
 		getUserFullProfile(locals.user!.id),
-		getOwnerWrappedHref(locals.user!.id, currentYear)
+		getOwnerWrappedHrefIfData(locals.user!.id, currentYear)
 	]);
 
 	const showCsrfWarning = csrfConfig.origin.source === 'default' && !csrfWarningDismissed;

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -288,14 +288,16 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 			</div>
 
 			<div class="wrapped-grid">
-				<a href={data.wrappedHref} class="wrapped-card personal" onclick={handleAdminNavigation}>
-					<div class="wrapped-card-glow"></div>
-					<div class="wrapped-icon-wrap">
-						<Star class="wrapped-icon" />
-					</div>
-					<span class="wrapped-label">My Wrapped</span>
-					<ArrowRight class="wrapped-arrow" />
-				</a>
+				{#if data.wrappedHref}
+					<a href={data.wrappedHref} class="wrapped-card personal" onclick={handleAdminNavigation}>
+						<div class="wrapped-card-glow"></div>
+						<div class="wrapped-icon-wrap">
+							<Star class="wrapped-icon" />
+						</div>
+						<span class="wrapped-label">My Wrapped</span>
+						<ArrowRight class="wrapped-arrow" />
+					</a>
+				{/if}
 
 				<a href="/wrapped/{data.year}" class="wrapped-card server" onclick={handleAdminNavigation}>
 					<div class="wrapped-card-glow"></div>

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -17,9 +17,10 @@ import type { PageServerLoad } from './$types';
 const KNOWN_TABS = new Set(['connections', 'security', 'data', 'system', 'appearance', 'privacy']);
 
 export const load: PageServerLoad = async ({ url }) => {
+	// Legacy ?tab=<name> redirects are preserved for backward compatibility.
+	// When no ?tab= param is present, render the hub index page instead of redirecting.
 	const tab = url.searchParams.get('tab');
 	if (tab && KNOWN_TABS.has(tab)) {
 		redirect(303, `/admin/settings/${tab}`);
 	}
-	redirect(303, '/admin/settings/connections');
 };

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+import ArrowRight from '@lucide/svelte/icons/arrow-right';
+import DatabaseIcon from '@lucide/svelte/icons/database';
+import LockKeyholeIcon from '@lucide/svelte/icons/lock-keyhole';
+import PaletteIcon from '@lucide/svelte/icons/palette';
+import PlugIcon from '@lucide/svelte/icons/plug';
+import Settings2Icon from '@lucide/svelte/icons/settings-2';
+import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
+
+const sections = [
+	{
+		name: 'Connections',
+		href: '/admin/settings/connections',
+		icon: PlugIcon,
+		description: 'Configure your Plex server URL, token, and API credentials.'
+	},
+	{
+		name: 'Security',
+		href: '/admin/settings/security',
+		icon: ShieldCheckIcon,
+		description: 'Manage authentication, registration, and access control.'
+	},
+	{
+		name: 'Data',
+		href: '/admin/settings/data',
+		icon: DatabaseIcon,
+		description: 'Control sync schedules, retention, and history settings.'
+	},
+	{
+		name: 'System',
+		href: '/admin/settings/system',
+		icon: Settings2Icon,
+		description: 'Logging levels, diagnostics, and maintenance options.'
+	},
+	{
+		name: 'Appearance',
+		href: '/admin/settings/appearance',
+		icon: PaletteIcon,
+		description: 'Theme, branding, and visual presentation preferences.'
+	},
+	{
+		name: 'Privacy',
+		href: '/admin/settings/privacy',
+		icon: LockKeyholeIcon,
+		description: 'Anonymization, sharing controls, and data visibility.'
+	}
+] as const;
+</script>
+
+<svelte:head>
+	<title>Settings — Admin — Obzorarr</title>
+</svelte:head>
+
+<div class="hub">
+	<p class="hub-intro">Select a section below to configure your server.</p>
+	<div class="hub-grid">
+		{#each sections as section (section.href)}
+			{@const Icon = section.icon}
+			<a href={section.href} class="hub-card">
+				<div class="hub-card-glow"></div>
+				<div class="hub-icon-wrap">
+					<Icon class="hub-icon" aria-hidden="true" />
+				</div>
+				<div class="hub-card-body">
+					<span class="hub-card-name">{section.name}</span>
+					<span class="hub-card-desc">{section.description}</span>
+				</div>
+				<ArrowRight class="hub-arrow" aria-hidden="true" />
+			</a>
+		{/each}
+	</div>
+</div>
+
+<style>
+	.hub {
+		padding: 1.5rem;
+	}
+
+	.hub-intro {
+		margin: 0 0 1.25rem;
+		font-size: 0.875rem;
+		color: oklch(var(--muted-foreground));
+	}
+
+	.hub-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 1rem;
+	}
+
+	.hub-card {
+		position: relative;
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+		padding: 1.125rem 1.25rem;
+		background: oklch(var(--card));
+		border: 1px solid oklch(var(--border));
+		border-radius: 0.75rem;
+		text-decoration: none;
+		overflow: hidden;
+		transition:
+			border-color 0.2s ease,
+			box-shadow 0.2s ease,
+			transform 0.2s ease;
+	}
+
+	.hub-card:hover {
+		border-color: oklch(var(--primary) / 0.5);
+		box-shadow: 0 6px 20px -4px oklch(var(--primary) / 0.15);
+		transform: translateY(-2px);
+	}
+
+	.hub-card:focus-visible {
+		outline: 2px solid oklch(var(--ring));
+		outline-offset: 2px;
+	}
+
+	.hub-card-glow {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 1px;
+		background: linear-gradient(90deg, transparent, oklch(var(--primary) / 0.5), transparent);
+		opacity: 0;
+		transition: opacity 0.2s ease;
+	}
+
+	.hub-card:hover .hub-card-glow {
+		opacity: 1;
+	}
+
+	.hub-icon-wrap {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 2.75rem;
+		height: 2.75rem;
+		border-radius: 0.625rem;
+		background: oklch(var(--primary) / 0.1);
+		flex-shrink: 0;
+		transition: background 0.2s ease;
+	}
+
+	.hub-card:hover .hub-icon-wrap {
+		background: oklch(var(--primary) / 0.18);
+	}
+
+	.hub-card :global(.hub-icon) {
+		width: 1.25rem;
+		height: 1.25rem;
+		color: oklch(var(--primary));
+	}
+
+	.hub-card-body {
+		flex: 1;
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+		position: relative;
+		z-index: 1;
+	}
+
+	.hub-card-name {
+		font-size: 0.9375rem;
+		font-weight: 600;
+		color: oklch(var(--foreground));
+	}
+
+	.hub-card-desc {
+		font-size: 0.8125rem;
+		color: oklch(var(--muted-foreground));
+		line-height: 1.4;
+	}
+
+	.hub-card :global(.hub-arrow) {
+		width: 1rem;
+		height: 1rem;
+		color: oklch(var(--muted-foreground) / 0.5);
+		flex-shrink: 0;
+		transition:
+			color 0.2s ease,
+			transform 0.2s ease;
+	}
+
+	.hub-card:hover :global(.hub-arrow) {
+		color: oklch(var(--primary));
+		transform: translateX(3px);
+	}
+
+	@media (max-width: 640px) {
+		.hub {
+			padding: 1rem;
+		}
+
+		.hub-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/src/routes/admin/settings/connections/+page.server.ts
+++ b/src/routes/admin/settings/connections/+page.server.ts
@@ -111,9 +111,18 @@ export const load: PageServerLoad = async () => {
 	// latter case instead of only the subtle "falls back" copy.
 	const hasEffectiveOpenAIKey = Boolean(apiConfig.openai.apiKey.value.trim());
 
+	// Never ship the raw URL to the client when it is ENV-locked — mirror the
+	// token masking pattern (toSafeConfigValue). The Svelte page initialises its
+	// plexServerUrl $state to '' when locked, then skips the formData.set on
+	// test-connection so the server-side submittedUrl || storedUrl fallback fires.
+	const plexServerUrlRaw = apiConfig.plex.serverUrl;
+	const plexServerUrlMasked: SettingValue = plexServerUrlRaw.isLocked
+		? { value: '', source: plexServerUrlRaw.source, isLocked: true }
+		: (plexServerUrlRaw as SettingValue);
+
 	return {
 		settings: {
-			plexServerUrl: apiConfig.plex.serverUrl as SettingValue,
+			plexServerUrl: plexServerUrlMasked,
 			plexToken: toSafeConfigValue(apiConfig.plex.token) satisfies SafeSettingValue,
 			plexAllowInsecureLocalHttp,
 			openaiApiKey: toSafeConfigValue(apiConfig.openai.apiKey) satisfies SafeSettingValue,

--- a/src/routes/admin/settings/connections/+page.svelte
+++ b/src/routes/admin/settings/connections/+page.svelte
@@ -138,7 +138,7 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 						id="plexServerUrl"
 						name="plexServerUrl"
 						type="url"
-						placeholder="http://plex.local:32400"
+						placeholder={plexServerUrlLocked ? '(set by environment)' : 'http://plex.local:32400'}
 						bind:value={plexServerUrl}
 						disabled={plexServerUrlLocked}
 					/>
@@ -205,7 +205,9 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 						}
 						isTestingPlex = true;
 						// Connection tests should exercise unsaved edits, not only loaded data.
-						formData.set('plexServerUrl', plexServerUrl);
+						// Mirror the token pattern: skip the set when ENV-locked so the
+						// server-side `submittedUrl || storedUrl` fallback uses the stored URL.
+						if (!plexServerUrlLocked) formData.set('plexServerUrl', plexServerUrl);
 						if (plexTokenInput) formData.set('plexToken', plexTokenInput);
 						formData.set(
 							'plexAllowInsecureLocalHttp',

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -1101,18 +1101,24 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 		/* SubmitButton and shadcn Button child-render the real controls, so
 		   the delete-confirmation palettes must be hoisted. */
 		:global(.confirm-button) {
-			padding: 0.25rem 0.5rem;
+			padding: 0.25rem 0.75rem;
 			background: oklch(var(--destructive));
 			color: oklch(var(--destructive-foreground));
 			border: none;
 			border-radius: var(--radius);
 			font-size: 0.75rem;
-			font-weight: 500;
+			font-weight: 700;
 			cursor: pointer;
 		}
 
 		:global(.confirm-button:hover) {
-			opacity: 0.9;
+			opacity: 0.88;
+			box-shadow: 0 0 0 2px oklch(var(--destructive) / 0.4);
+		}
+
+		:global(.confirm-button:focus-visible) {
+			outline: 2px solid oklch(var(--destructive));
+			outline-offset: 2px;
 		}
 
 		:global(.cancel-delete-button) {
@@ -1122,6 +1128,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			border: 1px solid oklch(var(--border));
 			border-radius: var(--radius);
 			font-size: 0.75rem;
+			font-weight: 400;
 			cursor: pointer;
 		}
 

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -580,7 +580,7 @@ async function goToPage(page: number) {
 				<div class="scheduler-controls">
 					{#if data.schedulerStatus.isPaused}
 						<form method="POST" action="?/resumeScheduler" use:enhance>
-							<SubmitButton class="control-btn resume tap-target">
+							<SubmitButton class="control-btn resume tap-target" data-testid="scheduler-resume">
 								{#snippet children()}
 									<PlayIcon class="size-4" fill="currentColor" />
 									Resume
@@ -589,7 +589,7 @@ async function goToPage(page: number) {
 						</form>
 					{:else if data.schedulerStatus.isRunning}
 						<form method="POST" action="?/pauseScheduler" use:enhance>
-							<SubmitButton class="control-btn pause tap-target">
+							<SubmitButton class="control-btn pause tap-target" data-testid="scheduler-pause">
 								{#snippet children()}
 									<PauseIcon class="size-4" fill="currentColor" />
 									Pause
@@ -601,6 +601,7 @@ async function goToPage(page: number) {
 							<input type="hidden" name="cronExpression" value={cronExpression} />
 							<SubmitButton
 								class="control-btn init tap-target"
+								data-testid="scheduler-initialize"
 								disabled={!!cronError}
 								aria-describedby={cronError ? 'cronExpression-error' : undefined}
 							>
@@ -628,7 +629,7 @@ async function goToPage(page: number) {
 								};
 							}}
 						>
-							<SubmitButton class="control-btn stop tap-target">
+							<SubmitButton class="control-btn stop tap-target" data-testid="scheduler-stop">
 								{#snippet children()}
 									<SquareIcon class="size-4" fill="currentColor" />
 									Stop

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -49,17 +49,23 @@ function markAvatarFailed(userId: number): void {
 			</div>
 			{#if data.availableYears.length > 0}
 				<form method="GET" class="year-form">
-					<select
-						name="year"
-						class="year-selector"
-						disabled={data.availableYears.length === 1}
-						onchange={(e) => e.currentTarget.form?.requestSubmit()}
-					>
-						{#each data.availableYears as yr}
-							<option value={yr} selected={yr === data.year}>{yr}</option>
-						{/each}
-					</select>
-					<noscript><button type="submit" class="year-submit">Go</button></noscript>
+					<div class="year-selector-wrap">
+						<select
+							name="year"
+							class="year-selector"
+							disabled={data.availableYears.length === 1}
+							title={data.availableYears.length === 1 ? 'Only one year of data available' : undefined}
+							onchange={(e) => e.currentTarget.form?.requestSubmit()}
+						>
+							{#each data.availableYears as yr}
+								<option value={yr} selected={yr === data.year}>{yr}</option>
+							{/each}
+						</select>
+						{#if data.availableYears.length === 1}
+							<p class="year-selector-hint">Only one year of data available</p>
+						{/if}
+						<noscript><button type="submit" class="year-submit">Go</button></noscript>
+					</div>
 				</form>
 			{/if}
 		</div>
@@ -398,6 +404,19 @@ function markAvatarFailed(userId: number): void {
 		.year-selector:disabled {
 			cursor: default;
 			opacity: 0.75;
+		}
+
+		.year-selector-wrap {
+			display: flex;
+			flex-direction: column;
+			align-items: flex-end;
+			gap: 0.25rem;
+		}
+
+		.year-selector-hint {
+			margin: 0;
+			font-size: 0.75rem;
+			color: oklch(var(--muted-foreground));
 		}
 
 		.section {

--- a/src/routes/admin/wrapped/+page.svelte
+++ b/src/routes/admin/wrapped/+page.svelte
@@ -58,12 +58,16 @@ function handleConfigNavigation(event: MouseEvent): void {
 						class="year-selector"
 						aria-label="Select wrapped year"
 						disabled={data.availableYears.length === 1}
+						title={data.availableYears.length === 1 ? 'Only one year of data available' : undefined}
 						onchange={(e) => e.currentTarget.form?.requestSubmit()}
 					>
 						{#each data.availableYears as yr}
 							<option value={yr} selected={yr === data.year}>{yr}</option>
 						{/each}
 					</select>
+					{#if data.availableYears.length === 1}
+						<p class="year-selector-hint">Only one year of data available</p>
+					{/if}
 					<noscript><button type="submit" class="year-submit">Go</button></noscript>
 				</form>
 			{/if}
@@ -202,6 +206,12 @@ function handleConfigNavigation(event: MouseEvent): void {
 		.year-selector:disabled {
 			cursor: default;
 			opacity: 0.75;
+		}
+
+		.year-selector-hint {
+			margin: 0.375rem 0 0;
+			font-size: 0.75rem;
+			color: oklch(var(--muted-foreground));
 		}
 
 		.ambient-glow {

--- a/src/routes/dashboard/+layout.server.ts
+++ b/src/routes/dashboard/+layout.server.ts
@@ -1,7 +1,6 @@
 import { redirect } from '@sveltejs/kit';
 import { isSafeReturnPath } from '$lib/client/plex-login';
-import { getUserFullProfile } from '$lib/server/admin/users.service';
-import { getOwnerWrappedHref } from '$lib/server/sharing/service';
+import { getOwnerWrappedHrefIfData, getUserFullProfile } from '$lib/server/admin/users.service';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals, url }) => {
@@ -21,9 +20,12 @@ export const load: LayoutServerLoad = async ({ locals, url }) => {
 	}
 
 	const currentYear = new Date().getFullYear();
+	// Null when the user has no plays this year, so no "My Wrapped" link is rendered
+	// to hover-preload (no recurring 404, ISSUE-001) and no share state is lazily
+	// minted for a no-data user on every load.
 	const [profile, wrappedHref] = await Promise.all([
 		getUserFullProfile(locals.user.id),
-		getOwnerWrappedHref(locals.user.id, currentYear)
+		getOwnerWrappedHrefIfData(locals.user.id, currentYear)
 	]);
 
 	return {

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -30,25 +30,27 @@ let { data }: Props = $props();
 	</header>
 
 	<div class="cards-container">
-		<a href={data.wrappedHref} class="wrapped-card personal">
-			<div class="card-glow"></div>
-			<div class="card-badge">
-				<span>Personal</span>
-			</div>
-			<div class="card-icon-wrap">
-				<Star class="card-icon" />
-			</div>
-			<div class="card-content">
-				<h2 class="card-title">My Wrapped</h2>
-				<p class="card-description">
-					Discover your personal viewing journey - your top shows, movies, and more
-				</p>
-			</div>
-			<div class="card-action">
-				<span>View your stats</span>
-				<ArrowRight class="card-arrow" />
-			</div>
-		</a>
+		{#if data.wrappedHref}
+			<a href={data.wrappedHref} class="wrapped-card personal">
+				<div class="card-glow"></div>
+				<div class="card-badge">
+					<span>Personal</span>
+				</div>
+				<div class="card-icon-wrap">
+					<Star class="card-icon" />
+				</div>
+				<div class="card-content">
+					<h2 class="card-title">My Wrapped</h2>
+					<p class="card-description">
+						Discover your personal viewing journey - your top shows, movies, and more
+					</p>
+				</div>
+				<div class="card-action">
+					<span>View your stats</span>
+					<ArrowRight class="card-arrow" />
+				</div>
+			</a>
+		{/if}
 
 		<a href="/wrapped/{data.currentYear}" class="wrapped-card server">
 			<div class="card-glow"></div>

--- a/src/routes/onboarding/+layout.server.ts
+++ b/src/routes/onboarding/+layout.server.ts
@@ -58,6 +58,8 @@ export const load: LayoutServerLoad = async ({ cookies, locals, url }) => {
 		{ id: OnboardingSteps.COMPLETE, label: 'Done' }
 	];
 
+	const plexServerUrlLocked = apiConfig.plex.serverUrl.isLocked;
+
 	return {
 		steps,
 		currentStep: displayedStep,
@@ -68,7 +70,11 @@ export const load: LayoutServerLoad = async ({ cookies, locals, url }) => {
 		username: locals.user?.username,
 		hasEnvConfig: hasEnvConfigValue,
 		plexConfigured: !!(apiConfig.plex.serverUrl.value && apiConfig.plex.token.value),
-		plexServerUrl: apiConfig.plex.serverUrl.value,
+		// Never ship the raw URL to the client when it is ENV-locked — mirror the
+		// token masking pattern (toSafeConfigValue). The Svelte page uses
+		// plexServerUrlLocked to show a placeholder instead of the real value.
+		plexServerUrl: plexServerUrlLocked ? '' : apiConfig.plex.serverUrl.value,
+		plexServerUrlLocked,
 		plexConfigSource: apiConfig.plex.serverUrl.source,
 		plexServerName: serverName,
 		uiTheme

--- a/src/routes/onboarding/claim/+page.svelte
+++ b/src/routes/onboarding/claim/+page.svelte
@@ -36,7 +36,9 @@ let isClaiming = $state(false);
 				id="bootstrap-token"
 				name="token"
 				type="password"
-				bind:value={token}
+				value={token}
+				oninput={(e) => (token = e.currentTarget.value)}
+				onchange={(e) => (token = e.currentTarget.value)}
 				class="bootstrap-token-input"
 				autocomplete="one-time-code"
 				autocapitalize="none"

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -548,10 +548,12 @@ function formatServerUrl(url: string | null): string {
 					{#if data.plexServerName}
 						<span class="preconfigured-server-name">{data.plexServerName}</span>
 					{/if}
-					{#if data.plexServerUrl}
+					{#if data.plexServerUrl || data.plexServerUrlLocked}
 						<div class="preconfigured-field-row">
 							<span class="preconfigured-field-label">Server URL</span>
-							<span class="preconfigured-url">{formatServerUrl(data.plexServerUrl)}</span>
+							<span class="preconfigured-url">
+								{data.plexServerUrlLocked ? '(set by environment)' : formatServerUrl(data.plexServerUrl)}
+							</span>
 							{#if data.plexServerUrlLocked}
 								<span class="preconfigured-badge" aria-label="Set by environment variable">
 									<svg

--- a/src/routes/wrapped/[year=year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year=year]/u/[identifier]/+page.server.ts
@@ -1,6 +1,7 @@
 import { error, fail } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
 import { getFunFactFrequency } from '$lib/server/admin/settings.service';
+import { resolveStatsAccountId } from '$lib/server/admin/users.service';
 import { db } from '$lib/server/db/client';
 import { users } from '$lib/server/db/schema';
 import { generateFunFacts } from '$lib/server/funfacts';
@@ -247,7 +248,7 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 		error(404, 'User not found');
 	}
 
-	const statsAccountId = user.accountId ?? user.plexId;
+	const statsAccountId = await resolveStatsAccountId(user);
 	const stats = await calculateUserStats(statsAccountId, year);
 	const userHasWatchHistory = hasWatchHistory(stats);
 
@@ -355,6 +356,12 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 		isAdmin,
 		isLoggedIn: !!locals.user,
 		globalFloor: globalFloorForUrl,
+		// ISSUE-013: display-only affordance. When the effective mode is
+		// server-members (private-oauth), any signed-in member can open this page by
+		// direct URL — intended by the sharing model, not a bypass. Surface a quiet
+		// badge so the OWNER knows their Wrapped is readable by all server members.
+		// No access-control change; anonymous/non-member denial is untouched.
+		visibleToServerMembers: isOwner && effectiveModeForUrl === ShareMode.PRIVATE_OAUTH,
 		currentUrl,
 		canonicalUrl: `/wrapped/${year}/u/${userId}`,
 		yearIdentifiers

--- a/src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
+++ b/src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte
@@ -224,6 +224,13 @@ function handleLogoToggle(): void {
 
 	<div class="user-header" class:with-logo={showLogo}>
 		<h1 class="user-title">{data.username}'s Year in Review</h1>
+		{#if data.visibleToServerMembers}
+			<!-- ISSUE-013: quiet owner-only affordance — under the server-members
+			     (private-oauth) floor any signed-in member can open this page. -->
+			<p class="visibility-note" title="Any signed-in member of this server can view this Wrapped">
+				Visible to server members
+			</p>
+		{/if}
 	</div>
 
 	{#if data.availableYears && data.availableYears.length > 1}
@@ -385,6 +392,15 @@ function handleLogoToggle(): void {
 			color: var(--foreground);
 			opacity: 0.8;
 			margin: 0;
+		}
+
+		.visibility-note {
+			font-size: 0.6875rem;
+			font-weight: 500;
+			color: var(--foreground);
+			opacity: 0.55;
+			margin: 0.125rem 0 0;
+			letter-spacing: 0.01em;
 		}
 
 		.empty-wrapped-state {

--- a/tests/unit/admin/users.service.test.ts
+++ b/tests/unit/admin/users.service.test.ts
@@ -2,10 +2,20 @@ import { beforeEach, describe, expect, it } from 'bun:test';
 import {
 	deriveEffectiveShareBadge,
 	getAllUsersWithStats,
-	getSyncedViewerCount
+	getOwnerWrappedHrefIfData,
+	getSyncedViewerCount,
+	resolvePlexAccountId,
+	resolveStatsAccountId,
+	userHasResolvablePlaysForYear
 } from '$lib/server/admin/users.service';
 import { db } from '$lib/server/db/client';
-import { appSettings, playHistory, shareSettings, users } from '$lib/server/db/schema';
+import {
+	appSettings,
+	playHistory,
+	plexAccounts,
+	shareSettings,
+	users
+} from '$lib/server/db/schema';
 import {
 	ShareMode,
 	ShareModePrivacyLevel,
@@ -198,6 +208,177 @@ describe('admin users service', () => {
 					}
 				}
 			}
+		});
+	});
+
+	// ISSUE-007 (T2): a registered user/admin whose plays live under a local
+	// play_history.accountId must show non-zero hours even when users.accountId is
+	// null, by bridging plexId -> accountId via plex_accounts — WITHOUT ever
+	// cross-attributing one viewer's history to another on an ambiguous lookup.
+	describe('resolvePlexAccountId (ISSUE-007, pure)', () => {
+		it('returns the local accountId for a single matching plex_accounts row', () => {
+			const rows = [{ accountId: 2001, plexId: 1001, isOwner: true }];
+			expect(resolvePlexAccountId(1001, rows)).toBe(2001);
+		});
+
+		it('returns null (fall back) when there is no matching row', () => {
+			const rows = [{ accountId: 2001, plexId: 1001, isOwner: true }];
+			expect(resolvePlexAccountId(9999, rows)).toBeNull();
+		});
+
+		it('prefers the unique owner row when multiple rows match the plexId', () => {
+			const rows = [
+				{ accountId: 3001, plexId: 1001, isOwner: false },
+				{ accountId: 3002, plexId: 1001, isOwner: true },
+				{ accountId: 3003, plexId: 1001, isOwner: false }
+			];
+			expect(resolvePlexAccountId(1001, rows)).toBe(3002);
+		});
+
+		it('refuses (returns null) when multiple rows match and none is owner', () => {
+			const rows = [
+				{ accountId: 3001, plexId: 1001, isOwner: false },
+				{ accountId: 3002, plexId: 1001, isOwner: false }
+			];
+			expect(resolvePlexAccountId(1001, rows)).toBeNull();
+		});
+
+		it('refuses (returns null) when multiple rows match and more than one is owner', () => {
+			const rows = [
+				{ accountId: 3001, plexId: 1001, isOwner: true },
+				{ accountId: 3002, plexId: 1001, isOwner: true }
+			];
+			expect(resolvePlexAccountId(1001, rows)).toBeNull();
+		});
+	});
+
+	describe('resolveStatsAccountId (ISSUE-007, DB-backed)', () => {
+		it('returns the user own accountId without consulting plex_accounts', async () => {
+			expect(await resolveStatsAccountId({ accountId: 2001, plexId: 1001 })).toBe(2001);
+		});
+
+		it('bridges a null accountId to the local accountId via a single plex_accounts row', async () => {
+			await db.insert(plexAccounts).values({
+				accountId: 2001,
+				plexId: 1001,
+				username: 'owner',
+				isOwner: true
+			});
+			expect(await resolveStatsAccountId({ accountId: null, plexId: 1001 })).toBe(2001);
+		});
+
+		it('falls back to plexId when no plex_accounts row matches', async () => {
+			expect(await resolveStatsAccountId({ accountId: null, plexId: 7777 })).toBe(7777);
+		});
+
+		it('prefers the owner row on an ambiguous (multi-row) plexId', async () => {
+			await db.insert(plexAccounts).values([
+				{ accountId: 4001, plexId: 1001, username: 'managed', isOwner: false },
+				{ accountId: 4002, plexId: 1001, username: 'owner', isOwner: true }
+			]);
+			expect(await resolveStatsAccountId({ accountId: null, plexId: 1001 })).toBe(4002);
+		});
+
+		it('falls back to plexId (never an arbitrary row) when ambiguous with no owner', async () => {
+			await db.insert(plexAccounts).values([
+				{ accountId: 4001, plexId: 1001, username: 'managed-a', isOwner: false },
+				{ accountId: 4002, plexId: 1001, username: 'managed-b', isOwner: false }
+			]);
+			expect(await resolveStatsAccountId({ accountId: null, plexId: 1001 })).toBe(1001);
+		});
+	});
+
+	describe('getAllUsersWithStats account bridging (ISSUE-007)', () => {
+		it('shows non-zero hours for a null-accountId user whose plays live under a bridged accountId', async () => {
+			await db.insert(users).values({ id: 1, plexId: 1001, accountId: null, username: 'admin' });
+			await db.insert(plexAccounts).values({
+				accountId: 2001,
+				plexId: 1001,
+				username: 'admin',
+				isOwner: true
+			});
+			await db.insert(playHistory).values([
+				{
+					historyKey: 'bridge-1',
+					ratingKey: 'r-1',
+					title: 'Movie 1',
+					type: 'movie',
+					viewedAt: createTimestamp(2025, 1, 15),
+					accountId: 2001,
+					librarySectionId: 1,
+					duration: 3600
+				}
+			]);
+
+			const [row] = await getAllUsersWithStats(2025);
+			expect(row?.totalWatchTimeMinutes).toBe(60);
+			expect(row?.totalPlays).toBe(1);
+			expect(row?.hasWatchHistory).toBe(true);
+		});
+
+		it('keeps 0h for a null-accountId user with genuinely no plays', async () => {
+			await db.insert(users).values({ id: 1, plexId: 1001, accountId: null, username: 'admin' });
+			const [row] = await getAllUsersWithStats(2025);
+			expect(row?.totalWatchTimeMinutes).toBe(0);
+			expect(row?.hasWatchHistory).toBe(false);
+		});
+	});
+
+	// ISSUE-001 (T1): the owner Wrapped href must be null for a user with no plays
+	// that year, so callers render no link to hover-preload (eliminating the recurring
+	// swallowed 404) AND no share_settings row is lazily minted on every page load.
+	describe('getOwnerWrappedHrefIfData (ISSUE-001)', () => {
+		it('returns null and mints NO share_settings row for a 0-play user', async () => {
+			await db.insert(users).values({ id: 1, plexId: 1001, accountId: null, username: 'admin' });
+
+			const href = await getOwnerWrappedHrefIfData(1, 2026);
+
+			expect(href).toBeNull();
+			const rows = await db.select().from(shareSettings);
+			expect(rows.length).toBe(0);
+		});
+
+		it('returns a Wrapped href for a user who has plays that year', async () => {
+			await db.insert(users).values({ id: 1, plexId: 1001, accountId: 2001, username: 'viewer' });
+			await db.insert(playHistory).values({
+				historyKey: 'href-1',
+				ratingKey: 'r-1',
+				title: 'Movie 1',
+				type: 'movie',
+				viewedAt: createTimestamp(2026, 1, 15),
+				accountId: 2001,
+				librarySectionId: 1,
+				duration: 3600
+			});
+
+			const href = await getOwnerWrappedHrefIfData(1, 2026);
+
+			expect(href).toMatch(/^\/wrapped\/2026\/u\//);
+		});
+
+		it('bridges plexId -> accountId so a null-accountId user with plays still gets a href', async () => {
+			await db.insert(users).values({ id: 1, plexId: 1001, accountId: null, username: 'admin' });
+			await db.insert(plexAccounts).values({
+				accountId: 2001,
+				plexId: 1001,
+				username: 'admin',
+				isOwner: true
+			});
+			await db.insert(playHistory).values({
+				historyKey: 'href-2',
+				ratingKey: 'r-2',
+				title: 'Movie 2',
+				type: 'movie',
+				viewedAt: createTimestamp(2026, 2, 15),
+				accountId: 2001,
+				librarySectionId: 1,
+				duration: 3600
+			});
+
+			expect(await userHasResolvablePlaysForYear({ accountId: null, plexId: 1001 }, 2026)).toBe(
+				true
+			);
+			expect(await getOwnerWrappedHrefIfData(1, 2026)).toMatch(/^\/wrapped\/2026\/u\//);
 		});
 	});
 

--- a/tests/unit/hooks-error-handler.test.ts
+++ b/tests/unit/hooks-error-handler.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it, spyOn } from 'bun:test';
+import { error as svelteError } from '@sveltejs/kit';
 import { logger } from '$lib/server/logging';
 import { handleError } from '../../src/hooks.server';
+
+/** A real @sveltejs/kit HttpError of the given status (error() throws it). */
+function makeHttpError(status: number, message: string): unknown {
+	try {
+		svelteError(status, message);
+	} catch (e) {
+		return e;
+	}
+	throw new Error('error() did not throw');
+}
 
 // ISSUE-010: an unmatched route (including a param-matcher rejection like
 // /wrapped/abc) surfaces in handleError as a native SvelteKitError(404) whose
@@ -88,6 +99,108 @@ describe('handleError — not-found demotion (ISSUE-010)', () => {
 			expect(result).toEqual({ message: 'An unexpected error occurred' });
 		} finally {
 			infoSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+});
+
+// ISSUE-009 (T3a): 4xx client errors are caller mistakes, not server faults, and
+// must log at WARN so the ERROR channel stays reserved for genuine 5xx/unexpected
+// failures. The 404 stays at info/[NotFound]; 5xx and non-HttpError throws stay at
+// error/[ErrorHandler].
+describe('handleError — 4xx demotion to WARN (ISSUE-009)', () => {
+	for (const status of [400, 403, 422]) {
+		it(`logs a ${status} HttpError at warn/[ClientError]`, async () => {
+			const infoSpy = spyOn(logger, 'info').mockImplementation(() => {});
+			const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+			const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+
+			try {
+				const result = await handleError({
+					error: makeHttpError(status, `client error ${status}`),
+					event: makeEvent('/admin/settings', '/admin/settings'),
+					status,
+					message: 'Error'
+				} as HandleErrorArgs);
+
+				expect(errorSpy).not.toHaveBeenCalled();
+				expect(infoSpy).not.toHaveBeenCalled();
+				expect(warnSpy).toHaveBeenCalledTimes(1);
+				expect(warnSpy.mock.calls[0]?.[1]).toBe('ClientError');
+				expect(result).toEqual({ message: `client error ${status}` });
+			} finally {
+				infoSpy.mockRestore();
+				warnSpy.mockRestore();
+				errorSpy.mockRestore();
+			}
+		});
+	}
+
+	it('keeps a 404 HttpError at info/[NotFound], not warn', async () => {
+		const infoSpy = spyOn(logger, 'info').mockImplementation(() => {});
+		const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+		const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+
+		try {
+			const result = await handleError({
+				error: makeHttpError(404, 'nope'),
+				event: makeEvent('/wrapped/2026/u/abc', '/wrapped/[year=year]/u/[identifier]'),
+				status: 404,
+				message: 'Not Found'
+			} as HandleErrorArgs);
+
+			expect(warnSpy).not.toHaveBeenCalled();
+			expect(errorSpy).not.toHaveBeenCalled();
+			expect(infoSpy).toHaveBeenCalledTimes(1);
+			expect(infoSpy.mock.calls[0]?.[1]).toBe('NotFound');
+			expect(result).toEqual({ message: 'nope' });
+		} finally {
+			infoSpy.mockRestore();
+			warnSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
+	it('keeps a 500 HttpError at error/[ErrorHandler]', async () => {
+		const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+		const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+
+		try {
+			const result = await handleError({
+				error: makeHttpError(500, 'boom'),
+				event: makeEvent('/admin', '/admin'),
+				status: 500,
+				message: 'Error'
+			} as HandleErrorArgs);
+
+			expect(warnSpy).not.toHaveBeenCalled();
+			expect(errorSpy).toHaveBeenCalledTimes(1);
+			expect(errorSpy.mock.calls[0]?.[1]).toBe('ErrorHandler');
+			expect(result).toEqual({ message: 'An unexpected error occurred' });
+		} finally {
+			warnSpy.mockRestore();
+			errorSpy.mockRestore();
+		}
+	});
+
+	it('keeps a non-HttpError throw at error/[ErrorHandler]', async () => {
+		const warnSpy = spyOn(logger, 'warn').mockImplementation(() => {});
+		const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+
+		try {
+			const result = await handleError({
+				error: new Error('unexpected'),
+				event: makeEvent('/admin', '/admin'),
+				status: 500,
+				message: 'Error'
+			} as HandleErrorArgs);
+
+			expect(warnSpy).not.toHaveBeenCalled();
+			expect(errorSpy).toHaveBeenCalledTimes(1);
+			expect(errorSpy.mock.calls[0]?.[1]).toBe('ErrorHandler');
+			expect(result).toEqual({ message: 'An unexpected error occurred' });
+		} finally {
+			warnSpy.mockRestore();
 			errorSpy.mockRestore();
 		}
 	});


### PR DESCRIPTION
## Summary

Remediates all 15 findings from the 2026-06-15 end-to-end dogfood run (0 critical, 0 high, 3 medium, 12 low). Implements `.omc/plans/fix-dogfood-2026-06-15-e2e-15findings.md`. No schema migrations, no auth-logic changes, no changes to sharing access-control / OCC semantics / sync-conflict 409 / CSRF / thumb-proxy JWT.

The work lands as two revert-isolated commits so a `git revert` of the correctness work leaves the cosmetic fixes intact:

1. `fix(dogfood 2026-06-15): correctness & observability (ISSUE-001/007/009)`
2. `fix(dogfood 2026-06-15): deterministic UI/server fixes (ISSUE-002/003/004/006/008/010/011/012/013/014/015)`

## Correctness and observability

- **ISSUE-007 (registered account shows 0h despite synced data):** a shared `resolveStatsAccountId` bridges `users.plexId -> plex_accounts.plexId -> local play_history.accountId` when `users.accountId` is null. Because `plex_accounts.plexId` is `notNull` but not unique, the resolver disambiguates deterministically: a single match wins; multiple matches resolve only to a unique owner row; otherwise it refuses and falls back to the legacy `plexId` behavior. It never selects an arbitrary row, so one viewer's history can never be cross-attributed to another. Used by the admin users table and the personal Wrapped page.
- **ISSUE-001 (recurring swallowed 404 on Wrapped/dashboard loads):** investigated together with ISSUE-007 as a shared root cause (a 0-play admin whose `users.accountId` is null and whose Plex.tv id differs from the local account id). `getOwnerWrappedHrefIfData` returns `null` when the user has no resolvable plays for the year, so no owner-Wrapped link is rendered. That removes the SvelteKit hover-preload request that produced the 404, and also stops the lazy `share_settings` row mint that previously ran on every admin/dashboard load for a 0-play user. The client console log is not suppressed; the originating request is eliminated at its source.
- **ISSUE-009 (4xx framed as ERROR):** `handleError` now demotes remaining 4xx `HttpError`s to `logger.warn`/[ClientError] before the `logger.error` fallthrough, after both existing 404 guards. 5xx and non-HttpError throws stay at ERROR.

## Deterministic UI and server fixes

- **ISSUE-002:** the disabled year selector on `/admin/wrapped` and `/admin/users` gains a `title` and a visible caption ("Only one year of data available") when only one year exists.
- **ISSUE-003:** the share modal body now has `max-height` and `overflow-y: auto`, so the "Regenerate share link" action is scrollable-to inside the dialog without dismissing it.
- **ISSUE-004:** the onboarding claim-token field gains explicit `oninput`/`onchange` handlers so autofill and programmatic writes enable Submit.
- **ISSUE-006:** when the Plex server URL is ENV-locked, the field renders the placeholder "(set by environment)", the raw relay host is no longer shipped to the client, and the placeholder literal is not submitted; `testPlexConnection` falls back to the stored URL and still succeeds.
- **ISSUE-008:** stable `data-testid` attributes on the scheduler Resume/Pause/Initialize/Stop buttons so automation selectors survive the conditional-render swap (automation-selector scope only; assistive-tech focus order is out of scope).
- **ISSUE-010:** `/admin/settings` now renders a landing hub of six subpage cards; legacy `?tab=` redirects are preserved.
- **ISSUE-011:** the optimistic-concurrency 409 conflict toast gains a working "Reload" action; the no-overwrite behavior is unchanged.
- **ISSUE-012:** the in-modal privacy-settings link opens in a new tab (`target="_blank" rel="noopener noreferrer"`) so navigating to it cannot unmount the focus-trapped share modal.
- **ISSUE-013:** an owner-only "Visible to server members" badge appears on the personal Wrapped page under the server-members (private-oauth) effective mode. Display-only; no access-control change.
- **ISSUE-014:** `formatMinutesDetailed` now emits a consistent `Nh` / `Nh Mm` / `Nm` format in chart aria-labels and tooltips.
- **ISSUE-015:** the slide-delete confirmation gives the destructive "Delete" stronger visual weight (heavier font, larger padding, destructive focus/hover ring) than "Cancel".

## Reclassified

- **ISSUE-005** (`[Parser] Unable to parse JSON: "undefined"`) originates in Plex's bundled OAuth JS, not Obzorarr, and is documented as a deliberate non-fix at `src/routes/auth/plex/+server.ts`. Reclassified external/won't-fix; no source change.

## Tests

- New unit coverage for the ISSUE-007 resolver (single match, no match, multi-row owner-preferred, refuse-on-ambiguity with no owner, refuse with multiple owners), the ISSUE-001 no-lazy-mint / null-href behavior, and the ISSUE-009 `handleError` level selection for 400/403/404/422/500 and non-HttpError throws.

## Verification

- `bun run check` (svelte-check): 0 errors across 3135 files
- `bun run check:biome`: clean
- `bun run test`: 2130 pass, 0 fail across 101 files

## Note on ISSUE-001 verification

The exact originating request URL could not be captured in the fix environment, and the original dogfood run (with a live browser and session) likewise could not identify the endpoint (no request URL was logged). The fix targets the report's leading hypothesis at the source and is covered by a unit test asserting no `share_settings` row is created and `null` is returned for a 0-play user. A live-browser "zero console entries on a 0-play admin" confirmation should be repeated on the next dogfood pass.
