### PR TITLE
fix: correct reverse-proxy onboarding guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,8 +24,8 @@
 # Server
 # PORT=3000
 # HOST=0.0.0.0
-# ORIGIN=https://your-domain.com    # Required for CSRF protection in production
-# TRUST_PROXY=false                 # Set to "true" only if your reverse proxy strips inbound X-Forwarded-* headers from clients
+# ORIGIN=https://your-domain.com    # Public SvelteKit request origin and CSRF origin; include any non-default port
+# TRUST_PROXY=false                 # Enable only behind an isolated proxy that overwrites both X-Forwarded-Proto and X-Forwarded-Host
 
 # Database
 # DATABASE_PATH=data/obzorarr.db

--- a/README.md
+++ b/README.md
@@ -135,29 +135,29 @@ bun run dev
 
 ## Reverse proxy header trust
 
-Obzorarr uses `X-Forwarded-Proto` and `X-Forwarded-Host` only when `TRUST_PROXY=true`.
-Enable it only when every request reaches Obzorarr through a trusted upstream proxy that strips or
-overwrites visitor-supplied values for both headers. Do not enable it when visitors can connect to
-Obzorarr directly.
-
-Configure the proxy to send the public request scheme and host, then use the onboarding or
-**Admin → Settings → Security** diagnostic to compare the browser, forwarded, and effective app
-origins. When `TRUST_PROXY` is controlled by the environment or container configuration, change the
-exact setting there and restart Obzorarr before rerunning the diagnostic:
+For a single public origin, set `ORIGIN` to the exact browser-facing origin, including any
+non-default port. The pinned Bun adapter uses it to construct SvelteKit's `request.url` before
+Obzorarr's hooks run, and Obzorarr also uses it as the environment-controlled CSRF origin:
 
 ```env
-TRUST_PROXY=true
 ORIGIN=https://obzorarr.example.com
 ```
 
-`ORIGIN` is the public origin used for CSRF validation. It must match the browser origin exactly,
-including scheme and any non-default port. The diagnostic reports header names and normalized
-origins only; it does not expose header values that may contain credentials or client addresses.
+`TRUST_PROXY` is a separate, optional in-app URL rewrite. When enabled, Obzorarr replaces the
+SvelteKit event URL's host and protocol from `X-Forwarded-Host` and `X-Forwarded-Proto`; it does
+not change `request.url` or client-IP handling. Leave it disabled when `ORIGIN` or the adapter's
+normal Host handling already gives Obzorarr the correct public origin.
 
-Use a strict virtual host or site match and set the forwarded host to the deployment's canonical public
-hostname; merely copying an unrestricted visitor `Host` value does not establish a trusted boundary.
-`TRUST_PROXY` affects Obzorarr's effective URL host and protocol only. Client-IP trust must be
-configured separately in the Bun adapter or runtime.
+Enable `TRUST_PROXY=true` only when Obzorarr cannot be reached around the proxy and the last
+trusted hop removes or overwrites visitor-supplied values for both headers. A matching diagnostic
+shows that the values are consistent with the browser origin; it cannot prove the proxy boundary
+from one request. Environment-controlled changes require an Obzorarr restart.
+
+Use the onboarding or **Admin → Settings → Security** diagnostic to compare the browser,
+forwarded, and effective app origins. Provider guidance in the diagnostic reflects differing
+defaults: Caddy manages both headers by default, while Nginx, Nginx Proxy Manager, and Apache
+need provider-specific handling. Client-IP trust is configured separately through the Bun
+adapter's `ADDRESS_HEADER` and `XFF_DEPTH` settings.
 
 ## License
 

--- a/src/lib/copy/reverse-proxy.ts
+++ b/src/lib/copy/reverse-proxy.ts
@@ -65,8 +65,8 @@ function observedEvidence(diagnostic: ReverseProxyDiagnostic): string {
 			if (diagnostic.facts.originComparison.forwardedPairMatchesBrowser === false) {
 				return `Both required headers arrived, but forwarded origin ${forwardedOrigin} does not match browser origin ${browserOrigin}.`;
 			}
-			if (diagnostic.facts.originComparison.browserMatchesRawApp === true) {
-				return `Both required headers arrived, but browser origin ${browserOrigin} already matches the direct app origin.`;
+			if (diagnostic.facts.originComparison.browserMatchesRequestUrl === true) {
+				return `Both required headers arrived, and the request origin Obzorarr received already matches browser origin ${browserOrigin}.`;
 			}
 			return `Both required headers arrived with forwarded origin ${forwardedOrigin}.`;
 		default: {
@@ -92,8 +92,8 @@ function reviewNextAction(diagnostic: ReverseProxyDiagnostic): string {
 			if (diagnostic.facts.originComparison.forwardedPairMatchesBrowser === false) {
 				return 'The forwarded origin conflicts with the browser origin. Set both headers from the public request, then rerun.';
 			}
-			if (diagnostic.facts.originComparison.browserMatchesRawApp === true) {
-				return 'The direct app origin already matches the browser, so these headers do not prove a trusted proxy is required. Remove unnecessary forwarding headers and leave TRUST_PROXY disabled, or open the intended public proxy address and rerun.';
+			if (diagnostic.facts.originComparison.browserMatchesRequestUrl === true) {
+				return 'Obzorarr already sees the browser origin, so in-app forwarding-header trust is not needed for this request.';
 			}
 			return 'The pair is valid, but Obzorarr could not confirm the trusted proxy boundary. Verify the last proxy overwrites both headers, then rerun.';
 		default: {
@@ -110,15 +110,15 @@ export function presentReverseProxyDiagnostic(
 	const diagnosis = observedEvidence(diagnostic);
 
 	switch (diagnostic.action) {
-		case 'enable':
+		case 'confirm-trust-boundary':
 			return {
 				tone: 'warning',
-				headline: 'Forwarded origin matches; trust is still disabled',
+				headline: 'Forwarded origin is consistent; proxy boundary is unverified',
 				diagnosis,
 				nextAction:
-					'Verify that the upstream proxy overwrites visitor-supplied forwarding headers, confirm the risk, then enable TRUST_PROXY.',
+					'Confirm that Obzorarr cannot be reached around the proxy and that the last proxy overwrites both forwarding headers, then enable TRUST_PROXY.',
 				consequence:
-					'Until enabled, Obzorarr continues using the internal app origin for generated public URLs.',
+					'Matching values show consistency, not that a trusted proxy supplied them. Until enabled, Obzorarr keeps using its adapter-constructed request origin.',
 				pairLabel,
 				safetyNotice: SAFETY_NOTICE,
 				documentationIds: [...PROXY_REPAIR_DOCUMENTATION_IDS]
@@ -126,11 +126,11 @@ export function presentReverseProxyDiagnostic(
 		case 'leave-disabled':
 			return {
 				tone: 'success',
-				headline: 'Direct origin is already consistent',
+				headline: 'Obzorarr already sees the browser origin',
 				diagnosis,
 				nextAction:
-					'Leave TRUST_PROXY disabled unless you later place Obzorarr behind a trusted proxy.',
-				consequence: 'No proxy-origin repair is needed for this request.',
+					'Leave TRUST_PROXY disabled; forwarding-header trust is unnecessary while the request origin remains correct.',
+				consequence: 'No host or protocol repair is needed for this request.',
 				pairLabel,
 				safetyNotice: SAFETY_NOTICE,
 				documentationIds: ['obzorarr-trust-proxy']
@@ -163,7 +163,7 @@ export function presentReverseProxyDiagnostic(
 			const enabled = diagnostic.facts.trustProxy.enabled;
 			const pair = diagnostic.facts.forwardedHeaders.pair;
 			const effectiveMatches = diagnostic.facts.originComparison.browserMatchesEffectiveApp;
-			const rawMatches = diagnostic.facts.originComparison.browserMatchesRawApp;
+			const requestMatches = diagnostic.facts.originComparison.browserMatchesRequestUrl;
 			const forwardedMatches = diagnostic.facts.originComparison.forwardedPairMatchesBrowser;
 
 			if (enabled && pair.isUsable && effectiveMatches === true) {
@@ -181,22 +181,22 @@ export function presentReverseProxyDiagnostic(
 				};
 			}
 
-			if (!enabled && rawMatches === true && pair.status === 'missing') {
+			if (!enabled && requestMatches === true) {
 				return {
 					tone: 'success',
-					headline: 'TRUST_PROXY is disabled by the environment and direct origin is consistent',
+					headline: 'TRUST_PROXY is disabled by the environment and the request origin matches',
 					diagnosis,
 					nextAction:
-						'Leave TRUST_PROXY=false. Change it only after placing Obzorarr behind a trusted proxy that overwrites both forwarding headers.',
+						'Leave TRUST_PROXY=false. Change it only when Obzorarr needs forwarded host/protocol values and is isolated behind a proxy that overwrites both headers.',
 					consequence:
-						'The environment-managed setting already matches this direct-access request.',
+						'The environment-managed setting already produces the correct origin for this request.',
 					pairLabel,
 					safetyNotice: SAFETY_NOTICE,
 					documentationIds: ['obzorarr-trust-proxy']
 				};
 			}
 
-			if (!enabled && pair.isUsable && forwardedMatches === true && rawMatches === false) {
+			if (!enabled && pair.isUsable && forwardedMatches === true && requestMatches === false) {
 				return {
 					tone: 'warning',
 					headline: 'TRUST_PROXY is disabled by the environment',
@@ -217,7 +217,11 @@ export function presentReverseProxyDiagnostic(
 				diagnosis,
 				nextAction: `${reviewNextAction(diagnostic)} Restart Obzorarr after changing TRUST_PROXY in the environment or container configuration.`,
 				consequence: enabled
-					? 'Obzorarr is trusting a host/protocol result that does not match the browser origin.'
+					? pair.isUsable
+						? 'Obzorarr is trusting a host/protocol result that does not match or cannot be verified against the browser origin.'
+						: effectiveMatches === false
+							? 'Obzorarr rejected the unusable forwarding metadata, and the adapter fallback does not match the browser origin.'
+							: 'Obzorarr rejected the unusable forwarding metadata; repair it before relying on proxy trust.'
 					: 'Do not enable TRUST_PROXY until the forwarding pair and replacement boundary are correct.',
 				pairLabel,
 				safetyNotice: SAFETY_NOTICE,
@@ -253,9 +257,9 @@ export const REVERSE_PROXY_DOCUMENTATION: ReverseProxyDocumentationLink[] = [
 	{
 		id: 'nginx-proxy-manager-custom-config',
 		provider: 'Nginx Proxy Manager',
-		url: 'https://nginxproxymanager.com/advanced-config/#custom-nginx-configurations',
+		url: 'https://github.com/NginxProxyManager/nginx-proxy-manager/blob/v2.14.0/docker/rootfs/etc/nginx/conf.d/include/proxy.conf',
 		purpose: 'forwarded-host-proto',
-		applicabilityLabel: 'Official custom Nginx configuration locations'
+		applicabilityLabel: 'Official v2.14.0 generated proxy header configuration'
 	},
 	{
 		id: 'caddy-reverse-proxy',
@@ -293,44 +297,41 @@ export const REVERSE_PROXY_PROVIDER_GUIDES: ReverseProxyProviderGuide[] = [
 		id: 'nginx',
 		label: 'Nginx',
 		steps: [
-			'Route only the intended public hostname to this server block. Replace the example hostname and scheme below with the exact public origin.',
-			'Add these directives in the location that proxies to Obzorarr, reload Nginx, then rerun. Restart Obzorarr too only when TRUST_PROXY is environment-controlled.'
+			'Use an exact server_name and reject unmatched hosts so the selected server name is an approved public hostname.',
+			'These directives derive protocol, hostname, and listener port from the selected public server. If external port translation changes the public port, configure an allowlisted public authority instead.'
 		],
 		config:
-			'# Replace with your exact public origin.\nproxy_set_header X-Forwarded-Proto https;\nproxy_set_header X-Forwarded-Host obzorarr.example.com;',
+			'proxy_set_header X-Forwarded-Proto $scheme;\nproxy_set_header X-Forwarded-Host $server_name:$server_port;',
 		documentationId: 'nginx-proxy-set-header'
 	},
 	{
 		id: 'nginx-proxy-manager',
 		label: 'Nginx Proxy Manager',
 		steps: [
-			'Make this Proxy Host match only the intended public hostname. In Advanced, replace the example hostname and scheme below with that exact public origin.',
-			'Save the host, then rerun. Restart Obzorarr too only when TRUST_PROXY is environment-controlled.'
+			'Use a Proxy Host for the exact public hostname. Nginx Proxy Manager 2.14.0 sets X-Forwarded-Proto by default but can preserve an incoming valid value, and it does not set X-Forwarded-Host.',
+			'Obzorarr does not provide a TRUST_PROXY recipe for NPM because the generated directive placement was not runtime-verified. Leave trust disabled when Obzorarr already sees the browser origin; otherwise verify that the generated Nginx configuration replaces both headers before enabling it.'
 		],
-		config:
-			'# Replace with your exact public origin.\nproxy_set_header X-Forwarded-Proto https;\nproxy_set_header X-Forwarded-Host obzorarr.example.com;',
 		documentationId: 'nginx-proxy-manager-custom-config'
 	},
 	{
 		id: 'caddy',
 		label: 'Caddy',
 		steps: [
-			'Use the exact public hostname as the Caddy site address. Replace the example upstream and hostname below for your deployment.',
-			'Reload Caddy, then rerun. Restart Obzorarr too only when TRUST_PROXY is environment-controlled.'
+			'Caddy sets X-Forwarded-Proto and X-Forwarded-Host and ignores incoming values for those managed headers by default. No header_up override is needed.',
+			'If another proxy is in front of Caddy, configure Caddy trusted_proxies for only that known upstream chain. Reload Caddy, then rerun.'
 		],
-		config:
-			'obzorarr.example.com {\n\treverse_proxy obzorarr:3000 {\n\t\theader_up X-Forwarded-Proto https\n\t\theader_up X-Forwarded-Host obzorarr.example.com\n\t}\n}',
+		config: 'obzorarr.example.com {\n\treverse_proxy obzorarr:3000\n}',
 		documentationId: 'caddy-reverse-proxy'
 	},
 	{
 		id: 'apache',
 		label: 'Apache',
 		steps: [
-			'Use a name-based virtual host for the exact public hostname. Replace the example hostname and scheme below for your deployment.',
-			'Enable mod_proxy, mod_proxy_http, and mod_headers; reload Apache, then rerun. Restart Obzorarr too only when TRUST_PROXY is environment-controlled.'
+			'Use a name-based VirtualHost for the exact public host and a separate first/default VirtualHost that rejects unmatched Host values.',
+			'Apache adds X-Forwarded-Host by default, but not X-Forwarded-Proto; these replacements derive both from the accepted VirtualHost and its listener. If external port translation changes the public port, configure an allowlisted public authority instead.'
 		],
 		config:
-			'# Replace with your exact public origin.\nRequestHeader set X-Forwarded-Proto "https"\nRequestHeader set X-Forwarded-Host "obzorarr.example.com"',
+			'RequestHeader set X-Forwarded-Proto "expr=%{REQUEST_SCHEME}"\nRequestHeader set X-Forwarded-Host "expr=%{SERVER_NAME}:%{SERVER_PORT}"',
 		documentationId: 'apache-request-header'
 	},
 	{

--- a/src/lib/security/reverse-proxy.ts
+++ b/src/lib/security/reverse-proxy.ts
@@ -45,7 +45,7 @@ export type SourceAddressCategory =
 	| 'unknown';
 
 export type ReverseProxyRecommendationAction =
-	| 'enable'
+	| 'confirm-trust-boundary'
 	| 'leave-disabled'
 	| 'review-proxy'
 	| 'appears-working'
@@ -57,7 +57,8 @@ export type ReverseProxyDiagnosticReasonCode =
 	| 'trust-proxy-env-locked-disabled'
 	| 'browser-origin-invalid'
 	| 'forwarded-pair-matches-browser'
-	| 'direct-access-without-forwarded-pair'
+	| 'request-origin-matches-without-forwarded-pair'
+	| 'request-origin-already-matches-browser'
 	| 'forwarded-pair-missing'
 	| 'forwarded-pair-partial'
 	| 'forwarded-pair-invalid'
@@ -118,7 +119,7 @@ export interface ReverseProxyDiagnosticFacts {
 		category: SourceAddressCategory;
 	};
 	originComparison: {
-		browserMatchesRawApp: boolean | null;
+		browserMatchesRequestUrl: boolean | null;
 		browserMatchesEffectiveApp: boolean | null;
 		forwardedPairMatchesBrowser: boolean | null;
 	};

--- a/src/lib/server/security/csrf-handle.ts
+++ b/src/lib/server/security/csrf-handle.ts
@@ -42,9 +42,9 @@ function isCsrfOriginRepairRequest(event: Parameters<Handle>[0]['event']): boole
 	return false;
 }
 
-// Exported so admin actions (e.g. updateCsrfOrigin) can predict the same
-// origin csrfHandle compares against, rather than rederiving from
-// `request.url` which is the immutable raw URL behind a reverse proxy.
+// Exported so admin actions (e.g. updateCsrfOrigin) use the same browser-supplied
+// Origin/Referer evidence as csrfHandle. The adapter constructs `request.url`
+// before hooks, so that URL is not an independent browser-origin observation.
 export function getOriginFromRequest(request: Request): string | null {
 	const origin = request.headers.get('origin');
 	if (origin) return origin;

--- a/src/lib/server/security/reverse-proxy-diagnostic.ts
+++ b/src/lib/server/security/reverse-proxy-diagnostic.ts
@@ -18,7 +18,6 @@ export type {
 
 export interface ReverseProxyDiagnosticInput {
 	request: Request;
-	rawAppUrl: string | URL;
 	effectiveAppUrl: string | URL;
 	browserOrigin?: string | null;
 	sourceAddress?: string | null;
@@ -136,11 +135,11 @@ function recommendationFor(input: {
 	trustEnabled: boolean;
 	trustSource: ReverseProxyDiagnostic['facts']['trustProxy']['source'];
 	browserOrigin: OriginDiagnostic;
-	rawAppOrigin: string | null;
+	requestOrigin: string | null;
 	effectiveAppOrigin: string | null;
 	forwardedPair: ReturnType<typeof parseForwardedProtoHost>;
 }): Pick<ReverseProxyDiagnostic, 'action' | 'reasonCodes'> {
-	const browserMatchesRawApp = originsEqual(input.browserOrigin.origin, input.rawAppOrigin);
+	const browserMatchesRequestUrl = originsEqual(input.browserOrigin.origin, input.requestOrigin);
 	const browserMatchesEffectiveApp = originsEqual(
 		input.browserOrigin.origin,
 		input.effectiveAppOrigin
@@ -165,20 +164,24 @@ function recommendationFor(input: {
 
 	if (!input.trustEnabled) {
 		if (
-			browserMatchesRawApp === false &&
+			browserMatchesRequestUrl === false &&
 			input.forwardedPair.isUsable &&
 			forwardedPairMatchesBrowser === true
 		) {
 			return {
-				action: 'enable',
+				action: 'confirm-trust-boundary',
 				reasonCodes: ['forwarded-pair-matches-browser']
 			};
 		}
 
-		if (browserMatchesRawApp === true && input.forwardedPair.status === 'missing') {
+		if (browserMatchesRequestUrl === true) {
 			return {
 				action: 'leave-disabled',
-				reasonCodes: ['direct-access-without-forwarded-pair']
+				reasonCodes: [
+					input.forwardedPair.status === 'missing'
+						? 'request-origin-matches-without-forwarded-pair'
+						: 'request-origin-already-matches-browser'
+				]
 			};
 		}
 
@@ -199,7 +202,7 @@ export function buildReverseProxyDiagnostic(
 	input: ReverseProxyDiagnosticBuildInput
 ): ReverseProxyDiagnostic {
 	const forwardedPair = parseForwardedProtoHost(input.request.headers);
-	const rawAppOrigin = originFromUrl(input.rawAppUrl);
+	const requestOrigin = originFromUrl(input.request.url);
 	const effectiveAppOrigin = originFromUrl(input.effectiveAppUrl);
 	const browserOrigin = normalizeOrigin(input.browserOrigin);
 	const configuredPublicOrigin = normalizeOrigin(input.csrfOrigin.value || null);
@@ -208,7 +211,7 @@ export function buildReverseProxyDiagnostic(
 		trustEnabled,
 		trustSource: input.trustProxy.source,
 		browserOrigin,
-		rawAppOrigin,
+		requestOrigin,
 		effectiveAppOrigin,
 		forwardedPair
 	});
@@ -247,7 +250,7 @@ export function buildReverseProxyDiagnostic(
 				category: classifySourceAddress(input.sourceAddress)
 			},
 			originComparison: {
-				browserMatchesRawApp: originsEqual(browserOrigin.origin, rawAppOrigin),
+				browserMatchesRequestUrl: originsEqual(browserOrigin.origin, requestOrigin),
 				browserMatchesEffectiveApp: originsEqual(browserOrigin.origin, effectiveAppOrigin),
 				forwardedPairMatchesBrowser: originsEqual(
 					browserOrigin.origin,
@@ -289,7 +292,7 @@ export type EnableTrustProxyDecision = { ok: true } | { ok: false; error: string
 export function assertEnableTrustProxyAllowed(
 	diagnostic: ReverseProxyDiagnostic
 ): EnableTrustProxyDecision {
-	if (diagnostic.action === 'enable') {
+	if (diagnostic.action === 'confirm-trust-boundary') {
 		return { ok: true };
 	}
 	return { ok: false, error: ENABLE_TRUST_PROXY_NOT_RECOMMENDED_MESSAGE };

--- a/src/routes/admin/settings/security/+page.server.ts
+++ b/src/routes/admin/settings/security/+page.server.ts
@@ -305,7 +305,6 @@ export const actions: Actions = requireAdminActions({
 		try {
 			const diagnostic = await createReverseProxyDiagnostic({
 				request,
-				rawAppUrl: request.url,
 				effectiveAppUrl: url,
 				browserOrigin: parsed.data.browserOrigin,
 				sourceAddress: getClientAddress()
@@ -383,7 +382,6 @@ export const actions: Actions = requireAdminActions({
 			}
 			const diagnostic = await createReverseProxyDiagnostic({
 				request,
-				rawAppUrl: request.url,
 				effectiveAppUrl: url,
 				browserOrigin: parsed.data.browserOrigin,
 				sourceAddress: getClientAddress()

--- a/src/routes/admin/settings/security/+page.svelte
+++ b/src/routes/admin/settings/security/+page.svelte
@@ -495,7 +495,7 @@ const applicableProviderGuides = $derived(
 						</Button>
 					</SettingsActionBar>
 				</form>
-			{:else if diagnostic?.action === 'enable'}
+			{:else if diagnostic?.action === 'confirm-trust-boundary'}
 				<SettingsActionBar>
 					<button
 						type="button"

--- a/src/routes/api/security/reverse-proxy-diagnostic/+server.ts
+++ b/src/routes/api/security/reverse-proxy-diagnostic/+server.ts
@@ -48,7 +48,6 @@ export const GET: RequestHandler = async ({ getClientAddress, locals, request, u
 
 	const diagnostic = await createReverseProxyDiagnostic({
 		request,
-		rawAppUrl: request.url,
 		effectiveAppUrl: url,
 		browserOrigin,
 		sourceAddress

--- a/src/routes/onboarding/proxy-trust/+page.server.ts
+++ b/src/routes/onboarding/proxy-trust/+page.server.ts
@@ -154,7 +154,6 @@ export const actions: Actions = {
 		try {
 			const diagnostic = await createReverseProxyDiagnostic({
 				request,
-				rawAppUrl: request.url,
 				effectiveAppUrl: url,
 				browserOrigin: parsed.data.browserOrigin,
 				sourceAddress: getClientAddress()
@@ -199,7 +198,6 @@ export const actions: Actions = {
 
 		const diagnostic = await createReverseProxyDiagnostic({
 			request,
-			rawAppUrl: request.url,
 			effectiveAppUrl: url,
 			browserOrigin: browserOriginParsed.data.browserOrigin,
 			sourceAddress: getClientAddress()

--- a/src/routes/onboarding/proxy-trust/+page.svelte
+++ b/src/routes/onboarding/proxy-trust/+page.svelte
@@ -38,7 +38,7 @@ const applicableProviderGuides = $derived(
 );
 const canEnable = $derived(
 	diagnosticStatus === 'success' &&
-		diagnostic?.action === 'enable' &&
+		diagnostic?.action === 'confirm-trust-boundary' &&
 		!diagnostic.facts.trustProxy.isLocked &&
 		savedState === 'idle'
 );

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -36,8 +36,9 @@ const config = {
 			precompress: true
 		}),
 		csrf: {
-			// Origin checking is incompatible with reverse proxy deployments.
-			// CSRF protection is maintained via SameSite=Lax cookies.
+			// Obzorarr enforces configured-origin checks in csrfHandle. SvelteKit's
+			// built-in form-origin gate is disabled here to preserve the dedicated
+			// self-repair path; SameSite=Lax cookies remain defense in depth.
 			trustedOrigins: ['*']
 		}
 	}

--- a/tests/integration/adapter-url-fixture.test.ts
+++ b/tests/integration/adapter-url-fixture.test.ts
@@ -1,0 +1,236 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const repositoryRoot = process.cwd();
+let fixtureRoot = '';
+
+function inheritedEnvironment(): Record<string, string> {
+	return Object.fromEntries(
+		Object.entries(Bun.env).filter((entry): entry is [string, string] => entry[1] !== undefined)
+	);
+}
+
+async function assertPinnedVersions(): Promise<void> {
+	const adapterPackage = await Bun.file(
+		join(repositoryRoot, 'node_modules/svelte-adapter-bun/package.json')
+	).json();
+	const kitPackage = await Bun.file(
+		join(repositoryRoot, 'node_modules/@sveltejs/kit/package.json')
+	).json();
+	expect(adapterPackage.version).toBe('1.0.1');
+	expect(kitPackage.version).toBe('2.57.1');
+}
+
+async function writeFixture(): Promise<void> {
+	fixtureRoot = await mkdtemp(join(tmpdir(), 'obzorarr-adapter-url-'));
+	await mkdir(join(fixtureRoot, 'node_modules'));
+	for (const dependency of ['@sveltejs', 'svelte', 'svelte-adapter-bun', 'vite']) {
+		await symlink(
+			join(repositoryRoot, 'node_modules', dependency),
+			join(fixtureRoot, 'node_modules', dependency),
+			'dir'
+		);
+	}
+	await Bun.write(
+		join(fixtureRoot, 'package.json'),
+		JSON.stringify({ type: 'module', scripts: { build: 'vite build' } })
+	);
+	await Bun.write(
+		join(fixtureRoot, 'svelte.config.js'),
+		"import adapter from 'svelte-adapter-bun';\nexport default { kit: { adapter: adapter() } };\n"
+	);
+	await Bun.write(
+		join(fixtureRoot, 'vite.config.ts'),
+		"import { sveltekit } from '@sveltejs/kit/vite';\nimport { defineConfig } from 'vite';\nexport default defineConfig({ plugins: [sveltekit()] });\n"
+	);
+	await mkdir(join(fixtureRoot, 'src/routes'), { recursive: true });
+	await writeFile(
+		join(fixtureRoot, 'src/app.html'),
+		'<!doctype html><html lang="en"><head><meta charset="utf-8">%sveltekit.head%</head><body><div style="display: contents">%sveltekit.body%</div></body></html>'
+	);
+	await writeFile(
+		join(fixtureRoot, 'src/routes/+server.ts'),
+		"import { json } from '@sveltejs/kit';\nexport const GET = ({ request, url }) => json({ requestUrl: request.url, eventUrl: url.href });\n"
+	);
+}
+
+async function buildFixture(): Promise<void> {
+	const process = Bun.spawn(
+		['bun', '--bun', join(repositoryRoot, 'node_modules/vite/bin/vite.js'), 'build'],
+		{
+			cwd: fixtureRoot,
+			env: { ...inheritedEnvironment(), NODE_ENV: 'production' },
+			stdout: 'pipe',
+			stderr: 'pipe'
+		}
+	);
+	const [exitCode, stdout, stderr] = await Promise.all([
+		process.exited,
+		new Response(process.stdout).text(),
+		new Response(process.stderr).text()
+	]);
+	if (exitCode !== 0) {
+		throw new Error(`Fixture build failed (${exitCode})\n${stdout}\n${stderr}`);
+	}
+}
+
+interface AdapterCase {
+	host: string;
+	env?: Record<string, string>;
+	headers?: Record<string, string>;
+}
+
+async function observeAdapterUrl(testCase: AdapterCase): Promise<{
+	requestUrl: string;
+	eventUrl: string;
+}> {
+	const port = String(44000 + Math.floor(Math.random() * 1000));
+	const environment = inheritedEnvironment();
+	for (const key of [
+		'ORIGIN',
+		'PROTOCOL_HEADER',
+		'HOST_HEADER',
+		'PORT_HEADER',
+		'ADDRESS_HEADER',
+		'XFF_DEPTH'
+	]) {
+		delete environment[key];
+	}
+	Object.assign(environment, {
+		NODE_ENV: 'production',
+		HOST: '127.0.0.1',
+		PORT: port,
+		...testCase.env
+	});
+	const server = Bun.spawn(['bun', 'build/index.js'], {
+		cwd: fixtureRoot,
+		env: environment,
+		stdout: 'ignore',
+		stderr: 'pipe'
+	});
+
+	try {
+		let response: Response | undefined;
+		for (let attempt = 0; attempt < 50; attempt += 1) {
+			try {
+				response = await fetch(`http://127.0.0.1:${port}/`, {
+					headers: { Host: testCase.host, ...testCase.headers }
+				});
+				break;
+			} catch {
+				await Bun.sleep(50);
+			}
+		}
+		if (!response) {
+			throw new Error('Fixture server did not start');
+		}
+		expect(response.status).toBe(200);
+		return (await response.json()) as { requestUrl: string; eventUrl: string };
+	} finally {
+		server.kill();
+		await server.exited;
+	}
+}
+
+beforeAll(async () => {
+	await assertPinnedVersions();
+	try {
+		await writeFixture();
+		await buildFixture();
+	} catch (error) {
+		if (fixtureRoot) await rm(fixtureRoot, { recursive: true, force: true });
+		throw error;
+	}
+}, 120_000);
+
+afterAll(async () => {
+	if (!fixtureRoot) return;
+	const cleanedPath = fixtureRoot;
+	await rm(cleanedPath, { recursive: true, force: true });
+	expect(await Bun.file(cleanedPath).exists()).toBe(false);
+});
+
+describe('pinned svelte-adapter-bun request URL construction', () => {
+	it('uses its documented HTTPS default and incoming Host when ORIGIN is unset', async () => {
+		const observed = await observeAdapterUrl({ host: 'public.example:8443' });
+		expect(observed).toEqual({
+			requestUrl: 'https://public.example:8443/',
+			eventUrl: 'https://public.example:8443/'
+		});
+	}, 30_000);
+
+	it('uses ORIGIN ahead of contradictory configured origin headers', async () => {
+		const observed = await observeAdapterUrl({
+			host: 'internal.example:3000',
+			env: {
+				ORIGIN: 'https://canonical.example',
+				PROTOCOL_HEADER: 'x-forwarded-proto',
+				HOST_HEADER: 'x-forwarded-host',
+				PORT_HEADER: 'x-forwarded-port'
+			},
+			headers: {
+				'x-forwarded-proto': 'http',
+				'x-forwarded-host': 'attacker.example',
+				'x-forwarded-port': '8080'
+			}
+		});
+		expect(observed).toEqual({
+			requestUrl: 'https://canonical.example/',
+			eventUrl: 'https://canonical.example/'
+		});
+	}, 30_000);
+
+	it('uses configured protocol and host headers', async () => {
+		const observed = await observeAdapterUrl({
+			host: 'internal.example:3000',
+			env: {
+				PROTOCOL_HEADER: 'x-forwarded-proto',
+				HOST_HEADER: 'x-forwarded-host'
+			},
+			headers: {
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'public.example'
+			}
+		});
+		expect(observed).toEqual({
+			requestUrl: 'https://public.example/',
+			eventUrl: 'https://public.example/'
+		});
+	}, 30_000);
+
+	it('uses a separately configured port header', async () => {
+		const observed = await observeAdapterUrl({
+			host: 'internal.example:3000',
+			env: {
+				PROTOCOL_HEADER: 'x-forwarded-proto',
+				HOST_HEADER: 'x-forwarded-host',
+				PORT_HEADER: 'x-forwarded-port'
+			},
+			headers: {
+				'x-forwarded-proto': 'https',
+				'x-forwarded-host': 'public.example',
+				'x-forwarded-port': '8443'
+			}
+		});
+		expect(observed).toEqual({
+			requestUrl: 'https://public.example:8443/',
+			eventUrl: 'https://public.example:8443/'
+		});
+	}, 30_000);
+
+	it('shows SvelteKit normalizing a default port while preserving an IPv6 non-default port', async () => {
+		const defaultPort = await observeAdapterUrl({ host: 'public.example:443' });
+		expect(defaultPort).toEqual({
+			requestUrl: 'https://public.example:443/',
+			eventUrl: 'https://public.example/'
+		});
+
+		const ipv6 = await observeAdapterUrl({ host: '[2001:db8::1]:8443' });
+		expect(ipv6).toEqual({
+			requestUrl: 'https://[2001:db8::1]:8443/',
+			eventUrl: 'https://[2001:db8::1]:8443/'
+		});
+	}, 30_000);
+});

--- a/tests/integration/adapter-url-fixture.test.ts
+++ b/tests/integration/adapter-url-fixture.test.ts
@@ -81,22 +81,50 @@ interface AdapterCase {
 	env?: Record<string, string>;
 	headers?: Record<string, string>;
 }
-async function readServerOrigin(stdout: ReadableStream<Uint8Array>): Promise<string> {
-	const reader = stdout.getReader();
-	const decoder = new TextDecoder();
-	let output = '';
+function consumeServerOutput(stdout: ReadableStream<Uint8Array>): {
+	origin: Promise<string>;
+	drained: Promise<void>;
+} {
+	let resolveOrigin!: (origin: string) => void;
+	let rejectOrigin!: (reason: unknown) => void;
+	const origin = new Promise<string>((resolve, reject) => {
+		resolveOrigin = resolve;
+		rejectOrigin = reject;
+	});
+	const drained = (async () => {
+		const reader = stdout.getReader();
+		const decoder = new TextDecoder();
+		let output = '';
+		let foundOrigin = false;
 
-	try {
-		while (true) {
-			const { done, value } = await reader.read();
-			if (done) throw new Error(`Fixture server exited before listening: ${output}`);
-			output += decoder.decode(value, { stream: true });
-			const origin = output.match(/Listening on (https?:\/\/\S+)/)?.[1];
-			if (origin) return origin;
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) {
+					if (!foundOrigin) {
+						rejectOrigin(new Error(`Fixture server exited before listening: ${output}`));
+					}
+					return;
+				}
+				if (foundOrigin) continue;
+
+				output += decoder.decode(value, { stream: true });
+				const listeningOrigin = output.match(/Listening on (https?:\/\/\S+)/)?.[1];
+				if (listeningOrigin) {
+					foundOrigin = true;
+					resolveOrigin(listeningOrigin);
+					output = '';
+				}
+			}
+		} catch (error) {
+			if (!foundOrigin) rejectOrigin(error);
+			throw error;
+		} finally {
+			reader.releaseLock();
 		}
-	} finally {
-		reader.releaseLock();
-	}
+	})();
+
+	return { origin, drained };
 }
 
 async function observeAdapterUrl(testCase: AdapterCase): Promise<{
@@ -127,9 +155,17 @@ async function observeAdapterUrl(testCase: AdapterCase): Promise<{
 		stdout: 'pipe',
 		stderr: 'inherit'
 	});
+	const serverOutput = consumeServerOutput(server.stdout);
+	let outputFailure: { error: unknown } | undefined;
+	const outputDrain = serverOutput.drained.catch((error) => {
+		outputFailure = { error };
+		server.kill();
+	});
+	let result: { requestUrl: string; eventUrl: string } | undefined;
+	let operationFailure: { error: unknown } | undefined;
 	try {
 		const serverOrigin = await Promise.race([
-			readServerOrigin(server.stdout),
+			serverOutput.origin,
 			server.exited.then((exitCode) => {
 				throw new Error(`Fixture server exited before listening (${exitCode})`);
 			}),
@@ -152,11 +188,17 @@ async function observeAdapterUrl(testCase: AdapterCase): Promise<{
 			throw new Error('Fixture server did not accept requests');
 		}
 		expect(response.status).toBe(200);
-		return (await response.json()) as { requestUrl: string; eventUrl: string };
+		result = (await response.json()) as { requestUrl: string; eventUrl: string };
+	} catch (error) {
+		operationFailure = { error };
 	} finally {
 		server.kill();
-		await server.exited;
+		await Promise.all([server.exited, outputDrain]);
 	}
+	if (outputFailure) throw outputFailure.error;
+	if (operationFailure) throw operationFailure.error;
+	if (!result) throw new Error('Fixture server returned no observation');
+	return result;
 }
 
 beforeAll(async () => {

--- a/tests/integration/adapter-url-fixture.test.ts
+++ b/tests/integration/adapter-url-fixture.test.ts
@@ -81,12 +81,29 @@ interface AdapterCase {
 	env?: Record<string, string>;
 	headers?: Record<string, string>;
 }
+async function readServerOrigin(stdout: ReadableStream<Uint8Array>): Promise<string> {
+	const reader = stdout.getReader();
+	const decoder = new TextDecoder();
+	let output = '';
+
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) throw new Error(`Fixture server exited before listening: ${output}`);
+			output += decoder.decode(value, { stream: true });
+			const origin = output.match(/Listening on (https?:\/\/\S+)/)?.[1];
+			if (origin) return origin;
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
 
 async function observeAdapterUrl(testCase: AdapterCase): Promise<{
 	requestUrl: string;
 	eventUrl: string;
 }> {
-	const port = String(44000 + Math.floor(Math.random() * 1000));
+	const port = '0';
 	const environment = inheritedEnvironment();
 	for (const key of [
 		'ORIGIN',
@@ -107,24 +124,32 @@ async function observeAdapterUrl(testCase: AdapterCase): Promise<{
 	const server = Bun.spawn(['bun', 'build/index.js'], {
 		cwd: fixtureRoot,
 		env: environment,
-		stdout: 'ignore',
-		stderr: 'pipe'
+		stdout: 'pipe',
+		stderr: 'inherit'
 	});
-
 	try {
+		const serverOrigin = await Promise.race([
+			readServerOrigin(server.stdout),
+			server.exited.then((exitCode) => {
+				throw new Error(`Fixture server exited before listening (${exitCode})`);
+			}),
+			Bun.sleep(2_500).then(() => {
+				throw new Error('Fixture server did not start');
+			})
+		]);
 		let response: Response | undefined;
-		for (let attempt = 0; attempt < 50; attempt += 1) {
+		for (let attempt = 0; attempt < 10; attempt += 1) {
 			try {
-				response = await fetch(`http://127.0.0.1:${port}/`, {
+				response = await fetch(serverOrigin, {
 					headers: { Host: testCase.host, ...testCase.headers }
 				});
 				break;
 			} catch {
-				await Bun.sleep(50);
+				await Bun.sleep(25);
 			}
 		}
 		if (!response) {
-			throw new Error('Fixture server did not start');
+			throw new Error('Fixture server did not accept requests');
 		}
 		expect(response.status).toBe(200);
 		return (await response.json()) as { requestUrl: string; eventUrl: string };

--- a/tests/integration/adapter-url-fixture.test.ts
+++ b/tests/integration/adapter-url-fixture.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
-import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -216,7 +216,7 @@ afterAll(async () => {
 	if (!fixtureRoot) return;
 	const cleanedPath = fixtureRoot;
 	await rm(cleanedPath, { recursive: true, force: true });
-	expect(await Bun.file(cleanedPath).exists()).toBe(false);
+	await expect(access(cleanedPath)).rejects.toThrow();
 });
 
 describe('pinned svelte-adapter-bun request URL construction', () => {

--- a/tests/unit/admin/security-actions.test.ts
+++ b/tests/unit/admin/security-actions.test.ts
@@ -237,17 +237,17 @@ describe('security nested route — updateTrustProxy (confirmRisk + OCC)', () =>
 		await resetSharedTestDb();
 	});
 
-	// Match the diagnostic's "enable" recommendation shape (cf. settings-actions
-	// test): raw app URL internal, forwarded proto+host matches browser origin.
-	// The new diagnostic gate in updateTrustProxy refuses enable when the
-	// recommendation is anything other than 'enable'.
+	// Match the diagnostic's boundary-confirmation shape: adapter request URL internal,
+	// while the forwarded pair matches the submitted browser origin. The write gate
+	// refuses enablement for every other recommendation.
 	const TRUST_BROWSER_ORIGIN = 'https://obzorarr.example.com';
 	const TRUST_FORWARDED_HOST = 'obzorarr.example.com';
 	const TRUST_APP_URL = `${ORIGIN}/admin/settings/security?/updateTrustProxy`;
 
 	function trustProxyRequest(
 		fields: Record<string, string>,
-		originHeader: string | null = TRUST_BROWSER_ORIGIN
+		originHeader: string | null = TRUST_BROWSER_ORIGIN,
+		requestUrl = TRUST_APP_URL
 	): Request {
 		const formData = new FormData();
 		for (const [k, v] of Object.entries(fields)) formData.set(k, v);
@@ -259,7 +259,7 @@ describe('security nested route — updateTrustProxy (confirmRisk + OCC)', () =>
 			'x-forwarded-host': TRUST_FORWARDED_HOST
 		};
 		if (originHeader !== null) headers.Origin = originHeader;
-		return new Request(TRUST_APP_URL, {
+		return new Request(requestUrl, {
 			method: 'POST',
 			body: formData,
 			headers
@@ -336,6 +336,22 @@ describe('security nested route — updateTrustProxy (confirmRisk + OCC)', () =>
 		);
 		expect(result).toMatchObject({ success: true });
 		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBe('true');
+	});
+	it('does not enable trust when the adapter request origin already matches the browser', async () => {
+		const result = await run(
+			trustProxyRequest(
+				{
+					enabled: 'true',
+					confirmRisk: 'true',
+					settingsVersion: new Date(0).toISOString()
+				},
+				TRUST_BROWSER_ORIGIN,
+				`${TRUST_BROWSER_ORIGIN}/admin/settings/security?/updateTrustProxy`
+			)
+		);
+
+		expect(result).toMatchObject({ status: 400 });
+		expect(await getAppSetting(AppSettingsKey.TRUST_PROXY)).toBeNull();
 	});
 	it('fails closed without a request Origin and does not write TRUST_PROXY', async () => {
 		const result = await run(

--- a/tests/unit/admin/security-diagnostic-toast.test.ts
+++ b/tests/unit/admin/security-diagnostic-toast.test.ts
@@ -37,9 +37,9 @@ describe('reverse-proxy diagnostic toast and progressive guidance', () => {
 		expect(src).not.toContain('function getForwardedPairLabel');
 	});
 
-	it('only offers enable when the live diagnostic recommends it and keeps client-IP scope separate', async () => {
+	it('only offers enable after the live diagnostic asks for boundary confirmation', async () => {
 		const src = await readSource(SECURITY_PAGE);
-		expect(src).toContain("{:else if diagnostic?.action === 'enable'}");
+		expect(src).toContain("{:else if diagnostic?.action === 'confirm-trust-boundary'}");
 		expect(src).toContain('Client-IP handling is configured separately');
 		expect(src).not.toContain('headers for client IP, host');
 		expect(src).not.toContain('Raw app origin');

--- a/tests/unit/onboarding/proxy-trust-actions.test.ts
+++ b/tests/unit/onboarding/proxy-trust-actions.test.ts
@@ -227,7 +227,7 @@ describe('onboarding proxy-trust actions', () => {
 						present: ['X-Forwarded-Host', 'X-Forwarded-Proto']
 					}
 				},
-				action: 'enable',
+				action: 'confirm-trust-boundary',
 				reasonCodes: ['forwarded-pair-matches-browser']
 			}
 		});

--- a/tests/unit/security/reverse-proxy-diagnostic.test.ts
+++ b/tests/unit/security/reverse-proxy-diagnostic.test.ts
@@ -24,8 +24,8 @@ function diagnosticFor({
 	trustProxy = 'false',
 	trustSource = 'default',
 	browserOrigin = 'https://browser.example.com',
-	rawAppUrl = 'http://internal.local/path',
-	effectiveAppUrl = rawAppUrl,
+	requestUrl = 'http://internal.local/path',
+	effectiveAppUrl = requestUrl,
 	headers = {},
 	csrfOrigin = '',
 	sourceAddress = '172.18.0.2'
@@ -33,15 +33,14 @@ function diagnosticFor({
 	trustProxy?: string;
 	trustSource?: ReverseProxyConfigSource;
 	browserOrigin?: string | null;
-	rawAppUrl?: string;
+	requestUrl?: string;
 	effectiveAppUrl?: string;
 	headers?: Readonly<Record<string, string>>;
 	csrfOrigin?: string;
 	sourceAddress?: string;
 } = {}) {
 	return buildReverseProxyDiagnostic({
-		request: new Request(rawAppUrl, { headers: { ...headers } }),
-		rawAppUrl,
+		request: new Request(requestUrl, { headers: { ...headers } }),
 		effectiveAppUrl,
 		browserOrigin,
 		sourceAddress,
@@ -93,24 +92,58 @@ describe('reverse proxy diagnostic contract', () => {
 			reason: 'browser-origin-invalid'
 		},
 		{
-			name: 'enable evidence',
+			name: 'matching forwarded pair requires boundary confirmation',
 			input: {
 				headers: {
 					'x-forwarded-proto': 'https',
 					'x-forwarded-host': 'browser.example.com'
 				}
 			},
-			action: 'enable',
+			action: 'confirm-trust-boundary',
 			reason: 'forwarded-pair-matches-browser'
 		},
 		{
 			name: 'direct access',
 			input: {
 				browserOrigin: 'http://internal.local',
-				rawAppUrl: 'http://internal.local/path'
+				requestUrl: 'http://internal.local/path'
 			},
 			action: 'leave-disabled',
-			reason: 'direct-access-without-forwarded-pair'
+			reason: 'request-origin-matches-without-forwarded-pair'
+		},
+		{
+			name: 'Caddy-shaped downstream values need no in-app trust when request origin matches',
+			input: {
+				requestUrl: 'https://browser.example.com/path',
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'browser.example.com'
+				}
+			},
+			action: 'leave-disabled',
+			reason: 'request-origin-already-matches-browser'
+		},
+		{
+			name: 'Caddy-shaped downstream values preserve a non-default public port',
+			input: {
+				browserOrigin: 'https://browser.example.com:8443',
+				requestUrl: 'https://browser.example.com:8443/path',
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'browser.example.com:8443'
+				}
+			},
+			action: 'leave-disabled',
+			reason: 'request-origin-already-matches-browser'
+		},
+		{
+			name: 'partial forwarding metadata is unused when the request origin matches',
+			input: {
+				requestUrl: 'https://browser.example.com/path',
+				headers: { 'x-forwarded-proto': 'https' }
+			},
+			action: 'leave-disabled',
+			reason: 'request-origin-already-matches-browser'
 		},
 		{
 			name: 'missing forwarded pair with mismatched origins',
@@ -127,6 +160,18 @@ describe('reverse proxy diagnostic contract', () => {
 		{
 			name: 'invalid forwarded pair',
 			input: {
+				requestUrl: 'https://browser.example.com/path',
+				headers: {
+					'x-forwarded-proto': 'ftp',
+					'x-forwarded-host': 'browser.example.com'
+				}
+			},
+			action: 'leave-disabled',
+			reason: 'request-origin-already-matches-browser'
+		},
+		{
+			name: 'invalid forwarded pair with mismatched origins',
+			input: {
 				headers: {
 					'x-forwarded-proto': 'ftp',
 					'x-forwarded-host': 'browser.example.com'
@@ -137,6 +182,18 @@ describe('reverse proxy diagnostic contract', () => {
 		},
 		{
 			name: 'ambiguous forwarded pair',
+			input: {
+				requestUrl: 'https://browser.example.com/path',
+				headers: {
+					'x-forwarded-proto': 'https',
+					'x-forwarded-host': 'different.example.com'
+				}
+			},
+			action: 'leave-disabled',
+			reason: 'request-origin-already-matches-browser'
+		},
+		{
+			name: 'ambiguous forwarded pair with mismatched origins',
 			input: {
 				headers: {
 					'x-forwarded-proto': 'https',
@@ -173,7 +230,7 @@ describe('reverse proxy diagnostic contract', () => {
 
 	it('serializes only safe facts, action, and stable reason codes', () => {
 		const diagnostic = diagnosticFor({
-			rawAppUrl: 'http://internal.local/path?token=secret-query',
+			requestUrl: 'http://internal.local/path?token=secret-query',
 			effectiveAppUrl: 'http://internal.local/path?token=secret-query',
 			browserOrigin: 'https://browser-secret.example.com',
 			csrfOrigin: 'https://configured-secret.example.com',
@@ -215,7 +272,7 @@ describe('reverse proxy diagnostic contract', () => {
 			},
 			sourceAddress: { category: 'public' },
 			originComparison: {
-				browserMatchesRawApp: false,
+				browserMatchesRequestUrl: false,
 				browserMatchesEffectiveApp: false,
 				forwardedPairMatchesBrowser: false
 			}
@@ -250,7 +307,7 @@ describe('reverse proxy diagnostic contract', () => {
 		expect(classifySourceAddress(address)).toBe(category);
 	});
 
-	it('keeps enabling authority with the action code', () => {
+	it('keeps enabling authority behind the explicit boundary-confirmation action', () => {
 		const enabled = diagnosticFor({
 			headers: {
 				'x-forwarded-proto': 'https',
@@ -334,7 +391,7 @@ describe('GET /api/security/reverse-proxy-diagnostic', () => {
 		expect(response.headers.get('Cache-Control')).toBe('no-store');
 		const body = await response.json();
 		expect(Object.keys(body).sort()).toEqual(['action', 'facts', 'reasonCodes']);
-		expect(body.action).toBe('enable');
+		expect(body.action).toBe('confirm-trust-boundary');
 		expect(body.facts.forwardedHeaders.present).toEqual([
 			'Forwarded',
 			'X-Forwarded-For',

--- a/tests/unit/security/reverse-proxy-presenter.test.ts
+++ b/tests/unit/security/reverse-proxy-presenter.test.ts
@@ -49,7 +49,7 @@ function diagnostic(
 			},
 			sourceAddress: { category: 'docker/private-range' },
 			originComparison: {
-				browserMatchesRawApp: false,
+				browserMatchesRequestUrl: false,
 				browserMatchesEffectiveApp: true,
 				forwardedPairMatchesBrowser: true
 			}
@@ -61,7 +61,7 @@ function diagnostic(
 
 describe('reverse proxy presenter', () => {
 	it.each([
-		'enable',
+		'confirm-trust-boundary',
 		'leave-disabled',
 		'review-proxy',
 		'appears-working',
@@ -118,6 +118,12 @@ describe('reverse proxy presenter', () => {
 		const view = presentReverseProxyDiagnostic(mismatch);
 		expect(view.nextAction).toContain('conflicts with the browser origin');
 	});
+	it('does not present matching forwarded values as proof of a trusted proxy', () => {
+		const view = presentReverseProxyDiagnostic(diagnostic('confirm-trust-boundary'));
+		expect(view.headline).toContain('boundary is unverified');
+		expect(view.consequence).toContain('consistency');
+		expect(view.consequence).toContain('not that a trusted proxy supplied them');
+	});
 
 	it('states the exact environment setting and restart requirement', () => {
 		const view = presentReverseProxyDiagnostic(
@@ -138,13 +144,40 @@ describe('reverse proxy presenter', () => {
 			source: 'env',
 			isLocked: true
 		});
-		direct.facts.originComparison.browserMatchesRawApp = true;
+		direct.facts.originComparison.browserMatchesRequestUrl = true;
 		direct.facts.originComparison.browserMatchesEffectiveApp = true;
 		direct.facts.originComparison.forwardedPairMatchesBrowser = null;
 		const view = presentReverseProxyDiagnostic(direct);
 		expect(view.tone).toBe('success');
 		expect(view.nextAction).toContain('Leave TRUST_PROXY=false');
 		expect(view.documentationIds).toEqual(['obzorarr-trust-proxy']);
+	});
+	it('keeps environment-managed trust disabled when Caddy headers are present but unnecessary', () => {
+		const caddy = diagnostic('env-controlled', 'usable', {
+			enabled: false,
+			source: 'env',
+			isLocked: true
+		});
+		caddy.facts.originComparison.browserMatchesRequestUrl = true;
+		const view = presentReverseProxyDiagnostic(caddy);
+		expect(view.tone).toBe('success');
+		expect(view.nextAction).toContain('Leave TRUST_PROXY=false');
+		expect(view.nextAction).not.toContain('TRUST_PROXY=true');
+	});
+	it('does not make unused malformed headers override an environment-managed false setting', () => {
+		const partial = diagnostic('env-controlled', 'partial', {
+			enabled: false,
+			source: 'env',
+			isLocked: true
+		});
+		partial.facts.originComparison.browserMatchesRequestUrl = true;
+		partial.facts.originComparison.browserMatchesEffectiveApp = true;
+		partial.facts.originComparison.forwardedPairMatchesBrowser = null;
+
+		const view = presentReverseProxyDiagnostic(partial);
+		expect(view.tone).toBe('success');
+		expect(view.nextAction).toContain('Leave TRUST_PROXY=false');
+		expect(view.nextAction).not.toContain('TRUST_PROXY=true');
 	});
 
 	it('distinguishes working and broken environment-managed trust', () => {
@@ -154,6 +187,21 @@ describe('reverse proxy presenter', () => {
 			isLocked: true
 		});
 		expect(presentReverseProxyDiagnostic(working).headline).toContain('origin matches');
+		const unusable = diagnostic('env-controlled', 'invalid-proto', {
+			enabled: true,
+			source: 'env',
+			isLocked: true
+		});
+		expect(presentReverseProxyDiagnostic(unusable).consequence).toContain(
+			'unusable forwarding metadata'
+		);
+		const unknown = diagnostic('env-controlled', 'usable', {
+			enabled: true,
+			source: 'env',
+			isLocked: true
+		});
+		unknown.facts.originComparison.browserMatchesEffectiveApp = null;
+		expect(presentReverseProxyDiagnostic(unknown).consequence).toContain('cannot be verified');
 
 		const broken = diagnostic('env-controlled', 'invalid-proto', {
 			enabled: true,
@@ -165,6 +213,7 @@ describe('reverse proxy presenter', () => {
 		expect(brokenView.tone).toBe('danger');
 		expect(brokenView.nextAction).toContain('exactly http or https');
 		expect(brokenView.nextAction).toContain('Restart Obzorarr');
+		expect(brokenView.consequence).toContain('rejected the unusable forwarding metadata');
 	});
 
 	it('keeps documentation official, purpose-scoped, and provider-complete', () => {
@@ -179,7 +228,11 @@ describe('reverse proxy presenter', () => {
 			'apache',
 			'other'
 		]);
-		expect(REVERSE_PROXY_PROVIDER_GUIDES.slice(0, 4).every((guide) => guide.config)).toBe(true);
+		expect(
+			REVERSE_PROXY_PROVIDER_GUIDES.filter((guide) =>
+				['nginx', 'caddy', 'apache'].includes(guide.id)
+			).every((guide) => guide.config)
+		).toBe(true);
 		expect(
 			REVERSE_PROXY_PROVIDER_GUIDES.every(
 				(guide) => documentationForGuide(guide).id === guide.documentationId
@@ -187,18 +240,31 @@ describe('reverse proxy presenter', () => {
 		).toBe(true);
 	});
 
-	it('uses canonical public hosts instead of reflecting an unrestricted request Host', () => {
-		const configs = REVERSE_PROXY_PROVIDER_GUIDES.flatMap((guide) =>
-			guide.config ? [guide.config] : []
-		).join('\n');
-		expect(configs).toContain('obzorarr.example.com');
-		expect(configs).not.toContain('$http_host');
-		expect(configs).not.toContain('{host}');
-		expect(configs).not.toContain('%{HTTP_HOST}');
+	it('uses provider-derived values without redundant or hardcoded forwarding headers', () => {
+		const guide = (id: (typeof REVERSE_PROXY_PROVIDER_GUIDES)[number]['id']) =>
+			REVERSE_PROXY_PROVIDER_GUIDES.find((candidate) => candidate.id === id);
+
+		const caddy = guide('caddy');
+		expect(caddy?.config).toBe('obzorarr.example.com {\n\treverse_proxy obzorarr:3000\n}');
+		expect(caddy?.config).not.toContain('header_up');
+		const npm = guide('nginx-proxy-manager');
+		expect(npm?.config).toBeUndefined();
+		expect(npm?.steps.join(' ')).toContain('not runtime-verified');
+
+		const nginx = guide('nginx');
+		expect(nginx?.config).toContain('X-Forwarded-Proto $scheme');
+		expect(nginx?.config).toContain('X-Forwarded-Host $server_name:$server_port');
+		expect(nginx?.config).not.toContain('X-Forwarded-Proto https');
+		expect(nginx?.config).not.toContain('$http_host');
+
+		expect(guide('apache')?.config).toContain('expr=%{REQUEST_SCHEME}');
+		expect(guide('apache')?.config).toContain('expr=%{SERVER_NAME}:%{SERVER_PORT}');
+		expect(guide('apache')?.steps.join(' ')).toContain('rejects unmatched Host values');
+		expect(guide('apache')?.config).not.toContain('%{HTTP_HOST}');
 	});
 
 	it('uses only host/protocol and Obzorarr configuration guidance', () => {
-		const links = documentationForDiagnostic(diagnostic('enable'));
+		const links = documentationForDiagnostic(diagnostic('confirm-trust-boundary'));
 		expect(links.length).toBeGreaterThan(0);
 		expect(
 			links.every((link) =>


### PR DESCRIPTION
## Problem

Reverse-proxy onboarding treated the adapter-created request URL as though it were an independent internal/upstream observation. With Caddy defaults, the adapter can already construct the public URL from `Host`, while Caddy also supplies a valid forwarded pair. The diagnostic therefore described a healthy request as ambiguous and directed operators toward redundant hardcoded `header_up` values.

## Confirmed root cause

- `svelte-adapter-bun@1.0.1` constructs the SvelteKit `Request` before hooks from `ORIGIN`, or otherwise from configurable protocol/host/port headers. Its default protocol is `https` and its default host source is `Host`. `request.url` is therefore adapter-created, not a raw socket/upstream origin.
- Obzorarr's `TRUST_PROXY` hook can subsequently replace only `event.url` from a complete usable terminal `X-Forwarded-Proto`/`X-Forwarded-Host` pair. It does not change `request.url` and does not configure client-IP trust.
- A single request cannot prove that a proxy exists, that the app has no bypass route, or that the last hop overwrote attacker-controlled headers. A matching forwarded pair is consistency evidence only.
- Environment `ORIGIN` affects adapter URL construction and also locks Obzorarr's custom CSRF origin. Database `CSRF_ORIGIN` affects only the custom CSRF check. Neither proves a forwarding-header trust boundary.

## Changes

- Renamed the misleading raw/direct-origin model to the adapter request origin and removed the redundant independently-supplied request URL input.
- Made request/browser equality authoritative when `TRUST_PROXY` is disabled, including unused malformed or conflicting forwarding metadata. Mismatched origins retain specific missing/partial/invalid/conflicting repair guidance.
- Replaced the confident enable recommendation with an explicit trusted-boundary confirmation state. Existing authenticated/claimed, origin, environment-lock, risk-confirmation, OCC, and live-recheck write gates remain intact.
- Removed Caddy `header_up` overrides and documented Caddy's managed defaults and multi-hop `trusted_proxies` condition.
- Kept stock Nginx replacement guidance dynamic (`$scheme`, `$server_name:$server_port`) under strict host routing, hardened Apache guidance with selected-vhost variables and a rejecting default vhost, disclosed external port-translation limits, and retained generic last-hop replacement guidance.
- Omitted an Nginx Proxy Manager trust snippet. Tagged v2.14.0 source shows its default limitations, but the Advanced block is inserted at server scope before a location-level `proxy.conf`; no representative runtime replacement recipe was proved.
- Clarified `ORIGIN`, database CSRF origin, `TRUST_PROXY`, and separate client-IP behavior in runtime guidance.
- Added a disposable integration fixture that builds and runs the exact installed `svelte-adapter-bun@1.0.1` / SvelteKit stack, exercises fallback/ORIGIN/header/port behavior, and verifies cleanup.

## Security implications

The UI no longer treats spoofable forwarding values as proof that trust should be enabled. Enabling `TRUST_PROXY` remains conditional on Obzorarr being unreachable around the proxy and on the terminal trusted hop replacing both host/protocol headers. Environment-managed values remain locked. The change does not broaden CSRF repair, authentication, authorization, rate limiting, cache invalidation, redaction, or client-IP trust.

## Primary evidence

- Caddy reverse-proxy defaults and trusted-proxy behavior: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#defaults
- Exact adapter source: https://github.com/gornostay25/svelte-adapter-bun/blob/v1.0.1/src/handler.ts
- SvelteKit adapter origin/header configuration: https://svelte.dev/docs/kit/adapter-node#Environment-variables-ORIGIN-PROTOCOL_HEADER-HOST_HEADER-and-PORT_HEADER
- SvelteKit CSRF configuration: https://svelte.dev/docs/kit/configuration#csrf
- Nginx `proxy_set_header`: https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header
- NPM v2.14.0 default proxy headers: https://github.com/NginxProxyManager/nginx-proxy-manager/blob/v2.14.0/docker/rootfs/etc/nginx/conf.d/include/proxy.conf
- NPM v2.14.0 proxy-host template/Advanced placement: https://github.com/NginxProxyManager/nginx-proxy-manager/blob/v2.14.0/backend/templates/proxy_host.conf
- Apache `ProxyAddHeaders`: https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxyaddheaders
- Apache `RequestHeader`: https://httpd.apache.org/docs/2.4/mod/mod_headers.html#requestheader
- Apache expression variables: https://httpd.apache.org/docs/2.4/expr.html

## Runtime confirmation

- Disposable pinned-adapter fixture: 4 passed, 0 failed. It observed Host fallback, `ORIGIN` precedence, configured protocol/host/port headers, explicit default ports, and IPv6 ports.
- Real Caddy v2.11.4 in Docker, using the minimal `reverse_proxy` block: a request forged with `X-Forwarded-Proto: http`, `X-Forwarded-Host: attacker.example`, and `X-Forwarded-For: 203.0.113.9` reached the upstream as `X-Forwarded-Proto: https`, `X-Forwarded-Host: obzorarr.test:43201`, and `X-Forwarded-For: 127.0.0.1`.
- NPM v2.14.0 image pulled at digest `sha256:2aa69b382a384b676c0d4f1d6f2eac40ecd478fcf7af1cfb3f9f1d3cd0c81e12`; no transform pass is claimed and no trust snippet ships.

## Verification

- `bun test --env-file=.env.test tests/integration/adapter-url-fixture.test.ts tests/unit/security/reverse-proxy-diagnostic.test.ts tests/unit/security/reverse-proxy-presenter.test.ts tests/unit/onboarding/proxy-trust-actions.test.ts tests/unit/admin/security-actions.test.ts tests/unit/admin/security-diagnostic-toast.test.ts` — 117 passed, 0 failed
- `bun run check` — 0 errors, 0 warnings
- `bun run check:biome` — 643 files checked, no fixes
- `bun run test` — 2232 passed, 0 failed across 108 files
- `bun run build` — successful production build with `svelte-adapter-bun`
- `DATABASE_PATH=/tmp/obzorarr-smoke.db bun run smoke:production` — production server became ready against an isolated database copy

## Residual limitation

Obzorarr cannot infer the internal upstream origin or verify header provenance, proxy presence, source-address allowlists, bypass reachability, or multi-hop replacement from one application request. Those remain deployment-boundary facts that an operator must verify.
