### PR TITLE
fix(dogfood 2026-06-16-e2e): data-aware dashboard empty state + finding reconciliation (ISSUE-001..005)

### DIFF
--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -24,7 +24,13 @@ let { data }: Props = $props();
 				<span class="greeting-text">Welcome back</span>
 			</div>
 			<h1 class="page-title">{data.user.username}</h1>
-			<p class="page-subtitle">Your Plex Wrapped for {data.currentYear} is ready to explore</p>
+			{#if data.wrappedHref}
+				<p class="page-subtitle">Your Plex Wrapped for {data.currentYear} is ready to explore</p>
+			{:else}
+				<p class="page-subtitle">
+					No {data.currentYear} viewing history synced yet — your Wrapped will appear here once you have activity
+				</p>
+			{/if}
 		</div>
 		<div class="header-glow"></div>
 	</header>
@@ -50,6 +56,21 @@ let { data }: Props = $props();
 					<ArrowRight class="card-arrow" />
 				</div>
 			</a>
+		{:else}
+			<div class="wrapped-card personal empty">
+				<div class="card-badge">
+					<span>Personal</span>
+				</div>
+				<div class="card-icon-wrap">
+					<Star class="card-icon" />
+				</div>
+				<div class="card-content">
+					<h2 class="card-title">Your {data.currentYear} Wrapped</h2>
+					<p class="card-description">
+						Appears here once you have viewing history this year.
+					</p>
+				</div>
+			</div>
 		{/if}
 
 		<a href="/wrapped/{data.currentYear}" class="wrapped-card server">
@@ -195,6 +216,17 @@ let { data }: Props = $props();
 			opacity: 0;
 			transition: opacity 0.4s ease;
 			pointer-events: none;
+		}
+
+		.wrapped-card.empty {
+			opacity: 0.6;
+			cursor: default;
+		}
+
+		.wrapped-card.empty:hover {
+			border-color: oklch(var(--border));
+			transform: none;
+			box-shadow: none;
 		}
 
 		.wrapped-card.personal .card-glow {

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -229,6 +229,10 @@ let { data }: Props = $props();
 			box-shadow: none;
 		}
 
+		.wrapped-card.empty:hover .card-icon-wrap {
+			transform: none;
+		}
+
 		.wrapped-card.personal .card-glow {
 			background: radial-gradient(circle, oklch(var(--primary) / 0.2) 0%, transparent 70%);
 		}

--- a/tests/unit/admin/dogfood-ui-invariants.test.ts
+++ b/tests/unit/admin/dogfood-ui-invariants.test.ts
@@ -12,6 +12,7 @@ async function readSource(relPath: string): Promise<string> {
 }
 
 const CONNECTIONS = 'src/routes/admin/settings/connections/+page.svelte';
+const PRIVACY_PAGE = 'src/routes/admin/settings/privacy/+page.svelte';
 const ONBOARDING = 'src/routes/onboarding/settings/+page.svelte';
 const ONBOARDING_PLEX = 'src/routes/onboarding/plex/+page.svelte';
 const WRAPPED_PAGE = 'src/routes/wrapped/[year=year]/u/[identifier]/+page.svelte';
@@ -359,5 +360,55 @@ describe('ISSUE-006 source-guard — admin dashboard sync card label is last-syn
 		expect(src).toContain('Records (last sync)');
 		// The old ambiguous label must be gone.
 		expect(src).not.toContain('>Records Synced<');
+	});
+});
+
+describe('ISSUE-002 source-guard — bulk-apply confirm dialog uses focus-trapping bits-ui primitive', () => {
+	// The bits-ui AlertDialogPrimitive.Content provides the focus trap; a
+	// Bun/JSDOM-free source suite cannot assert runtime focus movement, so this
+	// pins the primitive wiring instead; only a real Playwright pass should
+	// escalate to a primitive-prop fix if the trap is ever proven broken.
+
+	it('privacy page imports the AlertDialog primitive from $lib/components/ui/alert-dialog/index.js', async () => {
+		const src = await readSource(PRIVACY_PAGE);
+		expect(src).toContain("from '$lib/components/ui/alert-dialog/index.js'");
+	});
+
+	it('bulk-apply dialog uses <AlertDialog.Root bind:open={bulkApplyDialogOpen}> (ISSUE-002)', async () => {
+		const src = await readSource(PRIVACY_PAGE);
+		expect(src).toContain('<AlertDialog.Root bind:open={bulkApplyDialogOpen}>');
+	});
+
+	it('bulk-apply dialog uses <AlertDialog.Content> (the focus-trapping primitive) (ISSUE-002)', async () => {
+		const src = await readSource(PRIVACY_PAGE);
+		// AlertDialog.Content wraps AlertDialogPrimitive.Content from bits-ui which
+		// provides keyboard focus trapping for the modal. A regression that replaces
+		// it with a bare <div> would remove the trap silently.
+		const rootIdx = src.indexOf('<AlertDialog.Root bind:open={bulkApplyDialogOpen}>');
+		expect(rootIdx).toBeGreaterThan(-1);
+		const dialogBlock = src.slice(rootIdx);
+		expect(dialogBlock).toContain('<AlertDialog.Content>');
+	});
+
+	it('bulk-apply dialog has <AlertDialog.Title> (labelled for AT) (ISSUE-002)', async () => {
+		const src = await readSource(PRIVACY_PAGE);
+		const rootIdx = src.indexOf('<AlertDialog.Root bind:open={bulkApplyDialogOpen}>');
+		const dialogBlock = src.slice(rootIdx);
+		expect(dialogBlock).toContain('<AlertDialog.Title>');
+	});
+
+	it('bulk-apply dialog has <AlertDialog.Cancel> (keyboard-dismissable) (ISSUE-002)', async () => {
+		const src = await readSource(PRIVACY_PAGE);
+		const rootIdx = src.indexOf('<AlertDialog.Root bind:open={bulkApplyDialogOpen}>');
+		const dialogBlock = src.slice(rootIdx);
+		expect(dialogBlock).toContain('<AlertDialog.Cancel');
+	});
+
+	it('alert-dialog-content.svelte renders AlertDialogPrimitive.Content from bits-ui (the focus trap element)', async () => {
+		const src = await readSource('src/lib/components/ui/alert-dialog/alert-dialog-content.svelte');
+		// bits-ui's AlertDialogPrimitive.Content is the element that installs the
+		// focus trap. Confirming it is rendered here pins the primitive wiring so a
+		// refactor that swaps it for a bare element cannot go unnoticed.
+		expect(src).toContain('<AlertDialogPrimitive.Content');
 	});
 });

--- a/tests/unit/dashboard/dashboard-empty-state.test.ts
+++ b/tests/unit/dashboard/dashboard-empty-state.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+
+// Source guards for dashboard empty-state invariants (ISSUE-003, ISSUE-004).
+// Pins the subtitle gate and the no-data personal-card affordance so regressions
+// cannot silently reintroduce the unconditional "ready to explore" subtitle or
+// a link-bearing no-data card that would hit the ISSUE-001 incident class.
+
+const PROJECT_ROOT = join(import.meta.dir, '..', '..', '..');
+
+async function readSource(relPath: string): Promise<string> {
+	return Bun.file(join(PROJECT_ROOT, relPath)).text();
+}
+
+const DASHBOARD_PAGE = 'src/routes/dashboard/+page.svelte';
+
+describe('ISSUE-003 source-guard — dashboard subtitle is data-aware', () => {
+	it('subtitle "ready to explore" only appears inside the {#if data.wrappedHref} branch', async () => {
+		const src = await readSource(DASHBOARD_PAGE);
+		// The entire truthy branch must contain the "ready to explore" copy.
+		const ifIdx = src.indexOf('{#if data.wrappedHref}');
+		expect(ifIdx).toBeGreaterThan(-1);
+		const elseIdx = src.indexOf('{:else}', ifIdx);
+		expect(elseIdx).toBeGreaterThan(ifIdx);
+		const truthyBranch = src.slice(ifIdx, elseIdx);
+		expect(truthyBranch).toContain('ready to explore');
+		// The "ready to explore" copy must NOT appear outside the truthy branch.
+		// Everything before the first {#if data.wrappedHref} must not have it.
+		const beforeIf = src.slice(0, ifIdx);
+		expect(beforeIf).not.toContain('ready to explore');
+	});
+
+	it('{:else} branch contains the empty-state subtitle copy', async () => {
+		const src = await readSource(DASHBOARD_PAGE);
+		// Find the subtitle {#if}/{:else} gate (the first else after the subtitle if).
+		const subtitleIfIdx = src.indexOf('{#if data.wrappedHref}');
+		expect(subtitleIfIdx).toBeGreaterThan(-1);
+		const subtitleElseIdx = src.indexOf('{:else}', subtitleIfIdx);
+		expect(subtitleElseIdx).toBeGreaterThan(subtitleIfIdx);
+		const subtitleEndIfIdx = src.indexOf('{/if}', subtitleElseIdx);
+		expect(subtitleEndIfIdx).toBeGreaterThan(subtitleElseIdx);
+		const elseBranch = src.slice(subtitleElseIdx, subtitleEndIfIdx);
+		// The else branch must contain the empty-state subtitle text.
+		expect(elseBranch).toContain('viewing history synced yet');
+		expect(elseBranch).toContain('Wrapped will appear here');
+		// The "ready to explore" copy must NOT leak into the else branch.
+		expect(elseBranch).not.toContain('ready to explore');
+	});
+});
+
+describe('ISSUE-004 source-guard — dashboard personal-card empty-state affordance', () => {
+	it('the {#if data.wrappedHref} personal-card block has an {:else} branch', async () => {
+		const src = await readSource(DASHBOARD_PAGE);
+		// Find the card-area conditional (after the subtitle conditional).
+		// We look for the <a href={data.wrappedHref} live link to anchor ourselves.
+		const liveCardIdx = src.indexOf('<a href={data.wrappedHref}');
+		expect(liveCardIdx).toBeGreaterThan(-1);
+		// Walk back to find the enclosing {#if data.wrappedHref}.
+		const before = src.slice(0, liveCardIdx);
+		const cardIfIdx = before.lastIndexOf('{#if data.wrappedHref}');
+		expect(cardIfIdx).toBeGreaterThan(-1);
+		// After the live card block there must be an {:else} branch.
+		const afterCardIf = src.slice(cardIfIdx);
+		const elseIdx = afterCardIf.indexOf('{:else}');
+		expect(elseIdx).toBeGreaterThan(-1);
+		const endIfIdx = afterCardIf.indexOf('{/if}', elseIdx);
+		expect(endIfIdx).toBeGreaterThan(elseIdx);
+	});
+
+	it('the no-data personal-card {:else} branch renders a <div>, not an <a>', async () => {
+		const src = await readSource(DASHBOARD_PAGE);
+		const liveCardIdx = src.indexOf('<a href={data.wrappedHref}');
+		const before = src.slice(0, liveCardIdx);
+		const cardIfIdx = before.lastIndexOf('{#if data.wrappedHref}');
+		const afterCardIf = src.slice(cardIfIdx);
+		const elseIdx = afterCardIf.indexOf('{:else}');
+		const endIfIdx = afterCardIf.indexOf('{/if}', elseIdx);
+		const elseBranch = afterCardIf.slice(elseIdx, endIfIdx);
+		// The else branch must open with a <div …> element (non-anchor).
+		expect(elseBranch).toContain('<div class="wrapped-card personal empty">');
+		// The else branch must NOT contain an <a> element.
+		expect(elseBranch).not.toMatch(/<a\s/);
+	});
+
+	it('the no-data personal-card {:else} branch contains NO /u/ personal-wrapped href', async () => {
+		const src = await readSource(DASHBOARD_PAGE);
+		const liveCardIdx = src.indexOf('<a href={data.wrappedHref}');
+		const before = src.slice(0, liveCardIdx);
+		const cardIfIdx = before.lastIndexOf('{#if data.wrappedHref}');
+		const afterCardIf = src.slice(cardIfIdx);
+		const elseIdx = afterCardIf.indexOf('{:else}');
+		const endIfIdx = afterCardIf.indexOf('{/if}', elseIdx);
+		const elseBranch = afterCardIf.slice(elseIdx, endIfIdx);
+		// No /u/ path (personal wrapped slug) may appear in the else branch.
+		expect(elseBranch).not.toContain('/u/');
+		// No href={data.wrappedHref} may appear in the else branch.
+		expect(elseBranch).not.toContain('href={data.wrappedHref}');
+	});
+
+	it('the data-having branch still contains the live personal-wrapped <a href={data.wrappedHref}>', async () => {
+		const src = await readSource(DASHBOARD_PAGE);
+		// The live link must still exist in the file.
+		expect(src).toContain('<a href={data.wrappedHref}');
+		// And it must appear before the {:else} of the card conditional.
+		const liveCardIdx = src.indexOf('<a href={data.wrappedHref}');
+		const before = src.slice(0, liveCardIdx);
+		const cardIfIdx = before.lastIndexOf('{#if data.wrappedHref}');
+		const afterCardIf = src.slice(cardIfIdx);
+		const elseIdx = afterCardIf.indexOf('{:else}');
+		// The live card anchor must appear before the else.
+		expect(liveCardIdx).toBeLessThan(cardIfIdx + elseIdx);
+	});
+});

--- a/tests/unit/plex/thumbnail-auth.test.ts
+++ b/tests/unit/plex/thumbnail-auth.test.ts
@@ -211,6 +211,33 @@ describe('thumbnail auth tokens', () => {
 		await expectHttpStatus(() => authorizeThumbnailPayload(payload!, {}), 403);
 	});
 
+	it('mints thumbnail tokens with a ~30-minute TTL, not ~1 year (ISSUE-005 false-positive proof)', async () => {
+		// TOKEN_TTL_SECONDS = 30*60 = 1800 (thumbnail-auth.ts:15,163)
+		const before = Math.floor(Date.now() / 1000);
+
+		const signedUrl = await createSignedThumbnailUrl('/library/metadata/123/thumb/456', {
+			kind: 'server',
+			year: 2026
+		});
+
+		const payload = await verifyThumbnailToken(extractToken(signedUrl as string));
+		expect(payload).not.toBeNull();
+
+		const ttl = payload!.exp - before;
+
+		// Assert TTL is ~1800s (30 minutes), with a small tolerance for second-boundary crossing
+		expect(ttl).toBeGreaterThanOrEqual(1795);
+		expect(ttl).toBeLessThanOrEqual(1805);
+
+		// Assert it is definitively NOT ~1 year (~31_536_000s)
+		expect(ttl).toBeLessThan(60 * 60);
+
+		// The tester likely misread the `year:2026` payload field as a TTL.
+		// `year` is the Wrapped year (e.g. 2026), not an expiry timestamp.
+		expect(payload!.year).toBe(2026);
+		expect(payload!.year).not.toBe(payload!.exp);
+	});
+
 	it('rejects private-link thumbnail tokens without recreating missing share settings', async () => {
 		await setGlobalShareDefaults({
 			defaultShareMode: ShareMode.PRIVATE_LINK,

--- a/tests/unit/plex/thumbnail-auth.test.ts
+++ b/tests/unit/plex/thumbnail-auth.test.ts
@@ -221,16 +221,19 @@ describe('thumbnail auth tokens', () => {
 		});
 
 		const payload = await verifyThumbnailToken(extractToken(signedUrl as string));
+		const after = Math.floor(Date.now() / 1000);
 		expect(payload).not.toBeNull();
 
-		const ttl = payload!.exp - before;
-
-		// Assert TTL is ~1800s (30 minutes), with a small tolerance for second-boundary crossing
-		expect(ttl).toBeGreaterThanOrEqual(1795);
-		expect(ttl).toBeLessThanOrEqual(1805);
+		// Bound exp against both `before` and `after` so the assertion stays
+		// deterministic regardless of how long the (async) mint took: exp is
+		// stamped at mint time, so before+1800 <= exp <= after+1800 (±1s for
+		// second-boundary rounding). This is robust on slow CI runners.
+		const tolerance = 1;
+		expect(payload!.exp).toBeGreaterThanOrEqual(before + 1800 - tolerance);
+		expect(payload!.exp).toBeLessThanOrEqual(after + 1800 + tolerance);
 
 		// Assert it is definitively NOT ~1 year (~31_536_000s)
-		expect(ttl).toBeLessThan(60 * 60);
+		expect(payload!.exp - after).toBeLessThan(60 * 60);
 
 		// The tester likely misread the `year:2026` payload field as a TTL.
 		// `year` is the Wrapped year (e.g. 2026), not an expiry timestamp.


### PR DESCRIPTION
## Summary

Triage-first remediation of the 2026-06-16 end-to-end dogfood findings (`dogfood-output/report.md`, ISSUE-001..005 + INFO-001). The run reported PASS overall with 5 low-severity items. On code inspection, 2 of 5 were contradicted by the source and 1 is by-design, so this change fixes only what is real, satisfies the discoverability intent without regressing a load-bearing invariant, and closes the false positives with evidence rather than padding the diff.

## Changes

### ISSUE-003 - Dashboard empty-state copy is now data-aware (confirmed bug)
The `/dashboard` subtitle previously read "Your Plex Wrapped for {year} is ready to explore" unconditionally, including for members with no synced history (whose personal Wrapped then shows an empty state). The subtitle is now gated on the existing `wrappedHref` signal: data-having members keep the original copy; no-data members get accurate empty-state copy. No new server call and no `share_settings` mint.

### ISSUE-004 - No-data personal-card affordance (resolved by copy; link-gating is by-design)
No-data members now see a static, non-link empty-state personal card explaining where and when their Wrapped will appear. A live personal-Wrapped link is intentionally withheld for 0-play users: `getOwnerWrappedHrefIfData` returns `null` by design to prevent SvelteKit hover-preload firing a 404 and to prevent `getOrCreateShareSettings` lazily minting a `share_settings` row on every no-data load (the duplicate-row HIGH-severity incident class from #150). The affordance is a `<div>`, not an `<a>`, and contains no `/wrapped/.../u/...` href, hand-constructed or computed.

### ISSUE-002 - Confirm-dialog focus behavior (verified, documented)
The bulk-apply confirmation dialog on `/admin/settings/privacy` already uses the focus-trapping bits-ui `AlertDialog.Content` primitive. Added source-guard tests pinning that wiring. No production change: a Bun source suite cannot assert runtime focus movement, so this documents and locks the primitive rather than hand-rolling a trap. Escalate to a Playwright assertion only if the trap is ever proven broken.

### ISSUE-001 - Console JSON-parse warning (closed as external)
No unguarded client-side `JSON.parse` runs on `/wrapped/2026`: the only client parses are try/catch-guarded (`sync-status.svelte.ts`) or live on other routes (admin logs/sync, onboarding, plex-login). The literal text `Unable to parse JSON: "undefined"` is not V8/Bun native wording (native begins with `Unexpected token`), indicating a third-party script - consistent with the Google Identity Services deprecation warning observed on the same page. No code change.

### ISSUE-005 - Thumbnail-proxy token TTL (false positive, closed with proof)
The token TTL is already 30 minutes (`TOKEN_TTL_SECONDS = 30 * 60`, single mint path), not ~1 year. The `year:2026` payload field is the Wrapped year, not an expiry. Added a decoded-token proof test asserting `exp - mint-time` is approximately 1800 seconds.

INFO-001 (public landing lookup disabled) is an intentional config choice and out of scope.

## Files changed

- `src/routes/dashboard/+page.svelte` - data-aware subtitle and non-link empty-state personal card
- `tests/unit/dashboard/dashboard-empty-state.test.ts` (new) - source-guards for the subtitle gate and the no-link affordance
- `tests/unit/admin/dogfood-ui-invariants.test.ts` - source-guards for the bits-ui AlertDialog focus-trapping primitive
- `tests/unit/plex/thumbnail-auth.test.ts` - decoded-token ~30-minute TTL proof
- `dogfood-output/report.md` (gitignored) - status annotations for ISSUE-001..005

## Verification

- `bun run check` - 0 errors
- `bun run test` - 2151 pass / 0 fail, coverage >= 80% line/function
- `bun run check:biome` - clean

## Notes

- The net code change is intentionally smaller than the finding count: 3 of 5 items were false positives, external, or by-design.
- The `getOwnerWrappedHrefIfData` / `getOwnerWrappedHref` helper contracts are unchanged, so the admin blast radius (`admin/+layout.server.ts` shares the helper) and the #150 no-mint/no-preload invariant are preserved.
