### PR TITLE
fix(openai): surface API errors and support reasoning models

### DIFF
--- a/src/lib/server/funfacts/openai-api.ts
+++ b/src/lib/server/funfacts/openai-api.ts
@@ -1,4 +1,5 @@
 const MAX_ERROR_DETAIL_LENGTH = 1_000;
+const MAX_ERROR_BODY_BYTES = 16_384;
 
 export function buildCompletionOptions(
 	model: string,
@@ -7,7 +8,7 @@ export function buildCompletionOptions(
 ): { max_tokens: number; temperature?: number } | { max_completion_tokens: number } {
 	// GPT-5 and o-series models reject the legacy max_tokens parameter. They also
 	// do not support non-default temperature values on Chat Completions.
-	if (/^(?:gpt-5|o\d)(?:[.-]|$)/i.test(model)) {
+	if (/(?:^|\/)(?:gpt-5|o\d)(?:[.-]|$)/i.test(model)) {
 		return { max_completion_tokens: maxTokens };
 	}
 
@@ -18,7 +19,7 @@ export function buildCompletionOptions(
 }
 
 export async function readOpenAIErrorDetail(response: Response): Promise<string | null> {
-	const body = (await response.text().catch(() => '')).trim();
+	const body = (await readBoundedResponseText(response)).trim();
 	if (!body) return null;
 
 	let detail = body;
@@ -39,6 +40,39 @@ export async function readOpenAIErrorDetail(response: Response): Promise<string 
 	if (!normalized) return null;
 	if (normalized.length <= MAX_ERROR_DETAIL_LENGTH) return normalized;
 	return `${normalized.slice(0, MAX_ERROR_DETAIL_LENGTH - 1)}…`;
+}
+
+async function readBoundedResponseText(response: Response): Promise<string> {
+	const reader = response.body?.getReader();
+	if (!reader) {
+		return (await response.text().catch(() => '')).slice(0, MAX_ERROR_BODY_BYTES);
+	}
+
+	const decoder = new TextDecoder();
+	let body = '';
+	let bytesRead = 0;
+
+	try {
+		while (bytesRead < MAX_ERROR_BODY_BYTES) {
+			const { done, value } = await reader.read();
+			if (done) return body + decoder.decode();
+
+			const remaining = MAX_ERROR_BODY_BYTES - bytesRead;
+			const chunk = value.byteLength > remaining ? value.subarray(0, remaining) : value;
+			body += decoder.decode(chunk, { stream: true });
+			bytesRead += chunk.byteLength;
+
+			if (bytesRead === MAX_ERROR_BODY_BYTES) {
+				await reader.cancel().catch(() => undefined);
+				return body + decoder.decode();
+			}
+		}
+	} catch {
+		await reader.cancel().catch(() => undefined);
+		return '';
+	}
+
+	return body;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/lib/server/funfacts/openai-api.ts
+++ b/src/lib/server/funfacts/openai-api.ts
@@ -1,0 +1,46 @@
+const MAX_ERROR_DETAIL_LENGTH = 1_000;
+
+export function buildCompletionOptions(
+	model: string,
+	maxTokens: number,
+	temperature?: number
+): { max_tokens: number; temperature?: number } | { max_completion_tokens: number } {
+	// GPT-5 and o-series models reject the legacy max_tokens parameter. They also
+	// do not support non-default temperature values on Chat Completions.
+	if (/^(?:gpt-5|o\d)(?:[.-]|$)/i.test(model)) {
+		return { max_completion_tokens: maxTokens };
+	}
+
+	return {
+		...(temperature === undefined ? {} : { temperature }),
+		max_tokens: maxTokens
+	};
+}
+
+export async function readOpenAIErrorDetail(response: Response): Promise<string | null> {
+	const body = (await response.text().catch(() => '')).trim();
+	if (!body) return null;
+
+	let detail = body;
+	try {
+		const parsed: unknown = JSON.parse(body);
+		if (isRecord(parsed)) {
+			if (isRecord(parsed.error) && typeof parsed.error.message === 'string') {
+				detail = parsed.error.message;
+			} else if (typeof parsed.message === 'string') {
+				detail = parsed.message;
+			}
+		}
+	} catch {
+		// Plain-text upstream errors are already useful as-is.
+	}
+
+	const normalized = detail.replace(/\s+/g, ' ').trim();
+	if (!normalized) return null;
+	if (normalized.length <= MAX_ERROR_DETAIL_LENGTH) return normalized;
+	return `${normalized.slice(0, MAX_ERROR_DETAIL_LENGTH - 1)}…`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}

--- a/src/lib/server/funfacts/service.ts
+++ b/src/lib/server/funfacts/service.ts
@@ -381,7 +381,8 @@ export async function generateWithAI(
 			});
 
 			if (!response.ok) {
-				const errorDetail = (await readOpenAIErrorDetail(response)) ?? 'Unknown error';
+				const errorDetail =
+					(await readOpenAIErrorDetail(response)) || response.statusText || 'Unknown error';
 				const statusError = new AIGenerationError(
 					`OpenAI API error: ${response.status} - ${errorDetail}`
 				);

--- a/src/lib/server/funfacts/service.ts
+++ b/src/lib/server/funfacts/service.ts
@@ -11,6 +11,7 @@ import type { ServerStats, Stats, UserStats } from '$lib/server/stats/types';
 import { isUserStats } from '$lib/server/stats/types';
 import { buildEnhancedPrompt, enrichContext } from './ai';
 import { EQUIVALENCY_FACTORS, formatHour, MONTH_NAMES } from './constants';
+import { buildCompletionOptions, readOpenAIErrorDetail } from './openai-api';
 import { getAllTemplates, selectWeightedTemplates } from './registry';
 import type {
 	AIPersona,
@@ -374,16 +375,15 @@ export async function generateWithAI(
 						{ role: 'system', content: systemPrompt },
 						{ role: 'user', content: userPrompt }
 					],
-					temperature: 0.8,
-					max_tokens: 500
+					...buildCompletionOptions(model, 500, 0.8)
 				}),
 				signal: controller.signal
 			});
 
 			if (!response.ok) {
-				const errorText = await response.text().catch(() => 'Unknown error');
+				const errorDetail = (await readOpenAIErrorDetail(response)) ?? 'Unknown error';
 				const statusError = new AIGenerationError(
-					`OpenAI API error: ${response.status} - ${errorText}`
+					`OpenAI API error: ${response.status} - ${errorDetail}`
 				);
 
 				// 4xx usually means bad config or payload; only 429 is expected to heal with retry.

--- a/src/lib/server/funfacts/test-connection.ts
+++ b/src/lib/server/funfacts/test-connection.ts
@@ -2,6 +2,7 @@ import {
 	CredentialedUrlError,
 	normalizeOpenAIBaseUrl
 } from '$lib/server/security/credentialed-url';
+import { buildCompletionOptions, readOpenAIErrorDetail } from './openai-api';
 
 const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
 const DEFAULT_MODEL = 'gpt-4o-mini';
@@ -45,7 +46,7 @@ export async function testOpenAIConnection(
 			body: JSON.stringify({
 				model: resolvedModel,
 				messages: [{ role: 'user', content: 'ping' }],
-				max_tokens: 1
+				...buildCompletionOptions(resolvedModel, 1)
 			}),
 			signal: controller.signal
 		});
@@ -54,15 +55,24 @@ export async function testOpenAIConnection(
 			return { success: true, message: `Connected (model: ${resolvedModel})` };
 		}
 
+		const detail = await readOpenAIErrorDetail(response);
 		if (response.status === 401) {
-			return { success: false, error: 'Authentication failed — check your API key' };
+			return {
+				success: false,
+				error: appendErrorDetail('Authentication failed — check your API key', detail)
+			};
 		}
 		if (response.status === 404) {
-			return { success: false, error: 'Model not found or base URL is incorrect' };
+			return {
+				success: false,
+				error: appendErrorDetail('Model not found or base URL is incorrect', detail)
+			};
 		}
+
+		const status = `${response.status} ${response.statusText}`.trim();
 		return {
 			success: false,
-			error: `Request failed: ${response.status} ${response.statusText}`
+			error: appendErrorDetail(`Request failed: ${status}`, detail)
 		};
 	} catch (error) {
 		if (error instanceof Error && error.name === 'AbortError') {
@@ -75,4 +85,8 @@ export async function testOpenAIConnection(
 	} finally {
 		clearTimeout(timeoutId);
 	}
+}
+
+function appendErrorDetail(message: string, detail: string | null): string {
+	return detail ? `${message} — ${detail}` : message;
 }

--- a/src/lib/server/funfacts/test-connection.ts
+++ b/src/lib/server/funfacts/test-connection.ts
@@ -70,10 +70,14 @@ export async function testOpenAIConnection(
 			};
 		}
 
-		const status = `${response.status} ${response.statusText}`.trim();
+		const normalizedStatusText = response.statusText.replace(/\s+/g, ' ').trim();
+		const status = `${response.status} ${normalizedStatusText}`.trim();
 		return {
 			success: false,
-			error: appendErrorDetail(`Request failed: ${status}`, detail)
+			error: appendErrorDetail(
+				`Request failed: ${status}`,
+				detail === normalizedStatusText ? null : detail
+			)
 		};
 	} catch (error) {
 		if (error instanceof Error && error.name === 'AbortError') {

--- a/src/lib/server/funfacts/test-connection.ts
+++ b/src/lib/server/funfacts/test-connection.ts
@@ -56,16 +56,17 @@ export async function testOpenAIConnection(
 		}
 
 		const detail = await readOpenAIErrorDetail(response);
+		const statusDetail = detail || response.statusText || null;
 		if (response.status === 401) {
 			return {
 				success: false,
-				error: appendErrorDetail('Authentication failed — check your API key', detail)
+				error: appendErrorDetail('Authentication failed — check your API key', statusDetail)
 			};
 		}
 		if (response.status === 404) {
 			return {
 				success: false,
-				error: appendErrorDetail('Model not found or base URL is incorrect', detail)
+				error: appendErrorDetail('Model not found or base URL is incorrect', statusDetail)
 			};
 		}
 

--- a/tests/unit/funfacts/service.test.ts
+++ b/tests/unit/funfacts/service.test.ts
@@ -808,6 +808,30 @@ describe('generateWithAI', () => {
 		expect(facts[0]?.fact).toBe('Retried fact');
 	});
 
+	it('uses the response status text when a 5xx response body is empty', async () => {
+		fetchMock = spyOn(globalThis, 'fetch').mockImplementation((() =>
+			Promise.resolve({
+				ok: false,
+				status: 503,
+				statusText: 'Service Unavailable',
+				text: () => Promise.resolve('')
+			} as Response)) as unknown as typeof fetch);
+
+		const config = {
+			aiEnabled: true,
+			openaiApiKey: 'sk-test',
+			openaiBaseUrl: 'https://api.openai.com/v1',
+			openaiModel: 'gpt-5-mini',
+			maxAIRetries: 0,
+			aiTimeoutMs: 10000,
+			aiPersona: 'witty' as const
+		};
+
+		await expect(generateWithAI(mockStats, config, 1)).rejects.toThrow(
+			'OpenAI API error: 503 - Service Unavailable'
+		);
+	});
+
 	it('throws AIGenerationError on empty AI response', async () => {
 		fetchMock = spyOn(globalThis, 'fetch').mockImplementation((() =>
 			Promise.resolve({

--- a/tests/unit/funfacts/service.test.ts
+++ b/tests/unit/funfacts/service.test.ts
@@ -710,12 +710,18 @@ describe('generateWithAI', () => {
 				}
 			]
 		};
+		let requestBody: Record<string, unknown> = {};
 
-		fetchMock = spyOn(globalThis, 'fetch').mockImplementation((() =>
-			Promise.resolve({
+		fetchMock = spyOn(globalThis, 'fetch').mockImplementation(((
+			_input: RequestInfo | URL,
+			init?: RequestInit
+		) => {
+			requestBody = JSON.parse(init?.body as string);
+			return Promise.resolve({
 				ok: true,
 				json: () => Promise.resolve(mockResponse)
-			} as Response)) as unknown as typeof fetch);
+			} as Response);
+		}) as unknown as typeof fetch);
 
 		const config = {
 			aiEnabled: true,
@@ -732,6 +738,9 @@ describe('generateWithAI', () => {
 		expect(facts).toHaveLength(2);
 		expect(facts[0]?.fact).toBe('AI generated fact 1');
 		expect(facts[1]?.icon).toBe('📺');
+		expect(requestBody.max_completion_tokens).toBe(500);
+		expect(requestBody).not.toHaveProperty('max_tokens');
+		expect(requestBody).not.toHaveProperty('temperature');
 	});
 
 	it('throws on 4xx errors without retry (except 429)', async () => {

--- a/tests/unit/lib/server/funfacts/test-connection.test.ts
+++ b/tests/unit/lib/server/funfacts/test-connection.test.ts
@@ -86,6 +86,22 @@ describe('testOpenAIConnection', () => {
 		expect(JSON.parse(captured.body ?? '{}').model).toBe('gpt-4o-mini');
 	});
 
+	it('uses current completion parameters for GPT-5 models', async () => {
+		let body: Record<string, unknown> = {};
+
+		globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+			body = JSON.parse(init?.body as string);
+			return new Response(null, { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test', undefined, 'gpt-5-mini');
+
+		expect(result.success).toBe(true);
+		expect(body.max_completion_tokens).toBe(1);
+		expect(body).not.toHaveProperty('max_tokens');
+		expect(body).not.toHaveProperty('temperature');
+	});
+
 	it('rejects HTTP baseUrl without calling fetch', async () => {
 		let fetchCalled = false;
 		globalThis.fetch = mock(async () => {
@@ -108,7 +124,7 @@ describe('testOpenAIConnection', () => {
 
 		expect(result).toEqual({
 			success: false,
-			error: 'Authentication failed — check your API key'
+			error: 'Authentication failed — check your API key — Unauthorized'
 		});
 	});
 
@@ -121,11 +137,11 @@ describe('testOpenAIConnection', () => {
 
 		expect(result).toEqual({
 			success: false,
-			error: 'Model not found or base URL is incorrect'
+			error: 'Model not found or base URL is incorrect — Not Found'
 		});
 	});
 
-	it('maps other non-OK responses to status/statusText message', async () => {
+	it('includes plain-text error details in other non-OK responses', async () => {
 		globalThis.fetch = mock(async () => {
 			return new Response('Server Error', { status: 500, statusText: 'Internal Server Error' });
 		}) as unknown as typeof fetch;
@@ -134,7 +150,33 @@ describe('testOpenAIConnection', () => {
 
 		expect(result).toEqual({
 			success: false,
-			error: 'Request failed: 500 Internal Server Error'
+			error: 'Request failed: 500 Internal Server Error — Server Error'
+		});
+	});
+
+	it('extracts the OpenAI error message from a JSON response', async () => {
+		globalThis.fetch = mock(async () => {
+			return new Response(
+				JSON.stringify({
+					error: {
+						message: "Unsupported parameter: 'max_tokens' is not supported with this model.",
+						type: 'invalid_request_error'
+					}
+				}),
+				{
+					status: 400,
+					statusText: 'Bad Request',
+					headers: { 'Content-Type': 'application/json' }
+				}
+			);
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test', undefined, 'gpt-5-mini');
+
+		expect(result).toEqual({
+			success: false,
+			error:
+				"Request failed: 400 Bad Request — Unsupported parameter: 'max_tokens' is not supported with this model."
 		});
 	});
 

--- a/tests/unit/lib/server/funfacts/test-connection.test.ts
+++ b/tests/unit/lib/server/funfacts/test-connection.test.ts
@@ -133,7 +133,7 @@ describe('testOpenAIConnection', () => {
 
 	it('maps 401 to authentication error', async () => {
 		globalThis.fetch = mock(async () => {
-			return new Response('Unauthorized', { status: 401, statusText: 'Unauthorized' });
+			return new Response(null, { status: 401, statusText: 'Unauthorized' });
 		}) as unknown as typeof fetch;
 
 		const result = await testOpenAIConnection('sk-bad');
@@ -146,7 +146,7 @@ describe('testOpenAIConnection', () => {
 
 	it('maps 404 to model-not-found error', async () => {
 		globalThis.fetch = mock(async () => {
-			return new Response('Not Found', { status: 404, statusText: 'Not Found' });
+			return new Response(null, { status: 404, statusText: 'Not Found' });
 		}) as unknown as typeof fetch;
 
 		const result = await testOpenAIConnection('sk-test');
@@ -167,6 +167,19 @@ describe('testOpenAIConnection', () => {
 		expect(result).toEqual({
 			success: false,
 			error: 'Request failed: 500 Internal Server Error — Server Error'
+		});
+	});
+
+	it('does not duplicate status text when another error response has an empty body', async () => {
+		globalThis.fetch = mock(async () => {
+			return new Response(null, { status: 500, statusText: 'Internal Server Error' });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test');
+
+		expect(result).toEqual({
+			success: false,
+			error: 'Request failed: 500 Internal Server Error'
 		});
 	});
 

--- a/tests/unit/lib/server/funfacts/test-connection.test.ts
+++ b/tests/unit/lib/server/funfacts/test-connection.test.ts
@@ -170,6 +170,22 @@ describe('testOpenAIConnection', () => {
 		});
 	});
 
+	it('does not duplicate a response body that equals the status text', async () => {
+		globalThis.fetch = mock(async () => {
+			return new Response('Internal Server Error', {
+				status: 500,
+				statusText: 'Internal Server Error'
+			});
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test');
+
+		expect(result).toEqual({
+			success: false,
+			error: 'Request failed: 500 Internal Server Error'
+		});
+	});
+
 	it('does not duplicate status text when another error response has an empty body', async () => {
 		globalThis.fetch = mock(async () => {
 			return new Response(null, { status: 500, statusText: 'Internal Server Error' });

--- a/tests/unit/lib/server/funfacts/test-connection.test.ts
+++ b/tests/unit/lib/server/funfacts/test-connection.test.ts
@@ -102,6 +102,22 @@ describe('testOpenAIConnection', () => {
 		expect(body).not.toHaveProperty('temperature');
 	});
 
+	it('uses current completion parameters for provider-prefixed GPT-5 models', async () => {
+		let body: Record<string, unknown> = {};
+
+		globalThis.fetch = mock(async (_input: RequestInfo | URL, init?: RequestInit) => {
+			body = JSON.parse(init?.body as string);
+			return new Response(null, { status: 200 });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test', undefined, 'openai/gpt-5-mini');
+
+		expect(result.success).toBe(true);
+		expect(body.max_completion_tokens).toBe(1);
+		expect(body).not.toHaveProperty('max_tokens');
+		expect(body).not.toHaveProperty('temperature');
+	});
+
 	it('rejects HTTP baseUrl without calling fetch', async () => {
 		let fetchCalled = false;
 		globalThis.fetch = mock(async () => {
@@ -271,5 +287,34 @@ describe('testOpenAIConnection', () => {
 		expect(result.success).toBe(true);
 		expect(captured.url).toBe('https://api.openai.com/v1/chat/completions');
 		expect(JSON.parse(captured.body ?? '{}').model).toBe('gpt-4o-mini');
+	});
+	it('bounds error body reads from upstream providers', async () => {
+		let pulls = 0;
+		let cancelled = false;
+		const chunk = new TextEncoder().encode('x'.repeat(1_024));
+		const body = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				pulls++;
+				if (pulls > 100) {
+					controller.close();
+					return;
+				}
+				controller.enqueue(chunk);
+			},
+			cancel() {
+				cancelled = true;
+			}
+		});
+
+		globalThis.fetch = mock(async () => {
+			return new Response(body, { status: 500, statusText: 'Internal Server Error' });
+		}) as unknown as typeof fetch;
+
+		const result = await testOpenAIConnection('sk-test');
+
+		if (result.success) throw new Error('Expected the connection test to fail');
+		expect(result.error.length).toBeLessThan(1_100);
+		expect(cancelled).toBe(true);
+		expect(pulls).toBeLessThan(100);
 	});
 });


### PR DESCRIPTION
## Summary

- expose actionable OpenAI response details in connection-test errors, including nested JSON API messages and plain-text provider responses
- use `max_completion_tokens` and omit unsupported temperature values for GPT-5 and o-series models
- apply the same model-aware request options and normalized error extraction to AI fun-fact generation
- bound upstream error details before returning them to the UI

## Problem

The OpenAI connection test discarded response bodies for non-success responses, leaving users with generic messages such as `Request failed: 400 Bad Request`. GPT-5 and o-series models can also reject the legacy `max_tokens` parameter and non-default temperature values used by the current Chat Completions payload.

## Verification

- `bun test --env-file=.env.test tests/unit/lib/server/funfacts/test-connection.test.ts tests/unit/funfacts/service.test.ts` (74 passed)
- `bun run test` (2166 passed)
- `bun run check` (0 errors, 0 warnings)
- Biome check passed for all changed files and in the pre-commit hook

The repository-wide `bun run check:biome` still reports pre-existing diagnostics in GJC session metadata and `src/lib/assets/obzorarr-icon.svg`; none are in this change set.

Fixes engels74/obzorarr-docker#6