### PR TITLE
fix(dogfood 2026-06-16): remediate ISSUE-001/002/003

### DIFF
--- a/drizzle/0010_cynical_screwball.sql
+++ b/drizzle/0010_cynical_screwball.sql
@@ -1,0 +1,68 @@
+-- ISSUE-001: enforce one share_settings row per (user_id, year).
+--
+-- Shipped installs may already contain duplicate (user_id, year) rows produced
+-- by the non-atomic read-then-insert race in getOrCreateShareSettings (e.g. two
+-- concurrent loads of /dashboard/settings). We MUST collapse those duplicates
+-- before the unique index can be created, or the CREATE UNIQUE INDEX itself
+-- would fail on a corrupted DB.
+--
+-- drizzle's bun-sqlite migrate() wraps this whole file in one transaction, so
+-- the salvage -> delete -> index steps below are atomic together. Do NOT add a
+-- manual BEGIN/COMMIT (it would double-nest and throw). The dedup is a no-op on
+-- a clean DB (the GROUP BY ... HAVING COUNT(*) > 1 subqueries match nothing).
+--
+-- Survivor selection (highest priority first): a row that already carries a
+-- public_slug, then one with a share_token, then an explicit (user/admin-set)
+-- mode, then the lowest id. This keeps the row holding the most valuable
+-- identifiers; the slug/token columns are unique, so they are intentionally NOT
+-- copied between rows (that would trip their own unique constraint mid-migration
+-- and the survivor priority already retains whichever row holds them).
+
+-- (a) Salvage the only divergent field that is unambiguous to merge: a non-null
+-- show_logo preference set on a duplicate row. We deliberately do NOT salvage
+-- mode/mode_source: copying an explicit mode off a deleted loser onto a slug-
+-- holding survivor could leave it private-link with no token (a broken share
+-- URL) or silently pick the less-private of two explicit modes. The survivor
+-- priority already prefers an explicit row when it also holds a slug/token, and
+-- the global privacy floor still clamps the effective mode at read time, so the
+-- worst case here is reverting a stray duplicate's mode flag to default-sourced.
+UPDATE `share_settings` AS s
+SET `show_logo` = COALESCE(s.`show_logo`, m.`salvaged_show_logo`)
+FROM (
+	SELECT
+		`user_id`,
+		`year`,
+		MAX(`show_logo`) AS `salvaged_show_logo`
+	FROM `share_settings`
+	GROUP BY `user_id`, `year`
+	HAVING COUNT(*) > 1
+) AS m
+WHERE s.`user_id` = m.`user_id`
+	AND s.`year` = m.`year`
+	AND s.`id` = (
+		SELECT d.`id`
+		FROM `share_settings` d
+		WHERE d.`user_id` = m.`user_id` AND d.`year` = m.`year`
+		ORDER BY (d.`public_slug` IS NOT NULL) DESC, (d.`share_token` IS NOT NULL) DESC, (d.`mode_source` = 'explicit') DESC, d.`id` ASC
+		LIMIT 1
+	);
+--> statement-breakpoint
+-- (b) Delete the losing duplicate rows, keeping exactly the ranked survivor per
+-- (user_id, year). Safe: nothing FKs INTO share_settings (user_id is an outbound
+-- cascade FK only).
+DELETE FROM `share_settings`
+WHERE `id` IN (
+	SELECT `id` FROM (
+		SELECT
+			`id`,
+			ROW_NUMBER() OVER (
+				PARTITION BY `user_id`, `year`
+				ORDER BY (`public_slug` IS NOT NULL) DESC, (`share_token` IS NOT NULL) DESC, (`mode_source` = 'explicit') DESC, `id` ASC
+			) AS `rn`
+		FROM `share_settings`
+	) ranked
+	WHERE ranked.`rn` > 1
+);
+--> statement-breakpoint
+-- (c) Now that each (user_id, year) is unique, add the constraint.
+CREATE UNIQUE INDEX `share_settings_user_year_unq` ON `share_settings` (`user_id`,`year`);

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,885 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "090e1632-a4b2-4a7c-b59f-1f5daf906167",
+  "prevId": "49127a9e-5449-41d9-b233-5d8dc1b9ffb5",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast((julianday('now') - 2440587.5)*86400000 as integer))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "cached_stats": {
+      "name": "cached_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stats_type": {
+          "name": "stats_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stats_json": {
+          "name": "stats_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cached_stats_lookup": {
+          "name": "idx_cached_stats_lookup",
+          "columns": [
+            "user_id",
+            "year",
+            "stats_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_slides": {
+      "name": "custom_slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "logs": {
+      "name": "logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_logs_timestamp": {
+          "name": "idx_logs_timestamp",
+          "columns": [
+            "timestamp"
+          ],
+          "isUnique": false
+        },
+        "idx_logs_level": {
+          "name": "idx_logs_level",
+          "columns": [
+            "level"
+          ],
+          "isUnique": false
+        },
+        "idx_logs_level_timestamp": {
+          "name": "idx_logs_level_timestamp",
+          "columns": [
+            "level",
+            "timestamp"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metadata_cache": {
+      "name": "metadata_cache",
+      "columns": {
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fetch_failed": {
+          "name": "fetch_failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pin_transactions": {
+      "name": "pin_transactions",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pin_id": {
+          "name": "pin_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "callback_verified": {
+          "name": "callback_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "idx_pin_transactions_expires_at": {
+          "name": "idx_pin_transactions_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "play_history": {
+      "name": "play_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "history_key": {
+          "name": "history_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating_key": {
+          "name": "rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_section_id": {
+          "name": "library_section_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_title": {
+          "name": "grandparent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_rating_key": {
+          "name": "grandparent_rating_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "grandparent_thumb": {
+          "name": "grandparent_thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_title": {
+          "name": "parent_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "play_history_history_key_unique": {
+          "name": "play_history_history_key_unique",
+          "columns": [
+            "history_key"
+          ],
+          "isUnique": true
+        },
+        "idx_play_history_rating_key": {
+          "name": "idx_play_history_rating_key",
+          "columns": [
+            "rating_key"
+          ],
+          "isUnique": false
+        },
+        "idx_play_history_account_id": {
+          "name": "idx_play_history_account_id",
+          "columns": [
+            "account_id"
+          ],
+          "isUnique": false
+        },
+        "idx_play_history_viewed_at": {
+          "name": "idx_play_history_viewed_at",
+          "columns": [
+            "viewed_at"
+          ],
+          "isUnique": false
+        },
+        "idx_play_history_account_viewed": {
+          "name": "idx_play_history_account_viewed",
+          "columns": [
+            "account_id",
+            "viewed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plex_accounts": {
+      "name": "plex_accounts",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_id": {
+          "name": "plex_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_owner": {
+          "name": "is_owner",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plex_token": {
+          "name": "plex_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_settings": {
+      "name": "share_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "mode_source": {
+          "name": "mode_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'explicit'"
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_slug": {
+          "name": "public_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "can_user_control": {
+          "name": "can_user_control",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_logo": {
+          "name": "show_logo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "share_settings_share_token_unique": {
+          "name": "share_settings_share_token_unique",
+          "columns": [
+            "share_token"
+          ],
+          "isUnique": true
+        },
+        "share_settings_public_slug_unique": {
+          "name": "share_settings_public_slug_unique",
+          "columns": [
+            "public_slug"
+          ],
+          "isUnique": true
+        },
+        "share_settings_user_year_unq": {
+          "name": "share_settings_user_year_unq",
+          "columns": [
+            "user_id",
+            "year"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_settings_user_id_users_id_fk": {
+          "name": "share_settings_user_id_users_id_fk",
+          "tableFrom": "share_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_config": {
+      "name": "slide_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slide_type": {
+          "name": "slide_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sync_status": {
+      "name": "sync_status",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "records_processed": {
+          "name": "records_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_viewed_at": {
+          "name": "last_viewed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "plex_id": {
+          "name": "plex_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumb": {
+          "name": "thumb",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_plex_id_unique": {
+          "name": "users_plex_id_unique",
+          "columns": [
+            "plex_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1780950841100,
       "tag": "0009_mute_scarlet_witch",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1781617842203,
+      "tag": "0010_cynical_screwball",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/db/schema.ts
+++ b/src/lib/server/db/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
 
 export const users = sqliteTable('users', {
 	id: integer('id').primaryKey({ autoIncrement: true }),
@@ -66,24 +66,33 @@ export const cachedStats = sqliteTable(
 	(table) => [index('idx_cached_stats_lookup').on(table.userId, table.year, table.statsType)]
 );
 
-export const shareSettings = sqliteTable('share_settings', {
-	id: integer('id').primaryKey({ autoIncrement: true }),
-	userId: integer('user_id')
-		.notNull()
-		.references(() => users.id, { onDelete: 'cascade' }),
-	year: integer('year').notNull(),
-	mode: text('mode').notNull().default('public'),
-	modeSource: text('mode_source').notNull().default('explicit'),
-	shareToken: text('share_token').unique(),
-	// DF-04 / ISSUE-004: an opaque, non-sequential identifier used in share URLs
-	// for PUBLIC and PRIVATE_OAUTH modes, so the page is no longer served at the
-	// enumerable integer users.id. Lazily minted; NULL until the row is first
-	// shared/viewed. Distinct from shareToken (private-link UUID, own revocation
-	// story) — base62 so it never collides with the UUID-token or numeric-id space.
-	publicSlug: text('public_slug').unique(),
-	canUserControl: integer('can_user_control', { mode: 'boolean' }).default(false),
-	showLogo: integer('show_logo', { mode: 'boolean' })
-});
+export const shareSettings = sqliteTable(
+	'share_settings',
+	{
+		id: integer('id').primaryKey({ autoIncrement: true }),
+		userId: integer('user_id')
+			.notNull()
+			.references(() => users.id, { onDelete: 'cascade' }),
+		year: integer('year').notNull(),
+		mode: text('mode').notNull().default('public'),
+		modeSource: text('mode_source').notNull().default('explicit'),
+		shareToken: text('share_token').unique(),
+		// DF-04 / ISSUE-004: an opaque, non-sequential identifier used in share URLs
+		// for PUBLIC and PRIVATE_OAUTH modes, so the page is no longer served at the
+		// enumerable integer users.id. Lazily minted; NULL until the row is first
+		// shared/viewed. Distinct from shareToken (private-link UUID, own revocation
+		// story) — base62 so it never collides with the UUID-token or numeric-id space.
+		publicSlug: text('public_slug').unique(),
+		canUserControl: integer('can_user_control', { mode: 'boolean' }).default(false),
+		showLogo: integer('show_logo', { mode: 'boolean' })
+	},
+	// ISSUE-001: one share row per (user_id, year). Without this, the non-atomic
+	// read-then-insert in getOrCreateShareSettings could race two concurrent
+	// callers into duplicate rows, after which ensurePublicSlug's multi-row
+	// `WHERE ... IS NULL` UPDATE assigned one slug to two rows and tripped the
+	// public_slug unique constraint (HTTP 500 on /dashboard/settings).
+	(table) => [uniqueIndex('share_settings_user_year_unq').on(table.userId, table.year)]
+);
 
 export const customSlides = sqliteTable('custom_slides', {
 	id: integer('id').primaryKey({ autoIncrement: true }),

--- a/src/lib/server/onboarding/bootstrap.ts
+++ b/src/lib/server/onboarding/bootstrap.ts
@@ -9,7 +9,11 @@ import {
 } from '$lib/server/admin/settings.service';
 
 const BOOTSTRAP_TOKEN_TTL_MS = 15 * 60 * 1000;
-const CLAIM_TTL_SECONDS = 10 * 60;
+// ISSUE-002: 30 min (was 10). The onboarding claim must outlast a slow off-site
+// Plex OAuth round-trip; the return path lands on a page `load` (renewed there)
+// rather than an onboarding action, and a 10-minute window could lapse mid-flow.
+// Both the cookie maxAge and the stored-claim TTL derive from this one constant.
+const CLAIM_TTL_SECONDS = 30 * 60;
 const CLAIM_TTL_MS = CLAIM_TTL_SECONDS * 1000;
 const TOKEN_LENGTH = 14;
 const TOKEN_ALPHABET = 'abcdefghijklmnopqrstuvwxyz0123456789';

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -416,7 +416,14 @@ export async function getOrCreateShareSettings(
 	const allowUserControl = await getGlobalAllowUserControl();
 	const shareToken = defaultMode === ShareMode.PRIVATE_LINK ? generateShareToken() : null;
 
-	const result = await db
+	// Atomic create (ISSUE-001): a concurrent caller can insert the (user_id, year)
+	// row between the read above and this insert. `onConflictDoNothing` on the
+	// share_settings_user_year_unq index turns that race into a no-op instead of a
+	// duplicate row (which previously let ensurePublicSlug assign one slug to two
+	// rows and 500 the dashboard). Re-select via getShareSettings so every caller
+	// receives the canonical row plus its lazy private-link token mint and the
+	// toShareSettings global-folding — keeping the ShareSettings return contract.
+	await db
 		.insert(shareSettings)
 		.values({
 			userId,
@@ -426,14 +433,14 @@ export async function getOrCreateShareSettings(
 			shareToken,
 			canUserControl: allowUserControl
 		})
-		.returning();
+		.onConflictDoNothing({ target: [shareSettings.userId, shareSettings.year] });
 
-	const record = result[0];
-	if (!record) {
+	const created = await getShareSettings(userId, year);
+	if (!created) {
 		throw new ShareError('Failed to create share settings', 'CREATE_FAILED');
 	}
 
-	return toShareSettings(record, defaultMode, allowUserControl);
+	return created;
 }
 
 export async function updateShareSettings(

--- a/src/routes/dashboard/settings/+page.server.ts
+++ b/src/routes/dashboard/settings/+page.server.ts
@@ -41,9 +41,16 @@ export const load: PageServerLoad = async ({ locals, setHeaders }) => {
 	const userId = locals.user!.id;
 	const currentYear = new Date().getFullYear();
 
+	// ISSUE-001: resolve/create the (userId, currentYear) share row FIRST, before
+	// getOwnerWrappedHref (which resolves it again via getShareIdentifier). Running
+	// both inside one Promise.all raced two getOrCreateShareSettings inserts into
+	// duplicate rows, which then tripped the public_slug unique constraint and 500'd
+	// this page for brand-new users. The onConflictDoNothing upsert is the structural
+	// fix; this sequencing keeps the hot path single-create as belt-and-suspenders.
+	const shareSettings = await getOrCreateShareSettings({ userId, year: currentYear });
+
 	const [
 		userProfile,
-		shareSettings,
 		wrappedLogoMode,
 		userLogoPreference,
 		sessionExpiration,
@@ -51,7 +58,6 @@ export const load: PageServerLoad = async ({ locals, setHeaders }) => {
 		wrappedHref
 	] = await Promise.all([
 		getUserFullProfile(userId),
-		getOrCreateShareSettings({ userId, year: currentYear }),
 		getWrappedLogoMode(),
 		getUserLogoPreference(userId, currentYear),
 		getSessionExpiration(userId),

--- a/src/routes/onboarding/+layout.server.ts
+++ b/src/routes/onboarding/+layout.server.ts
@@ -10,7 +10,8 @@ import {
 	hasActiveOnboardingClaim,
 	isOnboardingComplete,
 	type OnboardingStep,
-	OnboardingSteps
+	OnboardingSteps,
+	renewOnboardingClaim
 } from '$lib/server/onboarding';
 import { getServerName } from '$lib/server/plex/server-name.service';
 import type { LayoutServerLoad } from './$types';
@@ -25,6 +26,21 @@ export const load: LayoutServerLoad = async ({ cookies, locals, url }) => {
 	const requestedPath = url.pathname;
 	const isClaimPath = requestedPath === '/onboarding/claim';
 	const hasActiveClaim = await hasActiveOnboardingClaim(cookies);
+
+	// ISSUE-002: renew the claim on every onboarding page load so it survives the
+	// off-site Plex OAuth round-trip. The return path (`/auth/plex/redirect`) lands
+	// back on an onboarding `load`, not an onboarding *action*, so without renewing
+	// here a slow OAuth could lapse the claim and wrongly demand "Setup claim
+	// required" after the owner already authenticated. Renewal still requires the
+	// existing valid claim cookie (anti-theft preserved) and is best-effort: a
+	// failed renewal must never block the onboarding page from rendering.
+	if (hasActiveClaim) {
+		try {
+			await renewOnboardingClaim(cookies, { requestUrl: url });
+		} catch {
+			// Keep the current expiry rather than breaking the page on a write error.
+		}
+	}
 
 	if (!hasActiveClaim && !isClaimPath) {
 		redirect(303, '/onboarding/claim');

--- a/src/routes/wrapped/[year=year]/+page.server.ts
+++ b/src/routes/wrapped/[year=year]/+page.server.ts
@@ -17,7 +17,23 @@ import {
 } from '$lib/server/slides';
 import { getServerStatsWithAnonymization } from '$lib/server/stats/engine';
 import { triggerLiveSyncIfNeeded } from '$lib/server/sync/live-sync';
+import { hasWatchHistory } from '$lib/stats/types';
 import type { PageServerLoad } from './$types';
+
+// ISSUE-003: friendly empty state for an authorized viewer hitting an in-range
+// year that has no synced recap yet. Returned in place of the old 404; the page
+// discriminates on `hasData` to render "No {year} data yet" instead of the
+// slideshow. Only the fields the empty-state branch actually reads are returned
+// (year for the copy; isAdmin/isLoggedIn for the Home button) — no stats/slides
+// are computed for an empty year.
+function buildEmptyState(year: number, isAdmin: boolean, isLoggedIn: boolean) {
+	return {
+		hasData: false as const,
+		year,
+		isAdmin,
+		isLoggedIn
+	};
+}
 
 export const load: PageServerLoad = async ({ params, locals, parent, setHeaders }) => {
 	setHeaders({ 'cache-control': 'no-store' });
@@ -29,10 +45,15 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 
 	const currentYear = new Date().getFullYear();
 	const { availableYears } = await parent();
-	if (!availableYears.includes(year) && year !== currentYear) {
-		error(404, 'No data found for this year');
-	}
 
+	// ISSUE-003: access control runs BEFORE any data-presence decision. The
+	// "no data for this year" branch used to fire first, which let an anonymous
+	// visitor on a private (private-oauth) server tell an in-range empty year apart
+	// from an access-denied one — an anti-enumeration leak. Gate first so an
+	// anonymous denial is the byte-identical WRAPPED_NOT_FOUND_MESSAGE 404 (parity
+	// with the personal route), an authenticated non-member keeps the deliberate
+	// 403, and only an authorized viewer proceeds to learn whether the year holds
+	// data.
 	try {
 		await checkServerWrappedAccess({
 			year,
@@ -40,10 +61,6 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 		});
 	} catch (err) {
 		if (err instanceof ShareAccessDeniedError) {
-			// Anonymous callers get the byte-identical anti-enumeration 404 (matching
-			// the personal route), so a denied server-wide page is indistinguishable
-			// from a non-existent one. Authenticated non-members keep the deliberate
-			// 403 signal since membership already proves they exist.
 			if (!locals.user) {
 				error(404, WRAPPED_NOT_FOUND_MESSAGE);
 			}
@@ -52,10 +69,26 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 		throw err;
 	}
 
+	const isAdmin = locals.user?.isAdmin ?? false;
+	const isLoggedIn = !!locals.user;
+
+	// A never-synced in-range year (not in availableYears and not the current year)
+	// has no recap to show. An authorized viewer now gets a friendly empty state
+	// instead of a hard 404 (ISSUE-003).
+	if (!availableYears.includes(year) && year !== currentYear) {
+		return buildEmptyState(year, isAdmin, isLoggedIn);
+	}
+
 	triggerLiveSyncIfNeeded('server-wrapped').catch(() => {});
 
 	const viewingUserId = locals.user?.id ?? null;
 	const stats = await getServerStatsWithAnonymization(year, viewingUserId);
+
+	// The current year can be in range yet not yet synced (empty stats). Render the
+	// same friendly empty state rather than an empty slideshow.
+	if (!hasWatchHistory(stats)) {
+		return buildEmptyState(year, isAdmin, isLoggedIn);
+	}
 
 	await initializeDefaultSlideConfig();
 	const [slideConfigs, customSlides] = await Promise.all([
@@ -84,16 +117,17 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 	const signedStats = await signStatsThumbnails(stats, { kind: 'server', year });
 
 	return {
+		hasData: true as const,
 		stats: signedStats,
 		slides,
 		customSlidesMap,
 		year,
-		isServerWrapped: true,
+		isServerWrapped: true as const,
 		serverName,
 		showLogo: logoVisibility.showLogo,
 		canUserControlLogo: false,
 		currentUrl: `/wrapped/${year}`,
-		isAdmin: locals.user?.isAdmin ?? false,
-		isLoggedIn: !!locals.user
+		isAdmin,
+		isLoggedIn
 	};
 };

--- a/src/routes/wrapped/[year=year]/+page.svelte
+++ b/src/routes/wrapped/[year=year]/+page.svelte
@@ -16,7 +16,7 @@ import type { PageProps } from './$types';
 
 let { data }: PageProps = $props();
 
-const messagingContext = $derived(createServerContext(data.serverName));
+const messagingContext = $derived(createServerContext(data.hasData ? data.serverName : null));
 
 type ViewMode = 'story' | 'scroll';
 let viewMode = $state<ViewMode>('story');
@@ -27,7 +27,8 @@ let viewMode = $state<ViewMode>('story');
 // deep-linked slide on its very first render. afterNavigate below re-applies the
 // hash once as a belt-and-suspenders guard.
 function readInitialSlideIndex(): number {
-	return browser ? parseSlideHash(window.location.hash, data.slides.length) : 0;
+	if (!browser || !data.hasData) return 0;
+	return parseSlideHash(window.location.hash, data.slides.length);
 }
 
 let currentSlideIndex = $state(readInitialSlideIndex());
@@ -50,7 +51,7 @@ let routerReady = $state(false);
 let hashSeeded = $state(false);
 afterNavigate(() => {
 	if (!hashSeeded) {
-		currentSlideIndex = parseSlideHash(window.location.hash, data.slides.length);
+		currentSlideIndex = data.hasData ? parseSlideHash(window.location.hash, data.slides.length) : 0;
 		hashSeeded = true;
 	}
 	routerReady = true;
@@ -133,21 +134,41 @@ function handleShare(): void {
 </svelte:head>
 
 <div class="wrapped-page">
-	{#if data.showLogo}
-		<div class="logo-watermark">
-			<Logo size="sm" />
+	{#if !data.hasData}
+		<!-- ISSUE-003: an authorized viewer reached an in-range year with no synced
+		recap yet. Friendly empty state (HTTP 200) instead of the old hard 404. -->
+		{#if data.availableYears && data.availableYears.length > 0}
+			<YearNavigation currentYear={data.year} availableYears={data.availableYears} />
+		{/if}
+		<div class="empty-state">
+			<div class="empty-card">
+				<h1>No {data.year} data yet</h1>
+				<p>
+					There's no Wrapped recap for {data.year} yet. It appears here once a sync has imported
+					viewing history for that year.
+				</p>
+				<div class="empty-actions">
+					<button type="button" class="btn secondary" onclick={handleClose}>Go back</button>
+					<button type="button" class="btn primary" onclick={handleHome}>Home</button>
+				</div>
+			</div>
 		</div>
-	{/if}
+	{:else}
+		{#if data.showLogo}
+			<div class="logo-watermark">
+				<Logo size="sm" />
+			</div>
+		{/if}
 
-	<div class="mode-toggle-container">
-		<ModeToggle mode={viewMode} onModeChange={handleModeChange} />
-	</div>
+		<div class="mode-toggle-container">
+			<ModeToggle mode={viewMode} onModeChange={handleModeChange} />
+		</div>
 
-	{#if data.availableYears && data.availableYears.length > 1}
-		<YearNavigation currentYear={data.year} availableYears={data.availableYears} />
-	{/if}
+		{#if data.availableYears && data.availableYears.length > 1}
+			<YearNavigation currentYear={data.year} availableYears={data.availableYears} />
+		{/if}
 
-	{#if showSummary}
+		{#if showSummary}
 		<SummaryPage
 			stats={data.stats}
 			year={data.year}
@@ -180,14 +201,15 @@ function handleShare(): void {
 		/>
 	{/if}
 
-	<ShareModal
-		bind:open={showShareModal}
-		onOpenChange={(v) => (showShareModal = v)}
-		currentUrl={data.currentUrl}
-		isOwner={false}
-		isAdmin={data.isAdmin}
-		isServerWrapped={true}
-	/>
+		<ShareModal
+			bind:open={showShareModal}
+			onOpenChange={(v) => (showShareModal = v)}
+			currentUrl={data.currentUrl}
+			isOwner={false}
+			isAdmin={data.isAdmin}
+			isServerWrapped={true}
+		/>
+	{/if}
 </div>
 
 <style>
@@ -220,5 +242,76 @@ function handleShare(): void {
 			top: 1rem;
 			right: 1rem;
 			z-index: 100;
+		}
+
+		.empty-state {
+			position: relative;
+			z-index: 1;
+			min-height: 100vh;
+			min-height: 100dvh;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			padding: 2rem;
+		}
+
+		.empty-card {
+			max-width: 480px;
+			width: 100%;
+			text-align: center;
+			background: oklch(var(--card));
+			border: 1px solid oklch(var(--border));
+			border-radius: var(--radius);
+			padding: 2.5rem 2rem;
+		}
+
+		.empty-card h1 {
+			font-size: 1.5rem;
+			font-weight: 600;
+			margin: 0 0 0.75rem;
+			color: oklch(var(--foreground));
+		}
+
+		.empty-card p {
+			color: oklch(var(--muted-foreground));
+			margin: 0 0 2rem;
+			line-height: 1.5;
+		}
+
+		.empty-actions {
+			display: flex;
+			gap: 0.75rem;
+			justify-content: center;
+			flex-wrap: wrap;
+		}
+
+		.btn {
+			padding: 0.625rem 1.25rem;
+			border-radius: var(--radius);
+			font-size: 0.875rem;
+			font-weight: 500;
+			cursor: pointer;
+			border: 1px solid oklch(var(--border));
+			transition: opacity 0.15s ease;
+			text-decoration: none;
+			display: inline-flex;
+			align-items: center;
+			justify-content: center;
+			line-height: 1;
+		}
+
+		.btn:hover {
+			opacity: 0.85;
+		}
+
+		.btn.primary {
+			background: oklch(var(--primary));
+			color: oklch(var(--primary-foreground));
+			border-color: oklch(var(--primary));
+		}
+
+		.btn.secondary {
+			background: oklch(var(--muted));
+			color: oklch(var(--foreground));
 		}
 </style>

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -102,6 +102,11 @@ sqlite.exec(`
 		show_logo INTEGER
 	);
 
+	-- ISSUE-001: mirror migration 0010's UNIQUE(user_id, year) so the test DB
+	-- matches production. getOrCreateShareSettings' onConflictDoNothing targets
+	-- this index; without it SQLite rejects the ON CONFLICT clause.
+	CREATE UNIQUE INDEX IF NOT EXISTS share_settings_user_year_unq ON share_settings (user_id, year);
+
 	CREATE TABLE IF NOT EXISTS custom_slides (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
 		title TEXT NOT NULL,

--- a/tests/unit/onboarding/bootstrap.test.ts
+++ b/tests/unit/onboarding/bootstrap.test.ts
@@ -13,6 +13,7 @@ import {
 	isBootstrapTokenExpired,
 	ONBOARDING_CLAIM_COOKIE,
 	printOnboardingBootstrapBanner,
+	renewOnboardingClaim,
 	validateBootstrapToken
 } from '$lib/server/onboarding/bootstrap';
 import { resetSharedTestDb } from '../../helpers/db';
@@ -189,5 +190,46 @@ describe('onboarding bootstrap token and claim', () => {
 		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED)).toBeNull();
 		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIM_PROOF_HASH)).toBeNull();
 		expect(await hasActiveOnboardingClaim(cookies as unknown as Cookies)).toBe(false);
+	});
+
+	// ISSUE-002: the onboarding layout `load` renews the claim on every page view
+	// so it survives a slow off-site Plex OAuth round-trip (the return path lands on
+	// a load, not an action). These lock the renew-on-load primitive it calls.
+	it('renews a still-active claim on load, extending its stored expiry (ISSUE-002)', async () => {
+		const cookies = createCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
+
+		// Backdate the claim to near-expiry (still valid, but old) to prove renewal
+		// pushes the expiry forward rather than being a no-op.
+		const backdated = Date.now() - 9 * 60 * 1000;
+		await setAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT, String(backdated));
+
+		const renewed = await renewOnboardingClaim(cookies as unknown as Cookies, {
+			requestUrl: new URL('https://example.com/onboarding/plex')
+		});
+		expect(renewed).toBe(true);
+
+		const claimedAt = Number(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT));
+		expect(claimedAt).toBeGreaterThan(backdated);
+		expect(await hasActiveOnboardingClaim(cookies as unknown as Cookies)).toBe(true);
+	});
+
+	it('does not let a foreign session renew an active claim (anti-theft preserved)', async () => {
+		const owner = createCookies();
+		const stranger = createCookies();
+		const token = createBootstrapToken();
+		expect(await claimOnboardingInstance(owner as unknown as Cookies, token)).toBe('claimed');
+
+		const before = await getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT);
+
+		// A different session with no valid claim cookie must not be able to renew
+		// (or thereby steal) the owner's active claim.
+		const renewed = await renewOnboardingClaim(stranger as unknown as Cookies, {
+			requestUrl: new URL('https://example.com/onboarding/plex')
+		});
+		expect(renewed).toBe(false);
+		expect(stranger.values.get(ONBOARDING_CLAIM_COOKIE)).toBeUndefined();
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT)).toBe(before);
 	});
 });

--- a/tests/unit/sharing/anon-denial-uniformity.test.ts
+++ b/tests/unit/sharing/anon-denial-uniformity.test.ts
@@ -126,13 +126,19 @@ describe('wrapped/[year]/u/[identifier]: ISSUE-009 anonymous-denial uniformity',
 		const oauthBlockedToken = await captureFailure({ year: YEAR, identifier: OAUTH_BLOCKED_TOKEN });
 
 		// Case 4: valid token for the WRONG year (the line-126 exit). Floor PUBLIC so
-		// the token still resolves; the year mismatch is what denies it.
+		// the token still resolves; the year mismatch is what denies it. Seed under a
+		// SEPARATE user so it does not collide with the case-3 row at (USER_ID, YEAR)
+		// now that share_settings enforces UNIQUE(user_id, year) (ISSUE-001). The
+		// token resolves globally (by token, not user), so a distinct owner does not
+		// change the wrong-year denial under test.
+		const WRONG_YEAR_USER = 43;
+		await seedUser(WRONG_YEAR_USER);
 		await setGlobalShareDefaults({
 			defaultShareMode: ShareMode.PUBLIC,
 			allowUserControl: false
 		});
 		await seedShareSettings({
-			userId: USER_ID,
+			userId: WRONG_YEAR_USER,
 			year: YEAR,
 			mode: ShareMode.PRIVATE_LINK,
 			token: WRONG_YEAR_TOKEN

--- a/tests/unit/sharing/server-wrapped-route.test.ts
+++ b/tests/unit/sharing/server-wrapped-route.test.ts
@@ -145,10 +145,14 @@ describe('server wrapped route year guard (ISSUE-009, ISSUE-018)', () => {
 		}
 	});
 
-	it('throws the exact "No data found for this year" 404 message (FIX-2 +error.svelte contract)', async () => {
-		// The route-scoped wrapped/[year=year]/+error.svelte detects this exact message
-		// to render its friendly empty-state. Lock the string so the boundary copy
-		// and the thrown error can never silently drift apart.
+	it('returns the byte-identical anti-enumeration 404 for an anonymous in-range empty year (ISSUE-003)', async () => {
+		// ISSUE-003 moved access control AHEAD of the data-presence decision, so an
+		// anonymous visitor on a private (private-oauth, the fresh-install default)
+		// server can no longer tell an in-range empty year apart from an
+		// access-denied one: both are now the byte-identical WRAPPED_NOT_FOUND_MESSAGE
+		// 404 (this used to be a distinguishable "No data found for this year" 404
+		// that leaked which years exist). The friendly empty state is reserved for
+		// AUTHORIZED viewers — see the hasData:false tests below.
 		const currentYear = new Date().getFullYear();
 		const emptyPastYear = currentYear - 1;
 		try {
@@ -159,13 +163,49 @@ describe('server wrapped route year guard (ISSUE-009, ISSUE-018)', () => {
 				url: new URL(`http://localhost/wrapped/${emptyPastYear}`),
 				setHeaders: () => {}
 			} as unknown as Parameters<ServerWrappedLoad>[0]);
-			expect.unreachable('Expected 404 for empty past year');
+			expect.unreachable('Expected anti-enumeration 404 for an anonymous empty past year');
 		} catch (err) {
 			expect(isHttpError(err)).toBe(true);
 			if (!isHttpError(err)) throw err;
 			expect(err.status).toBe(404);
-			expect(err.body.message).toBe('No data found for this year');
+			expect(err.body.message).toBe(WRAPPED_NOT_FOUND_MESSAGE);
 		}
+	});
+
+	it('renders a friendly empty state (hasData:false, no throw) for an authorized viewer on an in-range empty year', async () => {
+		// Server mode PUBLIC so the anonymous viewer passes access control; the
+		// in-range empty past year then yields the 200 empty state instead of a 404.
+		await setServerWrappedShareMode(ShareMode.PUBLIC);
+		const currentYear = new Date().getFullYear();
+		const emptyPastYear = currentYear - 1;
+
+		const result = (await load({
+			params: { year: String(emptyPastYear) },
+			locals: {},
+			parent: makeParent([currentYear]),
+			url: new URL(`http://localhost/wrapped/${emptyPastYear}`),
+			setHeaders: () => {}
+		} as unknown as Parameters<ServerWrappedLoad>[0])) as { hasData: boolean; year: number };
+
+		expect(result.hasData).toBe(false);
+		expect(result.year).toBe(emptyPastYear);
+	});
+
+	it('renders the empty state for an authenticated member on an in-range empty year (private-oauth)', async () => {
+		await setServerWrappedShareMode(ShareMode.PRIVATE_OAUTH);
+		const currentYear = new Date().getFullYear();
+		const emptyPastYear = currentYear - 1;
+
+		const result = (await load({
+			params: { year: String(emptyPastYear) },
+			locals: { user: { id: 5, plexId: 100005, username: 'member', isAdmin: false } },
+			parent: makeParent([currentYear]),
+			url: new URL(`http://localhost/wrapped/${emptyPastYear}`),
+			setHeaders: () => {}
+		} as unknown as Parameters<ServerWrappedLoad>[0])) as { hasData: boolean; year: number };
+
+		expect(result.hasData).toBe(false);
+		expect(result.year).toBe(emptyPastYear);
 	});
 
 	it('does not 404 for the current year even when not yet in availableYears (pre-first-sync)', async () => {

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { setUserDefaultsAtomic } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings, shareSettings } from '$lib/server/db/schema';
 import {
 	bulkApplyShareDefaults,
 	deleteShareSettings,
+	ensurePublicSlug,
+	ensureShareToken,
 	generateShareToken,
 	getAllUserShareSettings,
 	getEffectiveShareMode,
@@ -757,6 +759,99 @@ describe('Sharing Service', () => {
 				await expect(
 					getOrCreateShareSettings({ userId, year, createIfMissing: false })
 				).rejects.toBeInstanceOf(ShareSettingsNotFoundError);
+			});
+		});
+
+		describe('getOrCreateShareSettings concurrency (ISSUE-001)', () => {
+			it('creates exactly one row when two callers race for a fresh (user, year)', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: false
+				});
+
+				// This is the dogfood-500 reproduction: the dashboard load fired
+				// getOrCreateShareSettings twice in one Promise.all. Pre-fix both reads
+				// saw "missing" and both inserted, leaving two rows; now the
+				// onConflictDoNothing upsert collapses the race to a single row.
+				const [a, b] = await Promise.all([
+					getOrCreateShareSettings({ userId, year }),
+					getOrCreateShareSettings({ userId, year })
+				]);
+				expect(a.userId).toBe(userId);
+				expect(a.year).toBe(year);
+				expect(b.userId).toBe(userId);
+
+				const rows = await db
+					.select()
+					.from(shareSettings)
+					.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)));
+				expect(rows).toHaveLength(1);
+			});
+
+			it('keeps exactly one row across many concurrent calls (private-link default)', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: false
+				});
+
+				await Promise.all(
+					Array.from({ length: 8 }, () => getOrCreateShareSettings({ userId, year }))
+				);
+
+				const rows = await db
+					.select()
+					.from(shareSettings)
+					.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)));
+				expect(rows).toHaveLength(1);
+			});
+
+			it('ensurePublicSlug under concurrency assigns one slug to the single row (no unique violation)', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: false
+				});
+				await getOrCreateShareSettings({ userId, year });
+
+				// Pre-fix, duplicate rows let this multi-row `WHERE ... IS NULL` UPDATE
+				// assign the same slug to two rows and trip the public_slug unique
+				// constraint (the actual 500). With a single row it mints exactly once.
+				const slugs = await Promise.all([
+					ensurePublicSlug(userId, year),
+					ensurePublicSlug(userId, year)
+				]);
+				expect(slugs[0]).toBe(slugs[1]);
+
+				const rows = await db
+					.select()
+					.from(shareSettings)
+					.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)));
+				expect(rows).toHaveLength(1);
+				expect(rows[0]?.publicSlug).toBe(slugs[0]);
+			});
+
+			it('ensureShareToken under concurrency assigns one token to the single row', async () => {
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: false
+				});
+				await getOrCreateShareSettings({ userId, year });
+				// Clear the default-minted token so ensureShareToken must mint.
+				await db
+					.update(shareSettings)
+					.set({ shareToken: null })
+					.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)));
+
+				const tokens = await Promise.all([
+					ensureShareToken(userId, year),
+					ensureShareToken(userId, year)
+				]);
+				expect(tokens[0]).toBe(tokens[1]);
+
+				const rows = await db
+					.select()
+					.from(shareSettings)
+					.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)));
+				expect(rows).toHaveLength(1);
 			});
 		});
 


### PR DESCRIPTION
## Summary

Remediates the three findings from the 2026-06-16 dogfood run (`dogfood-output/report.md`): one HIGH, one MEDIUM, one LOW. Implements `.omc/plans/fix-dogfood-findings-2026-06-16.md`.

## ISSUE-001 (HIGH) — non-admin `/dashboard/settings` returned 500 + duplicate share rows

Root cause: a non-atomic read-then-insert in `getOrCreateShareSettings`, combined with the absence of a `(user_id, year)` uniqueness constraint, let two concurrent callers (the dashboard `load` fires `getOrCreateShareSettings` twice in one `Promise.all`) both insert a row. `ensurePublicSlug`'s multi-row `WHERE ... IS NULL` UPDATE then assigned one slug to both rows and tripped the `public_slug` unique constraint, surfacing as an HTTP 500.

Structural fix:
- `schema.ts`: add `uniqueIndex('share_settings_user_year_unq')` on `(user_id, year)`.
- Migration `0010_cynical_screwball.sql`: forward-only, data-safe dedup ordered within drizzle's single per-file transaction (no manual `BEGIN/COMMIT`):
  1. salvage a non-null `show_logo` onto the ranked survivor;
  2. delete losing duplicate rows, keeping the survivor ranked by `public_slug NOT NULL` > `share_token NOT NULL` > `mode_source='explicit'` > lowest `id`;
  3. create the unique index.
  The migration is a no-op on an already-clean DB. The unique slug/token columns are intentionally not copied between rows (survivor ranking already retains whichever row holds them, and copying would trip those unique constraints mid-migration).
- `sharing/service.ts`: `getOrCreateShareSettings` now performs `insert(...).onConflictDoNothing({ target: [userId, year] })` then re-selects via `getShareSettings`, preserving the `ShareSettings` return contract and the lazy private-link token mint.
- `dashboard/settings/+page.server.ts`: await `getOrCreateShareSettings` before computing `getOwnerWrappedHref`, removing the concurrent double-create from the hot path.
- `tests/setup.ts`: mirror the unique index in the test DDL so the test DB matches production (`onConflictDoNothing` requires the index to exist).

## ISSUE-002 (MEDIUM) — onboarding claim expired during Plex OAuth

The 10-minute claim TTL was renewed only inside onboarding actions; the off-site OAuth return path lands on a page `load`, so a slow round-trip could lapse the claim and wrongly demand "Setup claim required" after the owner had already authenticated.

- `bootstrap.ts`: raise `CLAIM_TTL_SECONDS` 600 -> 1800 (single source for the cookie `maxAge` and the stored TTL).
- `onboarding/+layout.server.ts`: renew the claim best-effort on every onboarding page load (try/catch, never blocks render). Renewal still requires the existing valid claim cookie, so the anti-theft property is preserved.

## ISSUE-003 (LOW) — server-wrapped no-data year was a distinguishable 404

The "No data found for this year" 404 fired before access control, letting an anonymous viewer on a private (private-oauth) server distinguish an in-range empty year from an access-denied one — an anti-enumeration leak.

- `wrapped/[year=year]/+page.server.ts`: run `checkServerWrappedAccess` BEFORE the data-presence decision. Anonymous denial is now the byte-identical `WRAPPED_NOT_FOUND_MESSAGE` 404 (parity with the personal route), authenticated non-members keep the deliberate 403, and only an authorized viewer reaches a friendly `hasData:false` 200 empty state.
- `wrapped/[year=year]/+page.svelte`: discriminated-union render — a friendly "No {year} data yet" empty-state card (with year navigation) for `hasData:false`, otherwise the existing slideshow.

## Tests

- `service.test.ts`: concurrent `getOrCreateShareSettings` (x2 and x8) creates exactly one row; concurrent `ensurePublicSlug`/`ensureShareToken` assign one identifier to the single row (the original 500 reproduction).
- `bootstrap.test.ts`: renew-on-load extends the stored expiry; a foreign session cannot renew or steal an active claim.
- `server-wrapped-route.test.ts`: anonymous in-range empty year returns the byte-identical anti-enumeration 404; authorized viewer (public, and authenticated member) gets `hasData:false` 200.
- `anon-denial-uniformity.test.ts`: the case that previously seeded two rows for one `(user_id, year)` now uses a distinct user to respect the new invariant; all six byte-identical-404 assertions are unchanged.

No tests were deleted.

## Verification

- `bun run lint`: clean
- `bun run check`: 0 errors, 0 warnings
- `bun run test`: 2138 pass, 0 fail (coverage thresholds held)
- Migration dedup verified empirically against seeded-duplicate and clean databases (correct survivor, no data loss, no-op on clean DB).