### PR TITLE
fix(onboarding): harmonize Done-page AI Fun Facts notice copy (ISSUE-001)

### DIFF
--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -89,7 +89,11 @@ export const load: PageServerLoad = async ({ parent, locals, url, cookies }) => 
 			logoMode: formatLogoMode(logoMode),
 			shareMode: formatShareMode(shareMode),
 			allowUserControl: allowUserControl ? 'Allowed' : 'Locked by admin',
-			funFacts: deriveFunFactsSummary(enableFunFacts, notice === 'ai-key-missing', funFactFrequency)
+			funFacts: _deriveFunFactsSummary(
+				enableFunFacts,
+				notice === 'ai-key-missing',
+				funFactFrequency
+			)
 		}
 	};
 };
@@ -161,7 +165,7 @@ export function _deriveAiKeyMissingNotice(
  *    mode", not disabled;
  *  - no key and fun facts were left off  -> genuinely "Disabled".
  */
-function deriveFunFactsSummary(
+export function _deriveFunFactsSummary(
 	hasOpenAiKey: boolean,
 	aiKeyMissing: boolean,
 	frequency: { mode: string; count: number }

--- a/src/routes/onboarding/complete/+page.svelte
+++ b/src/routes/onboarding/complete/+page.svelte
@@ -125,8 +125,8 @@ const summaryItems = $derived([
 						<line x1="12" y1="16" x2="12.01" y2="16" />
 					</svg>
 					<span>
-						AI Fun Facts is enabled but no OpenAI key was provided. Built-in templates will be used
-						until you add a key in <strong>Admin → Settings → AI</strong>.
+						AI Fun Facts will use built-in templates because no OpenAI key was provided. Add a key
+						in <strong>Admin → Settings → AI</strong> to enable AI-generated fun facts.
 					</span>
 				</div>
 			{/if}

--- a/tests/unit/onboarding/complete-notice.test.ts
+++ b/tests/unit/onboarding/complete-notice.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { _deriveAiKeyMissingNotice } from '../../../src/routes/onboarding/complete/+page.server';
+import {
+	_deriveAiKeyMissingNotice,
+	_deriveFunFactsSummary
+} from '../../../src/routes/onboarding/complete/+page.server';
 
 describe('_deriveAiKeyMissingNotice (ISSUE-010 stale-notice reconciliation)', () => {
 	it('shows the notice when fun facts were requested but no effective key exists', () => {
@@ -19,5 +22,25 @@ describe('_deriveAiKeyMissingNotice (ISSUE-010 stale-notice reconciliation)', ()
 
 	it('shows nothing when a key exists and no notice was requested', () => {
 		expect(_deriveAiKeyMissingNotice(true, false)).toBeNull();
+	});
+});
+
+describe('_deriveFunFactsSummary (ISSUE-001 Done-page copy consistency)', () => {
+	const frequency = { mode: 'balanced', count: 5 };
+
+	it('shows the frequency label when an effective OpenAI key is present', () => {
+		// Key present -> AI fun facts on; summary reflects the configured frequency.
+		expect(_deriveFunFactsSummary(true, false, frequency)).toBe('Balanced (5)');
+	});
+
+	it('shows template mode when fun facts were enabled but no key was provided', () => {
+		// No key + ai-key-missing notice -> built-in templates, not "Disabled".
+		expect(_deriveFunFactsSummary(false, true, frequency)).toBe(
+			'Template mode — add an OpenAI key to enable AI'
+		);
+	});
+
+	it('shows Disabled when there is no key and fun facts were left off', () => {
+		expect(_deriveFunFactsSummary(false, false, frequency)).toBe('Disabled');
 	});
 });


### PR DESCRIPTION
## Summary

Remediates the two Low-severity findings from the 2026-06-18 E2E dogfood run.

### ISSUE-001 — Done-page AI Fun Facts notice inconsistency (fixed)

The onboarding Done page presented a self-contradictory AI status: the notice banner read "AI Fun Facts is enabled but no OpenAI key was provided" while the configuration summary card simultaneously labeled the same state "Template mode".

Root cause is copy inconsistency, not a form-serialization defect. The Configure toggle is a `<button type="button">` that contributes no form field of its own; the value is posted via `formData.set` plus a hidden input, and the schema's `z.enum(['true','false']).transform` means a correct toggle-off cannot post `true`. The notice is also already reconciled against the saved key state through `_deriveAiKeyMissingNotice` (ISSUE-010), so the URL param cannot go stale. The reported toggle-off symptom was a stale-snapshot automation artifact; the genuine, reproducible problem was the wording.

Changes:
- Reframe the Done-page banner to the "built-in templates will be used because no OpenAI key was provided" wording so it is consistent with the summary card's "Template mode" label. The `Admin -> Settings -> AI` link is preserved.
- Export the summary helper as `_deriveFunFactsSummary`. The `_` prefix is required by the `+page.server.ts` route-export guard and matches the sibling `_deriveAiKeyMissingNotice` convention. Behavior is unchanged; only visibility changed to make it unit-testable.
- Extend `tests/unit/onboarding/complete-notice.test.ts` with a `_deriveFunFactsSummary` branch test pinning all three states: key present -> frequency label; no key + ai-key-missing -> "Template mode - add an OpenAI key to enable AI"; otherwise -> "Disabled". The existing `_deriveAiKeyMissingNotice` tests are unchanged.

No database, schema, access-control, or form rewrite. `settings/+page.*` is unchanged.

### ISSUE-002 — Anonymous "Server Members Only" denial (won't-fix by design)

Resolved as working-as-designed. The uniform 404 returned to anonymous visitors of a private-oauth personal Wrapped link is deliberate anti-enumeration behavior: the same minimal body is returned for nonexistent ids, revoked tokens, and members-only resources, so there is no oracle. This was previously deliberated and locked by a contract test (ISSUE-009 / DF-04 / DF-018) that explicitly forbids a members-only "sign in" prompt firing for real member ids alone.

The dogfood recommendation to redirect anonymous users to `/auth/plex` is rejected: a redirect would occur only when the resource exists and is private-oauth, while a nonexistent id returns 404 - redirect-vs-404 is itself a direct enumeration oracle. No source or test change; `WRAPPED_NOT_FOUND_MESSAGE`, both wrapped routes, and the sharing test literals/contract are byte-identical to `main`.

## Verification

- `bun run check` - 0 errors / 0 warnings
- `bun run check:biome` - clean
- `bun run test` - 2154 pass / 0 fail, coverage gate green; the sharing suite (256 tests) passes unchanged, confirming anonymous-denial byte-identity is preserved
- New `_deriveFunFactsSummary` branch test passes (`bun test -t "FunFactsSummary"` -> 3 pass)

## Notes

- ISSUE-002 has no code change in this PR; the dogfood report follow-up (gitignored) records the won't-fix-by-design rationale.
