### PR TITLE
fix(dogfood 2026-06-18): guard unauth settings actions + retention input (ISSUE-006/007)

### DIFF
--- a/src/lib/server/auth/guards.ts
+++ b/src/lib/server/auth/guards.ts
@@ -1,8 +1,10 @@
 import { error, fail } from '@sveltejs/kit';
 
 const ADMIN_REQUIRED_MESSAGE = 'Admin access required';
+const AUTH_REQUIRED_MESSAGE = 'Authentication required';
 
 type AdminActionEvent = { locals: App.Locals } & Record<string, unknown>;
+type UserActionEvent = { locals: App.Locals } & Record<string, unknown>;
 
 export function isAdminRouteId(routeId: string | null | undefined): boolean {
 	return routeId === '/admin' || routeId?.startsWith('/admin/') === true;
@@ -39,6 +41,40 @@ export function requireAdminActions<T extends Record<string, unknown>>(actions: 
 			if (denied) return denied;
 
 			return (action as (event: AdminActionEvent) => unknown | Promise<unknown>)(event);
+		};
+	}
+
+	return wrapped as T;
+}
+
+// Form actions do NOT run the route's redirecting `load`, so a same-origin POST
+// to a user-only action lands directly in the handler with `locals.user`
+// undefined for an unauthenticated caller. Without this guard those handlers
+// dereference `locals.user!.id` and 500 (ISSUE-006). requireUserAction returns
+// a 401 fail() instead, mirroring requireAdminAction's contract.
+export function requireUserAction(locals: App.Locals) {
+	if (!locals.user) {
+		return fail(401, { error: AUTH_REQUIRED_MESSAGE });
+	}
+
+	return null;
+}
+
+export function requireUserActions<T extends Record<string, unknown>>(actions: T): T {
+	const wrapped: Record<string, unknown> = {};
+
+	for (const key of Object.keys(actions)) {
+		const action = actions[key];
+		if (typeof action !== 'function') {
+			wrapped[key] = action;
+			continue;
+		}
+
+		wrapped[key] = async (event: UserActionEvent) => {
+			const denied = requireUserAction(event.locals);
+			if (denied) return denied;
+
+			return (action as (event: UserActionEvent) => unknown | Promise<unknown>)(event);
 		};
 	}
 

--- a/src/routes/admin/settings/system/+page.svelte
+++ b/src/routes/admin/settings/system/+page.svelte
@@ -111,6 +111,7 @@ function formatUptime(seconds: number): string {
 								type="number"
 								min="1"
 								max="365"
+								step="1"
 								{...props}
 								bind:value={$formData.retentionDays}
 							/>

--- a/src/routes/dashboard/settings/+page.server.ts
+++ b/src/routes/dashboard/settings/+page.server.ts
@@ -1,8 +1,10 @@
-import { fail } from '@sveltejs/kit';
+import { fail, redirect } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
+import { isSafeReturnPath } from '$lib/client/plex-login';
 import { getWrappedLogoMode, WrappedLogoMode } from '$lib/server/admin/settings.service';
 import { getUserFullProfile } from '$lib/server/admin/users.service';
+import { requireUserActions } from '$lib/server/auth/guards';
 import { db } from '$lib/server/db/client';
 import { sessions } from '$lib/server/db/schema';
 import {
@@ -31,14 +33,26 @@ async function getSessionExpiration(userId: number): Promise<Date | null> {
 	return result[0]?.expiresAt ?? null;
 }
 
-export const load: PageServerLoad = async ({ locals, setHeaders }) => {
+export const load: PageServerLoad = async ({ locals, setHeaders, url }) => {
+	// Page `load` runs in parallel with the layout `load` redirect, so guard the
+	// unauthenticated case here too — otherwise the `locals.user!.id` deref below
+	// can win the race and 500 with a TypeError instead of redirecting (ISSUE-006).
+	// Mirror the layout's isSafeReturnPath returnTo carrier to land back here post-login.
+	if (!locals.user) {
+		const requestedPath = url.pathname;
+		const location = isSafeReturnPath(requestedPath)
+			? `/?returnTo=${encodeURIComponent(requestedPath)}`
+			: '/';
+		redirect(303, location);
+	}
+
 	// The floor message and disabled-radio state are derived from the live
 	// global default share mode (admin-controlled). Browsers MUST refetch on
 	// every navigation, otherwise the page renders with a stale floor when the
 	// admin flips the global default in another tab.
 	setHeaders({ 'cache-control': 'no-store' });
 
-	const userId = locals.user!.id;
+	const userId = locals.user.id;
 	const currentYear = new Date().getFullYear();
 
 	// ISSUE-001: resolve/create the (userId, currentYear) share row FIRST, before
@@ -68,8 +82,8 @@ export const load: PageServerLoad = async ({ locals, setHeaders }) => {
 	return {
 		user: {
 			id: userProfile?.id ?? userId,
-			plexId: userProfile?.plexId ?? locals.user!.plexId ?? null,
-			username: userProfile?.username ?? locals.user!.username,
+			plexId: userProfile?.plexId ?? locals.user.plexId ?? null,
+			username: userProfile?.username ?? locals.user.username,
 			email: userProfile?.email ?? null,
 			thumb: userProfile?.thumb ?? null,
 			createdAt: userProfile?.createdAt ?? null
@@ -89,7 +103,7 @@ export const load: PageServerLoad = async ({ locals, setHeaders }) => {
 	};
 };
 
-export const actions: Actions = {
+export const actions: Actions = requireUserActions({
 	updateShareMode: async ({ request, locals }) => {
 		const userId = locals.user!.id;
 		const currentYear = new Date().getFullYear();
@@ -214,4 +228,4 @@ export const actions: Actions = {
 			return fail(500, { error: message, action: 'updateLogoPreference' });
 		}
 	}
-};
+});

--- a/tests/unit/dashboard/settings-auth-guard.test.ts
+++ b/tests/unit/dashboard/settings-auth-guard.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { db } from '$lib/server/db/client';
+import { users } from '$lib/server/db/schema';
+import { ShareMode } from '$lib/server/sharing/types';
+import { actions } from '../../../src/routes/dashboard/settings/+page.server';
+import { resetSharedTestDb } from '../../helpers/db';
+
+// ISSUE-006 regression: form actions do NOT run the route's redirecting `load`,
+// so a same-origin POST from an unauthenticated browser previously dereferenced
+// `locals.user!.id` and 500'd with a TypeError. requireUserActions must turn that
+// into a clean fail(401) for every user-only action while leaving the
+// authenticated path untouched.
+
+const USER_ID = 42;
+
+const anonymousLocals = { user: undefined } as unknown as App.Locals;
+const authedLocals = {
+	user: { id: USER_ID, plexId: 100042, username: 'user-42', isAdmin: false }
+} as App.Locals;
+
+type UpdateShareModeAction = NonNullable<typeof actions.updateShareMode>;
+type RegenerateTokenAction = NonNullable<typeof actions.regenerateToken>;
+type UpdateLogoPreferenceAction = NonNullable<typeof actions.updateLogoPreference>;
+
+function makeRequest(body?: FormData): Request {
+	return new Request('https://obzorarr.example/dashboard/settings', {
+		method: 'POST',
+		body: body ?? new FormData()
+	});
+}
+
+async function seedUser(): Promise<void> {
+	await db.insert(users).values({
+		id: USER_ID,
+		plexId: 100042,
+		accountId: 200042,
+		username: 'user-42'
+	});
+}
+
+describe('dashboard settings unauthenticated action guard (ISSUE-006)', () => {
+	beforeEach(async () => {
+		await resetSharedTestDb();
+	});
+
+	it('updateShareMode returns 401 (not a 500/TypeError) when locals.user is undefined', async () => {
+		const updateShareMode = actions.updateShareMode as UpdateShareModeAction;
+		const formData = new FormData();
+		formData.set('mode', ShareMode.PUBLIC);
+		const result = await updateShareMode({
+			request: makeRequest(formData),
+			locals: anonymousLocals
+		} as unknown as Parameters<UpdateShareModeAction>[0]);
+		expect((result as { status?: number }).status).toBe(401);
+	});
+
+	it('regenerateToken returns 401 when locals.user is undefined', async () => {
+		const regenerateToken = actions.regenerateToken as RegenerateTokenAction;
+		const result = await regenerateToken({
+			locals: anonymousLocals
+		} as unknown as Parameters<RegenerateTokenAction>[0]);
+		expect((result as { status?: number }).status).toBe(401);
+	});
+
+	it('updateLogoPreference returns 401 when locals.user is undefined', async () => {
+		const updateLogoPreference = actions.updateLogoPreference as UpdateLogoPreferenceAction;
+		const formData = new FormData();
+		formData.set('logoPreference', 'show');
+		const result = await updateLogoPreference({
+			request: makeRequest(formData),
+			locals: anonymousLocals
+		} as unknown as Parameters<UpdateLogoPreferenceAction>[0]);
+		expect((result as { status?: number }).status).toBe(401);
+	});
+
+	it('passes the guard for an authenticated user (invalid mode -> 400, never 401)', async () => {
+		// An invalid `mode` is rejected by the schema branch before any share-settings
+		// lookup, so seeding a user is the only setup the pass-through path touches.
+		await seedUser();
+
+		const updateShareMode = actions.updateShareMode as UpdateShareModeAction;
+		const formData = new FormData();
+		formData.set('mode', 'not-a-real-mode');
+		const result = await updateShareMode({
+			request: makeRequest(formData),
+			locals: authedLocals
+		} as unknown as Parameters<UpdateShareModeAction>[0]);
+		// Guard passed through to the handler, which rejects the bad mode with 400.
+		expect((result as { status?: number }).status).toBe(400);
+		expect((result as { status?: number }).status).not.toBe(401);
+	});
+});


### PR DESCRIPTION
## Summary

Verify-then-fix remediation of the 2026-06-18 dogfood findings (ISSUE-001…007). Per the plan (`.omc/plans/fix-dogfood-2026-06-18-findings.md`), every finding was first re-verified against current HEAD; only the **two still-broken** ones received code changes. The other five were already fixed by a concurrent remediation cycle or are third-party, and are documented here rather than re-patched.

## Phase 0 verification table

| Finding | Disposition | Evidence |
|---|---|---|
| ISSUE-001 (claim error silent) | ALREADY-FIXED | `onboarding/claim/+page.svelte:51-53` renders `role="alert"` from the action's `form.error`; server returns `fail(400,{error})` (`claim/+page.server.ts:36`). |
| ISSUE-002 (admin mobile nav) | ALREADY-FIXED | `admin/+layout.svelte:50-148` — `isMobileSidebar`, `.menu-button`, overlay, Tab focus-trap. |
| ISSUE-003 (console authToken/JSON noise) | THIRD-PARTY | Plex's bundled OAuth JS; documented at `auth/plex/+server.ts`. No Obzorarr code emits it; console deliberately not monkey-patched. |
| ISSUE-004 (pause == stop) | ALREADY-FIXED | `sync/scheduler.ts` `pausedByOperator`→`getSchedulerStatus().isPaused`; `admin/sync/+page.svelte:546/586` distinct "Paused" badge + "Resume" button. |
| ISSUE-005 (CSRF origin unvalidated) | ALREADY-FIXED | `admin/settings/security/+page.server.ts:179` runs `CsrfOriginSchema.safeParse` → `fail(400,'Invalid origin URL')`. |
| **ISSUE-006 (dashboard/settings 500 on unauth POST)** | **FIXED** | See below. |
| **ISSUE-007 (retention float, minor)** | **FIXED** | See below. |

## ISSUE-006 — unauthenticated settings actions return 401, not 500

SvelteKit form actions do **not** run the route's redirecting `load`, so a same-origin POST from an unauthenticated browser landed directly in the `dashboard/settings` handlers and dereferenced `locals.user!.id` → `TypeError` → HTTP 500.

- Added `requireUserAction` / `requireUserActions` to `src/lib/server/auth/guards.ts` (mirroring the existing `requireAdminActions`), returning `fail(401, { error: 'Authentication required' })` when `locals.user` is absent.
- Wrapped the three `dashboard/settings` actions (`updateShareMode`, `regenerateToken`, `updateLogoPreference`) with it.
- Guarded the page `load` with an unauthenticated redirect mirroring the layout's `isSafeReturnPath` returnTo carrier, closing the parallel-`load` race.
- Regression test (`tests/unit/dashboard/settings-auth-guard.test.ts`): each user-only action returns **401** (no TypeError) for an anonymous caller; the authenticated path still reaches the handler.

## ISSUE-007 — whole-number retention-days input

`admin/settings/system/+page.svelte` retention-days input gains `step="1"` to match the sibling max-log-count input. The server `LogSettingsSchema.retentionDays.int()` remains the authoritative guard; this aligns the client with that contract.

## Verification

- `bun run check` — 0 errors / 0 warnings
- `bun run test` — 2158 pass / 0 fail
- `bun run check:biome` — clean
- Architect review (read-only, Opus): APPROVED, approach OPTIMAL; confirmed no other user-only action route has the unguarded pattern (`wrapped/[identifier]` already inlines the 401 guard).

