### PR TITLE
feat: align public lookup privacy and proxy onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,32 @@ bun run dev
 > env-locked field render its `ENV` badge), run `bun run dev:env`, which loads `.env` via
 > `--env-file`.
 
+## Reverse proxy header trust
+
+Obzorarr uses `X-Forwarded-Proto` and `X-Forwarded-Host` only when `TRUST_PROXY=true`.
+Enable it only when every request reaches Obzorarr through a trusted upstream proxy that strips or
+overwrites visitor-supplied values for both headers. Do not enable it when visitors can connect to
+Obzorarr directly.
+
+Configure the proxy to send the public request scheme and host, then use the onboarding or
+**Admin → Settings → Security** diagnostic to compare the browser, forwarded, and effective app
+origins. When `TRUST_PROXY` is controlled by the environment or container configuration, change the
+exact setting there and restart Obzorarr before rerunning the diagnostic:
+
+```env
+TRUST_PROXY=true
+ORIGIN=https://obzorarr.example.com
+```
+
+`ORIGIN` is the public origin used for CSRF validation. It must match the browser origin exactly,
+including scheme and any non-default port. The diagnostic reports header names and normalized
+origins only; it does not expose header values that may contain credentials or client addresses.
+
+Use a strict virtual host or site match and set the forwarded host to the deployment's canonical public
+hostname; merely copying an unrestricted visitor `Host` value does not establish a trusted boundary.
+`TRUST_PROXY` affects Obzorarr's effective URL host and protocol only. Client-IP trust must be
+configured separately in the Bun adapter or runtime.
+
 ## License
 
 This project is licensed under the [GNU Affero General Public License v3.0](LICENSE).

--- a/biome.json
+++ b/biome.json
@@ -67,11 +67,13 @@
 			"!**/build",
 			"!**/.svelte-kit",
 			"!**/.omc",
+			"!**/.gjc",
 			"!**/node_modules",
 			"!/data",
 			"!**/dogfood-output",
 			"!**/drizzle",
 			"!**/*.db",
+			"!src/lib/assets/obzorarr-icon.svg",
 			"!**/bun.lock"
 		]
 	}

--- a/src/lib/copy/reverse-proxy.ts
+++ b/src/lib/copy/reverse-proxy.ts
@@ -1,14 +1,361 @@
-/**
- * Canonical copy for the reverse-proxy header-trust diagnostic surface.
- *
- * The same diagnostic UI appears in two places: the onboarding wizard at
- * /onboarding/proxy-trust and the admin tab at /admin/settings/security.
- * Both surfaces import labels from here so the panel title + manual-rerun
- * button stay in lockstep (ISSUE-001).
- */
+import type {
+	ForwardedProtoHostStatus,
+	ReverseProxyDiagnostic,
+	ReverseProxyDocumentationLink,
+	ReverseProxyPresentation,
+	ReverseProxyProviderId
+} from '$lib/security/reverse-proxy';
+
 export const REVERSE_PROXY_COPY = {
 	panelTitle: 'Reverse-proxy header trust',
-	panelSubtitle: 'Make sure Obzorarr correctly identifies your visitors',
+	panelSubtitle: 'Verify the public host and protocol Obzorarr receives from your proxy',
 	rerunButton: 'Re-run diagnostic',
-	rerunButtonInProgress: 'Re-checking…'
+	rerunButtonInProgress: 'Re-checking…',
+	detailsButton: 'Technical evidence and repair guides',
+	savedVerifying: 'Setting saved. Obzorarr is checking the new result…',
+	savedUnverified:
+		'The setting was saved, but Obzorarr could not verify the result. Re-run the diagnostic before relying on public URLs.',
+	continueWarning:
+		'Continuing keeps the detected host/protocol problem. Public links, Plex callbacks, or CSRF origin checks may use the wrong origin.'
 } as const;
+
+const SAFETY_NOTICE =
+	'Trust forwarding headers only when Obzorarr is reachable through a proxy that removes or overwrites visitor-supplied X-Forwarded-Proto and X-Forwarded-Host values. Never enable TRUST_PROXY for a directly exposed app.';
+
+const PROXY_REPAIR_DOCUMENTATION_IDS = [
+	'nginx-proxy-set-header',
+	'nginx-proxy-manager-custom-config',
+	'caddy-reverse-proxy',
+	'apache-request-header',
+	'obzorarr-trust-proxy'
+] as const;
+
+const PAIR_LABELS: Record<ForwardedProtoHostStatus, string> = {
+	usable: 'Both headers are present and valid',
+	missing: 'Both headers are missing',
+	partial: 'Only one required header is present',
+	'invalid-proto': 'X-Forwarded-Proto is invalid',
+	'unsafe-host': 'X-Forwarded-Host contains an unsafe value',
+	'invalid-host': 'X-Forwarded-Host is invalid'
+};
+
+function displayOrigin(origin: string | null): string {
+	return origin ?? 'not available';
+}
+
+function observedEvidence(diagnostic: ReverseProxyDiagnostic): string {
+	const pair = diagnostic.facts.forwardedHeaders.pair;
+	const browserOrigin = displayOrigin(diagnostic.facts.browserOrigin.origin);
+	const forwardedOrigin = displayOrigin(diagnostic.facts.origins.forwardedPair);
+
+	switch (pair.status) {
+		case 'missing':
+			return 'Neither X-Forwarded-Proto nor X-Forwarded-Host arrived with this request.';
+		case 'partial':
+			return pair.protoPresent
+				? 'X-Forwarded-Proto arrived, but X-Forwarded-Host is missing.'
+				: 'X-Forwarded-Host arrived, but X-Forwarded-Proto is missing.';
+		case 'invalid-proto':
+			return 'X-Forwarded-Proto arrived with a value other than http or https.';
+		case 'unsafe-host':
+			return 'X-Forwarded-Host arrived with characters that are unsafe in a public origin.';
+		case 'invalid-host':
+			return 'X-Forwarded-Host arrived, but it is not a valid public host and optional port.';
+		case 'usable':
+			if (diagnostic.facts.originComparison.forwardedPairMatchesBrowser === false) {
+				return `Both required headers arrived, but forwarded origin ${forwardedOrigin} does not match browser origin ${browserOrigin}.`;
+			}
+			if (diagnostic.facts.originComparison.browserMatchesRawApp === true) {
+				return `Both required headers arrived, but browser origin ${browserOrigin} already matches the direct app origin.`;
+			}
+			return `Both required headers arrived with forwarded origin ${forwardedOrigin}.`;
+		default: {
+			const exhaustive: never = pair.status;
+			return exhaustive;
+		}
+	}
+}
+
+function reviewNextAction(diagnostic: ReverseProxyDiagnostic): string {
+	const status = diagnostic.facts.forwardedHeaders.pair.status;
+	switch (status) {
+		case 'missing':
+			return 'Configure the proxy to overwrite both X-Forwarded-Proto and X-Forwarded-Host, then rerun.';
+		case 'partial':
+			return 'Add the missing member of the X-Forwarded-Proto/X-Forwarded-Host pair, overwrite both values at the proxy, then rerun.';
+		case 'invalid-proto':
+			return 'Set X-Forwarded-Proto to exactly http or https at the proxy, then rerun.';
+		case 'unsafe-host':
+		case 'invalid-host':
+			return 'Set X-Forwarded-Host to the public hostname (and port when non-standard), then rerun.';
+		case 'usable':
+			if (diagnostic.facts.originComparison.forwardedPairMatchesBrowser === false) {
+				return 'The forwarded origin conflicts with the browser origin. Set both headers from the public request, then rerun.';
+			}
+			if (diagnostic.facts.originComparison.browserMatchesRawApp === true) {
+				return 'The direct app origin already matches the browser, so these headers do not prove a trusted proxy is required. Remove unnecessary forwarding headers and leave TRUST_PROXY disabled, or open the intended public proxy address and rerun.';
+			}
+			return 'The pair is valid, but Obzorarr could not confirm the trusted proxy boundary. Verify the last proxy overwrites both headers, then rerun.';
+		default: {
+			const exhaustive: never = status;
+			return exhaustive;
+		}
+	}
+}
+
+export function presentReverseProxyDiagnostic(
+	diagnostic: ReverseProxyDiagnostic
+): ReverseProxyPresentation {
+	const pairLabel = PAIR_LABELS[diagnostic.facts.forwardedHeaders.pair.status];
+	const diagnosis = observedEvidence(diagnostic);
+
+	switch (diagnostic.action) {
+		case 'enable':
+			return {
+				tone: 'warning',
+				headline: 'Forwarded origin matches; trust is still disabled',
+				diagnosis,
+				nextAction:
+					'Verify that the upstream proxy overwrites visitor-supplied forwarding headers, confirm the risk, then enable TRUST_PROXY.',
+				consequence:
+					'Until enabled, Obzorarr continues using the internal app origin for generated public URLs.',
+				pairLabel,
+				safetyNotice: SAFETY_NOTICE,
+				documentationIds: [...PROXY_REPAIR_DOCUMENTATION_IDS]
+			};
+		case 'leave-disabled':
+			return {
+				tone: 'success',
+				headline: 'Direct origin is already consistent',
+				diagnosis,
+				nextAction:
+					'Leave TRUST_PROXY disabled unless you later place Obzorarr behind a trusted proxy.',
+				consequence: 'No proxy-origin repair is needed for this request.',
+				pairLabel,
+				safetyNotice: SAFETY_NOTICE,
+				documentationIds: ['obzorarr-trust-proxy']
+			};
+		case 'appears-working':
+			return {
+				tone: 'success',
+				headline: 'Trusted proxy origin appears to be working',
+				diagnosis,
+				nextAction:
+					'No setting change is needed. Confirm the proxy replacement boundary remains enforced, especially after proxy changes.',
+				consequence: 'Obzorarr’s effective public host and protocol match the browser origin.',
+				pairLabel,
+				safetyNotice: SAFETY_NOTICE,
+				documentationIds: ['obzorarr-trust-proxy']
+			};
+		case 'unable-to-determine':
+			return {
+				tone: 'warning',
+				headline: 'Open Obzorarr at its intended public address',
+				diagnosis,
+				nextAction:
+					'Load this page from the public http:// or https:// origin and rerun; forwarded headers alone are not trusted evidence.',
+				consequence: REVERSE_PROXY_COPY.continueWarning,
+				pairLabel,
+				safetyNotice: SAFETY_NOTICE,
+				documentationIds: ['obzorarr-trust-proxy']
+			};
+		case 'env-controlled': {
+			const enabled = diagnostic.facts.trustProxy.enabled;
+			const pair = diagnostic.facts.forwardedHeaders.pair;
+			const effectiveMatches = diagnostic.facts.originComparison.browserMatchesEffectiveApp;
+			const rawMatches = diagnostic.facts.originComparison.browserMatchesRawApp;
+			const forwardedMatches = diagnostic.facts.originComparison.forwardedPairMatchesBrowser;
+
+			if (enabled && pair.isUsable && effectiveMatches === true) {
+				return {
+					tone: 'success',
+					headline: 'TRUST_PROXY is enabled by the environment and the origin matches',
+					diagnosis,
+					nextAction:
+						'No environment change is needed. Keep the proxy replacement boundary enforced and rerun after proxy changes.',
+					consequence:
+						'Environment-managed TRUST_PROXY is working for this request; client-IP handling remains separate.',
+					pairLabel,
+					safetyNotice: SAFETY_NOTICE,
+					documentationIds: ['obzorarr-trust-proxy']
+				};
+			}
+
+			if (!enabled && rawMatches === true && pair.status === 'missing') {
+				return {
+					tone: 'success',
+					headline: 'TRUST_PROXY is disabled by the environment and direct origin is consistent',
+					diagnosis,
+					nextAction:
+						'Leave TRUST_PROXY=false. Change it only after placing Obzorarr behind a trusted proxy that overwrites both forwarding headers.',
+					consequence:
+						'The environment-managed setting already matches this direct-access request.',
+					pairLabel,
+					safetyNotice: SAFETY_NOTICE,
+					documentationIds: ['obzorarr-trust-proxy']
+				};
+			}
+
+			if (!enabled && pair.isUsable && forwardedMatches === true && rawMatches === false) {
+				return {
+					tone: 'warning',
+					headline: 'TRUST_PROXY is disabled by the environment',
+					diagnosis,
+					nextAction:
+						'After verifying the proxy replacement boundary, set TRUST_PROXY=true in the environment or container configuration, restart Obzorarr, and rerun.',
+					consequence:
+						'Obzorarr cannot use the matching forwarded public origin until the environment setting changes and the app restarts.',
+					pairLabel,
+					safetyNotice: SAFETY_NOTICE,
+					documentationIds: [...PROXY_REPAIR_DOCUMENTATION_IDS]
+				};
+			}
+
+			return {
+				tone: 'danger',
+				headline: `TRUST_PROXY is ${enabled ? 'enabled' : 'disabled'} by the environment, but the proxy evidence needs repair`,
+				diagnosis,
+				nextAction: `${reviewNextAction(diagnostic)} Restart Obzorarr after changing TRUST_PROXY in the environment or container configuration.`,
+				consequence: enabled
+					? 'Obzorarr is trusting a host/protocol result that does not match the browser origin.'
+					: 'Do not enable TRUST_PROXY until the forwarding pair and replacement boundary are correct.',
+				pairLabel,
+				safetyNotice: SAFETY_NOTICE,
+				documentationIds: [...PROXY_REPAIR_DOCUMENTATION_IDS]
+			};
+		}
+		case 'review-proxy':
+			return {
+				tone: 'danger',
+				headline: 'Proxy headers need repair',
+				diagnosis,
+				nextAction: reviewNextAction(diagnostic),
+				consequence: REVERSE_PROXY_COPY.continueWarning,
+				pairLabel,
+				safetyNotice: SAFETY_NOTICE,
+				documentationIds: [...PROXY_REPAIR_DOCUMENTATION_IDS]
+			};
+		default: {
+			const exhaustive: never = diagnostic.action;
+			return exhaustive;
+		}
+	}
+}
+
+export const REVERSE_PROXY_DOCUMENTATION: ReverseProxyDocumentationLink[] = [
+	{
+		id: 'nginx-proxy-set-header',
+		provider: 'Nginx',
+		url: 'https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header',
+		purpose: 'forwarded-host-proto',
+		applicabilityLabel: 'Official proxy_set_header reference'
+	},
+	{
+		id: 'nginx-proxy-manager-custom-config',
+		provider: 'Nginx Proxy Manager',
+		url: 'https://nginxproxymanager.com/advanced-config/#custom-nginx-configurations',
+		purpose: 'forwarded-host-proto',
+		applicabilityLabel: 'Official custom Nginx configuration locations'
+	},
+	{
+		id: 'caddy-reverse-proxy',
+		provider: 'Caddy',
+		url: 'https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#headers',
+		purpose: 'header-replacement-boundary',
+		applicabilityLabel: 'Official reverse_proxy header behavior'
+	},
+	{
+		id: 'apache-request-header',
+		provider: 'Apache',
+		url: 'https://httpd.apache.org/docs/2.4/mod/mod_headers.html#requestheader',
+		purpose: 'header-replacement-boundary',
+		applicabilityLabel: 'Official RequestHeader replacement reference'
+	},
+	{
+		id: 'obzorarr-trust-proxy',
+		provider: 'Obzorarr',
+		url: 'https://github.com/engels74/obzorarr#reverse-proxy-header-trust',
+		purpose: 'obzorarr-configuration',
+		applicabilityLabel: 'Obzorarr TRUST_PROXY and restart guidance'
+	}
+];
+
+export interface ReverseProxyProviderGuide {
+	id: ReverseProxyProviderId;
+	label: string;
+	steps: string[];
+	config?: string;
+	documentationId: ReverseProxyDocumentationLink['id'];
+}
+
+export const REVERSE_PROXY_PROVIDER_GUIDES: ReverseProxyProviderGuide[] = [
+	{
+		id: 'nginx',
+		label: 'Nginx',
+		steps: [
+			'Route only the intended public hostname to this server block. Replace the example hostname and scheme below with the exact public origin.',
+			'Add these directives in the location that proxies to Obzorarr, reload Nginx, then rerun. Restart Obzorarr too only when TRUST_PROXY is environment-controlled.'
+		],
+		config:
+			'# Replace with your exact public origin.\nproxy_set_header X-Forwarded-Proto https;\nproxy_set_header X-Forwarded-Host obzorarr.example.com;',
+		documentationId: 'nginx-proxy-set-header'
+	},
+	{
+		id: 'nginx-proxy-manager',
+		label: 'Nginx Proxy Manager',
+		steps: [
+			'Make this Proxy Host match only the intended public hostname. In Advanced, replace the example hostname and scheme below with that exact public origin.',
+			'Save the host, then rerun. Restart Obzorarr too only when TRUST_PROXY is environment-controlled.'
+		],
+		config:
+			'# Replace with your exact public origin.\nproxy_set_header X-Forwarded-Proto https;\nproxy_set_header X-Forwarded-Host obzorarr.example.com;',
+		documentationId: 'nginx-proxy-manager-custom-config'
+	},
+	{
+		id: 'caddy',
+		label: 'Caddy',
+		steps: [
+			'Use the exact public hostname as the Caddy site address. Replace the example upstream and hostname below for your deployment.',
+			'Reload Caddy, then rerun. Restart Obzorarr too only when TRUST_PROXY is environment-controlled.'
+		],
+		config:
+			'obzorarr.example.com {\n\treverse_proxy obzorarr:3000 {\n\t\theader_up X-Forwarded-Proto https\n\t\theader_up X-Forwarded-Host obzorarr.example.com\n\t}\n}',
+		documentationId: 'caddy-reverse-proxy'
+	},
+	{
+		id: 'apache',
+		label: 'Apache',
+		steps: [
+			'Use a name-based virtual host for the exact public hostname. Replace the example hostname and scheme below for your deployment.',
+			'Enable mod_proxy, mod_proxy_http, and mod_headers; reload Apache, then rerun. Restart Obzorarr too only when TRUST_PROXY is environment-controlled.'
+		],
+		config:
+			'# Replace with your exact public origin.\nRequestHeader set X-Forwarded-Proto "https"\nRequestHeader set X-Forwarded-Host "obzorarr.example.com"',
+		documentationId: 'apache-request-header'
+	},
+	{
+		id: 'other',
+		label: 'Other proxy',
+		steps: [
+			'At the last trusted hop, remove any inbound X-Forwarded-Proto and X-Forwarded-Host values.',
+			'Set X-Forwarded-Proto from the public request scheme and X-Forwarded-Host from its public host.',
+			'Reload the proxy, restart Obzorarr only if TRUST_PROXY is environment-controlled, then rerun.'
+		],
+		documentationId: 'obzorarr-trust-proxy'
+	}
+];
+
+export function documentationForDiagnostic(
+	diagnostic: ReverseProxyDiagnostic
+): ReverseProxyDocumentationLink[] {
+	const ids = new Set(presentReverseProxyDiagnostic(diagnostic).documentationIds);
+	return REVERSE_PROXY_DOCUMENTATION.filter((link) => ids.has(link.id));
+}
+
+export function documentationForGuide(
+	guide: ReverseProxyProviderGuide
+): ReverseProxyDocumentationLink {
+	const link = REVERSE_PROXY_DOCUMENTATION.find(({ id }) => id === guide.documentationId);
+	if (!link) throw new Error(`Missing reverse-proxy documentation: ${guide.documentationId}`);
+	return link;
+}

--- a/src/lib/security/reverse-proxy.ts
+++ b/src/lib/security/reverse-proxy.ts
@@ -1,0 +1,131 @@
+export type ReverseProxyConfigSource = 'env' | 'db' | 'default';
+
+export type ForwardedHeaderName =
+	| 'Forwarded'
+	| 'X-Forwarded-For'
+	| 'X-Forwarded-Host'
+	| 'X-Forwarded-Proto'
+	| 'X-Real-IP';
+
+export type ForwardedProtoHostStatus =
+	| 'usable'
+	| 'missing'
+	| 'partial'
+	| 'invalid-proto'
+	| 'unsafe-host'
+	| 'invalid-host';
+
+export interface ReverseProxyForwardedPairFact {
+	status: ForwardedProtoHostStatus;
+	isUsable: boolean;
+	protoPresent: boolean;
+	hostPresent: boolean;
+}
+
+export interface ReverseProxyConfigFact {
+	enabled: boolean;
+	source: ReverseProxyConfigSource;
+	isLocked: boolean;
+}
+
+export interface ReverseProxyConfiguredOriginFact {
+	isConfigured: boolean;
+	isValid: boolean;
+	source: ReverseProxyConfigSource;
+	isLocked: boolean;
+}
+
+export type SourceAddressCategory =
+	| 'loopback'
+	| 'private-lan'
+	| 'docker/private-range'
+	| 'tailscale/cgnat'
+	| 'link-local'
+	| 'public'
+	| 'unknown';
+
+export type ReverseProxyRecommendationAction =
+	| 'enable'
+	| 'leave-disabled'
+	| 'review-proxy'
+	| 'appears-working'
+	| 'unable-to-determine'
+	| 'env-controlled';
+
+export type ReverseProxyDiagnosticReasonCode =
+	| 'trust-proxy-env-locked-enabled'
+	| 'trust-proxy-env-locked-disabled'
+	| 'browser-origin-invalid'
+	| 'forwarded-pair-matches-browser'
+	| 'direct-access-without-forwarded-pair'
+	| 'forwarded-pair-missing'
+	| 'forwarded-pair-partial'
+	| 'forwarded-pair-invalid'
+	| 'forwarded-pair-ambiguous'
+	| 'trust-proxy-working'
+	| 'trust-proxy-enabled-broken';
+
+export type ReverseProxyDocumentationPurpose =
+	| 'forwarded-host-proto'
+	| 'header-replacement-boundary'
+	| 'obzorarr-configuration';
+
+export type ReverseProxyDocumentationId =
+	| 'nginx-proxy-set-header'
+	| 'nginx-proxy-manager-custom-config'
+	| 'caddy-reverse-proxy'
+	| 'apache-request-header'
+	| 'obzorarr-trust-proxy';
+
+export type ReverseProxyProviderId = 'nginx' | 'nginx-proxy-manager' | 'caddy' | 'apache' | 'other';
+
+export interface ReverseProxyDocumentationLink {
+	id: ReverseProxyDocumentationId;
+	provider: string;
+	url: string;
+	purpose: ReverseProxyDocumentationPurpose;
+	applicabilityLabel: string;
+}
+
+export type ReverseProxyPresentationTone = 'success' | 'warning' | 'danger' | 'neutral';
+
+export interface ReverseProxyPresentation {
+	tone: ReverseProxyPresentationTone;
+	headline: string;
+	diagnosis: string;
+	nextAction: string;
+	consequence: string;
+	pairLabel: string;
+	safetyNotice: string;
+	documentationIds: ReverseProxyDocumentationId[];
+}
+export interface ReverseProxyDiagnosticFacts {
+	trustProxy: ReverseProxyConfigFact;
+	browserOrigin: {
+		isValid: boolean;
+		origin: string | null;
+	};
+	configuredPublicOrigin: ReverseProxyConfiguredOriginFact;
+	origins: {
+		effectiveApp: string | null;
+		forwardedPair: string | null;
+	};
+	forwardedHeaders: {
+		present: ForwardedHeaderName[];
+		pair: ReverseProxyForwardedPairFact;
+	};
+	sourceAddress: {
+		category: SourceAddressCategory;
+	};
+	originComparison: {
+		browserMatchesRawApp: boolean | null;
+		browserMatchesEffectiveApp: boolean | null;
+		forwardedPairMatchesBrowser: boolean | null;
+	};
+}
+
+export interface ReverseProxyDiagnostic {
+	facts: ReverseProxyDiagnosticFacts;
+	action: ReverseProxyRecommendationAction;
+	reasonCodes: ReverseProxyDiagnosticReasonCode[];
+}

--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -51,11 +51,11 @@ export const AppSettingsKey = {
 	TRUST_PROXY: 'trust_proxy',
 	THUMBNAIL_SIGNING_SECRET: 'thumbnail_signing_secret',
 	/**
-	 * Admin opt-in for the public username lookup form on the landing page. When
-	 * absent, `getPublicLandingLookupEnabled()` defaults to `false` (login-only).
-	 * DB-only (no ENV companion) so it is NOT subject to `clearConflictingDbSettings`;
-	 * `ensurePublicLandingLookupDefault()` seeds `true` for already-onboarded servers
-	 * on upgrade so a live public landing page never silently flips to login-required.
+	 * Admin opt-in for public current-year Wrapped lookup from the landing page.
+	 * When absent, `getPublicLandingLookupEnabled()` defaults to `false`
+	 * (login-only). DB-only (no ENV companion), so it is not subject to
+	 * `clearConflictingDbSettings`; upgrade backfill also stays disabled until an
+	 * administrator explicitly enables the public access policy.
 	 */
 	PUBLIC_LANDING_LOOKUP: 'public_landing_lookup'
 } as const;
@@ -1363,23 +1363,15 @@ export async function setPublicLandingLookupEnabledAtomic(opts: {
 }
 
 /**
- * DB-idempotent backfill for `PUBLIC_LANDING_LOOKUP`. Seeds `'true'` for servers
- * that completed onboarding *before* this toggle existed, so upgrading never
- * silently flips a live public landing page to login-required. Correctness is
- * guaranteed by the DB row-absence check (safe across replicas/restarts); the
- * caller (`initializationHandle`) wraps this in a process-local "attempted" flag
- * purely as a hot-path optimisation — that flag is never the idempotency guard.
+ * DB-idempotent backfill for `PUBLIC_LANDING_LOOKUP`. Servers that completed
+ * onboarding before this setting existed receive the privacy-preserving `false`
+ * value. Public lookup now changes current-year access semantics, so an upgrade
+ * must not opt users into public reachability without an administrator's choice.
  *
- * Seeds ONLY when `ONBOARDING_COMPLETED === 'true'` AND no row exists:
- *   - a not-yet-onboarded install is left untouched (onboarding writes the
- *     toggle explicitly so the admin sees the choice);
- *   - an explicit `'true'`/`'false'` is never overwritten — the leading
- *     null-check skips the write, and `onConflictDoNothing` makes the insert a
- *     no-op under a concurrent first-request race.
- *
- * This is a *backfill*, not a schema migration: `app_settings` is a generic
- * key/value table, so no `db:generate` is required (per CLAUDE.md, the
- * "add a table/column" workflow does not apply to key/value rows).
+ * Seeds only when `ONBOARDING_COMPLETED === 'true'` and no row exists. New
+ * installs are left to onboarding, explicit values are never overwritten, and
+ * `onConflictDoNothing` keeps concurrent first requests idempotent. This remains
+ * a key/value backfill rather than a schema migration.
  */
 export async function ensurePublicLandingLookupDefault(): Promise<void> {
 	const onboardingCompleted = await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED);
@@ -1391,7 +1383,7 @@ export async function ensurePublicLandingLookupDefault(): Promise<void> {
 	const now = new Date();
 	await db
 		.insert(appSettings)
-		.values({ key: AppSettingsKey.PUBLIC_LANDING_LOOKUP, value: 'true', updatedAt: now })
+		.values({ key: AppSettingsKey.PUBLIC_LANDING_LOOKUP, value: 'false', updatedAt: now })
 		.onConflictDoNothing({ target: appSettings.key });
 }
 

--- a/src/lib/server/security/forwarded-headers.ts
+++ b/src/lib/server/security/forwarded-headers.ts
@@ -1,19 +1,6 @@
-export type ForwardedHeaderName =
-	| 'Forwarded'
-	| 'X-Forwarded-For'
-	| 'X-Forwarded-Host'
-	| 'X-Forwarded-Proto'
-	| 'X-Real-IP';
+import type { ForwardedHeaderName, ForwardedProtoHostStatus } from '$lib/security/reverse-proxy';
 
-export type ForwardedProto = 'http' | 'https';
-
-export type ForwardedProtoHostStatus =
-	| 'usable'
-	| 'missing'
-	| 'partial'
-	| 'invalid-proto'
-	| 'unsafe-host'
-	| 'invalid-host';
+type ForwardedProto = 'http' | 'https';
 
 export interface ForwardedProtoHostResult {
 	status: ForwardedProtoHostStatus;

--- a/src/lib/server/security/reverse-proxy-diagnostic.ts
+++ b/src/lib/server/security/reverse-proxy-diagnostic.ts
@@ -1,33 +1,20 @@
 import { isIP } from 'node:net';
+import type {
+	ReverseProxyDiagnostic,
+	ReverseProxyDiagnosticReasonCode,
+	SourceAddressCategory
+} from '$lib/security/reverse-proxy';
 import {
-	type ConfigSource,
 	type ConfigValue,
 	getCsrfConfigWithSource,
 	getTrustProxyConfigWithSource
 } from '$lib/server/admin/settings.service';
-import {
-	type ForwardedHeaderName,
-	type ForwardedProtoHostStatus,
-	getForwardedHeaderNamesPresent,
-	parseForwardedProtoHost
-} from './forwarded-headers';
+import { getForwardedHeaderNamesPresent, parseForwardedProtoHost } from './forwarded-headers';
 
-export type SourceAddressCategory =
-	| 'loopback'
-	| 'private-lan'
-	| 'docker/private-range'
-	| 'tailscale/cgnat'
-	| 'link-local'
-	| 'public'
-	| 'unknown';
-
-export type ReverseProxyRecommendationAction =
-	| 'enable'
-	| 'leave-disabled'
-	| 'review-proxy'
-	| 'appears-working'
-	| 'unable-to-determine'
-	| 'env-controlled';
+export type {
+	ReverseProxyDiagnostic,
+	ReverseProxyRecommendationAction
+} from '$lib/security/reverse-proxy';
 
 export interface ReverseProxyDiagnosticInput {
 	request: Request;
@@ -42,58 +29,10 @@ export interface ReverseProxyDiagnosticBuildInput extends ReverseProxyDiagnostic
 	csrfOrigin: ConfigValue<string>;
 }
 
-export interface OriginDiagnostic {
+interface OriginDiagnostic {
 	origin: string | null;
 	isValid: boolean;
 }
-
-export interface ConfiguredOriginDiagnostic extends OriginDiagnostic {
-	source: ConfigSource;
-	isConfigured: boolean;
-	isLocked: boolean;
-}
-
-export interface ForwardedPairDiagnostic {
-	status: ForwardedProtoHostStatus;
-	isUsable: boolean;
-	protoPresent: boolean;
-	hostPresent: boolean;
-}
-
-export interface ReverseProxyDiagnostic {
-	trustProxy: {
-		enabled: boolean;
-		source: ConfigSource;
-		isLocked: boolean;
-	};
-	origins: {
-		rawApp: string | null;
-		effectiveApp: string | null;
-		browser: OriginDiagnostic;
-		configuredPublic: ConfiguredOriginDiagnostic;
-	};
-	forwardedHeaders: {
-		present: ForwardedHeaderName[];
-		pair: ForwardedPairDiagnostic;
-	};
-	sourceAddress: {
-		category: SourceAddressCategory;
-	};
-	originComparison: {
-		browserMatchesRawApp: boolean | null;
-		browserMatchesEffectiveApp: boolean | null;
-		forwardedPairMatchesBrowser: boolean | null;
-	};
-	recommendation: {
-		action: ReverseProxyRecommendationAction;
-		summary: string;
-	};
-	reasons: string[];
-	safetyNotice: string;
-}
-
-const SAFETY_NOTICE =
-	'Only enable reverse proxy header trust when your upstream proxy strips visitor-supplied forwarding headers before requests reach Obzorarr.';
 
 function originFromUrl(value: string | URL): string | null {
 	try {
@@ -184,14 +123,23 @@ export function classifySourceAddress(address: string | null | undefined): Sourc
 	return 'public';
 }
 
+function reasonForReview(
+	forwardedPair: ReturnType<typeof parseForwardedProtoHost>
+): ReverseProxyDiagnosticReasonCode {
+	if (forwardedPair.status === 'missing') return 'forwarded-pair-missing';
+	if (forwardedPair.status === 'partial') return 'forwarded-pair-partial';
+	if (!forwardedPair.isUsable) return 'forwarded-pair-invalid';
+	return 'forwarded-pair-ambiguous';
+}
+
 function recommendationFor(input: {
 	trustEnabled: boolean;
-	trustSource: ConfigSource;
+	trustSource: ReverseProxyDiagnostic['facts']['trustProxy']['source'];
 	browserOrigin: OriginDiagnostic;
 	rawAppOrigin: string | null;
 	effectiveAppOrigin: string | null;
 	forwardedPair: ReturnType<typeof parseForwardedProtoHost>;
-}): Pick<ReverseProxyDiagnostic, 'recommendation' | 'reasons'> {
+}): Pick<ReverseProxyDiagnostic, 'action' | 'reasonCodes'> {
 	const browserMatchesRawApp = originsEqual(input.browserOrigin.origin, input.rawAppOrigin);
 	const browserMatchesEffectiveApp = originsEqual(
 		input.browserOrigin.origin,
@@ -201,38 +149,18 @@ function recommendationFor(input: {
 		input.browserOrigin.origin,
 		input.forwardedPair.url?.origin ?? null
 	);
-	const reasons: string[] = [];
 
 	if (input.trustSource === 'env') {
-		reasons.push(
-			`TRUST_PROXY is controlled by the environment and is currently ${input.trustEnabled ? 'enabled' : 'disabled'}.`
-		);
-		reasons.push('Obzorarr will not change this setting from the UI while it is locked.');
 		return {
-			recommendation: {
-				action: 'env-controlled',
-				summary: 'TRUST_PROXY is controlled by the environment.'
-			},
-			reasons
+			action: 'env-controlled',
+			reasonCodes: [
+				input.trustEnabled ? 'trust-proxy-env-locked-enabled' : 'trust-proxy-env-locked-disabled'
+			]
 		};
 	}
 
 	if (!input.browserOrigin.isValid) {
-		reasons.push(
-			'The browser origin was missing or invalid, so the server cannot compare it safely.'
-		);
-		if (input.forwardedPair.isUsable) {
-			reasons.push(
-				'A usable forwarded proto and host pair is present, but it was not trusted alone.'
-			);
-		}
-		return {
-			recommendation: {
-				action: 'unable-to-determine',
-				summary: 'Unable to determine safely without a valid browser origin.'
-			},
-			reasons
-		};
+		return { action: 'unable-to-determine', reasonCodes: ['browser-origin-invalid'] };
 	}
 
 	if (!input.trustEnabled) {
@@ -241,71 +169,30 @@ function recommendationFor(input: {
 			input.forwardedPair.isUsable &&
 			forwardedPairMatchesBrowser === true
 		) {
-			reasons.push('The browser origin differs from the raw app origin seen by Obzorarr.');
-			reasons.push('The forwarded proto and host pair is usable and matches the browser origin.');
-			reasons.push(
-				'Enabling trust may fix public URL detection after you verify proxy header stripping.'
-			);
 			return {
-				recommendation: {
-					action: 'enable',
-					summary: 'Enable reverse proxy header trust after confirming your proxy strips headers.'
-				},
-				reasons
+				action: 'enable',
+				reasonCodes: ['forwarded-pair-matches-browser']
 			};
 		}
 
 		if (browserMatchesRawApp === true && input.forwardedPair.status === 'missing') {
-			reasons.push('The browser origin already matches the raw app origin.');
-			reasons.push('No usable forwarded proto and host pair is present.');
 			return {
-				recommendation: {
-					action: 'leave-disabled',
-					summary: 'Leave reverse proxy header trust disabled.'
-				},
-				reasons
+				action: 'leave-disabled',
+				reasonCodes: ['direct-access-without-forwarded-pair']
 			};
 		}
 
-		reasons.push(
-			'Forwarded headers are partial, invalid, missing for this proxy shape, or do not match the browser origin.'
-		);
-		reasons.push('Review your reverse proxy configuration before enabling header trust.');
 		return {
-			recommendation: {
-				action: 'review-proxy',
-				summary: 'Review proxy configuration before changing reverse proxy header trust.'
-			},
-			reasons
+			action: 'review-proxy',
+			reasonCodes: [reasonForReview(input.forwardedPair)]
 		};
 	}
 
 	if (input.forwardedPair.isUsable && browserMatchesEffectiveApp === true) {
-		reasons.push('Reverse proxy header trust is enabled.');
-		reasons.push('The effective app origin matches the browser origin.');
-		reasons.push(
-			'This appears to be working only if the upstream proxy strips visitor-supplied forwarding headers.'
-		);
-		return {
-			recommendation: {
-				action: 'appears-working',
-				summary: 'Reverse proxy header trust appears to be working.'
-			},
-			reasons
-		};
+		return { action: 'appears-working', reasonCodes: ['trust-proxy-working'] };
 	}
 
-	reasons.push(
-		'Reverse proxy header trust is enabled, but the forwarded pair is missing, invalid, or not producing the browser origin.'
-	);
-	reasons.push('Review the proxy setup and disable trust if no trusted reverse proxy needs it.');
-	return {
-		recommendation: {
-			action: 'review-proxy',
-			summary: 'Review proxy configuration for the current TRUST_PROXY setting.'
-		},
-		reasons
-	};
+	return { action: 'review-proxy', reasonCodes: ['trust-proxy-enabled-broken'] };
 }
 
 export function buildReverseProxyDiagnostic(
@@ -317,7 +204,7 @@ export function buildReverseProxyDiagnostic(
 	const browserOrigin = normalizeOrigin(input.browserOrigin);
 	const configuredPublicOrigin = normalizeOrigin(input.csrfOrigin.value || null);
 	const trustEnabled = input.trustProxy.value === 'true';
-	const { recommendation, reasons } = recommendationFor({
+	const { action, reasonCodes } = recommendationFor({
 		trustEnabled,
 		trustSource: input.trustProxy.source,
 		browserOrigin,
@@ -327,45 +214,49 @@ export function buildReverseProxyDiagnostic(
 	});
 
 	return {
-		trustProxy: {
-			enabled: trustEnabled,
-			source: input.trustProxy.source,
-			isLocked: input.trustProxy.isLocked
-		},
-		origins: {
-			rawApp: rawAppOrigin,
-			effectiveApp: effectiveAppOrigin,
-			browser: browserOrigin,
-			configuredPublic: {
-				...configuredPublicOrigin,
+		facts: {
+			trustProxy: {
+				enabled: trustEnabled,
+				source: input.trustProxy.source,
+				isLocked: input.trustProxy.isLocked
+			},
+			browserOrigin: {
+				isValid: browserOrigin.isValid,
+				origin: browserOrigin.origin
+			},
+			configuredPublicOrigin: {
+				isValid: configuredPublicOrigin.isValid,
 				source: input.csrfOrigin.source,
 				isConfigured: Boolean(input.csrfOrigin.value),
 				isLocked: input.csrfOrigin.isLocked
+			},
+			origins: {
+				effectiveApp: effectiveAppOrigin,
+				forwardedPair: forwardedPair.url?.origin ?? null
+			},
+			forwardedHeaders: {
+				present: getForwardedHeaderNamesPresent(input.request.headers),
+				pair: {
+					status: forwardedPair.status,
+					isUsable: forwardedPair.isUsable,
+					protoPresent: forwardedPair.protoPresent,
+					hostPresent: forwardedPair.hostPresent
+				}
+			},
+			sourceAddress: {
+				category: classifySourceAddress(input.sourceAddress)
+			},
+			originComparison: {
+				browserMatchesRawApp: originsEqual(browserOrigin.origin, rawAppOrigin),
+				browserMatchesEffectiveApp: originsEqual(browserOrigin.origin, effectiveAppOrigin),
+				forwardedPairMatchesBrowser: originsEqual(
+					browserOrigin.origin,
+					forwardedPair.url?.origin ?? null
+				)
 			}
 		},
-		forwardedHeaders: {
-			present: getForwardedHeaderNamesPresent(input.request.headers),
-			pair: {
-				status: forwardedPair.status,
-				isUsable: forwardedPair.isUsable,
-				protoPresent: forwardedPair.protoPresent,
-				hostPresent: forwardedPair.hostPresent
-			}
-		},
-		sourceAddress: {
-			category: classifySourceAddress(input.sourceAddress)
-		},
-		originComparison: {
-			browserMatchesRawApp: originsEqual(browserOrigin.origin, rawAppOrigin),
-			browserMatchesEffectiveApp: originsEqual(browserOrigin.origin, effectiveAppOrigin),
-			forwardedPairMatchesBrowser: originsEqual(
-				browserOrigin.origin,
-				forwardedPair.url?.origin ?? null
-			)
-		},
-		recommendation,
-		reasons,
-		safetyNotice: SAFETY_NOTICE
+		action,
+		reasonCodes
 	};
 }
 
@@ -398,7 +289,7 @@ export type EnableTrustProxyDecision = { ok: true } | { ok: false; error: string
 export function assertEnableTrustProxyAllowed(
 	diagnostic: ReverseProxyDiagnostic
 ): EnableTrustProxyDecision {
-	if (diagnostic.recommendation.action === 'enable') {
+	if (diagnostic.action === 'enable') {
 		return { ok: true };
 	}
 	return { ok: false, error: ENABLE_TRUST_PROXY_NOT_RECOMMENDED_MESSAGE };

--- a/src/lib/server/sharing/access-control.ts
+++ b/src/lib/server/sharing/access-control.ts
@@ -1,4 +1,5 @@
 import {
+	getEffectiveShareMode,
 	getGlobalDefaultShareMode,
 	getOrCreateShareSettings,
 	getServerWrappedShareMode,
@@ -86,8 +87,7 @@ export async function checkWrappedAccess(
 
 	const settings = await getOrCreateShareSettings({ userId, year });
 
-	const globalFloor = await getGlobalDefaultShareMode();
-	const effectiveMode = getMoreRestrictiveMode(settings.mode, globalFloor);
+	const effectiveMode = await getEffectiveShareMode(userId, year);
 	const isOwner = currentUser?.id === userId || currentUser?.isAdmin === true;
 
 	// Private-link pages require the token even for owners/admins. Owner/admin
@@ -126,7 +126,8 @@ export async function checkWrappedAccess(
 	return {
 		settings: {
 			...settings,
-			mode: effectiveMode
+			mode: effectiveMode,
+			shareToken: effectiveMode === ShareMode.PRIVATE_LINK ? settings.shareToken : null
 		},
 		accessReason: result.reason ?? 'unknown'
 	};

--- a/src/lib/server/sharing/access-control.ts
+++ b/src/lib/server/sharing/access-control.ts
@@ -3,7 +3,8 @@ import {
 	getGlobalDefaultShareMode,
 	getOrCreateShareSettings,
 	getServerWrappedShareMode,
-	getShareSettingsByToken
+	getShareSettingsByToken,
+	getShareSettingsReadOnly
 } from './service';
 import {
 	type AccessCheckContext,
@@ -85,9 +86,12 @@ export async function checkWrappedAccess(
 ): Promise<CheckWrappedAccessResult> {
 	const { userId, year, currentUser, shareToken } = options;
 
-	const settings = await getOrCreateShareSettings({ userId, year });
-
 	const effectiveMode = await getEffectiveShareMode(userId, year);
+	const settings =
+		effectiveMode === ShareMode.PRIVATE_LINK
+			? await getOrCreateShareSettings({ userId, year })
+			: ((await getShareSettingsReadOnly(userId, year)) ??
+				(await getOrCreateShareSettings({ userId, year, mintPrivateLinkToken: false })));
 	const isOwner = currentUser?.id === userId || currentUser?.isAdmin === true;
 
 	// Private-link pages require the token even for owners/admins. Owner/admin

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -106,7 +106,11 @@ export async function getGlobalAllowUserControl(): Promise<boolean> {
 	return setting.value === 'true';
 }
 
-export async function getEffectiveShareMode(userId: number, year: number): Promise<ShareModeType> {
+export async function getEffectiveShareMode(
+	userId: number,
+	year: number,
+	currentYear = new Date().getFullYear()
+): Promise<ShareModeType> {
 	const [globalDefault, allowUserControl, publicLookupEnabled] = await Promise.all([
 		getGlobalDefaultShareMode(),
 		getGlobalAllowUserControl(),
@@ -127,7 +131,7 @@ export async function getEffectiveShareMode(userId: number, year: number): Promi
 	// not just a form-visibility switch. It establishes PUBLIC as the effective
 	// default. When user control is enabled, only an explicit non-public row opts
 	// that user out; when control is disabled, the administrator's choice wins.
-	if (publicLookupEnabled && year === new Date().getFullYear()) {
+	if (publicLookupEnabled && year === currentYear) {
 		if (!allowUserControl || !record) {
 			return ShareMode.PUBLIC;
 		}

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -425,9 +425,11 @@ function toShareSettings(
 export async function getOrCreateShareSettings(
 	options: GetOrCreateShareSettingsOptions
 ): Promise<ShareSettings> {
-	const { userId, year, createIfMissing = true } = options;
+	const { userId, year, createIfMissing = true, mintPrivateLinkToken = true } = options;
 
-	const existing = await getShareSettings(userId, year);
+	const existing = mintPrivateLinkToken
+		? await getShareSettings(userId, year)
+		: await getShareSettingsReadOnly(userId, year);
 	if (existing) {
 		return existing;
 	}
@@ -438,15 +440,15 @@ export async function getOrCreateShareSettings(
 
 	const defaultMode = await getGlobalDefaultShareMode();
 	const allowUserControl = await getGlobalAllowUserControl();
-	const shareToken = defaultMode === ShareMode.PRIVATE_LINK ? generateShareToken() : null;
+	const shareToken =
+		mintPrivateLinkToken && defaultMode === ShareMode.PRIVATE_LINK ? generateShareToken() : null;
 
 	// Atomic create (ISSUE-001): a concurrent caller can insert the (user_id, year)
 	// row between the read above and this insert. `onConflictDoNothing` on the
 	// share_settings_user_year_unq index turns that race into a no-op instead of a
 	// duplicate row (which previously let ensurePublicSlug assign one slug to two
-	// rows and 500 the dashboard). Re-select via getShareSettings so every caller
-	// receives the canonical row plus its lazy private-link token mint and the
-	// toShareSettings global-folding — keeping the ShareSettings return contract.
+	// rows and 500 the dashboard). Re-select through the same read mode so callers
+	// that explicitly suppress private-link token minting remain side-effect free.
 	await db
 		.insert(shareSettings)
 		.values({
@@ -459,7 +461,9 @@ export async function getOrCreateShareSettings(
 		})
 		.onConflictDoNothing({ target: [shareSettings.userId, shareSettings.year] });
 
-	const created = await getShareSettings(userId, year);
+	const created = mintPrivateLinkToken
+		? await getShareSettings(userId, year)
+		: await getShareSettingsReadOnly(userId, year);
 	if (!created) {
 		throw new ShareError('Failed to create share settings', 'CREATE_FAILED');
 	}

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -1,4 +1,5 @@
 import { and, eq, isNull, ne } from 'drizzle-orm';
+import { getPublicLandingLookupEnabled } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings, shareSettings } from '$lib/server/db/schema';
 import {
@@ -106,7 +107,11 @@ export async function getGlobalAllowUserControl(): Promise<boolean> {
 }
 
 export async function getEffectiveShareMode(userId: number, year: number): Promise<ShareModeType> {
-	const globalDefault = await getGlobalDefaultShareMode();
+	const [globalDefault, allowUserControl, publicLookupEnabled] = await Promise.all([
+		getGlobalDefaultShareMode(),
+		getGlobalAllowUserControl(),
+		getPublicLandingLookupEnabled()
+	]);
 	const result = await db
 		.select({
 			mode: shareSettings.mode,
@@ -117,6 +122,25 @@ export async function getEffectiveShareMode(userId: number, year: number): Promi
 		.limit(1);
 
 	const record = result[0];
+
+	// Public landing lookup is an access policy for the current-year Wrapped page,
+	// not just a form-visibility switch. It establishes PUBLIC as the effective
+	// default. When user control is enabled, only an explicit non-public row opts
+	// that user out; when control is disabled, the administrator's choice wins.
+	if (publicLookupEnabled && year === new Date().getFullYear()) {
+		if (!allowUserControl || !record) {
+			return ShareMode.PUBLIC;
+		}
+
+		const source = normalizeShareModeSource(record.modeSource);
+		if (source === ShareModeSource.DEFAULT) {
+			return ShareMode.PUBLIC;
+		}
+
+		const parsed = ShareModeSchema.safeParse(record.mode);
+		return parsed.success ? parsed.data : ShareMode.PRIVATE_OAUTH;
+	}
+
 	if (!record) {
 		return globalDefault;
 	}
@@ -624,6 +648,17 @@ export async function ensurePublicSlug(userId: number, year: number): Promise<st
 		.limit(1);
 
 	return refreshed[0]?.publicSlug ?? newSlug;
+}
+
+/**
+ * Return an opaque identifier that is safe to disclose from anonymous public
+ * lookup. The share row is created with the normal defaults when needed, but
+ * this helper can only mint or return `publicSlug`; it never reads or returns a
+ * private-link token.
+ */
+export async function getPublicShareIdentifier(userId: number, year: number): Promise<string> {
+	await getOrCreateShareSettings({ userId, year });
+	return ensurePublicSlug(userId, year);
 }
 
 /**

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -652,12 +652,35 @@ export async function ensurePublicSlug(userId: number, year: number): Promise<st
 
 /**
  * Return an opaque identifier that is safe to disclose from anonymous public
- * lookup. The share row is created with the normal defaults when needed, but
- * this helper can only mint or return `publicSlug`; it never reads or returns a
- * private-link token.
+ * lookup. A missing share row is created with the normal defaults except that
+ * private-link token creation is deliberately deferred; this helper only mints
+ * or returns `publicSlug`.
  */
 export async function getPublicShareIdentifier(userId: number, year: number): Promise<string> {
-	await getOrCreateShareSettings({ userId, year });
+	const existing = await db
+		.select({ userId: shareSettings.userId })
+		.from(shareSettings)
+		.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, year)))
+		.limit(1);
+
+	if (!existing[0]) {
+		const [defaultMode, allowUserControl] = await Promise.all([
+			getGlobalDefaultShareMode(),
+			getGlobalAllowUserControl()
+		]);
+		await db
+			.insert(shareSettings)
+			.values({
+				userId,
+				year,
+				mode: defaultMode,
+				modeSource: ShareModeSource.DEFAULT,
+				shareToken: null,
+				canUserControl: allowUserControl
+			})
+			.onConflictDoNothing({ target: [shareSettings.userId, shareSettings.year] });
+	}
+
 	return ensurePublicSlug(userId, year);
 }
 

--- a/src/lib/server/sharing/types.ts
+++ b/src/lib/server/sharing/types.ts
@@ -125,4 +125,5 @@ export interface GetOrCreateShareSettingsOptions {
 	userId: number;
 	year: number;
 	createIfMissing?: boolean;
+	mintPrivateLinkToken?: boolean;
 }

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -117,23 +117,31 @@ export const wrappedLogoOptions: OptionCopy<WrappedLogoOptionValue>[] = [
 ];
 
 /**
- * Copy for the public-landing-lookup toggle (the new dedicated admin setting).
- * `contradictionWarning` is surfaced in both settings and onboarding when the
- * toggle is on while the default share mode is non-public — visitors would see
- * the lookup form but every lookup would 404 until the default share mode is set to public.
- * (A non-public default is a privacy floor: per-user public rows are blocked at write
- * time and promoted back to the floor at read time, so only raising the default unblocks lookups.)
+ * Shared copy for the administrator-controlled landing lookup policy. Enabling
+ * it changes current-year access semantics as well as showing the form.
  */
 export const publicLandingLookupCopy = {
-	label: 'Allow public Wrapped lookup on the landing page',
+	label: 'Allow public current-year Wrapped lookup',
 	helper:
-		'Show a username field on the landing page so anyone can look up a public Wrapped without signing in.',
+		'Let anyone search a Plex username and open that user’s current-year Wrapped without signing in.',
 	enabledDescription:
-		'The landing page shows a username lookup field. Only Wrapped pages set to "Public" are reachable this way.',
+		'Current-year Wrapped pages are public by default. If user control is allowed, an explicit user opt-out stays hidden; otherwise this administrator setting applies to everyone.',
 	disabledDescription:
-		'The landing page hides the lookup field and shows a "Sign in with Plex" button instead.',
-	contradictionWarning:
-		'Public lookup is on, but your default share mode is non-public — every lookup will return "not found" until the default share mode is set to Public.'
+		'The public username field is hidden. Visitors use Plex sign-in, and normal per-page sharing rules continue to apply.',
+	protectedBoundary:
+		'This opens only eligible current-year Wrapped pages. Admin controls, user settings, dashboards, and the rest of Obzorarr still require authentication.',
+	privateOutcome:
+		'Unknown usernames and users who opted out receive the same “not publicly shared” response.'
+} as const;
+
+/** Canonical explanation of stored defaults versus effective access. */
+export const shareDefaultCopy = {
+	summary:
+		'New users and existing default-managed users follow the current default. Saving it does not rewrite explicit user choices.',
+	explicitRows:
+		'Explicit user choices stay stored. A stricter global floor can limit effective access; relaxing the floor can reveal the stored choice again.',
+	bulkApply:
+		'Apply the current defaults only to existing default-managed rows. Explicit user overrides are skipped, and users without a row already inherit the current default.'
 } as const;
 
 /**
@@ -174,35 +182,34 @@ export const PRIVACY_PREVIEW_ROW_TOOLTIPS: Record<
 > = {
 	namesInStats: {
 		admin:
-			'Admins always see real usernames in the dashboard and Users page. This setting only changes how names appear in public-facing, server-wide stats and leaderboards.',
+			'Admins always see real usernames in protected dashboards. This setting changes names only in Wrapped recap output and public-facing statistics.',
 		visitor:
-			'Anonymous visitors see real names, an anonymous placeholder, or no name at all — whichever anonymization mode you choose here.',
+			'On Wrapped output they can access, visitors see real names, anonymous labels, or hybrid labels according to this setting.',
 		member:
-			'With Hybrid, a signed-in member sees their own real name while everyone else stays anonymized. Real shows all names; Anonymous hides them for everyone.'
+			'Hybrid shows a signed-in member their own real name while other people stay anonymized. Real shows names; Anonymous replaces them.'
 	},
 	newUserDefault: {
 		admin:
-			'Sets the share mode applied to each newly-created user. Existing users keep their current setting until you apply defaults to all users.',
+			'New users and existing default-managed rows follow this baseline. Explicit choices are not rewritten, though a stricter global floor can limit effective access.',
 		visitor:
-			"A visitor can open a user's Wrapped without signing in when this default is Public, or Private Link if they have the share link. Server-members-only pages require signing in.",
+			'This controls ordinary personal Wrapped links. Public landing lookup is separate: when enabled, eligible current-year Wrapped pages are public by default.',
 		member:
-			'Signed-in members can open members-only Wrapped pages. If user control is allowed, each member can still override their own share mode.'
+			'Members can open members-only pages after sign-in. When user control is allowed, an explicit non-public choice also opts that user out of public lookup.'
 	},
 	serverWideRecap: {
 		admin:
-			"Controls who can open the server-wide Wrapped recap that aggregates every user's stats.",
+			'Controls only the aggregate server-wide /wrapped recap. It does not open admin pages, dashboards, settings, or every route on the server.',
 		visitor:
-			'A visitor sees the server-wide recap only when it is set to Public; otherwise they are prompted to sign in.',
-		member:
-			'Signed-in server members can open the server-wide recap whether it is set to members-only or public.'
+			'Visitors can open the server-wide recap only when it is Public; otherwise Plex server membership is required.',
+		member: 'Signed-in server members can open the recap whether it is members-only or Public.'
 	},
 	landingLookupForm: {
 		admin:
-			'Shows or hides the username lookup field on the public landing page. Only Wrapped pages set to Public are reachable through it.',
+			'Shows the public username field and makes eligible current-year personal Wrapped pages public by default. User opt-outs apply only when user control is allowed.',
 		visitor:
-			"When shown, a visitor can type a username to find that person's public Wrapped without signing in.",
+			'Visitors can search a username and open an eligible current-year Wrapped without signing in. Unknown and opted-out users look the same.',
 		member:
-			'Members normally reach Wrapped pages from the dashboard, so this form mainly affects anonymous visitors on the landing page.'
+			'This affects current-year personal Wrapped output only. Dashboards, settings, admin controls, and other private surfaces remain protected.'
 	}
 };
 
@@ -234,14 +241,14 @@ export interface PrivacyPreviewValueTooltips {
  */
 export const PRIVACY_PREVIEW_VALUE_TOOLTIPS: PrivacyPreviewValueTooltips = {
 	namesInStats: {
-		real: "Public, server-wide stats and leaderboards show each person's actual Plex username.",
+		real: 'Wrapped recap output and leaderboards show each person’s actual Plex username.',
 		anonymous:
 			'Usernames are replaced with neutral placeholders like “User #1” everywhere except the admin dashboard — no one is identifiable in public stats.',
 		'hybrid-self-sees-own':
 			'A signed-in member sees their own real name, while everyone else stays anonymized as “User #1”.'
 	},
 	newUserDefault: {
-		public: "New users' Wrapped pages are reachable by anyone with the link — no sign-in required.",
+		public: 'Ordinary personal Wrapped links are open without sign-in.',
 		'members-only':
 			"New users' Wrapped pages require signing in with a Plex account on this server.",
 		'private-link':
@@ -249,15 +256,14 @@ export const PRIVACY_PREVIEW_VALUE_TOOLTIPS: PrivacyPreviewValueTooltips = {
 	},
 	serverWideRecap: {
 		public:
-			"The server-wide /wrapped recap is open to anyone, including anonymous visitors who aren't signed in.",
+			'Only the aggregate server-wide /wrapped recap is open without sign-in; protected Obzorarr areas stay private.',
 		'members-only':
-			'The server-wide /wrapped recap requires signing in with a Plex account on this server.'
+			'The aggregate server-wide /wrapped recap requires signing in as a Plex member of this server.'
 	},
 	landingLookupForm: {
 		visible:
-			'The landing page shows a username lookup field so visitors can open any Public Wrapped without signing in.',
-		hidden:
-			'The landing page hides the lookup field and shows a “Sign in with Plex” button instead.'
+			'Visitors can search usernames and open eligible current-year Wrapped pages without signing in; other Obzorarr areas remain protected.',
+		hidden: 'The public username field is hidden and the landing page offers Plex sign-in instead.'
 	},
 	wrappedLogo: {
 		'always-show': "The Obzorarr logo is shown on every Wrapped page and users can't hide it.",
@@ -317,59 +323,60 @@ export interface PrivacyPreset {
  * documented order: anonymizationMode / defaultShareMode / serverWrappedShareMode
  * / publicLandingLookup / allowUserControl / logoMode.
  *
- * Note: "Balanced" ships with `publicLandingLookup: false` (a clean first-run,
- * members-only default that exposes nothing to anonymous visitors), so no shipped
- * preset trips the landing-lookup contradiction warning — that path is still
- * reachable (and tested) via a custom combination.
+ * Public lookup is a current-year policy rather than a form layered over the
+ * default share mode, so presets may combine it with a private ordinary-link
+ * baseline without creating a dead lookup experience.
  */
 export const PRIVACY_PRESETS: PrivacyPreset[] = [
 	{
 		id: 'maximum-privacy',
 		label: 'Maximum Privacy',
-		description: 'Everything locked down. Usernames hidden, nothing public, no landing lookup.',
-		exposureSummary: 'Anonymous stats, server-members-only recap, no public exposure.',
+		description: 'Personal and server recap links stay members-only; names are anonymous.',
+		exposureSummary:
+			'No public Wrapped output; protected dashboards still show admin-only details.',
 		values: {
 			anonymizationMode: 'anonymous',
 			defaultShareMode: ShareMode.PRIVATE_OAUTH,
 			serverWrappedShareMode: 'private-oauth',
 			publicLandingLookup: false,
 			allowUserControl: false,
-			logoMode: 'always_hide'
+			logoMode: 'always_show'
 		}
 	},
 	{
 		id: 'internal-community',
 		label: 'Internal Community',
-		description: 'Real names for your members, but nothing exposed to the public web.',
-		exposureSummary: 'Real names, server-members-only access, nothing public.',
+		description: 'Real names for signed-in members, with no public Wrapped output.',
+		exposureSummary: 'Members-only personal pages and recap; users may choose stricter sharing.',
 		values: {
 			anonymizationMode: 'real',
 			defaultShareMode: ShareMode.PRIVATE_OAUTH,
 			serverWrappedShareMode: 'private-oauth',
 			publicLandingLookup: false,
 			allowUserControl: true,
-			logoMode: 'user_choice'
+			logoMode: 'always_show'
 		}
 	},
 	{
 		id: 'balanced',
 		label: 'Balanced',
-		description: 'Recommended default. Members see their own name; nothing is public by default.',
-		exposureSummary: 'Hybrid names, members-only recap, nothing public.',
+		description: 'Recommended starting point: hybrid names and members-only sharing.',
+		exposureSummary: 'No public Wrapped output unless the administrator enables public lookup.',
 		values: {
 			anonymizationMode: 'hybrid',
 			defaultShareMode: ShareMode.PRIVATE_OAUTH,
 			serverWrappedShareMode: 'private-oauth',
 			publicLandingLookup: false,
 			allowUserControl: true,
-			logoMode: 'user_choice'
+			logoMode: 'always_show'
 		}
 	},
 	{
 		id: 'public-showcase',
 		label: 'Public Showcase',
-		description: 'Share everything publicly with real names and a public landing lookup.',
-		exposureSummary: 'Real names, public recap + landing lookup, users control their sharing.',
+		description: 'Public recap and current-year username lookup with real names.',
+		exposureSummary:
+			'Specific Wrapped output is public; dashboards, settings, and admin controls stay protected.',
 		values: {
 			anonymizationMode: 'real',
 			defaultShareMode: ShareMode.PUBLIC,
@@ -382,8 +389,9 @@ export const PRIVACY_PRESETS: PrivacyPreset[] = [
 	{
 		id: 'anonymous-public',
 		label: 'Anonymous Public',
-		description: 'Public stats, but every username stays anonymous and locked.',
-		exposureSummary: 'Anonymous names (forced), public recap + landing lookup.',
+		description: 'Public recap and current-year lookup with anonymous recap names.',
+		exposureSummary:
+			'Wrapped output is public and names stay anonymous; protected controls remain signed-in only.',
 		values: {
 			anonymizationMode: 'anonymous',
 			defaultShareMode: ShareMode.PUBLIC,
@@ -391,7 +399,7 @@ export const PRIVACY_PRESETS: PrivacyPreset[] = [
 			publicLandingLookup: true,
 			// Deliberate: "forced anonymization" only holds if users cannot reveal themselves.
 			allowUserControl: false,
-			logoMode: 'always_hide'
+			logoMode: 'always_show'
 		}
 	}
 ];

--- a/src/lib/sharing/preset-logic.ts
+++ b/src/lib/sharing/preset-logic.ts
@@ -8,17 +8,15 @@
  * functions to its own state source (onboarding `$state` runes vs. admin
  * Superform stores) and renders the result in its own idiom.
  *
- * Privacy trust is the top constraint: `derivePreview` deliberately separates
- * admin-controlled *form/recap visibility* from *per-user effective
- * reachability* (the server-side `getEffectiveShareMode` floor, which admin
- * defaults do NOT override), so the preview can never overstate exposure.
+ * Privacy trust is the top constraint: `derivePreview` names each independently
+ * controlled Wrapped surface and never implies that “public” opens protected
+ * dashboards, settings, or administration.
  */
 import {
 	PRIVACY_PRESETS,
 	type PrivacyPresetId,
 	type PrivacyPresetPrivacyKey,
 	type PrivacyPresetValues,
-	publicLandingLookupCopy,
 	type WrappedLogoOptionValue
 } from '$lib/sharing/options';
 
@@ -96,20 +94,17 @@ export function matchPresetPrivacy(
  * per-page in each flow's own markup. Each field is scoped precisely so the
  * preview never overstates exposure or privacy:
  *
- * - `landingLookupForm` — whether the landing page shows the username lookup
- *   FORM. Admin-controlled (the `publicLandingLookup` toggle). Showing the form
- *   never makes a non-public Wrapped reachable — the server still 404s those.
- * - `serverRecapVisibility` — who can view the server-wide `/wrapped` recap.
- *   Admin-controlled (`serverWrappedShareMode`).
- * - `perUserDefaultForNewUsers` — the default share mode applied to NEW users.
- *   Explicitly labeled "for new users": it does NOT change existing/private
- *   users, and the model never claims an existing private user becomes reachable.
+ * - `landingLookupForm` — whether anonymous visitors can search for eligible
+ *   current-year personal Wrapped pages. Enabling it also establishes the
+ *   current-year public default enforced by the server.
+ * - `serverRecapVisibility` — who can view the aggregate server-wide `/wrapped`
+ *   recap. This does not affect protected application surfaces.
+ * - `perUserDefaultForNewUsers` — the ordinary personal-link baseline followed
+ *   by new and default-managed users. Explicit rows retain their stored choice.
  * - `nameDisplay` — how usernames appear, mirroring anonymization (including the
  *   hybrid "self sees own name" nuance).
  * - `logoVisibility` — OPTIONAL. Present only when `logoMode` is supplied
  *   (onboarding). Admin omits it (logoMode is managed on a different route).
- * - `warnings` — surfaced contradiction copy, e.g. landing lookup on while the
- *   default is non-public.
  */
 export interface PrivacyPreviewModel {
 	landingLookupForm: 'visible' | 'hidden';
@@ -159,13 +154,6 @@ export function derivePreview(
 	values: Omit<PrivacyPresetValues, 'logoMode'> & { logoMode?: WrappedLogoOptionValue }
 ): PrivacyPreviewModel {
 	const warnings: string[] = [];
-
-	// Landing lookup on while the default is non-public: the form shows but every
-	// lookup 404s until the default share mode is set to public. Mirrors the live warning
-	// both flows already surface; sourced from the shared copy module.
-	if (values.publicLandingLookup && values.defaultShareMode !== 'public') {
-		warnings.push(publicLandingLookupCopy.contradictionWarning);
-	}
 
 	const model: PrivacyPreviewModel = {
 		landingLookupForm: values.publicLandingLookup ? 'visible' : 'hidden',

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -2,7 +2,7 @@ import { fail, redirect } from '@sveltejs/kit';
 import { z } from 'zod';
 import { getPublicLandingLookupEnabled } from '$lib/server/admin/settings.service';
 import { logger } from '$lib/server/logging';
-import { getEffectiveShareMode, getShareIdentifier } from '$lib/server/sharing/service';
+import { getEffectiveShareMode, getPublicShareIdentifier } from '$lib/server/sharing/service';
 import { ShareMode } from '$lib/server/sharing/types';
 import { triggerLiveSyncIfNeeded } from '$lib/server/sync/live-sync';
 import { findUserByUsername } from '$lib/server/sync/plex-accounts.service';
@@ -23,10 +23,9 @@ export const load: PageServerLoad = async ({ locals }) => {
 		redirect(303, locals.user.isAdmin ? '/admin' : '/dashboard');
 	}
 
-	// The toggle is the SOLE visibility gate (decision D1): the form renders iff
-	// the admin opted in, independent of the default share mode. A contradictory
-	// config (toggle on + non-public default) is surfaced to the admin as a
-	// warning in settings/onboarding rather than hidden from visitors here.
+	// The administrator controls whether anonymous current-year lookup exists.
+	// The same setting also establishes the effective public default enforced by
+	// the action and destination loader, so the form cannot advertise a dead path.
 	return {
 		currentYear: new Date().getFullYear(),
 		publicLookupEnabled: await getPublicLandingLookupEnabled(),
@@ -65,9 +64,9 @@ export const actions: Actions = {
 		const userResult = await findUserByUsername(username, { createIfMissing: false });
 		const currentYear = new Date().getFullYear();
 		const publicLookupFailure = {
-			error: 'No public Wrapped found for that username.',
+			error: 'No publicly shared Wrapped found for that username.',
 			username,
-			requiresAuth: true
+			requiresAuth: false
 		};
 
 		if (!userResult) {
@@ -99,11 +98,10 @@ export const actions: Actions = {
 			logger.error(`Lookup-triggered live sync failed: ${message}`, 'LandingLookup');
 		}
 
-		// DF-04: redirect to the opaque public slug, not the enumerable integer id.
-		// The visitor here is anonymous, and a numeric URL no longer resolves for
-		// non-owners — so an integer redirect would land on the anti-enumeration 404.
-		// effectiveMode is confirmed PUBLIC above, so getShareIdentifier returns a slug.
-		const shareIdentifier = await getShareIdentifier(userResult.userId, currentYear);
-		redirect(303, `/wrapped/${currentYear}/u/${shareIdentifier}`);
+		// The mode may become more restrictive while the nonblocking sync runs.
+		// Landing lookup must still never mint or disclose a private-link token;
+		// the opaque slug is authorized again by the destination loader.
+		const publicSlug = await getPublicShareIdentifier(userResult.userId, currentYear);
+		redirect(303, `/wrapped/${currentYear}/u/${publicSlug}`);
 	}
 };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -73,7 +73,7 @@ export const actions: Actions = {
 			return fail(404, publicLookupFailure);
 		}
 
-		const effectiveMode = await getEffectiveShareMode(userResult.userId, currentYear);
+		const effectiveMode = await getEffectiveShareMode(userResult.userId, currentYear, currentYear);
 		if (effectiveMode !== ShareMode.PUBLIC) {
 			return fail(404, publicLookupFailure);
 		}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -161,8 +161,11 @@ function handleCancelRedirect(): void {
 						use:enhance={() => {
 							isLookingUp = true;
 							return async ({ update }) => {
-								await update();
-								isLookingUp = false;
+								try {
+									await update();
+								} finally {
+									isLookingUp = false;
+								}
 								if (form?.error) {
 									await tick();
 									usernameInput?.focus();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
 import { animate } from 'motion';
+import { tick } from 'svelte';
 import { prefersReducedMotion } from 'svelte/motion';
 import { browser } from '$app/environment';
 import { enhance } from '$app/forms';
@@ -17,7 +18,6 @@ import PopupBlockedModal from '$lib/components/auth/PopupBlockedModal.svelte';
 import SubmitButton from '$lib/components/forms/SubmitButton.svelte';
 import Logo from '$lib/components/Logo.svelte';
 import { Button } from '$lib/components/ui/button';
-import { Input } from '$lib/components/ui/input';
 import type { ActionData, PageData } from './$types';
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
@@ -25,6 +25,7 @@ let { data, form }: { data: PageData; form: ActionData } = $props();
 let username = $state('');
 let usernameTouched = $state(false);
 let isLookingUp = $state(false);
+let usernameInput: HTMLInputElement | undefined = $state();
 
 // The 403 "public lookup disabled" failure has no `username` field, so narrow
 // the ActionData union with an `in` check before reading it.
@@ -160,16 +161,22 @@ function handleCancelRedirect(): void {
 						use:enhance={() => {
 							isLookingUp = true;
 							return async ({ update }) => {
-								isLookingUp = false;
 								await update();
+								isLookingUp = false;
+								if (form?.error) {
+									await tick();
+									usernameInput?.focus();
+								}
 							};
 						}}
 						class="username-form"
+						aria-busy={isLookingUp}
 					>
 						<div class="username-input-group">
-							<label for="username-input" class="sr-only">Plex username</label>
-							<Input
+							<label for="username-input" class="lookup-label">Find a current-year Wrapped</label>
+							<input
 								id="username-input"
+								bind:this={usernameInput}
 								type="text"
 								name="username"
 								bind:value={username}
@@ -179,24 +186,38 @@ function handleCancelRedirect(): void {
 								autocomplete="off"
 								autocapitalize="off"
 								spellcheck="false"
+								required
+								aria-describedby={form?.error
+									? 'username-help username-action-error'
+									: 'username-help'}
+								aria-invalid={form?.error ? 'true' : undefined}
 								onblur={() => (usernameTouched = true)}
 							/>
 							<SubmitButton
 								class="view-button tap-target"
 								submitting={isLookingUp}
-								disabled={!username.trim()}
 							>
 								{#snippet children()}
-									View My {data.currentYear} Wrapped
+									View {data.currentYear} Wrapped
 								{/snippet}
 								{#snippet submittingLabel()}
 									Looking up...
 								{/snippet}
 							</SubmitButton>
 						</div>
+						<p id="username-help" class="lookup-help">
+							Search a Plex username. Eligible pages open without sign-in; unknown and opted-out users
+							receive the same response.
+						</p>
+						<p class="lookup-boundary">
+							This opens only a Wrapped page. Dashboards, settings, and admin controls remain protected.
+						</p>
+						<p class="lookup-status" role="status" aria-live="polite">
+							{isLookingUp ? 'Looking for that Wrapped…' : ''}
+						</p>
 
 						{#if form?.error}
-							<p class="error-message" role="alert">
+							<p id="username-action-error" class="error-message" role="alert">
 								{form.error}
 								{#if form.requiresAuth}
 									<button type="button" class="link-button" onclick={handlePlexLogin}>
@@ -239,7 +260,7 @@ function handleCancelRedirect(): void {
 			{/if}
 
 			<div class="login-section">
-				<p class="login-prompt">Want to access your dashboard or change settings?</p>
+				<p class="login-prompt">Sign in to access your protected dashboard or change settings.</p>
 				<Button
 					type="button"
 					class="login-button secondary tap-target"
@@ -384,17 +405,33 @@ function handleCancelRedirect(): void {
 			align-items: center;
 		}
 
-		.sr-only {
-			position: absolute;
-			width: 1px;
-			height: 1px;
-			padding: 0;
-			margin: -1px;
-			overflow: hidden;
-			clip: rect(0, 0, 0, 0);
-			white-space: nowrap;
-			border: 0;
+		.lookup-label {
+			width: 100%;
+			font-size: 0.9rem;
+			font-weight: 600;
+			text-align: center;
 		}
+
+		.lookup-help,
+		.lookup-boundary,
+		.lookup-status {
+			max-width: 38rem;
+			margin: 0 auto;
+			overflow-wrap: anywhere;
+			font-size: 0.82rem;
+			line-height: 1.5;
+			color: oklch(var(--muted-foreground));
+		}
+
+		.lookup-boundary {
+			font-weight: 500;
+		}
+
+		.lookup-status {
+			min-height: 1.25rem;
+			color: oklch(var(--foreground));
+		}
+
 
 		/* shadcn Input renders inside a child component beyond Svelte's scoped
 		   style boundary, so the selector must be global to preserve the custom
@@ -547,7 +584,9 @@ function handleCancelRedirect(): void {
 			border-radius: var(--radius);
 			color: oklch(var(--destructive-foreground));
 			font-size: 0.875rem;
+			overflow-wrap: anywhere;
 		}
+
 
 		.link-button {
 			background: none;
@@ -579,7 +618,7 @@ function handleCancelRedirect(): void {
 		.footer p {
 			margin: 0;
 			font-size: 0.75rem;
-			color: oklch(var(--muted-foreground));
+			color: oklch(var(--foreground));
 			letter-spacing: 0.05em;
 		}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -199,6 +199,7 @@ function handleCancelRedirect(): void {
 							<SubmitButton
 								class="view-button tap-target"
 								submitting={isLookingUp}
+								disabled={browser && !username.trim()}
 							>
 								{#snippet children()}
 									View {data.currentYear} Wrapped

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -47,7 +47,8 @@ import {
 	type PrivacyPreset,
 	type PrivacyPresetId,
 	type PrivacyPreviewRowKey,
-	publicLandingLookupCopy
+	publicLandingLookupCopy,
+	shareDefaultCopy
 } from '$lib/sharing/options';
 import {
 	derivePreview,
@@ -183,24 +184,9 @@ const {
 let bulkApplyDialogOpen = $state(false);
 let isBulkApplying = $state(false);
 
-// Live contradiction warning: the toggle is the SOLE landing-page gate (D1), so a
-// non-public per-user default means visitors see the form but every lookup 404s.
-// Surface that to the admin instead of silently hiding the form. Reads across two
-// Superform stores so it updates as the admin edits either control.
-let showContradictionWarning = $derived(
-	$publicLandingLookupData.publicLandingLookup && $userDefaultsData.defaultShareMode !== 'public'
-);
-
-// Auto-open Advanced options at mount ONLY when the saved config is already
-// contradictory (public landing lookup on, but the per-user default isn't
-// public), so the contradiction Alert inside Collapsible.Content isn't hidden
-// on page load. This is a one-time init snapshot of showContradictionWarning,
-// not a $effect — the project rule forbids state updates in effects, and an
-// effect would intrusively re-open the section while the admin is editing.
-// After mount the admin can freely collapse/expand. The suppressor matches the
-// other one-time $state-from-reactive declarations above.
-// svelte-ignore state_referenced_locally
-let advancedOpen = $state(showContradictionWarning);
+// Advanced controls stay collapsed until the administrator opens them or stages
+// a preset. Public lookup no longer creates a contradictory default state.
+let advancedOpen = $state(false);
 
 // ISSUE-007: expanding "Advanced options" can push each section's Save button
 // below the fold. On expand only, scroll the freshly-revealed section to the top
@@ -283,12 +269,8 @@ function applyPrivacyPreset(preset: PrivacyPreset) {
 	advancedOpen = true;
 }
 
-// Privacy dogfood requires every preset card to be directly reachable with Tab,
-// so this intentionally deviates from the APG roving-tabindex radio pattern:
-// every card has tabindex=0 while Arrow/Home/End still move focus and select.
-// Native buttons handle Space/Enter, so this handler only owns navigation keys.
-// Refs are indexed by preset position so a keyboard move can both select and
-// shift DOM focus.
+// Use the same APG roving-tabindex radio pattern as onboarding: the selected
+// card is the single Tab stop, with the first card reachable for Custom state.
 let presetButtons = $state<(HTMLButtonElement | null)[]>([]);
 
 function handlePresetKeydown(event: KeyboardEvent, index: number) {
@@ -411,19 +393,15 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 				)}
 			</div>
 		</dl>
-		<!-- The only preview warning is the landing-lookup contradiction, which the
-		     inline Alert in the "Public landing lookup" card already surfaces (with
-		     icon, where the admin edits). Rendering it here too duplicated the same
-		     sentence across both preview panels + the Alert, so the warnings line is
-		     intentionally not shown in the preview. -->
 	{/snippet}
 
 	<Card>
 		<CardHeader>
 			<CardTitle>Privacy presets</CardTitle>
 			<CardDescription>
-				Pick a preset to set anonymization, sharing and landing-lookup in one step — then save each
-				section below. Logo behavior is configured separately on Appearance.
+				Pick a recommended starting point, then save each affected section below. These presets
+				stage five privacy fields here; the full onboarding presets also set the Wrapped logo to
+				Always Show.
 			</CardDescription>
 		</CardHeader>
 		<CardContent class="space-y-4">
@@ -439,7 +417,7 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 						type="button"
 						role="radio"
 						aria-checked={selectedPreset === preset.id}
-						tabindex={0}
+						tabindex={selectedPreset === preset.id || (selectedPreset === 'custom' && i === 0) ? 0 : -1}
 						onclick={() => applyPrivacyPreset(preset)}
 						onkeydown={(event) => handlePresetKeydown(event, i)}
 						class={selectedPreset === preset.id
@@ -465,11 +443,12 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 				<div class="space-y-1">
 					<p class="font-medium">Wrapped logo</p>
 					<p class="text-muted-foreground">
-						Logo behavior is configured on
+						Every shipped preset uses Always Show. This admin page does not change Appearance
+						settings, so confirm the current value under
 						<a
 							href="/admin/settings/appearance"
 							class="inline-flex items-center gap-1 underline"
-						>Appearance<ExternalLinkIcon class="size-3" /></a>. Presets don’t change it.
+						>Appearance<ExternalLinkIcon class="size-3" /></a>.
 					</p>
 				</div>
 			</div>
@@ -519,12 +498,6 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 		>
 			<span class="flex items-center gap-2">
 				Advanced options
-				{#if showContradictionWarning}
-					<!-- At-a-glance flag for the collapsed case: if the admin closes Advanced
-					     while the saved config is still contradictory, this keeps the broken
-					     public-lookup state visible without duplicating the Alert's full text. -->
-					<TriangleAlertIcon class="size-4 text-destructive" />
-				{/if}
 			</span>
 			<ChevronDownIcon class={advancedOpen ? 'size-4 rotate-180 transition-transform' : 'size-4 transition-transform'} />
 		</Collapsible.Trigger>
@@ -647,12 +620,13 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 					{/snippet}
 				</SettingsToggleRow>
 
-				{#if showContradictionWarning}
-					<Alert>
-						<TriangleAlertIcon />
-						<AlertDescription>{publicLandingLookupCopy.contradictionWarning}</AlertDescription>
-					</Alert>
-				{/if}
+				<Alert>
+					<GlobeIcon />
+					<AlertDescription>
+						{publicLandingLookupCopy.protectedBoundary}
+						{publicLandingLookupCopy.privateOutcome}
+					</AlertDescription>
+				</Alert>
 
 				<input
 					type="hidden"
@@ -738,9 +712,8 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 						{/snippet}
 					</Form.Control>
 					<Form.Description>
-						New users get this automatically; saving does not change existing users. For
-						retroactive changes use “Apply current defaults to all users” below, or each
-						user’s “Can Control” toggle on the
+						{shareDefaultCopy.summary} {shareDefaultCopy.explicitRows} Use the explicit bulk action
+						below for default-managed existing rows, or manage an individual user on the
 						<a href="/admin/users" class="underline">Users</a> page.
 					</Form.Description>
 					<Form.FieldErrors />
@@ -767,10 +740,7 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 	<Card>
 		<CardHeader>
 			<CardTitle>Apply defaults to existing users</CardTitle>
-			<CardDescription>
-				Reset every existing user's share mode + "can control" flag to match the current
-				defaults above. Users with an explicit per-user override are skipped, not reset.
-			</CardDescription>
+			<CardDescription>{shareDefaultCopy.bulkApply}</CardDescription>
 		</CardHeader>
 		<CardContent>
 			<SettingsActionBar>
@@ -781,7 +751,7 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 					disabled={isBulkApplying}
 				>
 					<UsersIcon />
-					Apply current defaults to all users
+					Apply defaults to managed users
 				</Button>
 			</SettingsActionBar>
 		</CardContent>
@@ -791,11 +761,9 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 <AlertDialog.Root bind:open={bulkApplyDialogOpen}>
 	<AlertDialog.Content>
 		<AlertDialog.Header>
-			<AlertDialog.Title>Apply current defaults to all users?</AlertDialog.Title>
+			<AlertDialog.Title>Apply defaults to default-managed users?</AlertDialog.Title>
 			<AlertDialog.Description>
-				This resets every existing user's share mode and "can control" setting back to the
-				current server defaults. Users with an explicit per-user override are skipped, not reset. Future users continue to
-				receive the current defaults.
+				{shareDefaultCopy.bulkApply} The result reports how many rows were updated and skipped.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
@@ -829,7 +797,7 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 				style="display: contents;"
 			>
 				<AlertDialog.Action type="submit" class="tap-target" disabled={isBulkApplying}>
-					{isBulkApplying ? 'Applying…' : 'Apply to all users'}
+					{isBulkApplying ? 'Applying…' : 'Apply managed defaults'}
 				</AlertDialog.Action>
 			</form>
 		</AlertDialog.Footer>

--- a/src/routes/admin/settings/security/+page.server.ts
+++ b/src/routes/admin/settings/security/+page.server.ts
@@ -284,7 +284,8 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	diagnoseReverseProxy: async ({ request, url, getClientAddress }) => {
+	diagnoseReverseProxy: async ({ request, url, getClientAddress, setHeaders }) => {
+		setHeaders?.({ 'Cache-Control': 'no-store' });
 		const formData = await request.formData();
 		const parsed = BrowserOriginSchema.safeParse({
 			browserOrigin: formData.get('browserOrigin')
@@ -317,7 +318,8 @@ export const actions: Actions = requireAdminActions({
 		}
 	},
 
-	updateTrustProxy: async ({ request, url, getClientAddress }) => {
+	updateTrustProxy: async ({ request, url, getClientAddress, setHeaders }) => {
+		setHeaders?.({ 'Cache-Control': 'no-store' });
 		const trustProxyConfig = await getTrustProxyConfigWithSource();
 		if (trustProxyConfig.trustProxy.isLocked) {
 			return fail(400, {
@@ -372,6 +374,11 @@ export const actions: Actions = requireAdminActions({
 				return fail(400, {
 					error:
 						'Browser origin is required to verify the reverse-proxy diagnostic before enabling header trust.'
+				});
+			}
+			if (!adminRequestOriginMatches(request, parsed.data.browserOrigin)) {
+				return fail(403, {
+					error: 'TRUST_PROXY can only be enabled from the submitted browser origin'
 				});
 			}
 			const diagnostic = await createReverseProxyDiagnostic({

--- a/src/routes/admin/settings/security/+page.svelte
+++ b/src/routes/admin/settings/security/+page.svelte
@@ -15,8 +15,13 @@ import {
 } from '$lib/components/ui/card/index.js';
 import { Input } from '$lib/components/ui/input/index.js';
 import { Label } from '$lib/components/ui/label/index.js';
-import { Switch } from '$lib/components/ui/switch/index.js';
-import { REVERSE_PROXY_COPY } from '$lib/copy/reverse-proxy';
+import {
+	documentationForGuide,
+	presentReverseProxyDiagnostic,
+	REVERSE_PROXY_COPY,
+	REVERSE_PROXY_PROVIDER_GUIDES
+} from '$lib/copy/reverse-proxy';
+import type { ReverseProxyDiagnostic } from '$lib/security/reverse-proxy';
 import { toast } from '$lib/services/toast';
 import { handleFormToast } from '$lib/utils/form-toast';
 import { submitAction } from '$lib/utils/submit-action';
@@ -48,47 +53,15 @@ let pendingMismatchMessage = $state('');
 
 let trustProxyConfirmDialogOpen = $state(false);
 
-type ReverseProxyDiagnosticView = {
-	trustProxy: {
-		enabled: boolean;
-		source: 'env' | 'db' | 'default';
-		isLocked: boolean;
-	};
-	forwardedHeaders: {
-		present: string[];
-		pair: {
-			status: string;
-			isUsable: boolean;
-			protoPresent: boolean;
-			hostPresent: boolean;
-		};
-	};
-	recommendation: {
-		action:
-			| 'enable'
-			| 'leave-disabled'
-			| 'review-proxy'
-			| 'appears-working'
-			| 'unable-to-determine'
-			| 'env-controlled';
-		summary: string;
-	};
-	reasons: string[];
-	safetyNotice: string;
-};
-
-let diagnostic = $state<ReverseProxyDiagnosticView | null>(null);
+let diagnostic = $state<ReverseProxyDiagnostic | null>(null);
 let diagnosticStatus = $state<'idle' | 'checking' | 'success' | 'failure'>('idle');
 let diagnosticError = $state<string | null>(null);
 let showDiagnosticDetails = $state(false);
 let hasRunInitialDiagnostic = $state(false);
 let diagnosticRunToken = 0;
+let trustProxyVerificationPending = $state(false);
+let copiedGuideId = $state<string | null>(null);
 
-// ISSUE-007: the on-mount auto-run must be silent (only the inline status panel
-// updates); a success/error toast fires ONLY when the user clicks "Re-run
-// diagnostic". `userInitiated` defaults to false so the on-mount $effect (which
-// calls runDiagnostic() with no args) never toasts. The toast is purely additive
-// — the inline panel still reflects every outcome regardless of `userInitiated`.
 async function runDiagnostic({ userInitiated = false }: { userInitiated?: boolean } = {}) {
 	if (diagnosticStatus === 'checking') return;
 
@@ -102,7 +75,7 @@ async function runDiagnostic({ userInitiated = false }: { userInitiated?: boolea
 
 	try {
 		const result = await submitAction<{
-			reverseProxyDiagnostic?: ReverseProxyDiagnosticView;
+			reverseProxyDiagnostic?: ReverseProxyDiagnostic;
 			diagnosticError?: string;
 		}>('?/diagnoseReverseProxy', formData);
 
@@ -134,6 +107,34 @@ async function runDiagnostic({ userInitiated = false }: { userInitiated?: boolea
 		if (userInitiated) toast.error(diagnosticError);
 	}
 }
+async function refreshDiagnosticAfterTrustProxyWrite() {
+	diagnostic = null;
+	diagnosticError = null;
+	diagnosticStatus = 'idle';
+	trustProxyVerificationPending = true;
+	try {
+		await invalidateAll();
+		await runDiagnostic();
+	} catch {
+		diagnosticStatus = 'failure';
+		diagnosticError = REVERSE_PROXY_COPY.savedUnverified;
+	} finally {
+		trustProxyVerificationPending = false;
+	}
+	if (!diagnostic) {
+		diagnosticStatus = 'failure';
+		diagnosticError = REVERSE_PROXY_COPY.savedUnverified;
+	}
+}
+
+async function copyGuide(id: string, config: string) {
+	try {
+		await navigator.clipboard.writeText(config);
+		copiedGuideId = id;
+	} catch {
+		copiedGuideId = `error:${id}`;
+	}
+}
 
 $effect(() => {
 	if (hasRunInitialDiagnostic) return;
@@ -141,74 +142,14 @@ $effect(() => {
 	void runDiagnostic();
 });
 
-type StatusTone = 'success' | 'warning' | 'neutral';
-
-const statusView = $derived.by<{
-	tone: StatusTone;
-	headline: string;
-	body: string;
-} | null>(() => {
-	if (!diagnostic) return null;
-	const action = diagnostic.recommendation.action;
-
-	if (action === 'appears-working') {
-		return {
-			tone: 'success',
-			headline: 'Header trust is working',
-			body: 'Obzorarr is correctly identifying visitor IP addresses and protocols from your reverse proxy.'
-		};
-	}
-	if (action === 'leave-disabled') {
-		return {
-			tone: 'success',
-			headline: 'No proxy detected',
-			body: 'Direct connection details look correct. Header trust does not need to be enabled.'
-		};
-	}
-	if (action === 'enable') {
-		return {
-			tone: 'warning',
-			headline: 'Proxy detected — header trust recommended',
-			body: 'Obzorarr appears to be behind a reverse proxy. Enable header trust to use forwarded IPs and protocols, but only if your proxy strips incoming x-forwarded-* headers from external traffic.'
-		};
-	}
-	if (action === 'review-proxy') {
-		return {
-			tone: 'warning',
-			headline: 'Proxy configuration needs review',
-			body: 'Some forwarded headers are present but do not match the browser origin. Check your reverse proxy configuration and re-run the check.'
-		};
-	}
-	if (action === 'env-controlled') {
-		return {
-			tone: 'neutral',
-			headline: 'Managed by environment',
-			body: 'TRUST_PROXY is controlled by the environment variable. Change it in your environment or container configuration to switch the setting.'
-		};
-	}
-	return {
-		tone: 'neutral',
-		headline: 'Could not verify automatically',
-		body: 'Obzorarr could not determine your proxy setup from the current request.'
-	};
-});
-
-function getForwardedPairLabel(status: string): string {
-	switch (status) {
-		case 'usable':
-			return 'Forwarded scheme and host look usable';
-		case 'missing':
-			return 'No forwarded scheme/host pair detected';
-		case 'partial':
-			return 'Forwarded scheme/host pair is incomplete';
-		case 'invalid-proto':
-		case 'unsafe-host':
-		case 'invalid-host':
-			return 'Forwarded scheme/host pair is invalid';
-		default:
-			return 'Forwarded scheme/host pair needs review';
-	}
-}
+const presentation = $derived(diagnostic ? presentReverseProxyDiagnostic(diagnostic) : null);
+const applicableProviderGuides = $derived(
+	presentation && presentation.documentationIds.length > 1
+		? REVERSE_PROXY_PROVIDER_GUIDES.filter((guide) =>
+				presentation.documentationIds.includes(guide.documentationId)
+			)
+		: []
+);
 </script>
 
 <svelte:head>
@@ -419,74 +360,29 @@ function getForwardedPairLabel(status: string): string {
 		</CardHeader>
 		<CardContent class="space-y-4">
 			{#if diagnosticStatus === 'checking' && !diagnostic}
-				<div class="status-card neutral">
+				<div class="status-card neutral" role="status" aria-live="polite" aria-busy="true">
 					<LoaderCircleIcon class="size-5 animate-spin status-icon" aria-hidden="true" />
 					<div class="status-text">
-						<span class="status-headline">Checking your connection…</span>
-						<span class="status-body">
-							Comparing what your browser sees with what Obzorarr receives.
-						</span>
+						<span class="status-headline">{trustProxyVerificationPending ? 'Saved. Verifying…' : 'Checking your connection…'}</span>
+						<span class="status-body">Comparing what your browser sees with what Obzorarr receives.</span>
 					</div>
 				</div>
 			{:else if diagnosticStatus === 'failure' && !diagnostic}
-				<div class="status-card warning">
-					<svg
-						class="status-icon"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<line x1="15" y1="9" x2="9" y2="15" stroke-linecap="round" />
-						<line x1="9" y1="9" x2="15" y2="15" stroke-linecap="round" />
-					</svg>
+				<div class="status-card warning" role="alert">
 					<div class="status-text">
 						<span class="status-headline">Could not run the diagnostic</span>
 						<span class="status-body">{diagnosticError ?? 'Diagnostic failed'}</span>
 					</div>
+					<Button type="button" variant="outline" class="tap-target" onclick={() => void runDiagnostic({ userInitiated: true })}>
+						{REVERSE_PROXY_COPY.rerunButton}
+					</Button>
 				</div>
-			{:else if statusView && diagnostic}
-				<div class="status-card {statusView.tone}">
-					{#if statusView.tone === 'success'}
-						<svg
-							class="status-icon"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-						>
-							<circle cx="12" cy="12" r="10" />
-							<path d="M9 12l2 2 4-4" stroke-linecap="round" stroke-linejoin="round" />
-						</svg>
-					{:else if statusView.tone === 'warning'}
-						<svg
-							class="status-icon"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-						>
-							<path d="M12 2l10 18H2z" stroke-linecap="round" stroke-linejoin="round" />
-							<line x1="12" y1="9" x2="12" y2="13" stroke-linecap="round" />
-							<circle cx="12" cy="16" r="0.6" fill="currentColor" />
-						</svg>
-					{:else}
-						<svg
-							class="status-icon"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-						>
-							<circle cx="12" cy="12" r="10" />
-							<path d="M12 16v-4" stroke-linecap="round" />
-							<path d="M12 8h.01" stroke-linecap="round" />
-						</svg>
-					{/if}
+			{:else if presentation && diagnostic}
+				<div class="status-card {presentation.tone}" role="status" aria-live="polite" aria-busy="false">
 					<div class="status-text">
-						<span class="status-headline">{statusView.headline}</span>
-						<span class="status-body">{statusView.body}</span>
+						<span class="status-headline">{presentation.headline}</span>
+						<span class="status-body">{presentation.diagnosis}</span>
+						<span class="status-body"><strong>Next action:</strong> {presentation.nextAction}</span>
 					</div>
 				</div>
 
@@ -495,70 +391,62 @@ function getForwardedPairLabel(status: string): string {
 					class="details-toggle"
 					onclick={() => (showDiagnosticDetails = !showDiagnosticDetails)}
 					aria-expanded={showDiagnosticDetails}
+					aria-controls="reverse-proxy-diagnostic-details"
 				>
-					<span>
-						{showDiagnosticDetails ? 'Hide technical details' : 'Show technical details'}
-					</span>
-					<ChevronDownIcon
-						class="size-4 chevron"
-						data-open={showDiagnosticDetails}
-						aria-hidden="true"
-					/>
+					<span>{showDiagnosticDetails ? 'Hide technical details' : 'Show technical details and proxy setup'}</span>
+					<ChevronDownIcon class="size-4 chevron" data-open={showDiagnosticDetails} aria-hidden="true" />
 				</button>
 
 				{#if showDiagnosticDetails}
-					<div class="details-panel">
+					<div id="reverse-proxy-diagnostic-details" class="details-panel">
 						<div class="diagnostic-facts">
-							<div>
-								<span class="fact-label">Forwarded headers</span>
-								<span class="fact-value">
-									{getForwardedPairLabel(diagnostic.forwardedHeaders.pair.status)}
-								</span>
-							</div>
-							<div>
-								<span class="fact-label">Signals present</span>
-								<span class="fact-value">
-									{diagnostic.forwardedHeaders.present.length > 0
-										? diagnostic.forwardedHeaders.present.join(', ')
-										: 'None'}
-								</span>
-							</div>
-							<div>
-								<span class="fact-label">Current setting</span>
-								<span class="fact-value">
-									{diagnostic.trustProxy.enabled ? 'Enabled' : 'Disabled'}
-									{#if diagnostic.trustProxy.isLocked}
-										<span class="inline-badge">ENV</span>
-									{/if}
-								</span>
-							</div>
+							<div><span class="fact-label">Present headers</span><span class="fact-value">{diagnostic.facts.forwardedHeaders.present.length ? diagnostic.facts.forwardedHeaders.present.join(', ') : 'None'}</span></div>
+							<div><span class="fact-label">Forwarded pair</span><span class="fact-value">{presentation.pairLabel}</span></div>
+							<div><span class="fact-label">Browser origin</span><span class="fact-value">{diagnostic.facts.browserOrigin.origin ?? 'not available'}</span></div>
+							<div><span class="fact-label">Effective app origin</span><span class="fact-value">{diagnostic.facts.origins.effectiveApp ?? 'not available'}</span></div>
+							<div><span class="fact-label">Forwarded origin</span><span class="fact-value">{diagnostic.facts.origins.forwardedPair ?? 'not available'}</span></div>
+							<div><span class="fact-label">TRUST_PROXY</span><span class="fact-value">{diagnostic.facts.trustProxy.enabled ? 'Enabled' : 'Disabled'} — {diagnostic.facts.trustProxy.source}{#if diagnostic.facts.trustProxy.isLocked} (locked){/if}</span></div>
 						</div>
-
-						{#if diagnostic.reasons.length > 0}
-							<div class="reasons-block">
-								<span class="reasons-label">Why we recommend this</span>
-								<ul>
-									{#each diagnostic.reasons as reason}
-										<li>{reason}</li>
-									{/each}
-								</ul>
-							</div>
+						<p class="safety-note">{presentation.safetyNotice}</p>
+						{#if applicableProviderGuides.length > 0}
+						<div class="provider-guides">
+							<span class="reasons-label">Repair steps by proxy</span>
+							{#each applicableProviderGuides as guide}
+								<details class="provider-guide">
+									<summary>{guide.label}</summary>
+									<div class="provider-guide-content">
+										<ol>
+											{#each guide.steps as step}
+												<li>{step}</li>
+											{/each}
+										</ol>
+										{#if guide.config}
+											<div class="provider-config">
+												<pre><code>{guide.config}</code></pre>
+												<Button type="button" variant="outline" class="tap-target" onclick={() => void copyGuide(guide.id, guide.config ?? '')}>
+													Copy configuration
+												</Button>
+											</div>
+											<span class="copy-status" role="status" aria-live="polite">
+												{copiedGuideId === guide.id
+													? `${guide.label} configuration copied`
+													: copiedGuideId === `error:${guide.id}`
+														? `Could not copy the ${guide.label} configuration`
+														: ''}
+											</span>
+										{/if}
+										<a href={documentationForGuide(guide).url} target="_blank" rel="noreferrer">
+											{guide.id === 'other' ? 'Open Obzorarr configuration guidance' : `Open official ${guide.label} documentation`}
+										</a>
+									</div>
+								</details>
+							{/each}
+						</div>
 						{/if}
-
-						<p class="safety-note">{diagnostic.safetyNotice}</p>
-
+						<p class="safety-note">{presentation.consequence} Restart Obzorarr after changing an environment-controlled TRUST_PROXY setting, then rerun this diagnostic.</p>
 						<div class="re-check">
-							<Button
-								type="button"
-								variant="outline"
-								class="tap-target"
-								onclick={() => void runDiagnostic({ userInitiated: true })}
-								disabled={diagnosticStatus === 'checking'}
-								aria-busy={diagnosticStatus === 'checking'}
-							>
-								{diagnosticStatus === 'checking'
-									? REVERSE_PROXY_COPY.rerunButtonInProgress
-									: REVERSE_PROXY_COPY.rerunButton}
+							<Button type="button" variant="outline" class="tap-target" onclick={() => void runDiagnostic({ userInitiated: true })} disabled={diagnosticStatus === 'checking'} aria-busy={diagnosticStatus === 'checking'}>
+								{diagnosticStatus === 'checking' ? REVERSE_PROXY_COPY.rerunButtonInProgress : REVERSE_PROXY_COPY.rerunButton}
 							</Button>
 						</div>
 					</div>
@@ -587,7 +475,7 @@ function getForwardedPairLabel(status: string): string {
 									);
 								}
 								await update({ reset: false });
-								if (result.type === 'success') await invalidateAll();
+								if (result.type === 'success') await refreshDiagnosticAfterTrustProxyWrite();
 							} finally {
 								isTogglingTrustProxy = false;
 							}
@@ -607,7 +495,7 @@ function getForwardedPairLabel(status: string): string {
 						</Button>
 					</SettingsActionBar>
 				</form>
-			{:else}
+			{:else if diagnostic?.action === 'enable'}
 				<SettingsActionBar>
 					<button
 						type="button"
@@ -673,9 +561,11 @@ function getForwardedPairLabel(status: string): string {
 		<AlertDialog.Header>
 			<AlertDialog.Title>Enable reverse-proxy header trust?</AlertDialog.Title>
 			<AlertDialog.Description>
-				Obzorarr will trust the upstream proxy's `x-forwarded-*` headers for client IP, host,
-				and protocol. If those headers can reach obzorarr unsanitised, attackers can spoof the
-				host or protocol used for security decisions and generated URLs.
+				Obzorarr will use the upstream proxy's X-Forwarded-Host and X-Forwarded-Proto
+				values for effective public URLs. Enable this only when the proxy removes or overwrites
+				visitor-supplied forwarding headers; otherwise attackers could spoof the host or protocol
+				used for security decisions and generated URLs. Client-IP handling is configured separately
+				by the runtime or adapter.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
@@ -693,7 +583,7 @@ function getForwardedPairLabel(status: string): string {
 								);
 							}
 							await update({ reset: false });
-							if (result.type === 'success') await invalidateAll();
+							if (result.type === 'success') await refreshDiagnosticAfterTrustProxyWrite();
 						} finally {
 							isConfirmingTrustProxy = false;
 							trustProxyConfirmDialogOpen = false;
@@ -909,11 +799,6 @@ function getForwardedPairLabel(status: string): string {
 		letter-spacing: 0.05em;
 	}
 
-	.reasons-block {
-		display: flex;
-		flex-direction: column;
-		gap: 0.35rem;
-	}
 
 	.reasons-label {
 		font-size: 0.7rem;
@@ -923,13 +808,59 @@ function getForwardedPairLabel(status: string): string {
 		color: oklch(var(--muted-foreground));
 	}
 
-	.reasons-block ul {
+	.provider-guides {
+		display: grid;
+		gap: 0.75rem;
+	}
+
+	.provider-guide {
+		min-width: 0;
+		border: 1px solid oklch(var(--border));
+		border-radius: 8px;
+	}
+
+	.provider-guide summary {
+		cursor: pointer;
+		padding: 0.65rem 0.75rem;
+		font-weight: 600;
+	}
+
+	.provider-guide-content {
+		display: grid;
+		gap: 0.65rem;
+		padding: 0 0.75rem 0.75rem;
+	}
+
+	.provider-guides ol {
 		margin: 0;
-		padding-left: 1.1rem;
-		color: oklch(var(--muted-foreground));
+		padding-left: 1.25rem;
 		font-size: 0.8rem;
 		line-height: 1.5;
 	}
+
+	.provider-config {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) auto;
+		gap: 0.5rem;
+		align-items: start;
+	}
+
+	.provider-config pre {
+		min-width: 0;
+		margin: 0;
+		overflow-x: auto;
+		padding: 0.6rem;
+		border: 1px solid oklch(var(--border));
+		border-radius: 8px;
+		font-size: 0.75rem;
+	}
+
+	.copy-status {
+		min-height: 1.25rem;
+		font-size: 0.75rem;
+		color: oklch(var(--muted-foreground));
+	}
+
 
 	.safety-note {
 		margin: 0;
@@ -945,6 +876,9 @@ function getForwardedPairLabel(status: string): string {
 
 	@media (max-width: 640px) {
 		.diagnostic-facts {
+			grid-template-columns: 1fr;
+		}
+		.provider-config {
 			grid-template-columns: 1fr;
 		}
 	}

--- a/src/routes/admin/settings/security/+page.svelte
+++ b/src/routes/admin/settings/security/+page.svelte
@@ -659,6 +659,11 @@ const applicableProviderGuides = $derived(
 		border-color: oklch(0.79 0.1606 79.6 / 0.25);
 	}
 
+	.status-card.danger {
+		background: oklch(var(--destructive) / 0.08);
+		border-color: oklch(var(--destructive) / 0.25);
+	}
+
 	.status-card.neutral {
 		background: oklch(var(--muted) / 0.4);
 	}

--- a/src/routes/onboarding/proxy-trust/+page.server.ts
+++ b/src/routes/onboarding/proxy-trust/+page.server.ts
@@ -128,10 +128,6 @@ export const actions: Actions = {
 		redirect(303, '/onboarding/plex');
 	},
 
-	// Rewind to the previous step so the user can review the security settings.
-	// Both steps are pure configuration with no destructive side effects, so the
-	// only state changed is the onboarding cursor; forward navigation re-runs the
-	// normal `continue` action and its validation.
 	goBack: async ({ cookies, url }) => {
 		const guardResult = await requireOnboardingProxyTrustAction(cookies, url, 'error');
 		if (guardResult) return guardResult;
@@ -140,7 +136,8 @@ export const actions: Actions = {
 		redirect(303, '/onboarding/csrf');
 	},
 
-	diagnoseReverseProxy: async ({ request, cookies, url, getClientAddress }) => {
+	diagnoseReverseProxy: async ({ request, cookies, url, getClientAddress, setHeaders }) => {
+		setHeaders({ 'Cache-Control': 'no-store' });
 		const guardResult = await requireOnboardingProxyTrustAction(cookies, url, 'diagnosticError');
 		if (guardResult) return guardResult;
 
@@ -170,7 +167,8 @@ export const actions: Actions = {
 		}
 	},
 
-	enableTrustProxy: async ({ request, cookies, url, getClientAddress }) => {
+	enableTrustProxy: async ({ request, cookies, url, getClientAddress, setHeaders }) => {
+		setHeaders({ 'Cache-Control': 'no-store' });
 		const guardResult = await requireOnboardingProxyTrustAction(cookies, url, 'trustProxyError');
 		if (guardResult) return guardResult;
 
@@ -182,10 +180,6 @@ export const actions: Actions = {
 			});
 		}
 
-		// Re-ordered per ISSUE-001: the diagnostic-recommendation guard must run
-		// BEFORE the confirmRisk guard, otherwise an API-direct caller posting
-		// `confirmRisk=1` on a system the diagnostic told to leave disabled would
-		// see the wrong error message and assume the diagnostic guard had passed.
 		const formData = await request.formData();
 		const browserOriginParsed = BrowserOriginSchema.safeParse({
 			browserOrigin: formData.get('browserOrigin')

--- a/src/routes/onboarding/proxy-trust/+page.svelte
+++ b/src/routes/onboarding/proxy-trust/+page.svelte
@@ -3,913 +3,239 @@ import ArrowLeftIcon from '@lucide/svelte/icons/arrow-left';
 import CheckIcon from '@lucide/svelte/icons/check';
 import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 import LoaderCircleIcon from '@lucide/svelte/icons/loader-circle';
-import { animate } from 'motion';
 import SubmitButton from '$lib/components/forms/SubmitButton.svelte';
 import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
 import { Button } from '$lib/components/ui/button';
-import { REVERSE_PROXY_COPY } from '$lib/copy/reverse-proxy';
+import {
+	documentationForGuide,
+	presentReverseProxyDiagnostic,
+	REVERSE_PROXY_COPY,
+	REVERSE_PROXY_PROVIDER_GUIDES
+} from '$lib/copy/reverse-proxy';
+import type { ReverseProxyDiagnostic } from '$lib/security/reverse-proxy';
 import { submitAction } from '$lib/utils/submit-action';
 import type { ActionData, PageData } from './$types';
 
 let { data, form }: { data: PageData; form: ActionData } = $props();
-
-type ReverseProxyDiagnosticView = {
-	trustProxy: {
-		enabled: boolean;
-		source: 'env' | 'db' | 'default';
-		isLocked: boolean;
-	};
-	forwardedHeaders: {
-		present: string[];
-		pair: {
-			status: string;
-			isUsable: boolean;
-			protoPresent: boolean;
-			hostPresent: boolean;
-		};
-	};
-	sourceAddress: {
-		category: string;
-	};
-	originComparison: {
-		browserMatchesRawApp: boolean | null;
-		browserMatchesEffectiveApp: boolean | null;
-		forwardedPairMatchesBrowser: boolean | null;
-	};
-	recommendation: {
-		action:
-			| 'enable'
-			| 'leave-disabled'
-			| 'review-proxy'
-			| 'appears-working'
-			| 'unable-to-determine'
-			| 'env-controlled';
-		summary: string;
-	};
-	reasons: string[];
-	safetyNotice: string;
-};
-
-let browserOrigin = $state<string>('');
-let reverseProxyDiagnostic = $state<ReverseProxyDiagnosticView | null>(null);
+let browserOrigin = $state('');
+let diagnostic = $state<ReverseProxyDiagnostic | null>(null);
 let diagnosticStatus = $state<'idle' | 'checking' | 'success' | 'failure'>('idle');
 let diagnosticError = $state<string | null>(null);
+let savedState = $state<'idle' | 'verifying' | 'unverified'>('idle');
 let showDetails = $state(false);
-let hasRunInitialDiagnostic = $state(false);
-let hasRefreshedAfterTrustProxySuccess = $state(false);
-let diagnosticRunToken = 0;
+let copiedGuide = $state<string | null>(null);
+let runToken = 0;
+let initialRun = false;
+let handledTrustProxySuccess = false;
 
-function updateDiagnosticFromActionForm() {
-	if (form?.trustProxySuccess) {
-		diagnosticError = null;
-		if (!hasRefreshedAfterTrustProxySuccess) {
-			hasRefreshedAfterTrustProxySuccess = true;
-			hasRunInitialDiagnostic = true;
-			void runDiagnostic();
+const presentation = $derived(diagnostic ? presentReverseProxyDiagnostic(diagnostic) : null);
+const applicableProviderGuides = $derived(
+	presentation && presentation.documentationIds.length > 1
+		? REVERSE_PROXY_PROVIDER_GUIDES.filter((guide) =>
+				presentation.documentationIds.includes(guide.documentationId)
+			)
+		: []
+);
+const canEnable = $derived(
+	diagnosticStatus === 'success' &&
+		diagnostic?.action === 'enable' &&
+		!diagnostic.facts.trustProxy.isLocked &&
+		savedState === 'idle'
+);
+const continueWarning = $derived(
+	savedState === 'unverified' ||
+		(diagnostic && ['review-proxy', 'unable-to-determine'].includes(diagnostic.action))
+		? REVERSE_PROXY_COPY.continueWarning
+		: null
+);
+
+async function runDiagnostic(afterSave = false) {
+	if (diagnosticStatus === 'checking') return;
+	const token = ++runToken;
+	browserOrigin = window.location.origin;
+	diagnostic = null;
+	diagnosticStatus = 'checking';
+	diagnosticError = null;
+	const formData = new FormData();
+	formData.set('browserOrigin', browserOrigin);
+	try {
+		const result = await submitAction<{
+			reverseProxyDiagnostic?: ReverseProxyDiagnostic;
+			diagnosticError?: string;
+		}>('?/diagnoseReverseProxy', formData);
+		if (token !== runToken) return;
+		if (result.type === 'success' && result.data.reverseProxyDiagnostic) {
+			diagnostic = result.data.reverseProxyDiagnostic;
+			diagnosticStatus = 'success';
+			savedState = 'idle';
+			return;
 		}
-		return;
+		diagnosticStatus = 'failure';
+		diagnosticError =
+			result.type === 'failure'
+				? (result.data.diagnosticError ?? 'Diagnostic failed')
+				: 'Diagnostic response was incomplete';
+		if (afterSave) savedState = 'unverified';
+	} catch {
+		if (token !== runToken) return;
+		diagnosticStatus = 'failure';
+		diagnosticError = 'Network error - could not complete diagnostic';
+		if (afterSave) savedState = 'unverified';
 	}
-	if (hasRefreshedAfterTrustProxySuccess) {
-		hasRefreshedAfterTrustProxySuccess = false;
-	}
+}
+
+function applyActionData() {
 	if (form?.reverseProxyDiagnostic) {
-		reverseProxyDiagnostic = form.reverseProxyDiagnostic as ReverseProxyDiagnosticView;
+		diagnostic = form.reverseProxyDiagnostic as ReverseProxyDiagnostic;
 		diagnosticStatus = 'success';
 		diagnosticError = null;
 	}
 	if (form?.diagnosticError) {
-		reverseProxyDiagnostic = null;
+		diagnostic = null;
 		diagnosticStatus = 'failure';
 		diagnosticError = form.diagnosticError;
 	}
-}
-
-async function runDiagnostic() {
-	if (diagnosticStatus === 'checking') return;
-
-	const myToken = ++diagnosticRunToken;
-	browserOrigin = window.location.origin;
-	reverseProxyDiagnostic = null;
-	diagnosticStatus = 'checking';
-	diagnosticError = null;
-
-	const formData = new FormData();
-	formData.set('browserOrigin', browserOrigin);
-
-	try {
-		const result = await submitAction<{
-			reverseProxyDiagnostic?: ReverseProxyDiagnosticView;
-			diagnosticError?: string;
-		}>('?/diagnoseReverseProxy', formData);
-
-		if (myToken !== diagnosticRunToken) return;
-
-		if (result.type === 'success') {
-			if (result.data.reverseProxyDiagnostic) {
-				reverseProxyDiagnostic = result.data.reverseProxyDiagnostic;
-				diagnosticStatus = 'success';
-			} else {
-				diagnosticStatus = 'failure';
-				diagnosticError = 'Diagnostic response was incomplete';
-			}
-		} else if (result.type === 'failure') {
-			diagnosticStatus = 'failure';
-			diagnosticError = result.data.diagnosticError ?? 'Diagnostic failed';
-		} else {
-			diagnosticStatus = 'failure';
-			diagnosticError = 'Unexpected diagnostic response';
-		}
-	} catch {
-		if (myToken !== diagnosticRunToken) return;
-		diagnosticStatus = 'failure';
-		diagnosticError = 'Network error - could not complete diagnostic';
+	if (form?.trustProxySuccess && !handledTrustProxySuccess) {
+		handledTrustProxySuccess = true;
+		diagnostic = null;
+		savedState = 'verifying';
+		void runDiagnostic(true);
+	} else if (!form?.trustProxySuccess) {
+		handledTrustProxySuccess = false;
 	}
 }
 
 $effect(() => {
-	updateDiagnosticFromActionForm();
-	if (hasRunInitialDiagnostic) return;
-	hasRunInitialDiagnostic = true;
-	if (data.trustProxy?.isLocked) {
-		diagnosticStatus = 'success';
-		reverseProxyDiagnostic = {
-			trustProxy: {
-				enabled: data.trustProxy.enabled,
-				source: data.trustProxy.source,
-				isLocked: true
-			},
-			forwardedHeaders: {
-				present: [],
-				pair: { status: 'missing', isUsable: false, protoPresent: false, hostPresent: false }
-			},
-			sourceAddress: { category: 'unknown' },
-			originComparison: {
-				browserMatchesRawApp: null,
-				browserMatchesEffectiveApp: null,
-				forwardedPairMatchesBrowser: null
-			},
-			recommendation: {
-				action: 'env-controlled',
-				summary: 'TRUST_PROXY is controlled by the environment.'
-			},
-			reasons: [
-				`TRUST_PROXY is controlled by the environment and is currently ${data.trustProxy.enabled ? 'enabled' : 'disabled'}.`,
-				'Obzorarr will not change this setting from the UI while it is locked.'
-			],
-			safetyNotice:
-				'Only enable reverse proxy header trust when your upstream proxy strips visitor-supplied forwarding headers before requests reach Obzorarr.'
-		};
-		return;
-	}
+	applyActionData();
+	if (initialRun) return;
+	initialRun = true;
 	void runDiagnostic();
 });
 
-let iconRef: HTMLElement | undefined = $state();
-let contentRef: HTMLElement | undefined = $state();
-
-$effect(() => {
-	if (!iconRef) return;
-	// biome-ignore lint/suspicious/noExplicitAny: Motion's animate function has complex overloads that TypeScript cannot infer correctly
-	const animation = (animate as any)(
-		iconRef,
-		{
-			opacity: [0, 1],
-			transform: ['scale(0.8)', 'scale(1)']
-		},
-		{ duration: 0.5, easing: [0.22, 1, 0.36, 1] }
-	);
-	return () => animation.stop?.();
-});
-
-type Tone = 'success' | 'warning' | 'neutral';
-
-type StatusView = {
-	tone: Tone;
-	headline: string;
-	body: string;
-};
-
-function getStatusView(
-	diagnostic: ReverseProxyDiagnosticView | null,
-	formState: ActionData
-): StatusView | null {
-	if (!diagnostic) return null;
-
-	if (formState?.trustProxySuccess) {
-		return {
-			tone: 'success',
-			headline: 'Header trust enabled',
-			body: 'Obzorarr will now identify visitors using your reverse proxy headers.'
-		};
+async function copyGuide(id: string, text: string) {
+	try {
+		await navigator.clipboard.writeText(text);
+		copiedGuide = id;
+	} catch {
+		copiedGuide = `error:${id}`;
 	}
-
-	const action = diagnostic.recommendation.action;
-
-	if (action === 'appears-working') {
-		return {
-			tone: 'success',
-			headline: 'Connection looks good',
-			body: 'Obzorarr can correctly identify visitor IP addresses and protocols.'
-		};
-	}
-
-	if (action === 'leave-disabled') {
-		return {
-			tone: 'success',
-			headline: 'Connection looks good',
-			body: "No proxy detected — Obzorarr will use the direct connection details. You're all set."
-		};
-	}
-
-	if (action === 'enable') {
-		return {
-			tone: 'warning',
-			headline: 'Proxy detected',
-			body: "Obzorarr is behind a proxy (like Nginx or Cloudflare) but isn't trusting its headers yet. Without header trust, visitor IPs and protocols may appear incorrect."
-		};
-	}
-
-	if (action === 'env-controlled') {
-		return {
-			tone: 'neutral',
-			headline: 'Controlled by environment',
-			body: 'Reverse-proxy header trust is fixed by the TRUST_PROXY environment variable. Change it in your environment or container configuration and restart Obzorarr.'
-		};
-	}
-
-	if (action === 'review-proxy') {
-		return {
-			tone: 'warning',
-			headline: 'Proxy needs a closer look',
-			body: 'Some forwarded headers are present but they do not line up with how your browser sees this site. Review your reverse proxy configuration, then re-run the check.'
-		};
-	}
-
-	return {
-		tone: 'neutral',
-		headline: 'Could not verify automatically',
-		body: 'Obzorarr could not determine your proxy setup. You can continue, but visitor data may be inaccurate.'
-	};
-}
-
-function getForwardedPairLabel(status: string): string {
-	switch (status) {
-		case 'usable':
-			return 'Forwarded scheme and host look usable';
-		case 'missing':
-			return 'No forwarded scheme/host pair detected';
-		case 'partial':
-			return 'Forwarded scheme/host pair is incomplete';
-		case 'invalid-proto':
-		case 'unsafe-host':
-		case 'invalid-host':
-			return 'Forwarded scheme/host pair is invalid';
-		default:
-			return 'Forwarded scheme/host pair needs review';
-	}
-}
-
-const statusView = $derived(getStatusView(reverseProxyDiagnostic, form));
-
-function canEnableTrustProxy(): boolean {
-	return (
-		diagnosticStatus === 'success' &&
-		reverseProxyDiagnostic?.recommendation.action === 'enable' &&
-		!reverseProxyDiagnostic.trustProxy.isLocked &&
-		!form?.trustProxySuccess
-	);
-}
-
-function toggleDetails() {
-	showDetails = !showDetails;
 }
 </script>
 
-<OnboardingCard
-	title={REVERSE_PROXY_COPY.panelTitle}
-	subtitle={REVERSE_PROXY_COPY.panelSubtitle}
->
-	<div class="proxy-content" bind:this={contentRef}>
-		<div class="icon-container" bind:this={iconRef}>
-			<div class="icon-wrapper">
-				<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-					<path d="M3 12h4m10 0h4" stroke-linecap="round" />
-					<rect
-						x="8"
-						y="8"
-						width="8"
-						height="8"
-						rx="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					/>
-				</svg>
-			</div>
-		</div>
-
-		<p class="intro-text">
-			If you put Obzorarr behind a reverse proxy like Nginx, Cloudflare, or Caddy, it needs to trust
-			the headers that proxy sends so visitor IPs and HTTPS detection work correctly.
-		</p>
-
-		{#if diagnosticStatus === 'checking' && !reverseProxyDiagnostic}
-			<div class="status-card neutral loading">
+<OnboardingCard title={REVERSE_PROXY_COPY.panelTitle} subtitle={REVERSE_PROXY_COPY.panelSubtitle}>
+	<div class="proxy-content">
+		{#if form?.trustProxyError}<div class="inline-error" role="alert">{form.trustProxyError}</div>{/if}
+		{#if diagnosticStatus === 'checking'}
+			<div class="status-card neutral" role="status" aria-live="polite" aria-busy="true">
 				<LoaderCircleIcon class="size-5 animate-spin" aria-hidden="true" />
-				<div class="status-text">
-					<span class="status-headline">Checking your connection…</span>
-					<span class="status-body">Comparing what your browser sees with what Obzorarr receives.</span>
-				</div>
+				<span>{savedState === 'verifying' ? REVERSE_PROXY_COPY.savedVerifying : REVERSE_PROXY_COPY.rerunButtonInProgress}</span>
 			</div>
-		{:else if diagnosticStatus === 'failure' && !reverseProxyDiagnostic}
-			<div class="status-card warning">
-				<svg
-					class="status-icon"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-				>
-					<circle cx="12" cy="12" r="10" />
-					<line x1="15" y1="9" x2="9" y2="15" stroke-linecap="round" />
-					<line x1="9" y1="9" x2="15" y2="15" stroke-linecap="round" />
-				</svg>
-				<div class="status-text">
-					<span class="status-headline">Could not run the check</span>
-					<span class="status-body">{diagnosticError ?? 'Diagnostic failed'}</span>
-				</div>
+		{:else if diagnosticStatus === 'failure'}
+			<div class="status-card danger" role="alert">
+				<span>{savedState === 'unverified' ? REVERSE_PROXY_COPY.savedUnverified : diagnosticError}</span>
+				<Button type="button" class="tap-target" onclick={() => runDiagnostic(savedState === 'unverified')}>{REVERSE_PROXY_COPY.rerunButton}</Button>
 			</div>
-		{:else if statusView && reverseProxyDiagnostic}
-			<div class="status-card {statusView.tone}">
-				{#if statusView.tone === 'success'}
-					<svg
-						class="status-icon"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<path d="M9 12l2 2 4-4" stroke-linecap="round" stroke-linejoin="round" />
-					</svg>
-				{:else if statusView.tone === 'warning'}
-					<svg
-						class="status-icon"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
-						<path d="M12 2l10 18H2z" stroke-linecap="round" stroke-linejoin="round" />
-						<line x1="12" y1="9" x2="12" y2="13" stroke-linecap="round" />
-						<circle cx="12" cy="16" r="0.6" fill="currentColor" />
-					</svg>
-				{:else}
-					<svg
-						class="status-icon"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-					>
-						<circle cx="12" cy="12" r="10" />
-						<path d="M12 16v-4" stroke-linecap="round" />
-						<path d="M12 8h.01" stroke-linecap="round" />
-					</svg>
-				{/if}
-				<div class="status-text">
-					<span class="status-headline">{statusView.headline}</span>
-					<span class="status-body">{statusView.body}</span>
+		{:else if presentation && diagnostic}
+			<div class="status-card {presentation.tone}" role="status" aria-live="polite">
+				{#if presentation.tone === 'success'}<CheckIcon class="size-5" aria-hidden="true" />{:else}<span aria-hidden="true">!</span>{/if}
+				<div>
+					<strong>{presentation.headline}</strong>
+					<p>{presentation.diagnosis}</p>
+					<p><strong>{presentation.nextAction}</strong></p>
 				</div>
 			</div>
 
-			{#if canEnableTrustProxy()}
-				<form method="POST" action="?/enableTrustProxy" class="trust-proxy-enable-form">
+			{#if canEnable}
+				<form method="POST" action="?/enableTrustProxy" class="enable-form">
 					<input type="hidden" name="browserOrigin" value={browserOrigin} />
-					<label class="risk-confirmation">
-						<input type="checkbox" name="confirmRisk" value="true" required />
-						<span>
-							I've confirmed my reverse proxy is configured to strip incoming
-							<code>x-forwarded-*</code> headers from external visitors.
-						</span>
-					</label>
-					<p class="risk-explainer">
-						This prevents attackers from spoofing their location, but should only be enabled if
-						your proxy is configured securely.
-					</p>
-					<SubmitButton class="enable-trust-btn tap-target">
-						{#snippet children()}
-							Enable Header Trust
-						{/snippet}
-					</SubmitButton>
+					<label><input type="checkbox" name="confirmRisk" value="true" required /> {presentation.safetyNotice}</label>
+					<SubmitButton class="tap-target"><span>Enable TRUST_PROXY</span></SubmitButton>
 				</form>
 			{/if}
 
-			{#if form?.trustProxyError}
-				<div class="inline-error">
-					<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-						<circle cx="12" cy="12" r="10" />
-						<line x1="15" y1="9" x2="9" y2="15" stroke-linecap="round" />
-						<line x1="9" y1="9" x2="15" y2="15" stroke-linecap="round" />
-					</svg>
-					<span>{form.trustProxyError}</span>
-				</div>
-			{/if}
-
-			<button type="button" class="details-toggle" onclick={toggleDetails} aria-expanded={showDetails}>
-				<span>{showDetails ? 'Hide technical details' : 'Show technical details'}</span>
-				<span class="chevron-wrap" class:open={showDetails} aria-hidden="true">
-					<ChevronDownIcon class="size-4" />
-				</span>
+			<button type="button" class="details-toggle tap-target" onclick={() => (showDetails = !showDetails)} aria-expanded={showDetails} aria-controls="proxy-technical-details">
+				{REVERSE_PROXY_COPY.detailsButton} <ChevronDownIcon class="size-4" aria-hidden="true" />
 			</button>
-
 			{#if showDetails}
-				<div class="details-panel">
-					<div class="diagnostic-facts">
-						<div>
-							<span class="fact-label">Forwarded headers</span>
-							<span class="fact-value">
-								{getForwardedPairLabel(reverseProxyDiagnostic.forwardedHeaders.pair.status)}
-							</span>
-						</div>
-						<div>
-							<span class="fact-label">Signals present</span>
-							<span class="fact-value">
-								{reverseProxyDiagnostic.forwardedHeaders.present.length > 0
-									? reverseProxyDiagnostic.forwardedHeaders.present.join(', ')
-									: 'None'}
-							</span>
-						</div>
-						<div>
-							<span class="fact-label">Current setting</span>
-							<span class="fact-value">
-								{reverseProxyDiagnostic.trustProxy.enabled ? 'Enabled' : 'Disabled'}
-								{#if reverseProxyDiagnostic.trustProxy.isLocked}
-									<span class="inline-badge">ENV</span>
-								{/if}
-							</span>
-						</div>
+				<div id="proxy-technical-details" class="details-panel">
+					<dl>
+						<div><dt>Browser origin</dt><dd>{diagnostic.facts.browserOrigin.origin ?? 'not available'}</dd></div>
+						<div><dt>Effective app origin</dt><dd>{diagnostic.facts.origins.effectiveApp ?? 'not available'}</dd></div>
+						<div><dt>Forwarded origin</dt><dd>{diagnostic.facts.origins.forwardedPair ?? 'not available'}</dd></div>
+						<div><dt>Forwarded headers present</dt><dd>{diagnostic.facts.forwardedHeaders.present.join(', ') || 'none'}</dd></div>
+						<div><dt>Forwarded pair</dt><dd>{presentation.pairLabel}</dd></div>
+						<div><dt>TRUST_PROXY source</dt><dd>{diagnostic.facts.trustProxy.source}{diagnostic.facts.trustProxy.isLocked ? ' (environment-controlled)' : ''}</dd></div>
+					</dl>
+					<p>{presentation.consequence}</p>
+					<p class="safety">{presentation.safetyNotice}</p>
+					{#if applicableProviderGuides.length > 0}
+						<div class="provider-guides">
+						<h3>Repair steps by proxy</h3>
+							{#each applicableProviderGuides as guide}
+							<details class="provider-guide">
+								<summary>{guide.label}</summary>
+								<div class="provider-guide-content">
+									<ol>
+										{#each guide.steps as step}
+											<li>{step}</li>
+										{/each}
+									</ol>
+									{#if guide.config}
+										<pre><code>{guide.config}</code></pre>
+										<Button type="button" variant="outline" class="tap-target" onclick={() => copyGuide(guide.id, guide.config ?? '')}>
+											Copy configuration
+										</Button>
+										<span class="copy-status" role="status" aria-live="polite">
+											{copiedGuide === guide.id
+												? `${guide.label} configuration copied`
+												: copiedGuide === `error:${guide.id}`
+													? `Could not copy the ${guide.label} configuration`
+													: ''}
+										</span>
+									{/if}
+									<a href={documentationForGuide(guide).url} target="_blank" rel="noreferrer">
+										{guide.id === 'other' ? 'Open Obzorarr configuration guidance' : `Open official ${guide.label} documentation`}
+									</a>
+								</div>
+							</details>
+						{/each}
 					</div>
-
-					{#if reverseProxyDiagnostic.reasons.length > 0}
-						<div class="reasons-block">
-							<span class="reasons-label">Why we recommend this</span>
-							<ul>
-								{#each reverseProxyDiagnostic.reasons as reason}
-									<li>{reason}</li>
-								{/each}
-							</ul>
-						</div>
 					{/if}
-
-					<p class="safety-note">{reverseProxyDiagnostic.safetyNotice}</p>
-
-					<div class="re-check">
-						<Button
-							type="button"
-							class="recheck-btn tap-target"
-							onclick={runDiagnostic}
-							disabled={diagnosticStatus === 'checking'}
-							aria-busy={diagnosticStatus === 'checking'}
-						>
-							{#if diagnosticStatus === 'checking'}
-								<LoaderCircleIcon class="size-3.5 animate-spin" aria-hidden="true" />
-								{REVERSE_PROXY_COPY.rerunButtonInProgress}
-							{:else}
-								{REVERSE_PROXY_COPY.rerunButton}
-							{/if}
-						</Button>
-					</div>
+					<Button type="button" variant="outline" class="tap-target" onclick={() => runDiagnostic()}>{REVERSE_PROXY_COPY.rerunButton}</Button>
 				</div>
 			{/if}
-		{/if}
-
-		{#if form?.trustProxySuccess}
-			<div class="success-banner">
-				<CheckIcon class="size-4" strokeWidth={2.5} />
-				<span>{form.trustProxyMessage ?? 'Reverse-proxy header trust enabled.'}</span>
-			</div>
 		{/if}
 	</div>
-
 	{#snippet footer()}
-		<form method="POST" action="?/goBack" class="mr-auto">
-			<Button type="submit" variant="outline" class="tap-target">
-				<ArrowLeftIcon class="size-[18px]" />
-				Previous
-			</Button>
-		</form>
-		<form method="POST" action="?/continue" class="continue-form">
-			<SubmitButton class="continue-btn tap-target">
-				{#snippet children()}
-					Continue
-				{/snippet}
-			</SubmitButton>
-		</form>
+		<form method="POST" action="?/goBack" class="mr-auto"><Button type="submit" variant="outline" class="tap-target"><ArrowLeftIcon class="size-[18px]" aria-hidden="true" />Previous</Button></form>
+		<div class="continue-area">
+			{#if continueWarning}<p role="status">{continueWarning}</p>{/if}
+			<form method="POST" action="?/continue"><SubmitButton class="tap-target"><span>Continue</span></SubmitButton></form>
+		</div>
 	{/snippet}
 </OnboardingCard>
 
 <style>
-	.proxy-content {
-		display: flex;
-		flex-direction: column;
-		gap: 1.25rem;
-		width: 100%;
-	}
-
-	.icon-container {
-		display: flex;
-		justify-content: center;
-		margin-bottom: 0.25rem;
-	}
-
-	.icon-wrapper {
-		width: 72px;
-		height: 72px;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background: linear-gradient(135deg, rgba(59, 130, 246, 0.15) 0%, rgba(59, 130, 246, 0.05) 100%);
-		border-radius: 18px;
-		color: oklch(0.6261 0.1859 259.6);
-	}
-
-	.icon-wrapper svg {
-		width: 40px;
-		height: 40px;
-	}
-
-	.intro-text {
-		margin: 0;
-		font-size: 0.875rem;
-		line-height: 1.55;
-		color: rgba(255, 255, 255, 0.6);
-		text-align: center;
-	}
-
-	.status-card {
-		display: flex;
-		align-items: flex-start;
-		gap: 0.875rem;
-		padding: 1rem 1.125rem;
-		border-radius: 12px;
-		border: 1px solid rgba(255, 255, 255, 0.1);
-		background: rgba(255, 255, 255, 0.04);
-	}
-
-	.status-card.success {
-		background: rgba(34, 197, 94, 0.09);
-		border-color: rgba(34, 197, 94, 0.22);
-	}
-
-	.status-card.warning {
-		background: rgba(245, 158, 11, 0.09);
-		border-color: rgba(245, 158, 11, 0.22);
-	}
-
-	.status-card.neutral {
-		background: rgba(255, 255, 255, 0.05);
-		border-color: rgba(255, 255, 255, 0.1);
-	}
-
-	.status-card.loading {
-		color: rgba(255, 255, 255, 0.6);
-	}
-
-	.status-icon {
-		flex-shrink: 0;
-		width: 22px;
-		height: 22px;
-		margin-top: 0.1rem;
-	}
-
-	.status-card.success .status-icon {
-		color: oklch(0.7946 0.1951 150.81);
-	}
-
-	.status-card.warning .status-icon {
-		color: oklch(0.79 0.1606 79.6);
-	}
-
-	.status-card.neutral .status-icon {
-		color: rgba(255, 255, 255, 0.55);
-	}
-
-	.status-text {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		min-width: 0;
-	}
-
-	.status-headline {
-		font-size: 0.95rem;
-		font-weight: 600;
-		color: rgba(255, 255, 255, 0.94);
-	}
-
-	.status-body {
-		font-size: 0.825rem;
-		line-height: 1.5;
-		color: rgba(255, 255, 255, 0.62);
-	}
-
-	.trust-proxy-enable-form {
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-		margin: 0;
-		padding: 1rem 1.125rem;
-		background: rgba(34, 197, 94, 0.05);
-		border: 1px solid rgba(34, 197, 94, 0.18);
-		border-radius: 12px;
-	}
-
-	.risk-confirmation {
-		display: flex;
-		align-items: flex-start;
-		gap: 0.625rem;
-		font-size: 0.825rem;
-		line-height: 1.5;
-		color: rgba(255, 255, 255, 0.78);
-	}
-
-	.risk-confirmation input {
-		flex-shrink: 0;
-		margin-top: 0.2rem;
-		accent-color: oklch(0.6261 0.1859 259.6);
-	}
-
-	.risk-confirmation code {
-		font-family: 'SF Mono', 'Monaco', 'Inconsolata', monospace;
-		font-size: 0.78rem;
-		background: rgba(255, 255, 255, 0.08);
-		padding: 0.05rem 0.3rem;
-		border-radius: 4px;
-		color: rgba(255, 255, 255, 0.8);
-	}
-
-	.risk-explainer {
-		margin: 0;
-		padding-left: 1.5rem;
-		font-size: 0.775rem;
-		line-height: 1.5;
-		color: rgba(255, 255, 255, 0.5);
-	}
-
-	:global(.enable-trust-btn) {
-		width: fit-content;
-		display: inline-flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0.375rem;
-		padding: 0.55rem 0.95rem;
-		border-radius: 8px;
-		font-size: 0.825rem;
-		font-weight: 600;
-		cursor: pointer;
-		background: rgba(34, 197, 94, 0.18);
-		border: 1px solid rgba(34, 197, 94, 0.35);
-		color: oklch(0.8046 0.1857 151.6);
-		transition:
-			background 0.2s,
-			border-color 0.2s,
-			transform 0.15s;
-	}
-
-	:global(.enable-trust-btn:hover:not(:disabled)) {
-		background: rgba(34, 197, 94, 0.26);
-		border-color: rgba(34, 197, 94, 0.5);
-		transform: translateY(-1px);
-	}
-
-	:global(.enable-trust-btn:disabled) {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.inline-error {
-		display: flex;
-		align-items: flex-start;
-		gap: 0.5rem;
-		padding: 0.7rem 0.875rem;
-		border-radius: 10px;
-		background: rgba(239, 68, 68, 0.1);
-		border: 1px solid rgba(239, 68, 68, 0.2);
-		color: oklch(0.6356 0.2082 25.38);
-		font-size: 0.825rem;
-		line-height: 1.45;
-	}
-
-	.inline-error svg {
-		flex-shrink: 0;
-		width: 18px;
-		height: 18px;
-		margin-top: 0.1rem;
-	}
-
-	.success-banner {
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-		padding: 0.7rem 0.875rem;
-		border-radius: 10px;
-		background: rgba(34, 197, 94, 0.12);
-		border: 1px solid rgba(34, 197, 94, 0.25);
-		color: oklch(0.8046 0.1857 151.6);
-		font-size: 0.85rem;
-		font-weight: 500;
-	}
-
-	.details-toggle {
-		align-self: center;
-		display: inline-flex;
-		align-items: center;
-		gap: 0.4rem;
-		background: transparent;
-		border: none;
-		padding: 0.4rem 0.6rem;
-		font-size: 0.78rem;
-		font-weight: 500;
-		color: rgba(255, 255, 255, 0.55);
-		cursor: pointer;
-		border-radius: 6px;
-		transition: color 0.2s, background 0.2s;
-	}
-
-	.details-toggle:hover {
-		color: rgba(255, 255, 255, 0.85);
-		background: rgba(255, 255, 255, 0.04);
-	}
-
-	.details-toggle:focus-visible {
-		outline: 2px solid oklch(0.6684 0.1625 259.49);
-		outline-offset: 2px;
-	}
-
-	.chevron-wrap {
-		display: inline-flex;
-		align-items: center;
-		transition: transform 0.2s ease;
-	}
-
-	.chevron-wrap.open {
-		transform: rotate(180deg);
-	}
-
-	.details-panel {
-		display: flex;
-		flex-direction: column;
-		gap: 1rem;
-		padding: 1rem 1.125rem;
-		background: rgba(255, 255, 255, 0.03);
-		border: 1px solid rgba(255, 255, 255, 0.07);
-		border-radius: 12px;
-	}
-
-	.diagnostic-facts {
-		display: grid;
-		grid-template-columns: repeat(3, minmax(0, 1fr));
-		gap: 0.75rem;
-	}
-
-	.diagnostic-facts > div {
-		display: flex;
-		flex-direction: column;
-		gap: 0.25rem;
-		min-width: 0;
-		padding: 0.7rem 0.75rem;
-		background: rgba(255, 255, 255, 0.04);
-		border: 1px solid rgba(255, 255, 255, 0.07);
-		border-radius: 8px;
-	}
-
-	.fact-label {
-		font-size: 0.65rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		color: rgba(255, 255, 255, 0.4);
-	}
-
-	.fact-value {
-		display: flex;
-		align-items: center;
-		gap: 0.375rem;
-		min-width: 0;
-		font-size: 0.78rem;
-		line-height: 1.35;
-		color: rgba(255, 255, 255, 0.74);
-		overflow-wrap: anywhere;
-	}
-
-	.inline-badge {
-		display: inline-flex;
-		align-items: center;
-		padding: 0.1rem 0.35rem;
-		border-radius: 4px;
-		background: rgba(34, 197, 94, 0.14);
-		border: 1px solid rgba(34, 197, 94, 0.25);
-		color: oklch(0.8116 0.1789 152.1);
-		font-size: 0.6rem;
-		font-weight: 700;
-		letter-spacing: 0.05em;
-	}
-
-	.reasons-block {
-		display: flex;
-		flex-direction: column;
-		gap: 0.45rem;
-	}
-
-	.reasons-label {
-		font-size: 0.7rem;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.05em;
-		color: rgba(255, 255, 255, 0.45);
-	}
-
-	.reasons-block ul {
-		margin: 0;
-		padding-left: 1.1rem;
-		color: rgba(255, 255, 255, 0.62);
-		font-size: 0.8rem;
-		line-height: 1.5;
-	}
-
-	.safety-note {
-		margin: 0;
-		font-size: 0.78rem;
-		line-height: 1.5;
-		color: rgba(255, 255, 255, 0.5);
-	}
-
-	.re-check {
-		display: flex;
-		justify-content: flex-end;
-	}
-
-	:global(.recheck-btn) {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.375rem;
-		padding: 0.45rem 0.75rem;
-		border-radius: 6px;
-		background: rgba(59, 130, 246, 0.08);
-		border: 1px solid rgba(59, 130, 246, 0.18);
-		color: oklch(0.695 0.1481 259.5);
-		font-size: 0.75rem;
-		font-weight: 600;
-		cursor: pointer;
-		transition: background 0.2s, border-color 0.2s;
-	}
-
-	:global(.recheck-btn:hover:not(:disabled)) {
-		background: rgba(59, 130, 246, 0.14);
-		border-color: rgba(59, 130, 246, 0.28);
-	}
-
-	:global(.recheck-btn:disabled) {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	.continue-form {
-		display: flex;
-		margin: 0;
-		width: 100%;
-	}
-
-	:global(.continue-btn) {
-		width: 100%;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: 0.5rem;
-		padding: 0.875rem 1.5rem;
-		background: linear-gradient(135deg, oklch(0.5869 0.2079 260) 0%, oklch(0.5516 0.2278 260.85) 100%);
-		border: none;
-		border-radius: 10px;
-		font-size: 0.9rem;
-		font-weight: 600;
-		color: white;
-		cursor: pointer;
-		transition: opacity 0.2s, transform 0.2s;
-	}
-
-	:global(.continue-btn:hover:not(:disabled)) {
-		opacity: 0.9;
-		transform: translateY(-1px);
-	}
-
-	:global(.continue-btn:disabled) {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-
-	@media (max-width: 480px) {
-		.diagnostic-facts {
-			grid-template-columns: 1fr;
-		}
-	}
+	.proxy-content, .details-panel, .continue-area { display: flex; flex-direction: column; gap: 1rem; min-width: 0; }
+	.status-card { display: flex; gap: .75rem; padding: 1rem; border: 1px solid rgba(255,255,255,.16); border-radius: .75rem; overflow-wrap: anywhere; }
+	.status-card p { margin: .35rem 0 0; }
+	.status-card.success { border-color: rgba(34,197,94,.55); }
+	.status-card.warning { border-color: rgba(245,158,11,.7); }
+	.status-card.danger { border-color: rgba(239,68,68,.7); }
+	.enable-form, .details-panel { padding: 1rem; border: 1px solid rgba(255,255,255,.14); border-radius: .75rem; }
+	.enable-form { display: flex; flex-direction: column; gap: .75rem; }
+	.details-toggle { align-self: flex-start; display: inline-flex; align-items: center; gap: .4rem; }
+	dl { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .75rem; margin: 0; }
+	dt { font-weight: 700; } dd { margin: .2rem 0 0; overflow-wrap: anywhere; }
+	pre { overflow-x: auto; white-space: pre-wrap; overflow-wrap: anywhere; }
+	.provider-guides { display: grid; gap: .75rem; }
+	.provider-guides h3 { margin: 0; font-size: 1rem; }
+	.provider-guide { border: 1px solid rgba(255,255,255,.14); border-radius: .625rem; }
+	.provider-guide summary { cursor: pointer; padding: .75rem; font-weight: 700; }
+	.provider-guide-content { display: grid; gap: .75rem; padding: 0 .75rem .75rem; }
+	.provider-guide-content ol { margin: 0; padding-left: 1.25rem; }
+	.copy-status { min-height: 1.25rem; font-size: .875rem; }
+	.safety, .inline-error { padding: .75rem; border-left: 3px solid currentColor; overflow-wrap: anywhere; }
+	.continue-area p { margin: 0; max-width: 32rem; overflow-wrap: anywhere; }
+	@media (max-width: 480px) { dl { grid-template-columns: 1fr; } }
 </style>

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -24,7 +24,8 @@ import {
 	type PrivacyPresetId,
 	type PrivacyPreviewRowKey,
 	publicLandingLookupCopy,
-	type ServerWrappedShareModeValue
+	type ServerWrappedShareModeValue,
+	shareDefaultCopy
 } from '$lib/sharing/options';
 import {
 	derivePreview,
@@ -79,8 +80,6 @@ let selectedPreset = $derived(
 	})
 );
 
-// Onboarding owns logoMode, so this preview is the one place that can surface
-// both logo visibility and landing-lookup contradiction warnings.
 let privacyPreview = $derived(
 	derivePreview({
 		anonymizationMode,
@@ -645,7 +644,7 @@ function getThemeColors(themeValue: string) {
 								</dd>
 							{/snippet}
 							<div class="privacy-preview" aria-live="polite">
-								<span class="preview-title">What this exposes</span>
+								<span class="preview-title">What this means</span>
 								<Tooltip.Provider delayDuration={150}>
 									<dl class="preview-rows">
 										<div class="preview-row">
@@ -656,7 +655,7 @@ function getThemeColors(themeValue: string) {
 											)}
 										</div>
 										<div class="preview-row">
-											{@render previewDt('newUserDefault', 'New-user default')}
+											{@render previewDt('newUserDefault', 'Personal link baseline')}
 											{@render previewDd(
 												PRIVACY_PREVIEW_VALUE_TOOLTIPS.newUserDefault[
 													privacyPreview.perUserDefaultForNewUsers
@@ -693,9 +692,11 @@ function getThemeColors(themeValue: string) {
 										{/if}
 									</dl>
 								</Tooltip.Provider>
-								{#each privacyPreview.warnings as warning}
-									<p class="landing-warning" role="status">{warning}</p>
-								{/each}
+								<div class="preview-boundary">
+									<strong>Protected areas stay protected.</strong>
+									{publicLandingLookupCopy.protectedBoundary}
+									{shareDefaultCopy.summary}
+								</div>
 							</div>
 
 							<div class="advanced-options">
@@ -767,7 +768,9 @@ function getThemeColors(themeValue: string) {
 
 							<div class="setting-group">
 								<span class="setting-label">Default Sharing Mode</span>
-								<p class="setting-description">How wrapped pages are shared by default</p>
+								<p class="setting-description">
+									{shareDefaultCopy.summary} {shareDefaultCopy.explicitRows}
+								</p>
 								<div class="radio-cards">
 									{#each data.shareModeOptions as option}
 										<label class="radio-card" class:selected={defaultShareMode === option.value}>
@@ -852,7 +855,11 @@ function getThemeColors(themeValue: string) {
 								<label class="toggle-row">
 									<div class="toggle-text">
 										<span class="toggle-label">{publicLandingLookupCopy.label}</span>
-										<span class="toggle-description">{publicLandingLookupCopy.helper}</span>
+										<span class="toggle-description">
+											{publicLandingLookup
+												? publicLandingLookupCopy.enabledDescription
+												: publicLandingLookupCopy.disabledDescription}
+										</span>
 									</div>
 									<button
 										type="button"
@@ -869,6 +876,7 @@ function getThemeColors(themeValue: string) {
 									</button>
 								</label>
 							</div>
+							<p class="setting-description">{publicLandingLookupCopy.protectedBoundary}</p>
 									</div>
 								{/if}
 							</div>
@@ -1518,16 +1526,6 @@ function getThemeColors(themeValue: string) {
 			border-radius: 0.625rem;
 		}
 
-		.landing-warning {
-			margin: 0.625rem 0 0;
-			padding: 0.625rem 0.75rem;
-			font-size: 0.78rem;
-			line-height: 1.4;
-			color: #fcd34d;
-			background: rgba(245, 158, 11, 0.12);
-			border: 1px solid rgba(245, 158, 11, 0.35);
-			border-radius: 0.625rem;
-		}
 
 		.preset-grid {
 			display: grid;
@@ -1680,6 +1678,21 @@ function getThemeColors(themeValue: string) {
 		.preview-row:last-child {
 			padding-bottom: 0;
 			border-bottom: none;
+		}
+
+		.preview-boundary {
+			display: grid;
+			gap: 0.35rem;
+			margin-top: 0.85rem;
+			padding-top: 0.85rem;
+			border-top: 1px solid rgba(255, 255, 255, 0.08);
+			font-size: 0.76rem;
+			line-height: 1.5;
+			color: rgba(255, 255, 255, 0.68);
+		}
+
+		.preview-boundary strong {
+			color: rgba(255, 255, 255, 0.9);
 		}
 
 		.preview-row dt {

--- a/tests/unit/admin/public-landing-lookup.test.ts
+++ b/tests/unit/admin/public-landing-lookup.test.ts
@@ -39,10 +39,10 @@ describe('PUBLIC_LANDING_LOOKUP setting', () => {
 	});
 
 	describe('ensurePublicLandingLookupDefault (upgrade backfill)', () => {
-		it('seeds true when onboarded and no row exists', async () => {
+		it('seeds false when an upgraded server has no explicit administrator choice', async () => {
 			await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
 			await ensurePublicLandingLookupDefault();
-			expect(await getAppSetting(AppSettingsKey.PUBLIC_LANDING_LOOKUP)).toBe('true');
+			expect(await getAppSetting(AppSettingsKey.PUBLIC_LANDING_LOOKUP)).toBe('false');
 		});
 
 		it('does NOT seed when onboarding is not complete', async () => {
@@ -77,7 +77,7 @@ describe('PUBLIC_LANDING_LOOKUP setting', () => {
 			const rows = await db.select().from(appSettings);
 			const lookupRows = rows.filter((r) => r.key === AppSettingsKey.PUBLIC_LANDING_LOOKUP);
 			expect(lookupRows).toHaveLength(1);
-			expect(lookupRows[0]?.value).toBe('true');
+			expect(lookupRows[0]?.value).toBe('false');
 		});
 	});
 });

--- a/tests/unit/admin/security-actions.test.ts
+++ b/tests/unit/admin/security-actions.test.ts
@@ -14,6 +14,7 @@ type UpdateCsrfOriginAction = NonNullable<typeof actions.updateCsrfOrigin>;
 type ToggleCsrfSkipAction = NonNullable<typeof actions.toggleCsrfSkip>;
 type ResetCsrfWarningAction = NonNullable<typeof actions.resetCsrfWarning>;
 type UpdateTrustProxyAction = NonNullable<typeof actions.updateTrustProxy>;
+type DiagnoseReverseProxyAction = NonNullable<typeof actions.diagnoseReverseProxy>;
 
 const ORIGIN = 'http://localhost:5173';
 
@@ -211,6 +212,26 @@ describe('security nested route — resetCsrfWarning', () => {
 	});
 });
 
+describe('security nested route — diagnoseReverseProxy cache controls', () => {
+	it('sets no-store when setHeaders is available', async () => {
+		const handler = actions.diagnoseReverseProxy as DiagnoseReverseProxyAction;
+		const formData = new FormData();
+		formData.set('browserOrigin', ORIGIN);
+		const headers: Record<string, string>[] = [];
+		await handler({
+			request: new Request(`${ORIGIN}/admin/settings/security?/diagnoseReverseProxy`, {
+				method: 'POST',
+				body: formData,
+				headers: { Origin: ORIGIN }
+			}),
+			url: new URL(ORIGIN),
+			getClientAddress: () => '127.0.0.1',
+			setHeaders: (headersToSet: Record<string, string>) => headers.push(headersToSet),
+			locals: adminLocals
+		} as unknown as Parameters<DiagnoseReverseProxyAction>[0]);
+		expect(headers).toEqual([{ 'Cache-Control': 'no-store' }]);
+	});
+});
 describe('security nested route — updateTrustProxy (confirmRisk + OCC)', () => {
 	beforeEach(async () => {
 		await resetSharedTestDb();
@@ -224,28 +245,34 @@ describe('security nested route — updateTrustProxy (confirmRisk + OCC)', () =>
 	const TRUST_FORWARDED_HOST = 'obzorarr.example.com';
 	const TRUST_APP_URL = `${ORIGIN}/admin/settings/security?/updateTrustProxy`;
 
-	function trustProxyRequest(fields: Record<string, string>): Request {
+	function trustProxyRequest(
+		fields: Record<string, string>,
+		originHeader: string | null = TRUST_BROWSER_ORIGIN
+	): Request {
 		const formData = new FormData();
 		for (const [k, v] of Object.entries(fields)) formData.set(k, v);
 		if (!formData.has('browserOrigin')) {
 			formData.set('browserOrigin', TRUST_BROWSER_ORIGIN);
 		}
+		const headers: HeadersInit = {
+			'x-forwarded-proto': 'https',
+			'x-forwarded-host': TRUST_FORWARDED_HOST
+		};
+		if (originHeader !== null) headers.Origin = originHeader;
 		return new Request(TRUST_APP_URL, {
 			method: 'POST',
 			body: formData,
-			headers: {
-				'x-forwarded-proto': 'https',
-				'x-forwarded-host': TRUST_FORWARDED_HOST
-			}
+			headers
 		});
 	}
 
-	async function run(request: Request) {
+	async function run(request: Request, setHeaders?: (headers: Record<string, string>) => void) {
 		const handler = actions.updateTrustProxy as UpdateTrustProxyAction;
 		return handler({
 			request,
 			url: new URL(TRUST_APP_URL),
 			getClientAddress: () => '203.0.113.1',
+			setHeaders,
 			locals: adminLocals
 		} as Parameters<UpdateTrustProxyAction>[0]);
 	}
@@ -309,6 +336,36 @@ describe('security nested route — updateTrustProxy (confirmRisk + OCC)', () =>
 		);
 		expect(result).toMatchObject({ success: true });
 		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBe('true');
+	});
+	it('fails closed without a request Origin and does not write TRUST_PROXY', async () => {
+		const result = await run(
+			trustProxyRequest(
+				{ enabled: 'true', confirmRisk: 'true', settingsVersion: new Date(0).toISOString() },
+				null
+			)
+		);
+		expect(result).toMatchObject({ status: 403 });
+		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+	});
+
+	it('fails closed when request Origin mismatches browserOrigin and does not write TRUST_PROXY', async () => {
+		const result = await run(
+			trustProxyRequest(
+				{ enabled: 'true', confirmRisk: 'true', settingsVersion: new Date(0).toISOString() },
+				'https://attacker.example.com'
+			)
+		);
+		expect(result).toMatchObject({ status: 403 });
+		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
+	});
+
+	it('sets no-store for TRUST_PROXY actions when setHeaders is available', async () => {
+		const headers: Record<string, string>[] = [];
+		await run(
+			trustProxyRequest({ enabled: 'false', settingsVersion: new Date(0).toISOString() }),
+			(headersToSet) => headers.push(headersToSet)
+		);
+		expect(headers).toEqual([{ 'Cache-Control': 'no-store' }]);
 	});
 
 	it('rejects blank settingsVersion as 409 conflict', async () => {

--- a/tests/unit/admin/security-diagnostic-toast.test.ts
+++ b/tests/unit/admin/security-diagnostic-toast.test.ts
@@ -17,10 +17,51 @@ async function readSource(relPath: string): Promise<string> {
 	return Bun.file(join(PROJECT_ROOT, relPath)).text();
 }
 
-describe('ISSUE-007 — reverse-proxy diagnostic toast is user-initiated only', () => {
+describe('reverse-proxy diagnostic toast and progressive guidance', () => {
 	it('imports the toast service', async () => {
 		const src = await readSource(SECURITY_PAGE);
 		expect(src).toContain("import { toast } from '$lib/services/toast'");
+	});
+	it('uses the shared diagnostic DTO and presenter rather than route-local semantic maps', async () => {
+		const src = await readSource(SECURITY_PAGE);
+		expect(src).toContain(
+			"import type { ReverseProxyDiagnostic } from '$lib/security/reverse-proxy'"
+		);
+		expect(src).toContain('presentReverseProxyDiagnostic(diagnostic)');
+		expect(src).toContain('documentationForGuide(guide)');
+		expect(src).toContain('REVERSE_PROXY_PROVIDER_GUIDES');
+		expect(src).toContain('<details class="provider-guide">');
+		expect(src).toContain('Copy configuration');
+		expect(src).toContain('role="status" aria-live="polite"');
+		expect(src).not.toContain('type ReverseProxyDiagnosticView');
+		expect(src).not.toContain('function getForwardedPairLabel');
+	});
+
+	it('only offers enable when the live diagnostic recommends it and keeps client-IP scope separate', async () => {
+		const src = await readSource(SECURITY_PAGE);
+		expect(src).toContain("{:else if diagnostic?.action === 'enable'}");
+		expect(src).toContain('Client-IP handling is configured separately');
+		expect(src).not.toContain('headers for client IP, host');
+		expect(src).not.toContain('Raw app origin');
+	});
+
+	it('scopes provider repair guides to the presenter and keeps failure recovery actionable', async () => {
+		const src = await readSource(SECURITY_PAGE);
+		expect(src).toContain('presentation.documentationIds.includes(guide.documentationId)');
+		expect(src).toContain('{#each applicableProviderGuides as guide}');
+		expect(src).toMatch(
+			/diagnosticStatus === 'failure'[\s\S]*runDiagnostic\(\{ userInitiated: true \}\)/
+		);
+		expect(src).toMatch(/try \{[\s\S]*await invalidateAll\(\)[\s\S]*finally \{/);
+	});
+
+	it('clears stale results and silently reruns after a TRUST_PROXY write', async () => {
+		const src = await readSource(SECURITY_PAGE);
+		expect(src).toMatch(
+			/async function refreshDiagnosticAfterTrustProxyWrite\(\)[\s\S]*diagnostic = null[\s\S]*await invalidateAll\(\)[\s\S]*await runDiagnostic\(\)/
+		);
+		expect(src).toContain('diagnosticError = REVERSE_PROXY_COPY.savedUnverified');
+		expect(src).toContain('Saved. Verifying…');
 	});
 
 	it('runDiagnostic accepts a userInitiated option defaulting to false', async () => {

--- a/tests/unit/landing-lookup.test.ts
+++ b/tests/unit/landing-lookup.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { isRedirect } from '@sveltejs/kit';
+import { eq } from 'drizzle-orm';
 import {
 	getPublicLandingLookupEnabled,
 	setPublicLandingLookupEnabled
@@ -15,6 +16,7 @@ import {
 import { ShareMode, ShareModeSource } from '$lib/server/sharing/types';
 import type { LiveSyncResult } from '$lib/server/sync/live-sync';
 import * as liveSync from '$lib/server/sync/live-sync';
+import { load as loadWrapped } from '../../src/routes/wrapped/[year=year]/u/[identifier]/+page.server';
 
 let liveSyncResult: LiveSyncResult = {
 	triggered: false,
@@ -199,29 +201,93 @@ describe('landing username lookup', () => {
 		}
 	});
 
-	it('returns the same generic response for private users and missing users', async () => {
-		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
+	it('returns the same generic response for an allowed opt-out and an unknown user', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_OAUTH,
+			allowUserControl: true
+		});
 		await seedUser(ShareMode.PRIVATE_OAUTH);
 
-		const privateResult = await invokeLookup('alice', '198.51.100.2');
+		const optedOutResult = await invokeLookup('alice', '198.51.100.2');
 		const missingResult = await invokeLookup('nobody', '198.51.100.3');
 
-		expect(privateResult).toEqual({
+		expect(optedOutResult).toEqual({
 			status: 404,
 			data: {
-				error: 'No public Wrapped found for that username.',
+				error: 'No publicly shared Wrapped found for that username.',
 				username: 'alice',
-				requiresAuth: true
+				requiresAuth: false
 			}
 		});
 		expect(missingResult).toEqual({
 			status: 404,
 			data: {
-				error: 'No public Wrapped found for that username.',
+				error: 'No publicly shared Wrapped found for that username.',
 				username: 'nobody',
-				requiresAuth: true
+				requiresAuth: false
 			}
 		});
+		expect(liveSyncCalls).toEqual([]);
+	});
+
+	it('uses public lookup as the default even when the global share default is private', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_OAUTH,
+			allowUserControl: true
+		});
+		await seedUser();
+
+		try {
+			await invokeLookup('alice', '198.51.100.13');
+			throw new Error('Expected redirect');
+		} catch (error) {
+			expect(isRedirect(error)).toBe(true);
+		}
+	});
+
+	it('redirects with a slug but denies destination access when sync makes the page private-link', async () => {
+		const PRIVATE_TOKEN = '550e8400-e29b-41d4-a716-446655440999';
+		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: true });
+		await seedUser(ShareMode.PUBLIC);
+		triggerLiveSyncSpy.mockImplementation(async (source: string) => {
+			liveSyncCalls.push(source);
+			await db
+				.update(shareSettings)
+				.set({ mode: ShareMode.PRIVATE_LINK, shareToken: PRIVATE_TOKEN })
+				.where(eq(shareSettings.userId, USER_ID));
+			return { triggered: false, syncInProgress: false, reason: 'disabled' };
+		});
+
+		let slug = '';
+		try {
+			await invokeLookup('alice', '198.51.100.15');
+			throw new Error('Expected redirect');
+		} catch (error) {
+			expect(isRedirect(error)).toBe(true);
+			if (!isRedirect(error)) throw error;
+			slug = error.location.replace(`/wrapped/${YEAR}/u/`, '');
+		}
+
+		expect(isValidSlugFormat(slug)).toBe(true);
+		expect(slug).not.toBe(PRIVATE_TOKEN);
+		const row = await db
+			.select({ publicSlug: shareSettings.publicSlug, shareToken: shareSettings.shareToken })
+			.from(shareSettings)
+			.where(eq(shareSettings.userId, USER_ID))
+			.limit(1);
+		expect(row[0]).toEqual({ publicSlug: slug, shareToken: PRIVATE_TOKEN });
+
+		try {
+			await loadWrapped({
+				params: { year: String(YEAR), identifier: slug },
+				locals: {},
+				parent: async () => ({ availableYears: [YEAR] }),
+				setHeaders: () => {}
+			} as unknown as Parameters<typeof loadWrapped>[0]);
+			expect.unreachable('Expected private-link slug destination to be denied');
+		} catch (error) {
+			expect((error as { status?: number }).status).toBe(404);
+		}
 	});
 
 	it('does not create local users from anonymous lookup', async () => {
@@ -236,17 +302,34 @@ describe('landing username lookup', () => {
 		await invokeLookup('synced-only', '198.51.100.4');
 
 		const createdUsers = await db.select().from(users);
+		const createdShareSettings = await db.select().from(shareSettings);
 		expect(createdUsers).toHaveLength(0);
+		expect(createdShareSettings).toHaveLength(0);
 	});
 
-	it('rejects over-length usernames before lookup side effects', async () => {
-		const result = await invokeLookup('a'.repeat(1001), '198.51.100.9');
+	it('accepts trimmed, case-insensitive usernames and enforces the 100-character boundary', async () => {
+		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: false });
+		await seedUser();
 
-		expect(result).toMatchObject({
+		try {
+			await invokeLookup('  ALICE  ', '198.51.100.9');
+			throw new Error('Expected redirect');
+		} catch (error) {
+			expect(isRedirect(error)).toBe(true);
+		}
+
+		const oneHundredCharacters = await invokeLookup('a'.repeat(100), '198.51.100.10');
+		expect(oneHundredCharacters).toMatchObject({
+			status: 404,
+			data: { requiresAuth: false }
+		});
+
+		const oneHundredAndOneCharacters = await invokeLookup('a'.repeat(101), '198.51.100.11');
+		expect(oneHundredAndOneCharacters).toMatchObject({
 			status: 400,
 			data: { error: 'Username is too long', requiresAuth: false }
 		});
-		expect(liveSyncCalls).toEqual([]);
+		expect(liveSyncCalls).toEqual(['landing-page-lookup']);
 	});
 
 	describe('public landing lookup gate', () => {
@@ -275,23 +358,41 @@ describe('landing username lookup', () => {
 				warnSpy.mockRestore();
 			}
 		});
-
-		it('still 404s a non-public user when the toggle is on (per-user gate intact)', async () => {
+		it('does not mint a slug, start sync, or set cookies when disabled', async () => {
 			await setGlobalShareDefaults({
 				defaultShareMode: ShareMode.PUBLIC,
 				allowUserControl: false
 			});
+			await seedUser(ShareMode.PUBLIC);
+			await setPublicLandingLookupEnabled(false);
+			const cookies = createCookies();
+
+			const result = await invokeLookup('alice', '198.51.100.16', cookies);
+
+			expect(result).toMatchObject({ status: 403, data: { requiresAuth: true } });
+			expect(liveSyncCalls).toEqual([]);
+			expect(cookies.sets).toEqual([]);
+			const row = await db
+				.select({ publicSlug: shareSettings.publicSlug, shareToken: shareSettings.shareToken })
+				.from(shareSettings)
+				.where(eq(shareSettings.userId, USER_ID))
+				.limit(1);
+			expect(row[0]).toEqual({ publicSlug: null, shareToken: null });
+		});
+
+		it('lets the administrator make every user public when user control is disabled', async () => {
+			await setGlobalShareDefaults({
+				defaultShareMode: ShareMode.PRIVATE_OAUTH,
+				allowUserControl: false
+			});
 			await seedUser(ShareMode.PRIVATE_OAUTH);
 
-			const result = await invokeLookup('alice', '198.51.100.8');
-			expect(result).toEqual({
-				status: 404,
-				data: {
-					error: 'No public Wrapped found for that username.',
-					username: 'alice',
-					requiresAuth: true
-				}
-			});
+			try {
+				await invokeLookup('alice', '198.51.100.8');
+				throw new Error('Expected redirect');
+			} catch (error) {
+				expect(isRedirect(error)).toBe(true);
+			}
 		});
 	});
 

--- a/tests/unit/landing-lookup.test.ts
+++ b/tests/unit/landing-lookup.test.ts
@@ -245,6 +245,32 @@ describe('landing username lookup', () => {
 		}
 	});
 
+	it('does not mint a private-link token for a new user during anonymous lookup', async () => {
+		await setGlobalShareDefaults({
+			defaultShareMode: ShareMode.PRIVATE_LINK,
+			allowUserControl: true
+		});
+		await seedUser();
+
+		let slug = '';
+		try {
+			await invokeLookup('alice', '198.51.100.14');
+			throw new Error('Expected redirect');
+		} catch (error) {
+			expect(isRedirect(error)).toBe(true);
+			if (!isRedirect(error)) throw error;
+			slug = error.location.replace(`/wrapped/${YEAR}/u/`, '');
+		}
+
+		expect(isValidSlugFormat(slug)).toBe(true);
+		const row = await db
+			.select({ publicSlug: shareSettings.publicSlug, shareToken: shareSettings.shareToken })
+			.from(shareSettings)
+			.where(eq(shareSettings.userId, USER_ID))
+			.limit(1);
+		expect(row[0]).toEqual({ publicSlug: slug, shareToken: null });
+	});
+
 	it('redirects with a slug but denies destination access when sync makes the page private-link', async () => {
 		const PRIVATE_TOKEN = '550e8400-e29b-41d4-a716-446655440999';
 		await setGlobalShareDefaults({ defaultShareMode: ShareMode.PUBLIC, allowUserControl: true });

--- a/tests/unit/onboarding/proxy-trust-actions.test.ts
+++ b/tests/unit/onboarding/proxy-trust-actions.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { readFile } from 'node:fs/promises';
 import type { Cookies } from '@sveltejs/kit';
 import { isRedirect } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
@@ -37,6 +38,7 @@ function createCookies() {
 
 let cookies: ReturnType<typeof createCookies>;
 let previousTrustProxyEnv: string | undefined;
+let actionHeaders: Record<string, string>[] = [];
 
 function createThrowingClaimCookies(errorToThrow: Error): ReturnType<typeof createCookies> {
 	return {
@@ -102,21 +104,25 @@ async function runContinue(request: Request) {
 
 async function runDiagnoseReverseProxy(request: Request) {
 	const action = actions.diagnoseReverseProxy as DiagnoseReverseProxyAction;
+	actionHeaders = [];
 	return action({
 		request,
 		cookies,
 		url: new URL(request.url),
-		getClientAddress: () => '172.18.0.2'
+		getClientAddress: () => '172.18.0.2',
+		setHeaders: (headers: Record<string, string>) => actionHeaders.push(headers)
 	} as unknown as Parameters<DiagnoseReverseProxyAction>[0]);
 }
 
 async function runEnableTrustProxy(request: Request) {
 	const action = actions.enableTrustProxy as EnableTrustProxyAction;
+	actionHeaders = [];
 	return action({
 		request,
 		cookies,
 		url: new URL(request.url),
-		getClientAddress: () => '172.18.0.2'
+		getClientAddress: () => '172.18.0.2',
+		setHeaders: (headers: Record<string, string>) => actionHeaders.push(headers)
 	} as unknown as Parameters<EnableTrustProxyAction>[0]);
 }
 
@@ -155,6 +161,28 @@ describe('onboarding proxy-trust actions', () => {
 		expect(typeof actions.diagnoseReverseProxy).toBe('function');
 		expect(typeof actions.enableTrustProxy).toBe('function');
 	});
+	it('uses the shared presenter and accessible progressive disclosure in the onboarding UI', async () => {
+		const page = await readFile('src/routes/onboarding/proxy-trust/+page.svelte', 'utf8');
+
+		expect(page).toContain('presentReverseProxyDiagnostic(diagnostic)');
+		expect(page).toContain('documentationForGuide(guide)');
+		expect(page).toContain('REVERSE_PROXY_PROVIDER_GUIDES');
+		expect(page).toContain('role="status"');
+		expect(page).toContain('role="alert"');
+		expect(page).toContain('aria-controls="proxy-technical-details"');
+		expect(page).toContain('REVERSE_PROXY_COPY.continueWarning');
+		expect(page).toContain('navigator.clipboard.writeText');
+		expect(page).toContain('<details class="provider-guide">');
+		expect(page).toContain('role="status" aria-live="polite"');
+		expect(page).toContain('Copy configuration');
+		expect(page).toContain("savedState = 'verifying'");
+		expect(page).toContain('void runDiagnostic(true)');
+		expect(page).toContain('REVERSE_PROXY_COPY.savedUnverified');
+		expect(page).toContain('presentation.documentationIds.includes(guide.documentationId)');
+		expect(page).toContain('{#each applicableProviderGuides as guide}');
+		expect(page).toContain('class="details-toggle tap-target"');
+		expect(page).toContain('<SubmitButton class="tap-target">');
+	});
 
 	it('continue advances to plex and redirects', async () => {
 		await expectRedirect(() => runContinue(createContinueRequest()), '/onboarding/plex');
@@ -189,18 +217,23 @@ describe('onboarding proxy-trust actions', () => {
 
 		expect(result).toMatchObject({
 			reverseProxyDiagnostic: {
-				trustProxy: {
-					enabled: false,
-					source: 'default',
-					isLocked: false
+				facts: {
+					trustProxy: {
+						enabled: false,
+						source: 'default',
+						isLocked: false
+					},
+					forwardedHeaders: {
+						present: ['X-Forwarded-Host', 'X-Forwarded-Proto']
+					}
 				},
-				recommendation: {
-					action: 'enable'
-				}
+				action: 'enable',
+				reasonCodes: ['forwarded-pair-matches-browser']
 			}
 		});
 		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.PROXY_TRUST);
+		expect(actionHeaders).toEqual([{ 'Cache-Control': 'no-store' }]);
 	});
 
 	it('rejects structurally abusive reverse proxy diagnostic browser origins', async () => {
@@ -235,6 +268,7 @@ describe('onboarding proxy-trust actions', () => {
 		expect(serialized).not.toContain('198.51.100.88');
 		expect(serialized).not.toContain('hidden-client');
 		expect(serialized).not.toContain('hidden.example');
+		expect(actionHeaders).toEqual([{ 'Cache-Control': 'no-store' }]);
 	});
 
 	it('rejects enabling TRUST_PROXY without explicit risk confirmation', async () => {
@@ -322,6 +356,7 @@ describe('onboarding proxy-trust actions', () => {
 		});
 		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBe('true');
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.PROXY_TRUST);
+		expect(actionHeaders).toEqual([{ 'Cache-Control': 'no-store' }]);
 	});
 
 	it('rejects enabling TRUST_PROXY when the current diagnostic does not recommend it', async () => {

--- a/tests/unit/security/reverse-proxy-diagnostic.test.ts
+++ b/tests/unit/security/reverse-proxy-diagnostic.test.ts
@@ -1,14 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { env } from '$env/dynamic/private';
+import type {
+	ReverseProxyConfigSource,
+	ReverseProxyDiagnosticReasonCode,
+	ReverseProxyRecommendationAction
+} from '$lib/security/reverse-proxy';
 import { AppSettingsKey, setAppSetting } from '$lib/server/admin/settings.service';
 import { clearRateLimitStore } from '$lib/server/ratelimit';
 import {
 	assertEnableTrustProxyAllowed,
+	buildReverseProxyDiagnostic,
 	classifySourceAddress,
-	createReverseProxyDiagnostic,
-	ENABLE_TRUST_PROXY_NOT_RECOMMENDED_MESSAGE,
-	type ReverseProxyDiagnostic,
-	type ReverseProxyRecommendationAction
+	ENABLE_TRUST_PROXY_NOT_RECOMMENDED_MESSAGE
 } from '$lib/server/security/reverse-proxy-diagnostic';
 import { GET as diagnosticGET } from '../../../src/routes/api/security/reverse-proxy-diagnostic/+server';
 import { resetSharedTestDb } from '../../helpers/db';
@@ -17,214 +20,221 @@ function envRecord(): Record<string, string | undefined> {
 	return env as Record<string, string | undefined>;
 }
 
-function requestWith(headers: Record<string, string> = {}): Request {
-	return new Request('http://internal.local/onboarding/csrf', { headers });
-}
-
-describe('reverse proxy diagnostic', () => {
-	beforeEach(async () => {
-		await resetSharedTestDb();
-		delete envRecord().TRUST_PROXY;
-		delete envRecord().ORIGIN;
-	});
-
-	afterEach(() => {
-		delete envRecord().TRUST_PROXY;
-		delete envRecord().ORIGIN;
-	});
-
-	it('recommends enabling when disabled and the usable forwarded pair matches the browser origin', async () => {
-		const diagnostic = await createReverseProxyDiagnostic({
-			request: requestWith({
-				'x-forwarded-proto': 'https',
-				'x-forwarded-host': 'wrapped.example.com'
-			}),
-			rawAppUrl: 'http://internal.local/onboarding/csrf',
-			effectiveAppUrl: 'http://internal.local/onboarding/csrf',
-			browserOrigin: 'https://wrapped.example.com',
-			sourceAddress: '172.18.0.2'
-		});
-
-		expect(diagnostic.trustProxy).toEqual({
-			enabled: false,
+function diagnosticFor({
+	trustProxy = 'false',
+	trustSource = 'default',
+	browserOrigin = 'https://browser.example.com',
+	rawAppUrl = 'http://internal.local/path',
+	effectiveAppUrl = rawAppUrl,
+	headers = {},
+	csrfOrigin = '',
+	sourceAddress = '172.18.0.2'
+}: {
+	trustProxy?: string;
+	trustSource?: ReverseProxyConfigSource;
+	browserOrigin?: string | null;
+	rawAppUrl?: string;
+	effectiveAppUrl?: string;
+	headers?: Readonly<Record<string, string>>;
+	csrfOrigin?: string;
+	sourceAddress?: string;
+} = {}) {
+	return buildReverseProxyDiagnostic({
+		request: new Request(rawAppUrl, { headers: { ...headers } }),
+		rawAppUrl,
+		effectiveAppUrl,
+		browserOrigin,
+		sourceAddress,
+		trustProxy: {
+			value: trustProxy,
+			source: trustSource,
+			isLocked: trustSource === 'env'
+		},
+		csrfOrigin: {
+			value: csrfOrigin,
 			source: 'default',
 			isLocked: false
-		});
-		expect(diagnostic.origins.rawApp).toBe('http://internal.local');
-		expect(diagnostic.origins.effectiveApp).toBe('http://internal.local');
-		expect(diagnostic.origins.browser).toEqual({
-			origin: 'https://wrapped.example.com',
-			isValid: true
-		});
-		expect(diagnostic.forwardedHeaders.present).toEqual(['X-Forwarded-Host', 'X-Forwarded-Proto']);
-		expect(diagnostic.forwardedHeaders.pair).toEqual({
-			status: 'usable',
-			isUsable: true,
-			protoPresent: true,
-			hostPresent: true
-		});
-		expect(diagnostic.sourceAddress.category).toBe('docker/private-range');
-		expect(diagnostic.originComparison).toEqual({
-			browserMatchesRawApp: false,
-			browserMatchesEffectiveApp: false,
-			forwardedPairMatchesBrowser: true
-		});
-		expect(diagnostic.recommendation.action).toBe('enable');
-		expect(diagnostic.safetyNotice).toContain('strips visitor-supplied forwarding headers');
+		}
+	});
+}
+
+describe('reverse proxy diagnostic contract', () => {
+	it.each([
+		{
+			name: 'environment lock enabled',
+			input: {
+				trustProxy: 'true',
+				trustSource: 'env' as const,
+				browserOrigin: 'not a URL'
+			},
+			action: 'env-controlled',
+			reason: 'trust-proxy-env-locked-enabled'
+		},
+		{
+			name: 'environment lock disabled',
+			input: {
+				trustProxy: 'false',
+				trustSource: 'env' as const,
+				browserOrigin: 'not a URL'
+			},
+			action: 'env-controlled',
+			reason: 'trust-proxy-env-locked-disabled'
+		},
+		{
+			name: 'invalid browser origin',
+			input: {
+				browserOrigin: 'not a URL',
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'browser.example.com'
+				}
+			},
+			action: 'unable-to-determine',
+			reason: 'browser-origin-invalid'
+		},
+		{
+			name: 'enable evidence',
+			input: {
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'browser.example.com'
+				}
+			},
+			action: 'enable',
+			reason: 'forwarded-pair-matches-browser'
+		},
+		{
+			name: 'direct access',
+			input: {
+				browserOrigin: 'http://internal.local',
+				rawAppUrl: 'http://internal.local/path'
+			},
+			action: 'leave-disabled',
+			reason: 'direct-access-without-forwarded-pair'
+		},
+		{
+			name: 'missing forwarded pair with mismatched origins',
+			input: {},
+			action: 'review-proxy',
+			reason: 'forwarded-pair-missing'
+		},
+		{
+			name: 'partial forwarded pair',
+			input: { headers: { 'x-forwarded-proto': 'https' } },
+			action: 'review-proxy',
+			reason: 'forwarded-pair-partial'
+		},
+		{
+			name: 'invalid forwarded pair',
+			input: {
+				headers: {
+					'x-forwarded-proto': 'ftp',
+					'x-forwarded-host': 'browser.example.com'
+				}
+			},
+			action: 'review-proxy',
+			reason: 'forwarded-pair-invalid'
+		},
+		{
+			name: 'ambiguous forwarded pair',
+			input: {
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'different.example.com'
+				}
+			},
+			action: 'review-proxy',
+			reason: 'forwarded-pair-ambiguous'
+		},
+		{
+			name: 'working enabled trust',
+			input: {
+				trustProxy: 'true',
+				effectiveAppUrl: 'https://browser.example.com/path',
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'browser.example.com'
+				}
+			},
+			action: 'appears-working',
+			reason: 'trust-proxy-working'
+		},
+		{
+			name: 'enabled but broken trust',
+			input: { trustProxy: 'true' },
+			action: 'review-proxy',
+			reason: 'trust-proxy-enabled-broken'
+		}
+	] as const)('$name returns $action with $reason', ({ input, action, reason }) => {
+		const diagnostic = diagnosticFor(input as Parameters<typeof diagnosticFor>[0]);
+		expect(diagnostic.action).toBe(action as ReverseProxyRecommendationAction);
+		expect(diagnostic.reasonCodes).toEqual([reason as ReverseProxyDiagnosticReasonCode]);
 	});
 
-	it('recommends leaving trust disabled for direct access without a forwarded pair', async () => {
-		const diagnostic = await createReverseProxyDiagnostic({
-			request: requestWith(),
-			rawAppUrl: 'http://localhost:5173/settings',
-			effectiveAppUrl: 'http://localhost:5173/settings',
-			browserOrigin: 'http://localhost:5173',
-			sourceAddress: '127.0.0.1'
-		});
-
-		expect(diagnostic.forwardedHeaders.present).toEqual([]);
-		expect(diagnostic.forwardedHeaders.pair.status).toBe('missing');
-		expect(diagnostic.sourceAddress.category).toBe('loopback');
-		expect(diagnostic.originComparison.browserMatchesRawApp).toBe(true);
-		expect(diagnostic.recommendation.action).toBe('leave-disabled');
-	});
-
-	it('recommends reviewing proxy config for partial forwarded headers', async () => {
-		const diagnostic = await createReverseProxyDiagnostic({
-			request: requestWith({ 'x-forwarded-proto': 'https' }),
-			rawAppUrl: 'http://internal.local/admin/settings',
-			effectiveAppUrl: 'http://internal.local/admin/settings',
-			browserOrigin: 'https://wrapped.example.com',
-			sourceAddress: '10.0.0.5'
-		});
-
-		expect(diagnostic.forwardedHeaders.pair).toEqual({
-			status: 'partial',
-			isUsable: false,
-			protoPresent: true,
-			hostPresent: false
-		});
-		expect(diagnostic.sourceAddress.category).toBe('private-lan');
-		expect(diagnostic.recommendation.action).toBe('review-proxy');
-	});
-
-	it('reports environment-controlled TRUST_PROXY as locked', async () => {
-		await setAppSetting(AppSettingsKey.TRUST_PROXY, 'false');
-		envRecord().TRUST_PROXY = 'true';
-
-		const diagnostic = await createReverseProxyDiagnostic({
-			request: requestWith({
-				'x-forwarded-proto': 'https',
-				'x-forwarded-host': 'wrapped.example.com'
-			}),
-			rawAppUrl: 'http://internal.local/p',
-			effectiveAppUrl: 'https://wrapped.example.com/p',
-			browserOrigin: 'https://wrapped.example.com',
-			sourceAddress: '100.80.0.12'
-		});
-
-		expect(diagnostic.trustProxy).toEqual({
-			enabled: true,
-			source: 'env',
-			isLocked: true
-		});
-		expect(diagnostic.sourceAddress.category).toBe('tailscale/cgnat');
-		expect(diagnostic.recommendation.action).toBe('env-controlled');
-		expect(diagnostic.reasons.join(' ')).toContain('currently enabled');
-	});
-
-	it('reports enabled trust as working when effective origin matches the browser', async () => {
-		await setAppSetting(AppSettingsKey.TRUST_PROXY, 'true');
-
-		const diagnostic = await createReverseProxyDiagnostic({
-			request: requestWith({
-				'x-forwarded-proto': 'https',
-				'x-forwarded-host': 'wrapped.example.com'
-			}),
-			rawAppUrl: 'http://internal.local/wrapped/2025',
-			effectiveAppUrl: 'https://wrapped.example.com/wrapped/2025',
-			browserOrigin: 'https://wrapped.example.com',
-			sourceAddress: '192.168.1.10'
-		});
-
-		expect(diagnostic.trustProxy.enabled).toBe(true);
-		expect(diagnostic.originComparison.browserMatchesEffectiveApp).toBe(true);
-		expect(diagnostic.recommendation.action).toBe('appears-working');
-	});
-
-	it('does not trust forwarded headers alone when the browser origin is invalid', async () => {
-		const diagnostic = await createReverseProxyDiagnostic({
-			request: requestWith({
-				'x-forwarded-proto': 'https',
-				'x-forwarded-host': 'wrapped.example.com'
-			}),
-			rawAppUrl: 'http://internal.local/onboarding/csrf',
-			effectiveAppUrl: 'http://internal.local/onboarding/csrf',
-			browserOrigin: 'not a url',
-			sourceAddress: '8.8.8.8'
-		});
-
-		expect(diagnostic.origins.browser).toEqual({ origin: null, isValid: false });
-		expect(diagnostic.sourceAddress.category).toBe('public');
-		expect(diagnostic.originComparison.forwardedPairMatchesBrowser).toBeNull();
-		expect(diagnostic.recommendation.action).toBe('unable-to-determine');
-	});
-
-	it('includes configured CSRF/public origin without requiring admin auth context', async () => {
-		await setAppSetting(AppSettingsKey.CSRF_ORIGIN, 'https://configured.example.com');
-
-		const diagnostic = await createReverseProxyDiagnostic({
-			request: requestWith(),
-			rawAppUrl: 'http://internal.local/onboarding/csrf',
-			effectiveAppUrl: 'http://internal.local/onboarding/csrf',
-			browserOrigin: 'http://internal.local',
-			sourceAddress: null
-		});
-
-		expect(diagnostic.origins.configuredPublic).toEqual({
-			origin: 'https://configured.example.com',
-			isValid: true,
-			source: 'db',
-			isConfigured: true,
-			isLocked: false
-		});
-		expect(diagnostic.sourceAddress.category).toBe('unknown');
-	});
-
-	it('reports only safe forwarded-header presence signals and no raw sensitive values', async () => {
-		const diagnostic = await createReverseProxyDiagnostic({
-			request: requestWith({
+	it('serializes only safe facts, action, and stable reason codes', () => {
+		const diagnostic = diagnosticFor({
+			rawAppUrl: 'http://internal.local/path?token=secret-query',
+			effectiveAppUrl: 'http://internal.local/path?token=secret-query',
+			browserOrigin: 'https://browser-secret.example.com',
+			csrfOrigin: 'https://configured-secret.example.com',
+			sourceAddress: '203.0.113.44',
+			headers: {
 				cookie: 'session=secret-cookie',
 				authorization: 'Bearer secret-authorization',
-				'x-forwarded-proto': 'https',
-				'x-forwarded-host': 'secret-forwarded.example',
+				forwarded: 'for=secret-client;proto=https;host=hidden.example',
 				'x-forwarded-for': '203.0.113.77',
-				'x-real-ip': '198.51.100.88',
-				forwarded: 'for=secret-forwarded-client;proto=https;host=hidden.example'
-			}),
-			rawAppUrl: 'http://internal.local/onboarding/csrf?token=secret-query',
-			effectiveAppUrl: 'http://internal.local/onboarding/csrf?token=secret-query',
-			browserOrigin: 'https://browser.example.com',
-			sourceAddress: '203.0.113.44'
+				'x-forwarded-host': 'secret-forwarded.example',
+				'x-forwarded-proto': 'https',
+				'x-real-ip': '198.51.100.88'
+			}
 		});
 
-		expect(diagnostic.forwardedHeaders.present).toEqual([
-			'Forwarded',
-			'X-Forwarded-For',
-			'X-Forwarded-Host',
-			'X-Forwarded-Proto',
-			'X-Real-IP'
-		]);
+		expect(Object.keys(diagnostic).sort()).toEqual(['action', 'facts', 'reasonCodes']);
+		expect(diagnostic.facts).toEqual({
+			trustProxy: { enabled: false, source: 'default', isLocked: false },
+			browserOrigin: { isValid: true, origin: 'https://browser-secret.example.com' },
+			configuredPublicOrigin: {
+				isConfigured: true,
+				isValid: true,
+				source: 'default',
+				isLocked: false
+			},
+			origins: {
+				effectiveApp: 'http://internal.local',
+				forwardedPair: 'https://secret-forwarded.example'
+			},
+			forwardedHeaders: {
+				present: [
+					'Forwarded',
+					'X-Forwarded-For',
+					'X-Forwarded-Host',
+					'X-Forwarded-Proto',
+					'X-Real-IP'
+				],
+				pair: { status: 'usable', isUsable: true, protoPresent: true, hostPresent: true }
+			},
+			sourceAddress: { category: 'public' },
+			originComparison: {
+				browserMatchesRawApp: false,
+				browserMatchesEffectiveApp: false,
+				forwardedPairMatchesBrowser: false
+			}
+		});
 
 		const serialized = JSON.stringify(diagnostic);
-		expect(serialized).not.toContain('secret-cookie');
-		expect(serialized).not.toContain('secret-authorization');
-		expect(serialized).not.toContain('secret-forwarded.example');
-		expect(serialized).not.toContain('203.0.113.77');
-		expect(serialized).not.toContain('198.51.100.88');
-		expect(serialized).not.toContain('secret-forwarded-client');
-		expect(serialized).not.toContain('hidden.example');
-		expect(serialized).not.toContain('secret-query');
+		for (const secret of [
+			'secret-cookie',
+			'secret-authorization',
+			'secret-client',
+			'203.0.113.77',
+			'198.51.100.88',
+			'hidden.example',
+			'203.0.113.44',
+			'secret-query',
+			'configured-secret.example.com'
+		]) {
+			expect(serialized).not.toContain(secret);
+		}
 	});
 
 	it.each([
@@ -239,59 +249,20 @@ describe('reverse proxy diagnostic', () => {
 	] as const)('classifies %s as %s without returning the raw address', (address, category) => {
 		expect(classifySourceAddress(address)).toBe(category);
 	});
-});
 
-describe('assertEnableTrustProxyAllowed', () => {
-	function diagnosticWith(action: ReverseProxyRecommendationAction): ReverseProxyDiagnostic {
-		return {
-			trustProxy: { enabled: false, source: 'default', isLocked: false },
-			origins: {
-				rawApp: null,
-				effectiveApp: null,
-				browser: { origin: null, isValid: false },
-				configuredPublic: {
-					origin: null,
-					isValid: false,
-					source: 'default',
-					isConfigured: false,
-					isLocked: false
-				}
-			},
-			forwardedHeaders: {
-				present: [],
-				pair: { status: 'missing', isUsable: false, protoPresent: false, hostPresent: false }
-			},
-			sourceAddress: { category: 'unknown' },
-			originComparison: {
-				browserMatchesRawApp: null,
-				browserMatchesEffectiveApp: null,
-				forwardedPairMatchesBrowser: null
-			},
-			recommendation: { action, summary: '' },
-			reasons: [],
-			safetyNotice: ''
-		};
-	}
-
-	it('allows enabling when the diagnostic recommends enable', () => {
-		expect(assertEnableTrustProxyAllowed(diagnosticWith('enable'))).toEqual({ ok: true });
+	it('keeps enabling authority with the action code', () => {
+		const enabled = diagnosticFor({
+			headers: {
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'browser.example.com'
+			}
+		});
+		expect(assertEnableTrustProxyAllowed(enabled)).toEqual({ ok: true });
+		expect(assertEnableTrustProxyAllowed({ ...enabled, action: 'review-proxy' })).toEqual({
+			ok: false,
+			error: ENABLE_TRUST_PROXY_NOT_RECOMMENDED_MESSAGE
+		});
 	});
-
-	it.each([
-		'leave-disabled',
-		'review-proxy',
-		'appears-working',
-		'unable-to-determine',
-		'env-controlled'
-	] as ReverseProxyRecommendationAction[])(
-		'rejects enabling when the diagnostic recommendation is "%s"',
-		(action) => {
-			expect(assertEnableTrustProxyAllowed(diagnosticWith(action))).toEqual({
-				ok: false,
-				error: ENABLE_TRUST_PROXY_NOT_RECOMMENDED_MESSAGE
-			});
-		}
-	);
 });
 
 type HandlerArgs = Parameters<typeof diagnosticGET>[0];
@@ -334,18 +305,22 @@ describe('GET /api/security/reverse-proxy-diagnostic', () => {
 		delete envRecord().ORIGIN;
 	});
 
+	afterEach(() => {
+		delete envRecord().TRUST_PROXY;
+		delete envRecord().ORIGIN;
+	});
+
 	it.each([
 		['anonymous requests with 401', {} as HandlerArgs['locals'], 401, { message: 'Unauthorized' }],
 		['non-admin requests with 403', userLocals, 403, { message: 'Admin access required' }]
 	] as const)('rejects %s', async (_label, locals, status, body) => {
 		const response = await runDiagnosticGET({ locals });
-
 		expect(response.status).toBe(status);
 		expect(response.headers.get('Cache-Control')).toBe('no-store');
 		expect(await response.json()).toEqual(body);
 	});
 
-	it('returns the sanitized diagnostic payload for admins', async () => {
+	it('returns the client-safe diagnostic contract for admins with no-store', async () => {
 		const response = await runDiagnosticGET({
 			headers: {
 				'x-forwarded-proto': 'https',
@@ -355,45 +330,24 @@ describe('GET /api/security/reverse-proxy-diagnostic', () => {
 				forwarded: 'for=secret-client;proto=https;host=hidden.example'
 			}
 		});
-
 		expect(response.status).toBe(200);
 		expect(response.headers.get('Cache-Control')).toBe('no-store');
 		const body = await response.json();
-		expect(Object.keys(body).sort()).toEqual([
-			'forwardedHeaders',
-			'originComparison',
-			'origins',
-			'reasons',
-			'recommendation',
-			'safetyNotice',
-			'sourceAddress',
-			'trustProxy'
+		expect(Object.keys(body).sort()).toEqual(['action', 'facts', 'reasonCodes']);
+		expect(body.action).toBe('enable');
+		expect(body.facts.forwardedHeaders.present).toEqual([
+			'Forwarded',
+			'X-Forwarded-For',
+			'X-Forwarded-Host',
+			'X-Forwarded-Proto',
+			'X-Real-IP'
 		]);
-		expect(body.recommendation.action).toBe('enable');
-		expect(body.forwardedHeaders).toEqual({
-			present: [
-				'Forwarded',
-				'X-Forwarded-For',
-				'X-Forwarded-Host',
-				'X-Forwarded-Proto',
-				'X-Real-IP'
-			],
-			pair: {
-				status: 'usable',
-				isUsable: true,
-				protoPresent: true,
-				hostPresent: true
-			}
-		});
-		expect(body.sourceAddress).toEqual({ category: 'docker/private-range' });
+		expect(body.facts.sourceAddress).toEqual({ category: 'docker/private-range' });
 	});
 
-	it('compares the browser, raw app, and effective app origins', async () => {
+	it('reports normalized browser, forwarded, and effective origins without a raw app origin', async () => {
 		await setAppSetting(AppSettingsKey.TRUST_PROXY, 'true');
-
 		const response = await runDiagnosticGET({
-			requestUrl:
-				'http://internal.local/api/security/reverse-proxy-diagnostic?browserOrigin=https%3A%2F%2Fwrapped.example.com',
 			effectiveUrl:
 				'https://wrapped.example.com/api/security/reverse-proxy-diagnostic?browserOrigin=https%3A%2F%2Fwrapped.example.com',
 			headers: {
@@ -401,54 +355,29 @@ describe('GET /api/security/reverse-proxy-diagnostic', () => {
 				'x-forwarded-host': 'wrapped.example.com'
 			}
 		});
-
 		const body = await response.json();
-		expect(body.origins.rawApp).toBe('http://internal.local');
-		expect(body.origins.effectiveApp).toBe('https://wrapped.example.com');
-		expect(body.origins.browser).toEqual({
+		expect(body.facts.browserOrigin).toEqual({
 			origin: 'https://wrapped.example.com',
 			isValid: true
 		});
-		expect(body.originComparison).toEqual({
-			browserMatchesRawApp: false,
-			browserMatchesEffectiveApp: true,
-			forwardedPairMatchesBrowser: true
+		expect(body.facts.origins).toEqual({
+			effectiveApp: 'https://wrapped.example.com',
+			forwardedPair: 'https://wrapped.example.com'
 		});
-		expect(body.recommendation.action).toBe('appears-working');
+		expect(body.facts.origins.rawApp).toBeUndefined();
+		expect(body.action).toBe('appears-working');
 	});
 
-	it.each([
-		['missing', 'http://internal.local/api/security/reverse-proxy-diagnostic'],
-		[
-			'invalid',
-			'http://internal.local/api/security/reverse-proxy-diagnostic?browserOrigin=not-a-url'
-		]
-	] as const)('handles %s browserOrigin without failing', async (_label, requestUrl) => {
-		const response = await runDiagnosticGET({
-			requestUrl,
-			headers: {
-				'x-forwarded-proto': 'https',
-				'x-forwarded-host': 'wrapped.example.com'
-			}
-		});
-
-		expect(response.status).toBe(200);
-		const body = await response.json();
-		expect(body.origins.browser).toEqual({ origin: null, isValid: false });
-		expect(body.recommendation.action).toBe('unable-to-determine');
-	});
-
-	it('rejects structurally abusive browserOrigin values', async () => {
+	it('rejects an overlong browser origin with no-store', async () => {
 		const response = await runDiagnosticGET({
 			requestUrl: `http://internal.local/api/security/reverse-proxy-diagnostic?browserOrigin=${'a'.repeat(2049)}`
 		});
-
 		expect(response.status).toBe(400);
 		expect(response.headers.get('Cache-Control')).toBe('no-store');
 		expect(await response.json()).toEqual({ message: 'browserOrigin is too long' });
 	});
 
-	it('does not expose raw secrets, forwarded values, source IPs, or query strings', async () => {
+	it('does not expose credentials, client addresses, queries, or unrelated forwarding values', async () => {
 		const response = await runDiagnosticGET({
 			requestUrl:
 				'http://internal.local/api/security/reverse-proxy-diagnostic?browserOrigin=https%3A%2F%2Fbrowser.example.com&token=secret-query',
@@ -456,19 +385,17 @@ describe('GET /api/security/reverse-proxy-diagnostic', () => {
 				cookie: 'session=secret-cookie',
 				authorization: 'Bearer secret-authorization',
 				'x-forwarded-proto': 'https',
-				'x-forwarded-host': 'secret-forwarded.example',
+				'x-forwarded-host': 'browser.example.com',
 				'x-forwarded-for': '203.0.113.77',
 				'x-real-ip': '198.51.100.88',
 				forwarded: 'for=secret-client;proto=https;host=hidden.example'
 			},
 			ip: '203.0.113.44'
 		});
-
 		const serialized = JSON.stringify(await response.json());
 		for (const secret of [
 			'secret-cookie',
 			'secret-authorization',
-			'secret-forwarded.example',
 			'203.0.113.77',
 			'198.51.100.88',
 			'secret-client',
@@ -480,10 +407,9 @@ describe('GET /api/security/reverse-proxy-diagnostic', () => {
 		}
 	});
 
-	it('rate limits repeated diagnostic requests per admin and source address', async () => {
+	it('rate limits repeated diagnostics per admin and source address', async () => {
 		let response: Response | undefined;
 		for (let i = 0; i < 13; i++) response = await runDiagnosticGET();
-
 		expect(response?.status).toBe(429);
 		expect(response?.headers.get('Cache-Control')).toBe('no-store');
 		expect(response?.headers.get('Retry-After')).toBeTruthy();

--- a/tests/unit/security/reverse-proxy-presenter.test.ts
+++ b/tests/unit/security/reverse-proxy-presenter.test.ts
@@ -89,6 +89,17 @@ describe('reverse proxy presenter', () => {
 		);
 	});
 
+	it('identifies a missing forwarded proto when only the host arrives', () => {
+		const partial = diagnostic('review-proxy', 'partial');
+		partial.facts.forwardedHeaders.present = ['X-Forwarded-Host'];
+		partial.facts.forwardedHeaders.pair.protoPresent = false;
+		partial.facts.forwardedHeaders.pair.hostPresent = true;
+
+		expect(presentReverseProxyDiagnostic(partial).diagnosis).toContain(
+			'X-Forwarded-Host arrived, but X-Forwarded-Proto is missing'
+		);
+	});
+
 	it.each([
 		['missing', 'both X-Forwarded-Proto and X-Forwarded-Host'],
 		['partial', 'missing member'],

--- a/tests/unit/security/reverse-proxy-presenter.test.ts
+++ b/tests/unit/security/reverse-proxy-presenter.test.ts
@@ -17,6 +17,8 @@ function diagnostic(
 	status: ForwardedProtoHostStatus = 'usable',
 	overrides: Partial<ReverseProxyDiagnostic['facts']['trustProxy']> = {}
 ): ReverseProxyDiagnostic {
+	const protoPresent = status !== 'missing';
+	const hostPresent = status !== 'missing' && status !== 'partial';
 	return {
 		facts: {
 			trustProxy: { enabled: false, source: 'default', isLocked: false, ...overrides },
@@ -32,12 +34,17 @@ function diagnostic(
 				forwardedPair: 'https://wrapped.example.com'
 			},
 			forwardedHeaders: {
-				present: ['X-Forwarded-Host', 'X-Forwarded-Proto'],
+				present:
+					status === 'missing'
+						? []
+						: status === 'partial'
+							? ['X-Forwarded-Proto']
+							: ['X-Forwarded-Host', 'X-Forwarded-Proto'],
 				pair: {
 					status,
 					isUsable: status === 'usable',
-					protoPresent: status !== 'missing',
-					hostPresent: status !== 'missing'
+					protoPresent,
+					hostPresent
 				}
 			},
 			sourceAddress: { category: 'docker/private-range' },

--- a/tests/unit/security/reverse-proxy-presenter.test.ts
+++ b/tests/unit/security/reverse-proxy-presenter.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	documentationForDiagnostic,
+	documentationForGuide,
+	presentReverseProxyDiagnostic,
+	REVERSE_PROXY_DOCUMENTATION,
+	REVERSE_PROXY_PROVIDER_GUIDES
+} from '$lib/copy/reverse-proxy';
+import type {
+	ForwardedProtoHostStatus,
+	ReverseProxyDiagnostic,
+	ReverseProxyRecommendationAction
+} from '$lib/security/reverse-proxy';
+
+function diagnostic(
+	action: ReverseProxyRecommendationAction,
+	status: ForwardedProtoHostStatus = 'usable',
+	overrides: Partial<ReverseProxyDiagnostic['facts']['trustProxy']> = {}
+): ReverseProxyDiagnostic {
+	return {
+		facts: {
+			trustProxy: { enabled: false, source: 'default', isLocked: false, ...overrides },
+			browserOrigin: { isValid: true, origin: 'https://wrapped.example.com' },
+			configuredPublicOrigin: {
+				isConfigured: true,
+				isValid: true,
+				source: 'db',
+				isLocked: false
+			},
+			origins: {
+				effectiveApp: 'https://wrapped.example.com',
+				forwardedPair: 'https://wrapped.example.com'
+			},
+			forwardedHeaders: {
+				present: ['X-Forwarded-Host', 'X-Forwarded-Proto'],
+				pair: {
+					status,
+					isUsable: status === 'usable',
+					protoPresent: status !== 'missing',
+					hostPresent: status !== 'missing'
+				}
+			},
+			sourceAddress: { category: 'docker/private-range' },
+			originComparison: {
+				browserMatchesRawApp: false,
+				browserMatchesEffectiveApp: true,
+				forwardedPairMatchesBrowser: true
+			}
+		},
+		action,
+		reasonCodes: []
+	};
+}
+
+describe('reverse proxy presenter', () => {
+	it.each([
+		'enable',
+		'leave-disabled',
+		'review-proxy',
+		'appears-working',
+		'unable-to-determine',
+		'env-controlled'
+	] as const)('presents %s with a diagnosis and persistent action', (action) => {
+		const view = presentReverseProxyDiagnostic(diagnostic(action));
+		expect(view.headline.length).toBeGreaterThan(0);
+		expect(view.diagnosis).toContain('Both required headers arrived');
+		expect(view.diagnosis).toContain('forwarded origin https://wrapped.example.com');
+		expect(view.nextAction.length).toBeGreaterThan(0);
+		expect(view.consequence.length).toBeGreaterThan(0);
+		expect(view.safetyNotice).toContain('removes or overwrites visitor-supplied');
+	});
+
+	it.each([
+		['missing', 'Neither X-Forwarded-Proto nor X-Forwarded-Host arrived'],
+		['partial', 'X-Forwarded-Proto arrived, but X-Forwarded-Host is missing'],
+		['invalid-proto', 'value other than http or https'],
+		['unsafe-host', 'characters that are unsafe'],
+		['invalid-host', 'not a valid public host']
+	] as const)('states the observed %s header condition', (status, expected) => {
+		expect(presentReverseProxyDiagnostic(diagnostic('review-proxy', status)).diagnosis).toContain(
+			expected
+		);
+	});
+
+	it.each([
+		['missing', 'both X-Forwarded-Proto and X-Forwarded-Host'],
+		['partial', 'missing member'],
+		['invalid-proto', 'exactly http or https'],
+		['unsafe-host', 'public hostname'],
+		['invalid-host', 'public hostname'],
+		['usable', 'pair is valid']
+	] as const)('gives a specific repair for %s', (status, expected) => {
+		const view = presentReverseProxyDiagnostic(diagnostic('review-proxy', status));
+		expect(view.nextAction).toContain(expected);
+	});
+
+	it('distinguishes a forwarded-origin mismatch from an ambiguous valid pair', () => {
+		const mismatch = diagnostic('review-proxy', 'usable');
+		mismatch.facts.originComparison.forwardedPairMatchesBrowser = false;
+		const view = presentReverseProxyDiagnostic(mismatch);
+		expect(view.nextAction).toContain('conflicts with the browser origin');
+	});
+
+	it('states the exact environment setting and restart requirement', () => {
+		const view = presentReverseProxyDiagnostic(
+			diagnostic('env-controlled', 'usable', {
+				enabled: false,
+				source: 'env',
+				isLocked: true
+			})
+		);
+		expect(view.headline).toContain('disabled by the environment');
+		expect(view.nextAction).toContain('TRUST_PROXY=true');
+		expect(view.nextAction).toContain('restart Obzorarr');
+	});
+
+	it('does not tell an environment-managed direct deployment to enable proxy trust', () => {
+		const direct = diagnostic('env-controlled', 'missing', {
+			enabled: false,
+			source: 'env',
+			isLocked: true
+		});
+		direct.facts.originComparison.browserMatchesRawApp = true;
+		direct.facts.originComparison.browserMatchesEffectiveApp = true;
+		direct.facts.originComparison.forwardedPairMatchesBrowser = null;
+		const view = presentReverseProxyDiagnostic(direct);
+		expect(view.tone).toBe('success');
+		expect(view.nextAction).toContain('Leave TRUST_PROXY=false');
+		expect(view.documentationIds).toEqual(['obzorarr-trust-proxy']);
+	});
+
+	it('distinguishes working and broken environment-managed trust', () => {
+		const working = diagnostic('env-controlled', 'usable', {
+			enabled: true,
+			source: 'env',
+			isLocked: true
+		});
+		expect(presentReverseProxyDiagnostic(working).headline).toContain('origin matches');
+
+		const broken = diagnostic('env-controlled', 'invalid-proto', {
+			enabled: true,
+			source: 'env',
+			isLocked: true
+		});
+		broken.facts.originComparison.browserMatchesEffectiveApp = false;
+		const brokenView = presentReverseProxyDiagnostic(broken);
+		expect(brokenView.tone).toBe('danger');
+		expect(brokenView.nextAction).toContain('exactly http or https');
+		expect(brokenView.nextAction).toContain('Restart Obzorarr');
+	});
+
+	it('keeps documentation official, purpose-scoped, and provider-complete', () => {
+		for (const link of REVERSE_PROXY_DOCUMENTATION) {
+			expect(new URL(link.url).protocol).toBe('https:');
+			expect(link.applicabilityLabel.length).toBeGreaterThan(0);
+		}
+		expect(REVERSE_PROXY_PROVIDER_GUIDES.map((guide) => guide.id)).toEqual([
+			'nginx',
+			'nginx-proxy-manager',
+			'caddy',
+			'apache',
+			'other'
+		]);
+		expect(REVERSE_PROXY_PROVIDER_GUIDES.slice(0, 4).every((guide) => guide.config)).toBe(true);
+		expect(
+			REVERSE_PROXY_PROVIDER_GUIDES.every(
+				(guide) => documentationForGuide(guide).id === guide.documentationId
+			)
+		).toBe(true);
+	});
+
+	it('uses canonical public hosts instead of reflecting an unrestricted request Host', () => {
+		const configs = REVERSE_PROXY_PROVIDER_GUIDES.flatMap((guide) =>
+			guide.config ? [guide.config] : []
+		).join('\n');
+		expect(configs).toContain('obzorarr.example.com');
+		expect(configs).not.toContain('$http_host');
+		expect(configs).not.toContain('{host}');
+		expect(configs).not.toContain('%{HTTP_HOST}');
+	});
+
+	it('uses only host/protocol and Obzorarr configuration guidance', () => {
+		const links = documentationForDiagnostic(diagnostic('enable'));
+		expect(links.length).toBeGreaterThan(0);
+		expect(
+			links.every((link) =>
+				['forwarded-host-proto', 'header-replacement-boundary', 'obzorarr-configuration'].includes(
+					link.purpose
+				)
+			)
+		).toBe(true);
+	});
+});

--- a/tests/unit/sharing/access-control.test.ts
+++ b/tests/unit/sharing/access-control.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { and, eq } from 'drizzle-orm';
+import { setPublicLandingLookupEnabled } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { shareSettings } from '$lib/server/db/schema';
 import {
@@ -236,6 +237,35 @@ describe('Sharing Access Control', () => {
 				const result = await checkWrappedAccess({ userId, year, currentUser });
 
 				expect(result.accessReason).toBe('owner');
+			});
+		});
+
+		describe('with public landing lookup enabled', () => {
+			it('does not mint a private-link token when the current-year effective mode is public', async () => {
+				const currentYear = new Date().getFullYear();
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: false
+				});
+				await setPublicLandingLookupEnabled(true);
+				await db.insert(shareSettings).values({
+					userId,
+					year: currentYear,
+					mode: ShareMode.PRIVATE_LINK,
+					shareToken: null,
+					canUserControl: false
+				});
+
+				const result = await checkWrappedAccess({ userId, year: currentYear });
+				const [stored] = await db
+					.select({ shareToken: shareSettings.shareToken })
+					.from(shareSettings)
+					.where(and(eq(shareSettings.userId, userId), eq(shareSettings.year, currentYear)));
+
+				expect(result.accessReason).toBe('public');
+				expect(result.settings.mode).toBe(ShareMode.PUBLIC);
+				expect(result.settings.shareToken).toBeNull();
+				expect(stored?.shareToken).toBeNull();
 			});
 		});
 

--- a/tests/unit/sharing/presets.test.ts
+++ b/tests/unit/sharing/presets.test.ts
@@ -35,7 +35,7 @@ describe('matchPresetFull (onboarding, 6 fields)', () => {
 
 	it('returns "custom" for an off-map combination', () => {
 		const balanced = byId('balanced').values;
-		const offMap: PrivacyPresetValues = { ...balanced, logoMode: 'always_show' };
+		const offMap: PrivacyPresetValues = { ...balanced, logoMode: 'always_hide' };
 		expect(matchPresetFull(offMap)).toBe('custom');
 	});
 });
@@ -48,7 +48,7 @@ describe('matchPresetPrivacy (admin, 5 fields, logoMode excluded)', () => {
 		}
 	});
 
-	it('matches regardless of logoMode: Balanced 5 fields + logoMode always_hide => "balanced"', () => {
+	it('matches regardless of the separately persisted admin logo mode', () => {
 		const balanced = byId('balanced').values;
 		const { logoMode: _logoMode, ...fiveFields } = balanced;
 		// logoMode is NOT part of the admin match, so passing only the five fields
@@ -76,12 +76,12 @@ describe('derivePreview', () => {
 		expect(preview.logoVisibility).toBeUndefined();
 	});
 
-	it('separates form/recap visibility from per-user reachability for a public showcase', () => {
+	it('separates current-year lookup, recap visibility, and ordinary personal-link defaults', () => {
 		const preview = derivePreview(byId('public-showcase').values);
 		expect(preview.landingLookupForm).toBe('visible');
 		expect(preview.serverRecapVisibility).toBe('public');
 		expect(preview.perUserDefaultForNewUsers).toBe('public');
-		// No field on the model claims an existing/private user is reachable.
+		expect(preview.logoVisibility).toBe('always-show');
 		expect(preview.warnings).toHaveLength(0);
 	});
 
@@ -111,7 +111,7 @@ describe('derivePreview', () => {
 		expect(derivePreview(byId('internal-community').values).nameDisplay).toBe('real');
 	});
 
-	it('emits the contradiction warning for a custom combo (public lookup on + non-public default)', () => {
+	it('allows public lookup with a private ordinary-link baseline without a contradiction', () => {
 		const preview = derivePreview({
 			anonymizationMode: 'hybrid',
 			defaultShareMode: 'private-oauth',
@@ -119,11 +119,18 @@ describe('derivePreview', () => {
 			publicLandingLookup: true,
 			allowUserControl: true
 		});
-		expect(preview.warnings.length).toBeGreaterThan(0);
-		expect(preview.warnings.some((w) => /public lookup is on/i.test(w))).toBe(true);
+		expect(preview.landingLookupForm).toBe('visible');
+		expect(preview.perUserDefaultForNewUsers).toBe('members-only');
+		expect(preview.warnings).toHaveLength(0);
 	});
 
-	it('no shipped preset trips the contradiction warning', () => {
+	it('sets every shipped preset logo mode to Always Show', () => {
+		for (const preset of PRIVACY_PRESETS) {
+			expect(preset.values.logoMode).toBe('always_show');
+		}
+	});
+
+	it('keeps every shipped preset warning-free', () => {
 		for (const preset of PRIVACY_PRESETS) {
 			expect(derivePreview(preset.values).warnings).toHaveLength(0);
 		}

--- a/tests/unit/sharing/public-slug.test.ts
+++ b/tests/unit/sharing/public-slug.test.ts
@@ -5,6 +5,7 @@ import { shareSettings, users } from '$lib/server/db/schema';
 import {
 	ensurePublicSlug,
 	generatePublicSlug,
+	generateShareToken,
 	getExistingShareIdentifier,
 	getShareIdentifier,
 	isPureNumericId,
@@ -84,6 +85,21 @@ describe('DF-04 public slug: minting + resolution', () => {
 		await expect(ensurePublicSlug(USER_ID, YEAR)).rejects.toBeInstanceOf(
 			ShareSettingsNotFoundError
 		);
+	});
+	it('mints and returns only a public slug for a private-link row without changing its token', async () => {
+		const token = generateShareToken();
+		await seedRow(ShareMode.PRIVATE_LINK, token);
+
+		const slug = await ensurePublicSlug(USER_ID, YEAR);
+
+		expect(isValidSlugFormat(slug)).toBe(true);
+		expect(slug).not.toBe(token);
+		const row = await db
+			.select({ publicSlug: shareSettings.publicSlug, shareToken: shareSettings.shareToken })
+			.from(shareSettings)
+			.where(and(eq(shareSettings.userId, USER_ID), eq(shareSettings.year, YEAR)))
+			.limit(1);
+		expect(row[0]).toEqual({ publicSlug: slug, shareToken: token });
 	});
 
 	it('resolveSlug returns null for malformed and unknown slugs', async () => {

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -632,6 +632,22 @@ describe('Sharing Service', () => {
 				expect(await getEffectiveShareMode(userId, currentYear)).toBe(ShareMode.PRIVATE_OAUTH);
 			});
 
+			it('uses the caller current-year snapshot for public lookup policy', async () => {
+				const boundaryYear = 2099;
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PRIVATE_LINK,
+					allowUserControl: false
+				});
+				await setPublicLandingLookupEnabled(true);
+
+				expect(await getEffectiveShareMode(userId, boundaryYear, boundaryYear)).toBe(
+					ShareMode.PUBLIC
+				);
+				expect(await getEffectiveShareMode(userId, boundaryYear, boundaryYear + 1)).toBe(
+					ShareMode.PRIVATE_LINK
+				);
+			});
+
 			it('maps shareToken correctly', async () => {
 				const token = generateShareToken();
 				await db.insert(shareSettings).values({

--- a/tests/unit/sharing/service.test.ts
+++ b/tests/unit/sharing/service.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { and, eq } from 'drizzle-orm';
-import { setUserDefaultsAtomic } from '$lib/server/admin/settings.service';
+import {
+	setPublicLandingLookupEnabled,
+	setUserDefaultsAtomic
+} from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings, shareSettings } from '$lib/server/db/schema';
 import {
@@ -608,6 +611,25 @@ describe('Sharing Service', () => {
 				expect(readOnlySettings?.storedMode).toBe(ShareMode.PRIVATE_OAUTH);
 				expect(readOnlySettings?.mode).toBe(ShareMode.PRIVATE_OAUTH);
 				expect(effectiveMode).toBe(ShareMode.PRIVATE_OAUTH);
+			});
+
+			it('fails closed for a malformed explicit opt-out while public lookup is enabled', async () => {
+				const currentYear = new Date().getFullYear();
+				await setGlobalShareDefaults({
+					defaultShareMode: ShareMode.PUBLIC,
+					allowUserControl: true
+				});
+				await setPublicLandingLookupEnabled(true);
+				await db.insert(shareSettings).values({
+					userId,
+					year: currentYear,
+					mode: 'invalid-mode',
+					modeSource: ShareModeSource.EXPLICIT,
+					shareToken: null,
+					canUserControl: true
+				});
+
+				expect(await getEffectiveShareMode(userId, currentYear)).toBe(ShareMode.PRIVATE_OAUTH);
 			});
 
 			it('maps shareToken correctly', async () => {


### PR DESCRIPTION
## Problem

Obzorarr exposed a landing-page username lookup that could still resolve every user as private, making the advertised public flow contradictory. Privacy presets and related copy also blurred the boundary between public Wrapped output and protected application surfaces. Reverse-proxy onboarding reported problems without giving administrators enough evidence or concrete repair steps.

## Behavioral changes

### Public Wrapped lookup

- Makes the enabled landing lookup a coherent current-year public-sharing default.
- Allows anonymous visitors to resolve eligible Plex users to opaque public Wrapped URLs without weakening authentication for dashboards, settings, or administration.
- Preserves an explicit user opt-out when administrator-managed user controls are enabled.
- Makes the administrator's lookup policy authoritative when user controls are disabled.
- Uses the same non-enumerating response for unknown and opted-out usernames.
- Reauthorizes public destinations against the user's current effective share mode.
- Keeps disabled lookup requests unavailable and prevents crafted requests from performing lookup work.

### Privacy presets and copy

- Sets every shipped preset to `Always Show` for the Wrapped Obzorarr logo, including Anonymous Public.
- Keeps preset matching, previews, and persistence aligned with the revised values.
- Sources concise privacy explanations consistently across onboarding and admin settings.
- Separates Wrapped-page viewers, name presentation, anonymous landing lookup, user overrides, and protected authenticated surfaces.
- Improves keyboard behavior and selection semantics for preset controls.

### Reverse-proxy diagnostics

- Adds a client-safe diagnostic model and shared recommendation presenter backed by observed forwarding headers and origin state.
- Distinguishes missing, partial, invalid, inconsistent, origin-mismatch, trust-disabled, trust-working, environment-locked, and indeterminate states.
- Leads with one diagnosis and one next action, with technical evidence and repair guides behind progressive disclosure.
- Provides safe, copyable guidance for Nginx, Nginx Proxy Manager, Caddy, Apache, and other proxies.
- Explains that a trusted upstream must strip or overwrite visitor-supplied forwarding headers before `TRUST_PROXY` is enabled.
- Shows environment-controlled settings and restart requirements, supports rerunning diagnostics, and explains the concrete consequence of continuing.
- Preserves no-store responses, admin authorization, CSRF protection, rate limiting, and diagnostic sanitization.

## Privacy and security decisions

“Public” applies only to the intended Wrapped recap output. Admin controls, user settings, dashboards, and other private surfaces remain authenticated. Public lookup returns opaque public slugs rather than private tokens and intentionally does not distinguish an unknown username from a user who opted out. Proxy examples use canonical host handling and never expose full sensitive headers, secrets, or infrastructure details.

## UX approach

The proxy experience uses progressive disclosure: the primary card states what Obzorarr observed and the single most relevant repair action; evidence, explanation, and provider-specific snippets remain available in keyboard-accessible details. Status text and icons carry meaning independently of color, controls use mobile-friendly targets, and reruns visibly replace stale results. Privacy and landing copy stay brief while stating the exact public/private boundary.

## Verification

- `bun run check`
- `bun run check:biome`
- `bun run test` — 2,214 passed, 0 failed
- `bun run build`
- `prek run --all-files`
- `bun run smoke:production` against a disposable database outside the repository; the committed production server became ready on an ephemeral port and cleanup left the worktree clean
- Focused Bun suites for landing lookup, sharing access/service/presets, proxy diagnostics/presentation, onboarding actions, admin security actions, and UI contracts
- Browser automation against a disposable onboarding database and a controlled overwrite proxy, covering proxy enable/rerun/disable, no-store and CSRF boundaries, privacy keyboard selection, mobile layouts, generic public-lookup failure, and opaque current-year redirects
