### PR TITLE
fix(startup): remove reconciliation import cycle

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -94,3 +94,12 @@ jobs:
 
       - name: Run tests
         run: bun run test
+
+      - name: Build production bundle
+        run: bun run build
+
+      - name: Smoke test production server
+        env:
+          DATABASE_PATH: ${{ runner.temp }}/obzorarr-smoke.db
+          PORT: 3000
+        run: bun run smoke:production

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -101,5 +101,4 @@ jobs:
       - name: Smoke test production server
         env:
           DATABASE_PATH: ${{ runner.temp }}/obzorarr-smoke.db
-          PORT: 3000
         run: bun run smoke:production

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 		"dev": "bun --bun vite dev",
 		"dev:env": "bun --bun --env-file=.env vite dev",
 		"build": "bun --bun vite build",
+		"smoke:production": "bun run scripts/smoke-production.ts",
 		"preview": "bun --bun vite preview",
 		"start": "bun ./build",
 		"prepare": "svelte-kit sync || echo ''",

--- a/scripts/smoke-production.ts
+++ b/scripts/smoke-production.ts
@@ -1,3 +1,5 @@
+import { stopSubprocess } from './subprocess';
+
 const databasePath = process.env.DATABASE_PATH;
 if (!databasePath) {
 	throw new Error('DATABASE_PATH must point to a disposable database');
@@ -44,6 +46,7 @@ const stdout = new Response(server.stdout).text();
 const stderr = new Response(server.stderr).text();
 const deadline = Date.now() + timeoutMs;
 let ready = false;
+const shutdownTimeoutMs = 2_000;
 
 try {
 	while (Date.now() < deadline) {
@@ -69,10 +72,7 @@ try {
 		await Bun.sleep(250);
 	}
 } finally {
-	if (server.exitCode === null) {
-		server.kill();
-	}
-	await server.exited;
+	await stopSubprocess(server, shutdownTimeoutMs);
 }
 
 if (!ready) {

--- a/scripts/smoke-production.ts
+++ b/scripts/smoke-production.ts
@@ -3,23 +3,40 @@ if (!databasePath) {
 	throw new Error('DATABASE_PATH must point to a disposable database');
 }
 
-const port = Number(process.env.PORT ?? '3000');
-if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+const requestedPort = Number(process.env.PORT ?? '0');
+if (!Number.isInteger(requestedPort) || requestedPort < 0 || requestedPort > 65_535) {
 	throw new Error(`Invalid PORT: ${process.env.PORT}`);
 }
+
+let portReservation: ReturnType<typeof Bun.serve>;
+try {
+	portReservation = Bun.serve({
+		hostname: '127.0.0.1',
+		port: requestedPort,
+		fetch: () => new Response(null, { status: 503 })
+	});
+} catch (cause) {
+	throw new Error(`Smoke-test port ${requestedPort} is already in use`, { cause });
+}
+const port = portReservation.port;
+await portReservation.stop(true);
 
 const timeoutMs = Number(process.env.SMOKE_TIMEOUT_MS ?? '30000');
 if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
 	throw new Error(`Invalid SMOKE_TIMEOUT_MS: ${process.env.SMOKE_TIMEOUT_MS}`);
 }
 
+const childEnv = {
+	...process.env,
+	DATABASE_PATH: databasePath,
+	HOST: '127.0.0.1',
+	NODE_ENV: 'production',
+	PORT: String(port)
+};
+delete childEnv.SOCKET_PATH;
+
 const server = Bun.spawn(['bun', './build'], {
-	env: {
-		...process.env,
-		DATABASE_PATH: databasePath,
-		NODE_ENV: 'production',
-		PORT: String(port)
-	},
+	env: childEnv,
 	stdout: 'pipe',
 	stderr: 'pipe'
 });
@@ -39,8 +56,11 @@ try {
 				signal: AbortSignal.timeout(2_000)
 			});
 			if (response.ok) {
-				ready = true;
-				break;
+				await Bun.sleep(50);
+				if (server.exitCode === null) {
+					ready = true;
+					break;
+				}
 			}
 		} catch {
 			// The listener may not be ready yet.

--- a/scripts/smoke-production.ts
+++ b/scripts/smoke-production.ts
@@ -1,0 +1,66 @@
+const databasePath = process.env.DATABASE_PATH;
+if (!databasePath) {
+	throw new Error('DATABASE_PATH must point to a disposable database');
+}
+
+const port = Number(process.env.PORT ?? '3000');
+if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+	throw new Error(`Invalid PORT: ${process.env.PORT}`);
+}
+
+const timeoutMs = Number(process.env.SMOKE_TIMEOUT_MS ?? '30000');
+if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+	throw new Error(`Invalid SMOKE_TIMEOUT_MS: ${process.env.SMOKE_TIMEOUT_MS}`);
+}
+
+const server = Bun.spawn(['bun', './build'], {
+	env: {
+		...process.env,
+		DATABASE_PATH: databasePath,
+		NODE_ENV: 'production',
+		PORT: String(port)
+	},
+	stdout: 'pipe',
+	stderr: 'pipe'
+});
+const stdout = new Response(server.stdout).text();
+const stderr = new Response(server.stderr).text();
+const deadline = Date.now() + timeoutMs;
+let ready = false;
+
+try {
+	while (Date.now() < deadline) {
+		if (server.exitCode !== null) {
+			break;
+		}
+
+		try {
+			const response = await fetch(`http://127.0.0.1:${port}/`, {
+				signal: AbortSignal.timeout(2_000)
+			});
+			if (response.ok) {
+				ready = true;
+				break;
+			}
+		} catch {
+			// The listener may not be ready yet.
+		}
+
+		await Bun.sleep(250);
+	}
+} finally {
+	if (server.exitCode === null) {
+		server.kill();
+	}
+	await server.exited;
+}
+
+if (!ready) {
+	console.error(`Production server did not become ready within ${timeoutMs}ms`);
+	const [stdoutText, stderrText] = await Promise.all([stdout, stderr]);
+	if (stdoutText) console.error(stdoutText);
+	if (stderrText) console.error(stderrText);
+	process.exit(1);
+}
+
+console.log(`Production server became ready on port ${port}`);

--- a/scripts/subprocess.ts
+++ b/scripts/subprocess.ts
@@ -1,0 +1,41 @@
+export interface StoppableSubprocess {
+	readonly exitCode: number | null;
+	readonly exited: Promise<number>;
+	kill(signal?: number | NodeJS.Signals): void;
+	unref(): void;
+}
+
+async function waitForExit(
+	subprocess: StoppableSubprocess,
+	shutdownTimeoutMs: number
+): Promise<boolean> {
+	return await new Promise((resolve) => {
+		let timedOut = false;
+		const timer = setTimeout(() => {
+			timedOut = true;
+			resolve(false);
+		}, shutdownTimeoutMs);
+
+		void subprocess.exited.then(() => {
+			if (timedOut) return;
+			clearTimeout(timer);
+			resolve(true);
+		});
+	});
+}
+
+export async function stopSubprocess(
+	subprocess: StoppableSubprocess,
+	shutdownTimeoutMs: number
+): Promise<void> {
+	if (subprocess.exitCode !== null) return;
+
+	subprocess.kill();
+	if (await waitForExit(subprocess, shutdownTimeoutMs)) return;
+
+	subprocess.kill('SIGKILL');
+	if (await waitForExit(subprocess, shutdownTimeoutMs)) return;
+
+	subprocess.unref();
+	throw new Error(`Subprocess did not terminate within ${shutdownTimeoutMs * 2}ms`);
+}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,4 @@
-import type { Handle, HandleServerError } from '@sveltejs/kit';
+import type { Handle, HandleServerError, ServerInit } from '@sveltejs/kit';
 import { isHttpError, isRedirect } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import { dev } from '$app/environment';
@@ -35,7 +35,9 @@ import {
 	rateLimitHandle,
 	requestFilterHandle
 } from '$lib/server/security';
+import { initializeServer } from '$lib/server/startup';
 
+export const init: ServerInit = initializeServer;
 // `event.url.protocol` is the single source of truth: proxyHandle rewrites
 // event.url from x-forwarded-proto only when TRUST_PROXY is enabled, so reading
 // it here keeps the HSTS decision aligned with the trust-proxy gate rather than

--- a/src/lib/server/db/client.ts
+++ b/src/lib/server/db/client.ts
@@ -43,15 +43,6 @@ export const db = drizzle(sqlite, { schema });
 
 if (databasePath !== ':memory:') {
 	migrate(db, { migrationsFolder: './drizzle' });
-
-	// Reconcile sync rows orphaned in the `running` state by a crash/restart,
-	// exactly once at process start — before any request can begin a sync
-	// (ISSUE-001 restart deadlock). Dynamic import of the LIGHT reconcile module
-	// (no Plex/`$env` graph) avoids a static import cycle — `sync/reconcile.ts`
-	// imports `db` from this module, which is already assigned above — and is
-	// skipped entirely for in-memory test databases.
-	const { reconcileInterruptedSyncs } = await import('$lib/server/sync/reconcile');
-	await reconcileInterruptedSyncs();
 }
 
 export { sqlite };

--- a/src/lib/server/startup.ts
+++ b/src/lib/server/startup.ts
@@ -1,0 +1,16 @@
+import { reconcileInterruptedSyncs } from '$lib/server/sync/reconcile';
+
+type StartupTask = () => Promise<unknown>;
+
+export function createServerInitializer(task: StartupTask): () => Promise<void> {
+	let initialization: Promise<void> | undefined;
+
+	return () => {
+		initialization ??= Promise.resolve()
+			.then(task)
+			.then(() => undefined);
+		return initialization;
+	};
+}
+
+export const initializeServer = createServerInitializer(reconcileInterruptedSyncs);

--- a/src/lib/server/sync/reconcile.ts
+++ b/src/lib/server/sync/reconcile.ts
@@ -7,13 +7,10 @@ import { logger } from '$lib/server/logging';
  * Marks any pre-existing `running` sync rows as failed. A crash or restart
  * mid-sync leaves `status='running'` forever, which would otherwise permanently
  * block every future sync via the atomic single-flight claim in
- * `createSyncRecord` (ISSUE-001, restart deadlock). Runs exactly once at process
- * start (from `db/client.ts`, right after migrations) — before any request can
- * begin a sync — so it can never clobber a sync started by this process.
- *
- * Kept in its own lightweight module (importing only `db`, the schema, and the
- * logger — no Plex/`$env` graph) so `db/client.ts` can call it at boot without
- * pulling SvelteKit virtual modules into raw-bun import contexts.
+ * `createSyncRecord` (ISSUE-001, restart deadlock). The server startup hook
+ * invokes this after the database client has finished evaluating and before
+ * SvelteKit serves a request, so it cannot clobber a sync started by this
+ * process.
  *
  * Returns the number of interrupted rows reconciled.
  */

--- a/src/lib/server/sync/service.ts
+++ b/src/lib/server/sync/service.ts
@@ -132,8 +132,8 @@ async function createSyncRecord(): Promise<number | null> {
 	return record ? record.id : null;
 }
 
-// Re-exported from the lightweight `reconcile` module so it can also be invoked
-// at boot from `db/client.ts` without pulling this module's Plex/`$env` graph.
+// Re-exported from the focused `reconcile` module for callers that need to
+// perform or test stale-sync recovery without importing the rest of this service.
 export { reconcileInterruptedSyncs } from './reconcile';
 
 async function completeSyncRecord(

--- a/tests/unit/scripts/smoke-production.test.ts
+++ b/tests/unit/scripts/smoke-production.test.ts
@@ -2,8 +2,45 @@ import { describe, expect, it } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { type StoppableSubprocess, stopSubprocess } from '../../../scripts/subprocess';
 
 const PROJECT_ROOT = join(import.meta.dir, '..', '..', '..');
+type Signal = number | NodeJS.Signals | undefined;
+
+function createFakeSubprocess(onKill?: (signal: Signal, exit: (code: number) => void) => void) {
+	let exitCode: number | null = null;
+	let resolveExit!: (code: number) => void;
+	const signals: Signal[] = [];
+	let unrefCalls = 0;
+	const exited = new Promise<number>((resolve) => {
+		resolveExit = resolve;
+	});
+	const exit = (code: number) => {
+		exitCode = code;
+		resolveExit(code);
+	};
+	const subprocess: StoppableSubprocess = {
+		get exitCode() {
+			return exitCode;
+		},
+		exited,
+		kill(signal) {
+			signals.push(signal);
+			onKill?.(signal, exit);
+		},
+		unref() {
+			unrefCalls += 1;
+		}
+	};
+
+	return {
+		subprocess,
+		signals,
+		get unrefCalls() {
+			return unrefCalls;
+		}
+	};
+}
 
 describe('production smoke runner', () => {
 	it('rejects an occupied port instead of accepting a foreign HTTP server', async () => {
@@ -40,5 +77,39 @@ describe('production smoke runner', () => {
 			await foreignServer.stop(true);
 			rmSync(tempDir, { recursive: true, force: true });
 		}
+	});
+});
+
+describe('bounded subprocess shutdown', () => {
+	it('returns after graceful termination', async () => {
+		const fake = createFakeSubprocess((signal, exit) => {
+			if (signal === undefined) exit(0);
+		});
+
+		await stopSubprocess(fake.subprocess, 20);
+
+		expect(fake.signals).toEqual([undefined]);
+		expect(fake.unrefCalls).toBe(0);
+	});
+
+	it('escalates to SIGKILL when graceful termination times out', async () => {
+		const fake = createFakeSubprocess((signal, exit) => {
+			if (signal === 'SIGKILL') exit(137);
+		});
+
+		await stopSubprocess(fake.subprocess, 5);
+
+		expect(fake.signals).toEqual([undefined, 'SIGKILL']);
+		expect(fake.unrefCalls).toBe(0);
+	});
+
+	it('unrefs and fails after both termination attempts time out', async () => {
+		const fake = createFakeSubprocess();
+
+		await expect(stopSubprocess(fake.subprocess, 5)).rejects.toThrow(
+			'Subprocess did not terminate within 10ms'
+		);
+		expect(fake.signals).toEqual([undefined, 'SIGKILL']);
+		expect(fake.unrefCalls).toBe(1);
 	});
 });

--- a/tests/unit/scripts/smoke-production.test.ts
+++ b/tests/unit/scripts/smoke-production.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const PROJECT_ROOT = join(import.meta.dir, '..', '..', '..');
+
+describe('production smoke runner', () => {
+	it('rejects an occupied port instead of accepting a foreign HTTP server', async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), 'obzorarr-smoke-test-'));
+		const foreignServer = Bun.serve({
+			hostname: '127.0.0.1',
+			port: 0,
+			fetch: () => new Response('foreign server')
+		});
+
+		try {
+			const result = Bun.spawn(['bun', 'run', 'scripts/smoke-production.ts'], {
+				cwd: PROJECT_ROOT,
+				env: {
+					...process.env,
+					DATABASE_PATH: join(tempDir, 'smoke.db'),
+					PORT: String(foreignServer.port),
+					SMOKE_TIMEOUT_MS: '1000'
+				},
+				stdout: 'pipe',
+				stderr: 'pipe'
+			});
+			const [exitCode, stdout, stderr] = await Promise.all([
+				result.exited,
+				new Response(result.stdout).text(),
+				new Response(result.stderr).text()
+			]);
+
+			expect(exitCode).not.toBe(0);
+			expect(`${stdout}\n${stderr}`).toContain(
+				`Smoke-test port ${foreignServer.port} is already in use`
+			);
+		} finally {
+			await foreignServer.stop(true);
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/unit/startup.test.ts
+++ b/tests/unit/startup.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { db } from '$lib/server/db/client';
+import { syncStatus } from '$lib/server/db/schema';
+import { createServerInitializer, initializeServer } from '$lib/server/startup';
+import { resetSharedTestDb } from '../helpers/db';
+
+describe('server startup initialization', () => {
+	it('shares one initialization across concurrent callers', async () => {
+		let calls = 0;
+		let release!: () => void;
+		const task = () => {
+			calls += 1;
+			return new Promise<void>((resolve) => {
+				release = resolve;
+			});
+		};
+		const initialize = createServerInitializer(task);
+
+		const first = initialize();
+		const second = initialize();
+
+		expect(first).toBe(second);
+		expect(calls).toBe(0);
+
+		await Promise.resolve();
+		expect(calls).toBe(1);
+		release();
+		await Promise.all([first, second]);
+		expect(calls).toBe(1);
+	});
+
+	it('propagates and caches startup failures', async () => {
+		const failure = new Error('startup failed');
+		let calls = 0;
+		const initialize = createServerInitializer(async () => {
+			calls += 1;
+			throw failure;
+		});
+
+		const first = initialize();
+		const second = initialize();
+
+		expect(first).toBe(second);
+		await expect(first).rejects.toBe(failure);
+		await expect(second).rejects.toBe(failure);
+		expect(calls).toBe(1);
+	});
+
+	it('reconciles only rows that predate server startup', async () => {
+		await resetSharedTestDb();
+		await db.insert(syncStatus).values({
+			startedAt: new Date(Date.now() - 60_000),
+			status: 'running',
+			recordsProcessed: 0
+		});
+
+		await initializeServer();
+
+		const failedRows = await db.select().from(syncStatus).where(eq(syncStatus.status, 'failed'));
+		expect(failedRows).toHaveLength(1);
+		expect(failedRows[0]?.error).toBe('Interrupted by restart');
+
+		await db.insert(syncStatus).values({
+			startedAt: new Date(),
+			status: 'running',
+			recordsProcessed: 0
+		});
+		await initializeServer();
+
+		const runningRows = await db.select().from(syncStatus).where(eq(syncStatus.status, 'running'));
+		expect(runningRows).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## Summary

- move interrupted-sync reconciliation out of the database client's module evaluation path
- run reconciliation from SvelteKit's fail-closed server `init` hook
- cache concurrent initialization and rejected startup attempts
- add a production-bundle HTTP readiness smoke to Code Quality CI

## Root cause

Commit `3c29a2a` made `db/client.ts` await a dynamic import of `sync/reconcile.ts`. The reconciliation module imported the still-evaluating database client directly and through logging, creating a circular top-level-await graph. The built server remained supervised but never reached HTTP listener creation.

The last-good and first-bad historical images were replayed locally under the same Bun runtime. The good image answered HTTP, while the bad image stopped at `bun ./build`. Removing only the awaited reconciliation import in a disposable first-bad source copy restored readiness.

## Implementation

- `db/client.ts` now owns only database setup and migrations.
- `startup.ts` provides one shared initialization promise and invokes stale-sync reconciliation after database module evaluation.
- `hooks.server.ts` exports the initializer as SvelteKit `ServerInit`, so failure rejects startup before requests are served.
- focused tests cover concurrent initialization, cached failure propagation, and preservation of sync rows created after startup.
- `smoke-production.ts` launches the built adapter with a disposable database, probes HTTP readiness with a bounded timeout, captures logs on failure, and terminates the child process.
- Code Quality CI builds the production bundle and runs this smoke after the unit test suite.

## CI and image validation

The application repository does not import or duplicate `obzorarr-docker` workflows. This source-level production smoke catches adapter/bundle startup deadlocks quickly on pull requests. Full image construction and independent AMD64/ARM64 smoke validation remain the responsibility of the existing `obzorarr-docker` CI after the upstream SHA advances.

## Verification

- `bun test tests/unit/startup.test.ts tests/unit/sync/service.test.ts tests/unit/db/client.test.ts` — 24 passed
- `bun run test` — 2174 passed
- `bun run check` — 0 errors and 0 warnings
- `bunx prek run --all-files --hook-stage manual` — all hooks passed
- `bun run build` — production adapter built successfully
- `bun run smoke:production` with a disposable file-backed database — HTTP readiness passed
- two-start file-backed smoke with a stale `running` sync row — row reconciled to `failed` with `Interrupted by restart`
