### PR TITLE
fix(dogfood 2026-06-19): surface invalid CSRF origin error + guard test (ISSUE-001/003)

### DIFF
--- a/src/routes/admin/settings/security/+page.svelte
+++ b/src/routes/admin/settings/security/+page.svelte
@@ -227,8 +227,13 @@ function getForwardedPairLabel(status: string): string {
 		</CardHeader>
 		<CardContent class="space-y-4">
 			{#if !security.originLocked}
+				<!-- novalidate defers URL validation to the server so an invalid origin
+				     reaches the `?/updateCsrfOrigin` action and `csrfOriginError` can render
+				     the field error, instead of the browser silently blocking submit on the
+				     type="url" input. Mirrors `openai-settings-form` (connections/+page.svelte:264). -->
 				<form
 					id="csrf-origin-form"
+					novalidate
 					method="POST"
 					action="?/updateCsrfOrigin"
 					use:enhance={({ cancel }) => {

--- a/tests/unit/wrapped/identifier-actions-auth-guard.test.ts
+++ b/tests/unit/wrapped/identifier-actions-auth-guard.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { ShareMode } from '$lib/server/sharing/types';
+import { actions } from '../../../src/routes/wrapped/[year=year]/u/[identifier]/+page.server';
+import { resetSharedTestDb } from '../../helpers/db';
+
+// ISSUE-001 regression: SvelteKit form actions do NOT run the route's `load`,
+// so a same-origin POST from an unauthenticated browser must be rejected by each
+// action's own inline `!locals.user` guard rather than dereferencing `locals.user`
+// and 500'ing with a TypeError. The dogfood-logged TypeErrors on this surface were
+// stale (pre-ISSUE-006 build); the guards below are already correct. This test
+// locks that in so removing any guard fails CI instead of regressing to a 500.
+//
+// Recorded `locals.user` deref sweep (verified against source) — all surfaces
+// self-guard before dereferencing the user:
+// | Surface                              | Deref site            | Guard                                   |
+// | dashboard/settings load              | +page.server.ts:55    | !locals.user -> 303 at L41-47           |
+// | dashboard/settings actions           | L108/158/198          | requireUserActions -> fail(401)         |
+// | dashboard/+layout load               | L18-34                | !locals.user -> 303 at L7               |
+// | wrapped/[identifier] actions         | L387/405/427/486      | inline !locals.user -> fail(401) (here) |
+// | admin/+layout, admin/wrapped         | locals.user!.id       | authorizationHandle gates /admin/**     |
+// | api/security/dismiss-csrf-warning    | :11/18                | !locals.user -> 401 at :7               |
+// | api/security/reverse-proxy-diagnostic| :33                   | !locals.user -> 401 at :16              |
+// | api/onboarding/servers/select/test   | .isAdmin/.username    | !locals.user / !isAdmin -> 401/403      |
+// | onboarding/plex actions              | :116/180/318          | !locals.user -> fail at L68/162/187/228 |
+// | onboarding/settings actions          | :369/408              | locals.user?.isAdmin optional-chain     |
+// | auth/plex/redirect, root +page.server| :9 / :23              | load behind redirecting guards          |
+
+const anonymousLocals = { user: undefined } as unknown as App.Locals;
+const authedLocals = {
+	user: { id: 42, plexId: 100042, username: 'user-42', isAdmin: false }
+} as App.Locals;
+
+type ToggleLogoAction = NonNullable<typeof actions.toggleLogo>;
+type UpdateShareModeAction = NonNullable<typeof actions.updateShareMode>;
+type RegenerateTokenAction = NonNullable<typeof actions.regenerateToken>;
+
+function makeRequest(body?: FormData): Request {
+	return new Request('https://obzorarr.example/wrapped/2024/u/42', {
+		method: 'POST',
+		body: body ?? new FormData()
+	});
+}
+
+describe('wrapped [identifier] unauthenticated action guard (ISSUE-001)', () => {
+	beforeEach(async () => {
+		await resetSharedTestDb();
+	});
+
+	it('toggleLogo returns 401 (not a 500/TypeError) when locals.user is undefined', async () => {
+		const toggleLogo = actions.toggleLogo as ToggleLogoAction;
+		const result = await toggleLogo({
+			request: makeRequest(),
+			params: { year: '2024', identifier: '42' },
+			locals: anonymousLocals
+		} as unknown as Parameters<ToggleLogoAction>[0]);
+		expect((result as { status?: number }).status).toBe(401);
+	});
+
+	it('updateShareMode returns 401 when locals.user is undefined', async () => {
+		const updateShareMode = actions.updateShareMode as UpdateShareModeAction;
+		const formData = new FormData();
+		formData.set('mode', ShareMode.PUBLIC);
+		const result = await updateShareMode({
+			request: makeRequest(formData),
+			params: { year: '2024', identifier: '42' },
+			locals: anonymousLocals
+		} as unknown as Parameters<UpdateShareModeAction>[0]);
+		expect((result as { status?: number }).status).toBe(401);
+	});
+
+	it('regenerateToken returns 401 when locals.user is undefined', async () => {
+		const regenerateToken = actions.regenerateToken as RegenerateTokenAction;
+		const result = await regenerateToken({
+			params: { year: '2024', identifier: '42' },
+			locals: anonymousLocals
+		} as unknown as Parameters<RegenerateTokenAction>[0]);
+		expect((result as { status?: number }).status).toBe(401);
+	});
+
+	// For an authenticated user the guard passes through; an invalid `year` param is
+	// rejected by the next check with 400, proving the user guard never short-circuits
+	// a legitimate session to 401. The invalid-year branch sits immediately after the
+	// user guard in all three actions, so it isolates the guard without touching the DB.
+	it('toggleLogo passes the guard for an authenticated user (invalid year -> 400, never 401)', async () => {
+		const toggleLogo = actions.toggleLogo as ToggleLogoAction;
+		const result = await toggleLogo({
+			request: makeRequest(),
+			params: { year: 'not-a-year', identifier: '42' },
+			locals: authedLocals
+		} as unknown as Parameters<ToggleLogoAction>[0]);
+		expect((result as { status?: number }).status).toBe(400);
+		expect((result as { status?: number }).status).not.toBe(401);
+	});
+
+	it('updateShareMode passes the guard for an authenticated user (invalid year -> 400, never 401)', async () => {
+		const updateShareMode = actions.updateShareMode as UpdateShareModeAction;
+		const formData = new FormData();
+		formData.set('mode', ShareMode.PUBLIC);
+		const result = await updateShareMode({
+			request: makeRequest(formData),
+			params: { year: 'not-a-year', identifier: '42' },
+			locals: authedLocals
+		} as unknown as Parameters<UpdateShareModeAction>[0]);
+		expect((result as { status?: number }).status).toBe(400);
+		expect((result as { status?: number }).status).not.toBe(401);
+	});
+
+	it('regenerateToken passes the guard for an authenticated user (invalid year -> 400, never 401)', async () => {
+		const regenerateToken = actions.regenerateToken as RegenerateTokenAction;
+		const result = await regenerateToken({
+			params: { year: 'not-a-year', identifier: '42' },
+			locals: authedLocals
+		} as unknown as Parameters<RegenerateTokenAction>[0]);
+		expect((result as { status?: number }).status).toBe(400);
+		expect((result as { status?: number }).status).not.toBe(401);
+	});
+});


### PR DESCRIPTION
## Summary

Resolves the three findings from the current dogfood run (ISSUE-001/002/003) per the consensus-approved plan `.omc/plans/fix-dogfood-findings-2026-06-19.md` (Option A, evidence-scoped). The guiding principle was to fix what the code actually does: of the three reported findings, only one was a live code defect, one was already fixed (stale logs), and one was not sourced in this app.

## Changes

### ISSUE-003 (Low) - invalid CSRF origin now surfaces an app-level error

Added the `novalidate` attribute to `<form id="csrf-origin-form">` in `src/routes/admin/settings/security/+page.svelte`.

Previously, the `type="url"` input triggered native browser validation that silently blocked submit, so the server-side validation never fired and the user saw no feedback. With `novalidate`, an invalid origin reaches the `?/updateCsrfOrigin` action, which returns `fail(400, { fieldErrors: { csrfOrigin: ['Invalid URL format'] } })`, and the existing `csrfOriginError` block renders the message inline.

This matches the established `openai-settings-form` idiom in `connections/+page.svelte` rather than downgrading the input to `type="text"`. The `type="url"` semantics (keyboard/autofill), the `use:enhance` handler, and the server-side Zod `.url()` schema are all unchanged and remain authoritative. An inline comment documents why the attribute is present, to prevent a future regression.

### ISSUE-001 (Low) - unauthenticated action TypeError (already fixed; test gap closed)

No production code change. The dogfood-logged `TypeError: ...'locals.user.id'` was stale (pre-ISSUE-006 build). A full `locals.user` dereference sweep confirms every user-facing surface self-guards before dereferencing the user: the wrapped `[identifier]` actions already return a clean `fail(401)` via their inline `!locals.user` guards.

To lock this in, this PR adds `tests/unit/wrapped/identifier-actions-auth-guard.test.ts` (mirroring the existing `dashboard/settings-auth-guard.test.ts`), which asserts that `toggleLogo`, `updateShareMode`, and `regenerateToken`:

- return 401 (not a 500/TypeError) when `locals.user` is undefined, and
- pass the guard for an authenticated user (invalid input yields 400, never 401).

The verified deref-sweep audit table is reproduced in the test-file header. Removing any guard now fails CI.

### ISSUE-002 (Low) - Plex signin console warning (closed as environmental)

No code change. The `clients.plex.tv/api/v2/users/signin` 400 is not sourced in this application: there is no Plex web SDK in `package.json`/`node_modules`, and no `users/signin` or `clients.plex.tv` reference anywhere in `src` (the only Plex client call is `plex-login.ts` -> `plex.tv/api/v2/pins`). It is third-party browser/extension noise. No console-warning suppressor was added, since the app does not own this request.

## Verification

- `bun run check` - 0 errors, 0 warnings
- `bunx biome check` (touched files) - clean
- `bun run test` (full suite) - 2164 pass / 0 fail, exit 0 (80% line/function coverage thresholds held)
- New test file - 6/6 pass

## Notes

The documentation addendum for this run lives in `dogfood-output/report.md`, which is gitignored (local QA artifact), so it is not part of this diff. The committed deliverables are the form fix and the new regression test.