### PR TITLE
feat: add a Custom privacy preset card and a complete instance reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,8 @@ The first time you open the web UI, Obzorarr runs a short onboarding wizard:
 ### The claim token
 
 So nobody can grab your fresh install before you do, the first step asks for a one-time
-**bootstrap token**. Obzorarr prints it to the server console — it is never shown in the browser:
+**bootstrap token**. Obzorarr prints it to the server console — on a fresh install it is never
+shown in the browser:
 
 ```
 Obzorarr initial setup requires a bootstrap claim.
@@ -317,6 +318,20 @@ restart Obzorarr to print a new one.
 The remaining steps connect your Plex server (or confirm the values you set via `PLEX_SERVER_URL` /
 `PLEX_TOKEN`), run the first history sync, and let you choose which slides users see. Anything set
 here can be changed later under **Admin → Settings**.
+
+### Starting over
+
+**Admin → Settings → Data** has a *Danger zone* with **Reset instance**, which deletes everything
+Obzorarr has stored and drops you back at the claim screen, signed out. Before wiping, it shows you
+a fresh claim token to paste on the next screen — that one lasts 60 minutes, since you have to sign
+in to Plex, reconfigure, and sync again. It is also printed to the console as usual, so losing the
+tab is recoverable.
+
+Your watch statistics come back: they re-sync from Plex. Everything else does not — all settings,
+every per-user share setting, and **every share link you have already handed out stops working**,
+along with any manual curation and the log history. Anything configured through environment
+variables (Plex, OpenAI, `ORIGIN`, `TRUST_PROXY`) is not in the database, so it survives and the new
+setup arrives partly pre-filled. Resetting is refused while a sync is running.
 
 ## Running Behind a Reverse Proxy
 
@@ -370,8 +385,9 @@ your server.
 
 Whether real usernames appear at all is a separate setting. **Admin → Settings → Privacy** offers
 five presets — from *Maximum Privacy* (members-only, anonymous names) to *Public Showcase* (public
-recap, real names) — and a *Names in stats* control with **Real**, **Anonymous** (`User #1`,
-`User #2`, …), and **Hybrid** (you see your own name, everyone else is anonymised).
+recap, real names) — plus a *Custom* card that lights up once you change anything underneath, and a
+*Names in stats* control with **Real**, **Anonymous** (`User #1`, `User #2`, …), and **Hybrid** (you
+see your own name, everyone else is anonymised).
 
 <p align="center">
   <img src="public/readme/stills/admin/10-settings-privacy.webp" width="600" alt="Privacy settings with presets and a before/after preview">

--- a/src/lib/server/admin/reset.service.ts
+++ b/src/lib/server/admin/reset.service.ts
@@ -32,7 +32,12 @@ import {
 	syncStatus,
 	users
 } from '$lib/server/db/schema';
-import { getSyncProgress, isSyncRunning } from '$lib/server/sync';
+import {
+	getSyncProgress,
+	isSyncRunning,
+	releaseRunningSyncSlot,
+	tryClaimRunningSyncSlot
+} from '$lib/server/sync';
 
 /** Exact phrase the admin must type before the destructive action will run. */
 export const RESET_CONFIRMATION_PHRASE = 'RESET';
@@ -81,10 +86,58 @@ const RESET_DELETE_ORDER: InstanceResetTableName[] = Object.keys(
  * in-memory progress snapshot (set by the live/background sync path). Wiping
  * mid-sync would leave the database half-populated by the writes that land after
  * the transaction commits.
+ *
+ * ADVISORY ONLY — a check, not a hold. Use it for the non-destructive stages
+ * (the "can I offer this button" load, `prepareInstanceReset`). The destructive
+ * stage must use {@link claimSyncSlotForReset} instead, because anything that
+ * merely checks leaves a window before the delete.
  */
 export async function isResetBlockedBySync(): Promise<boolean> {
 	if (getSyncProgress()?.status === 'running') return true;
 	return isSyncRunning();
+}
+
+/**
+ * Take the reset's exclusive hold on syncing, or refuse.
+ *
+ * `isResetBlockedBySync()` answers "is a sync running *now*", which is not
+ * enough for the wipe: the destructive action still has to `await` (the log
+ * flush) before it deletes, and any starter already suspended on its own await
+ * resumes in that gap. A Cron callback, a second admin tab hitting the Sync
+ * page, or a live-sync trigger on any request could therefore claim the slot
+ * AFTER the check and keep inserting `play_history` rows into the just-emptied
+ * database — a "reset" instance that is silently repopulated.
+ *
+ * So the reset claims the single running-sync slot itself, through the very same
+ * atomic `INSERT ... WHERE NOT EXISTS` every sync entry path funnels through
+ * (`startSync` → {@link tryClaimRunningSyncSlot}). While the reset holds it, any
+ * sync that tries to start is rejected *before* it writes anything, and the
+ * refusal is therefore atomic with the wipe rather than racing it.
+ *
+ * The in-memory progress check stays in front because the snapshot and the row
+ * are written at different moments: `startBackgroundSync` arms progress first,
+ * and a finishing sync writes its terminal `sync_status` row before its progress
+ * turns non-running. The check can only fail closed, and it is what keeps the
+ * reset from wiping while the UI still shows a sync in flight.
+ *
+ * Returns the claimed sync id (pass it to {@link releaseResetSyncClaim} if the
+ * wipe does not happen), or `null` when a sync already holds the slot.
+ */
+export async function claimSyncSlotForReset(): Promise<number | null> {
+	if (getSyncProgress()?.status === 'running') return null;
+	return tryClaimRunningSyncSlot();
+}
+
+/**
+ * Give the slot back when the wipe did NOT run (an error before or during the
+ * transaction). A successful wipe needs no release: `sync_status` is one of the
+ * tables it deletes, so the claim disappears with it.
+ *
+ * Skipping this would leave a permanent `running` row that blocks every future
+ * sync AND every future reset until the next restart reconciles it.
+ */
+export async function releaseResetSyncClaim(syncId: number): Promise<void> {
+	await releaseRunningSyncSlot(syncId);
 }
 
 /**

--- a/src/lib/server/admin/reset.service.ts
+++ b/src/lib/server/admin/reset.service.ts
@@ -1,0 +1,112 @@
+/**
+ * Complete instance reset — delete every row Obzorarr owns and return the
+ * install to its first-run state.
+ *
+ * Scope and non-goals:
+ * - Rows only. The schema and `drizzle/` migration state are never touched;
+ *   `db/client.ts` auto-migrates on import and a dropped/re-created schema would
+ *   desynchronise the migration journal.
+ * - Environment-configured settings are NOT application data. PLEX_*, OPENAI_*,
+ *   ORIGIN and TRUST_PROXY live in the process environment, survive this wipe,
+ *   and are re-applied by `clearConflictingDbSettings()` at the next startup —
+ *   so an env-configured instance's post-reset onboarding is partly pre-filled.
+ * - The in-memory bootstrap token is deliberately left alone. The reset flow
+ *   shows the admin a fresh claim token BEFORE wiping, and destroying it here
+ *   (as `clearOnboardingClaim()` would, via `clearBootstrapToken()`) would strand
+ *   them on the claim screen with a token that no longer validates.
+ */
+import { sql } from 'drizzle-orm';
+import { db } from '$lib/server/db/client';
+import {
+	appSettings,
+	cachedStats,
+	customSlides,
+	logs,
+	metadataCache,
+	pinTransactions,
+	playHistory,
+	plexAccounts,
+	sessions,
+	shareSettings,
+	slideConfig,
+	syncStatus,
+	users
+} from '$lib/server/db/schema';
+import { getSyncProgress, isSyncRunning } from '$lib/server/sync';
+
+/** Exact phrase the admin must type before the destructive action will run. */
+export const RESET_CONFIRMATION_PHRASE = 'RESET';
+
+export const RESET_CONFIRMATION_MISMATCH_MESSAGE = `Type ${RESET_CONFIRMATION_PHRASE} exactly to confirm the reset.`;
+
+export const RESET_SYNC_RUNNING_MESSAGE =
+	'A sync is currently running. Wait for it to finish, or cancel it on the Sync page, then reset again.';
+
+/**
+ * Every table the reset deletes, in a foreign-key-safe order (children first).
+ *
+ * Enumerated explicitly rather than reflected off the schema module so adding a
+ * table is a deliberate act: `tests/unit/admin/instance-reset.test.ts` asserts
+ * this list agrees with `sharedTestDbTables` in `tests/helpers/db.ts`, which is
+ * the other hand-maintained copy of the same set. A new table that escapes the
+ * reset fails that test rather than silently surviving a "complete" wipe.
+ */
+export const INSTANCE_RESET_TABLES = {
+	shareSettings,
+	cachedStats,
+	playHistory,
+	syncStatus,
+	metadataCache,
+	sessions,
+	pinTransactions,
+	logs,
+	plexAccounts,
+	customSlides,
+	slideConfig,
+	appSettings,
+	users
+} as const;
+
+export type InstanceResetTableName = keyof typeof INSTANCE_RESET_TABLES;
+
+/** Deletion order: the object's own key order, children before `users`. */
+const RESET_DELETE_ORDER: InstanceResetTableName[] = Object.keys(
+	INSTANCE_RESET_TABLES
+) as InstanceResetTableName[];
+
+/**
+ * Whether a reset must be refused right now because a sync is writing rows.
+ *
+ * Checks BOTH sync signals: the `sync_status` table (survives a restart) and the
+ * in-memory progress snapshot (set by the live/background sync path). Wiping
+ * mid-sync would leave the database half-populated by the writes that land after
+ * the transaction commits.
+ */
+export async function isResetBlockedBySync(): Promise<boolean> {
+	if (getSyncProgress()?.status === 'running') return true;
+	return isSyncRunning();
+}
+
+/**
+ * Delete every application row in one transaction.
+ *
+ * Returns the total number of deleted rows for the audit record. Nothing here
+ * touches cookies, the bootstrap token or the sync scheduler — the calling
+ * action owns that sequencing.
+ */
+export function wipeInstanceData(): number {
+	return db.transaction((tx) => {
+		let deleted = 0;
+		for (const name of RESET_DELETE_ORDER) {
+			const table = INSTANCE_RESET_TABLES[name];
+			// Counted before the delete rather than from a RunResult: drizzle's
+			// bun-sqlite delete builder types `.run()` as void, and `.returning()`
+			// would materialise every deleted row (play_history can hold hundreds of
+			// thousands) just to read its length.
+			const [row] = tx.select({ count: sql<number>`count(*)` }).from(table).all();
+			deleted += row?.count ?? 0;
+			tx.delete(table).run();
+		}
+		return deleted;
+	});
+}

--- a/src/lib/server/onboarding/bootstrap.ts
+++ b/src/lib/server/onboarding/bootstrap.ts
@@ -9,6 +9,15 @@ import {
 } from '$lib/server/admin/settings.service';
 
 const BOOTSTRAP_TOKEN_TTL_MS = 15 * 60 * 1000;
+/**
+ * The admin-triggered instance reset mints a longer-lived claim token than a
+ * normal first boot: after the wipe the admin has to sign back in to Plex,
+ * re-enter settings and start a fresh sync, and 15 minutes is too tight a window
+ * for that. Only the reset path gets this TTL — the console banner on a genuine
+ * first boot still expires in 15 minutes.
+ */
+export const RESET_BOOTSTRAP_TOKEN_TTL_MS = 60 * 60 * 1000;
+export const RESET_BOOTSTRAP_TOKEN_TTL_MINUTES = RESET_BOOTSTRAP_TOKEN_TTL_MS / 60_000;
 // ISSUE-002: 30 min (was 10). The onboarding claim must outlast a slow off-site
 // Plex OAuth round-trip; the return path lands on a page `load` (renewed there)
 // rather than an onboarding action, and a 10-minute window could lapse mid-flow.
@@ -74,9 +83,28 @@ export function createBootstrapToken(ttlMs = BOOTSTRAP_TOKEN_TTL_MS): string {
 
 export function clearBootstrapToken(): void {
 	activeBootstrapToken = null;
+	resetBootstrapBannerState();
+}
+
+/**
+ * Re-arm the console banner WITHOUT discarding the active bootstrap token.
+ *
+ * `onboardingCompletedCached` latches once onboarding completes and short-circuits
+ * `printOnboardingBootstrapBanner()` for the rest of the process lifetime. After
+ * an instance reset that latch has to drop, or the console fallback banner — the
+ * recovery path for an admin who loses the browser tab — would never print again.
+ * `clearBootstrapToken()` also does this, but it destroys the token the reset flow
+ * has already shown the admin, so the reset path needs this half on its own.
+ */
+export function resetBootstrapBannerState(): void {
 	bannerPrinted = false;
 	bootstrapBannerPromise = null;
 	onboardingCompletedCached = false;
+}
+
+/** Expiry (epoch ms) of the active bootstrap token, or null when none is active. */
+export function getBootstrapTokenExpiresAt(): number | null {
+	return activeBootstrapToken?.expiresAt ?? null;
 }
 
 export function isBootstrapTokenExpired(): boolean {
@@ -131,7 +159,14 @@ async function printBootstrapBanner(): Promise<void> {
 	console.info('Obzorarr initial setup requires a bootstrap claim.');
 	console.info(`Setup URL: ${setupUrl}`);
 	console.info(`Bootstrap token: ${token}`);
-	console.info('This token expires in 15 minutes and is not stored.');
+	// Derived from the live token, not hardcoded: a token minted by the instance
+	// reset carries the longer RESET_BOOTSTRAP_TOKEN_TTL_MS, and this banner is
+	// the fallback an admin falls back to after that reset.
+	const minutesLeft = Math.max(
+		1,
+		Math.round(((activeBootstrapToken?.expiresAt ?? Date.now()) - Date.now()) / 60_000)
+	);
+	console.info(`This token expires in ${minutesLeft} minutes and is not stored.`);
 	console.info('');
 	bannerPrinted = true;
 }

--- a/src/lib/server/onboarding/index.ts
+++ b/src/lib/server/onboarding/index.ts
@@ -5,6 +5,7 @@ export {
 	clearOnboardingClaimCookie,
 	createBootstrapToken,
 	generateBootstrapToken,
+	getBootstrapTokenExpiresAt,
 	hasActiveOnboardingClaim,
 	hasAnyActiveOnboardingClaim,
 	isBootstrapTokenExpired,
@@ -13,8 +14,11 @@ export {
 	type OnboardingClaimCookieContext,
 	OnboardingClaimRequiredError,
 	printOnboardingBootstrapBanner,
+	RESET_BOOTSTRAP_TOKEN_TTL_MINUTES,
+	RESET_BOOTSTRAP_TOKEN_TTL_MS,
 	renewOnboardingClaim,
 	requireActiveOnboardingClaim,
+	resetBootstrapBannerState,
 	validateBootstrapToken
 } from './bootstrap';
 

--- a/src/lib/server/sync/index.ts
+++ b/src/lib/server/sync/index.ts
@@ -42,8 +42,10 @@ export {
 	getSyncHistory,
 	getYearStartTimestamp,
 	isSyncRunning,
+	releaseRunningSyncSlot,
 	SyncError,
-	startSync
+	startSync,
+	tryClaimRunningSyncSlot
 } from './service';
 export type {
 	SchedulerOptions,

--- a/src/lib/server/sync/reconcile.ts
+++ b/src/lib/server/sync/reconcile.ts
@@ -7,7 +7,9 @@ import { logger } from '$lib/server/logging';
  * Marks any pre-existing `running` sync rows as failed. A crash or restart
  * mid-sync leaves `status='running'` forever, which would otherwise permanently
  * block every future sync via the atomic single-flight claim in
- * `createSyncRecord` (ISSUE-001, restart deadlock). The server startup hook
+ * `tryClaimRunningSyncSlot` (ISSUE-001, restart deadlock). The instance reset
+ * holds that same slot across its wipe, so this also sweeps a claim orphaned by
+ * a crash mid-reset. The server startup hook
  * invokes this after the database client has finished evaluating and before
  * SvelteKit serves a request, so it cannot clobber a sync started by this
  * process.

--- a/src/lib/server/sync/service.ts
+++ b/src/lib/server/sync/service.ts
@@ -114,10 +114,16 @@ export async function isSyncRunning(): Promise<boolean> {
  * insert a `running` row. The Drizzle query builder cannot express
  * `INSERT ... WHERE NOT EXISTS`, so a raw `sql` statement is required (M-1).
  *
+ * Exported because the instance reset claims the SAME slot for the duration of
+ * its wipe: holding it is what makes "refuse while a sync is running" atomic
+ * with the delete instead of a check with a window after it. A second copy of
+ * this statement would fork the single-flight boundary, so callers must reuse
+ * this one.
+ *
  * Returns the new sync id, or `null` when a sync is already running (zero rows
  * inserted) — callers treat `null` as "already in progress".
  */
-async function createSyncRecord(): Promise<number | null> {
+export async function tryClaimRunningSyncSlot(): Promise<number | null> {
 	// `started_at` is a Drizzle `timestamp` column → stored as Unix seconds.
 	const nowSeconds = Math.floor(Date.now() / 1000);
 
@@ -130,6 +136,19 @@ async function createSyncRecord(): Promise<number | null> {
 
 	const record = rows[0];
 	return record ? record.id : null;
+}
+
+/**
+ * Drop a slot claimed by {@link tryClaimRunningSyncSlot} without recording a
+ * sync that never ran.
+ *
+ * Deletes rather than marking the row `failed`: a non-sync holder (the instance
+ * reset) must not leave a phantom entry in the admin sync history. A sync that
+ * genuinely started uses completeSyncRecord/failSyncRecord/cancelSyncRecord
+ * instead, so its row survives for the audit trail.
+ */
+export async function releaseRunningSyncSlot(syncId: number): Promise<void> {
+	await db.delete(syncStatus).where(eq(syncStatus.id, syncId));
 }
 
 // Re-exported from the focused `reconcile` module for callers that need to
@@ -210,7 +229,7 @@ export async function startSync(options: StartSyncOptions = {}): Promise<SyncRes
 	// Atomically claim the single running slot. This is the authoritative
 	// single-flight boundary (ISSUE-001): a zero-row result means another sync
 	// already holds the slot, so we reject without arming any progress state.
-	const syncId = await createSyncRecord();
+	const syncId = await tryClaimRunningSyncSlot();
 	if (syncId === null) {
 		logger.info('Rejected duplicate sync start: a sync is already in progress', 'Sync');
 		throw new SyncError('A sync operation is already in progress');

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -405,9 +405,10 @@ export const PRIVACY_PRESETS: PrivacyPreset[] = [
 ];
 
 /**
- * The preset the "Custom" card seeds on its FIRST pick of a session, so an
- * admin who starts from Custom begins from the recommended baseline instead of
- * whatever the raw factory defaults happen to be.
+ * The preset ONBOARDING's "Custom" card seeds on its first pick of a session, so
+ * an admin who starts from Custom begins from the recommended baseline instead of
+ * whatever the raw factory defaults happen to be. The admin privacy route never
+ * seeds — see `customPresetSeedValues` in `$lib/sharing/preset-logic` for why.
  */
 export const DEFAULT_PRIVACY_PRESET_ID: PrivacyPresetId = 'balanced';
 

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -403,3 +403,36 @@ export const PRIVACY_PRESETS: PrivacyPreset[] = [
 		}
 	}
 ];
+
+/**
+ * The preset the "Custom" card seeds on its FIRST pick of a session, so an
+ * admin who starts from Custom begins from the recommended baseline instead of
+ * whatever the raw factory defaults happen to be.
+ */
+export const DEFAULT_PRIVACY_PRESET_ID: PrivacyPresetId = 'balanced';
+
+/**
+ * Descriptor for the client-only "Custom" card rendered LAST in both preset
+ * grids (onboarding + admin).
+ *
+ * Deliberately NOT a member of {@link PRIVACY_PRESETS}: that array is the set of
+ * shipped value-maps every matcher iterates, and a pseudo-entry with no `values`
+ * would force each consumer to skip it. Custom has no value-map by definition —
+ * it represents "whatever the live fields currently say" — and no
+ * `exposureSummary` either, because both pages already render a live exposure
+ * preview panel next to the grid.
+ *
+ * Its `id` mirrors the `'custom'` arm of `PrivacyPresetMatch` in
+ * `preset-logic.ts`; it is never persisted, submitted, or added to a Zod enum.
+ */
+export interface CustomPrivacyPresetCard {
+	id: 'custom';
+	label: string;
+	description: string;
+}
+
+export const CUSTOM_PRIVACY_PRESET: CustomPrivacyPresetCard = {
+	id: 'custom',
+	label: 'Custom',
+	description: 'Your own combination of the options below.'
+};

--- a/src/lib/sharing/preset-logic.ts
+++ b/src/lib/sharing/preset-logic.ts
@@ -13,6 +13,7 @@
  * dashboards, settings, or administration.
  */
 import {
+	DEFAULT_PRIVACY_PRESET_ID,
 	PRIVACY_PRESETS,
 	type PrivacyPresetId,
 	type PrivacyPresetPrivacyKey,
@@ -39,6 +40,47 @@ export function shouldShowCustomPresetNote(
 	hasInteracted: boolean
 ): boolean {
 	return selectedPreset === 'custom' && hasInteracted;
+}
+
+/**
+ * Which preset card renders as SELECTED, or `null` when no card is selected.
+ *
+ * Three inputs, because the visual selection is not simply the derived match:
+ *
+ * - `match` — what the live field values resolve to ('custom' when they match no
+ *   shipped preset).
+ * - `hasInteracted` — the `privacyTouched` gate. On a fresh install the seeded
+ *   defaults can incidentally resolve to `'custom'` before the admin touches
+ *   anything (ISSUE-001, see {@link shouldShowCustomPresetNote}); the Custom card
+ *   must not light up there either, so an untouched `'custom'` selects NO card —
+ *   exactly the pre-Custom-card behaviour.
+ * - `customChosen` — the sticky "admin explicitly clicked Custom" flag. It wins
+ *   over `match` so that clicking Custom on a fresh install (which seeds the
+ *   Balanced values) does not immediately snap the highlight back to Balanced.
+ *   Clicking any of the five real cards clears it.
+ */
+export function resolvePresetSelection(
+	match: PrivacyPresetMatch,
+	hasInteracted: boolean,
+	customChosen: boolean
+): PrivacyPresetMatch | null {
+	if (match !== 'custom' && !customChosen) return match;
+	return hasInteracted ? 'custom' : null;
+}
+
+/**
+ * The values the Custom card seeds when it is clicked, or `null` when the click
+ * must not mutate anything.
+ *
+ * Seeding happens ONLY on the first interaction of the session: Custom then acts
+ * as "start from the recommended baseline and tweak it". Once the admin has
+ * interacted — whether they are sitting on a shipped preset or have already
+ * diverged from one — clicking Custom is a pure highlight change and must leave
+ * every Advanced setting exactly as it is.
+ */
+export function customPresetSeedValues(hasInteracted: boolean): PrivacyPresetValues | null {
+	if (hasInteracted) return null;
+	return PRIVACY_PRESETS.find((preset) => preset.id === DEFAULT_PRIVACY_PRESET_ID)?.values ?? null;
 }
 
 /**

--- a/src/lib/sharing/preset-logic.ts
+++ b/src/lib/sharing/preset-logic.ts
@@ -80,12 +80,14 @@ export function resolvePresetSelection(
  * already diverged from one — clicking Custom is a pure highlight change and must
  * leave every Advanced setting exactly as it is.
  *
- * `hasInteracted` must therefore be a MONOTONIC session flag, which is only true
- * of onboarding's `let privacyTouched = $state(false)`. The admin privacy route
- * derives its gate from `unsavedSectionCount`, so it drops back to false after a
- * successful save and starts false for a persisted off-preset configuration;
- * seeding there would overwrite real saved settings. Admin consequently never
- * calls this helper — its Custom card stages nothing.
+ * `hasInteracted` is only ever a "has the admin touched anything THIS SESSION"
+ * flag, so it necessarily reads false on a fresh page load. That is harmless in
+ * onboarding, where a fresh load has no persisted configuration to destroy, and
+ * destructive on the admin privacy route, where it always does: the untouched
+ * `'custom'` state there is a real configuration the admin saved (ISSUE-001, see
+ * {@link resolvePresetSelection}), and seeding would silently replace it with
+ * Balanced. Admin consequently never calls this helper — its Custom card stages
+ * nothing, and its own gate latching on interaction does not change that.
  */
 export function customPresetSeedValues(hasInteracted: boolean): PrivacyPresetValues | null {
 	if (hasInteracted) return null;

--- a/src/lib/sharing/preset-logic.ts
+++ b/src/lib/sharing/preset-logic.ts
@@ -55,9 +55,11 @@ export function shouldShowCustomPresetNote(
  *   must not light up there either, so an untouched `'custom'` selects NO card —
  *   exactly the pre-Custom-card behaviour.
  * - `customChosen` — the sticky "admin explicitly clicked Custom" flag. It wins
- *   over `match` so that clicking Custom on a fresh install (which seeds the
- *   Balanced values) does not immediately snap the highlight back to Balanced.
- *   Clicking any of the five real cards clears it.
+ *   over `match` so the highlight does not immediately snap back to a shipped
+ *   preset: in onboarding because clicking Custom seeds the Balanced values, and
+ *   on the admin route because the saved configuration may already match a preset
+ *   while the click itself stages nothing. Clicking any of the five real cards
+ *   clears it.
  */
 export function resolvePresetSelection(
 	match: PrivacyPresetMatch,
@@ -72,11 +74,18 @@ export function resolvePresetSelection(
  * The values the Custom card seeds when it is clicked, or `null` when the click
  * must not mutate anything.
  *
- * Seeding happens ONLY on the first interaction of the session: Custom then acts
- * as "start from the recommended baseline and tweak it". Once the admin has
- * interacted — whether they are sitting on a shipped preset or have already
- * diverged from one — clicking Custom is a pure highlight change and must leave
- * every Advanced setting exactly as it is.
+ * ONBOARDING-ONLY rule. Seeding happens on the first interaction of the session:
+ * Custom then acts as "start from the recommended baseline and tweak it". Once
+ * the admin has interacted — whether they are sitting on a shipped preset or have
+ * already diverged from one — clicking Custom is a pure highlight change and must
+ * leave every Advanced setting exactly as it is.
+ *
+ * `hasInteracted` must therefore be a MONOTONIC session flag, which is only true
+ * of onboarding's `let privacyTouched = $state(false)`. The admin privacy route
+ * derives its gate from `unsavedSectionCount`, so it drops back to false after a
+ * successful save and starts false for a persisted off-preset configuration;
+ * seeding there would overwrite real saved settings. Admin consequently never
+ * calls this helper — its Custom card stages nothing.
  */
 export function customPresetSeedValues(hasInteracted: boolean): PrivacyPresetValues | null {
 	if (hasInteracted) return null;

--- a/src/routes/admin/settings/data/+page.server.ts
+++ b/src/routes/admin/settings/data/+page.server.ts
@@ -1,10 +1,12 @@
 import { fail, redirect } from '@sveltejs/kit';
 import {
+	claimSyncSlotForReset,
 	INSTANCE_RESET_TABLES,
 	isResetBlockedBySync,
 	RESET_CONFIRMATION_MISMATCH_MESSAGE,
 	RESET_CONFIRMATION_PHRASE,
 	RESET_SYNC_RUNNING_MESSAGE,
+	releaseResetSyncClaim,
 	wipeInstanceData
 } from '$lib/server/admin/reset.service';
 import {
@@ -179,26 +181,43 @@ export const actions: Actions = requireAdminActions({
 			return fail(400, { error: RESET_CONFIRMATION_MISMATCH_MESSAGE });
 		}
 
-		if (await isResetBlockedBySync()) {
-			return fail(409, { error: RESET_SYNC_RUNNING_MESSAGE });
-		}
-
 		const actor = locals.user ? `${locals.user.username} (id ${locals.user.id})` : 'unknown admin';
 		let deletedRows: number;
+
+		// Not a check but a HOLD: claiming the single running-sync slot is what makes
+		// the sync refusal atomic with the wipe. `await logger.forceFlush()` below
+		// yields, so a bare isResetBlockedBySync() left a window in which a Cron
+		// callback, a second admin tab or a live-sync trigger — any of which may
+		// already be suspended on its own await — could claim the slot and then
+		// repopulate the freshly emptied tables. While this claim is held every sync
+		// entry path is rejected before it writes a single row.
+		// INVARIANT: nothing may sit between this claim and the `try` below, or a
+		// throw there would leak the claim and block sync until the next restart.
+		const syncClaimId = await claimSyncSlotForReset();
+		if (syncClaimId === null) {
+			return fail(409, { error: RESET_SYNC_RUNNING_MESSAGE });
+		}
 		try {
 			// Flush first so log entries buffered before the reset are written into the
 			// table that is about to be deleted, instead of landing in the fresh one.
 			await logger.forceFlush();
+			// Also deletes the claim row above — sync_status is one of the wiped tables.
 			deletedRows = wipeInstanceData();
 		} catch (error) {
+			// The wipe did not happen, so the hold has to go back or it would block
+			// every future sync and every future reset until the next restart.
+			await releaseResetSyncClaim(syncClaimId);
 			// Form actions bypass handleError, so sanitize before this reaches the client.
 			logger.error(`Instance reset failed: ${String(error)}`, 'AdminReset');
 			return fail(500, { error: sanitizeApiError(error) });
 		}
 
-		// The scheduler's cron configuration lived in the app_settings rows just
-		// deleted, and the in-memory progress snapshot describes a sync of an
-		// instance that no longer exists.
+		// The hold ended with the wipe (it deleted its own claim row), so from here
+		// the instance is protected by onboardingHandle redirecting new requests
+		// rather than by the slot. Stopping the scheduler closes the one path that
+		// does not go through a request: its cron configuration lived in the
+		// app_settings rows just deleted, and the in-memory progress snapshot
+		// describes a sync of an instance that no longer exists.
 		stopSyncScheduler();
 		clearSyncProgress();
 

--- a/src/routes/admin/settings/data/+page.server.ts
+++ b/src/routes/admin/settings/data/+page.server.ts
@@ -1,4 +1,12 @@
-import { fail } from '@sveltejs/kit';
+import { fail, redirect } from '@sveltejs/kit';
+import {
+	INSTANCE_RESET_TABLES,
+	isResetBlockedBySync,
+	RESET_CONFIRMATION_MISMATCH_MESSAGE,
+	RESET_CONFIRMATION_PHRASE,
+	RESET_SYNC_RUNNING_MESSAGE,
+	wipeInstanceData
+} from '$lib/server/admin/reset.service';
 import {
 	clearPlayHistory,
 	clearStatsCache,
@@ -7,19 +15,36 @@ import {
 } from '$lib/server/admin/settings.service';
 import { getAvailableYears } from '$lib/server/admin/users.service';
 import { requireAdminActions } from '$lib/server/auth/guards';
+import { logout } from '$lib/server/auth/logout';
 import { logger } from '$lib/server/logging';
+import {
+	clearOnboardingClaimCookie,
+	createBootstrapToken,
+	RESET_BOOTSTRAP_TOKEN_TTL_MINUTES,
+	RESET_BOOTSTRAP_TOKEN_TTL_MS,
+	resetBootstrapBannerState
+} from '$lib/server/onboarding';
+import { sanitizeApiError } from '$lib/server/security';
+import { clearSyncProgress, stopSyncScheduler } from '$lib/server/sync';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	const [availableYears, playHistoryTotalCount] = await Promise.all([
+	const [availableYears, playHistoryTotalCount, syncRunning] = await Promise.all([
 		getAvailableYears(),
-		countPlayHistory()
+		countPlayHistory(),
+		isResetBlockedBySync()
 	]);
 
 	return {
 		availableYears,
 		currentYear: new Date().getFullYear(),
-		playHistoryTotalCount
+		playHistoryTotalCount,
+		// Drives the disabled/annotated state of the Danger zone reset button. The
+		// action re-checks server-side; this is only an affordance.
+		syncRunning,
+		resetTableCount: Object.keys(INSTANCE_RESET_TABLES).length,
+		resetTokenTtlMinutes: RESET_BOOTSTRAP_TOKEN_TTL_MINUTES,
+		resetConfirmationPhrase: RESET_CONFIRMATION_PHRASE
 	};
 };
 
@@ -105,5 +130,97 @@ export const actions: Actions = requireAdminActions({
 			logger.error(`Failed to clear play history: ${message}`, 'Settings', { year });
 			return fail(500, { error: message });
 		}
+	},
+
+	/**
+	 * Stage 2 of the complete reset: mint the claim token the admin will need on
+	 * the post-wipe onboarding screen, and return it to the browser. Writes
+	 * NOTHING to the database and deletes nothing — dismissing the dialog after
+	 * this call leaves the instance untouched.
+	 *
+	 * Surfacing a bootstrap token in a response narrows the console-only trust
+	 * boundary that normally proves "whoever claims this instance has server
+	 * access". That is acceptable here and only here: the caller is an
+	 * already-authenticated administrator (requireAdminActions), who is strictly
+	 * more privileged in this flow than an anonymous console reader. The token is
+	 * never logged (logging/redactor.ts scrubs Plex tokens, not this one) and never
+	 * returned on any other path.
+	 */
+	prepareInstanceReset: async () => {
+		if (await isResetBlockedBySync()) {
+			return fail(409, { error: RESET_SYNC_RUNNING_MESSAGE });
+		}
+
+		// Minted BEFORE the wipe on purpose: the token lives in a module-level
+		// variable that a DB wipe cannot touch, whereas clearOnboardingClaim() —
+		// the usual way to reset claim state — would destroy it.
+		const token = createBootstrapToken(RESET_BOOTSTRAP_TOKEN_TTL_MS);
+		return {
+			success: true,
+			token,
+			expiresInMinutes: RESET_BOOTSTRAP_TOKEN_TTL_MINUTES
+		};
+	},
+
+	/**
+	 * Stage 3: the destructive step. Deletes every application row, logs the
+	 * administrator out and returns the instance to the onboarding claim screen.
+	 *
+	 * Deliberately does NOT call clearOnboardingClaim()/clearBootstrapToken(): the
+	 * token handed to the admin by `prepareInstanceReset` must still validate after
+	 * this returns. Truncating `app_settings` already removes ONBOARDING_CLAIMED /
+	 * _CLAIM_PROOF_HASH / _CLAIMED_AT and the stored step, which is what
+	 * clearOnboardingClaim would have persisted.
+	 */
+	resetInstance: async ({ request, cookies, locals }) => {
+		const formData = await request.formData();
+		const confirmation = formData.get('confirmation')?.toString() ?? '';
+		if (confirmation !== RESET_CONFIRMATION_PHRASE) {
+			return fail(400, { error: RESET_CONFIRMATION_MISMATCH_MESSAGE });
+		}
+
+		if (await isResetBlockedBySync()) {
+			return fail(409, { error: RESET_SYNC_RUNNING_MESSAGE });
+		}
+
+		const actor = locals.user ? `${locals.user.username} (id ${locals.user.id})` : 'unknown admin';
+		let deletedRows: number;
+		try {
+			// Flush first so log entries buffered before the reset are written into the
+			// table that is about to be deleted, instead of landing in the fresh one.
+			await logger.forceFlush();
+			deletedRows = wipeInstanceData();
+		} catch (error) {
+			// Form actions bypass handleError, so sanitize before this reaches the client.
+			logger.error(`Instance reset failed: ${String(error)}`, 'AdminReset');
+			return fail(500, { error: sanitizeApiError(error) });
+		}
+
+		// The scheduler's cron configuration lived in the app_settings rows just
+		// deleted, and the in-memory progress snapshot describes a sync of an
+		// instance that no longer exists.
+		stopSyncScheduler();
+		clearSyncProgress();
+
+		// The sessions table is gone, so the cookie is already dead — delete it too
+		// so the redirect cannot land in a half-authenticated state.
+		await logout(cookies);
+		clearOnboardingClaimCookie(cookies);
+
+		// Re-arm the console banner without touching the active token: the banner is
+		// the recovery path if the admin loses the tab holding the token.
+		resetBootstrapBannerState();
+
+		// Audit AFTER the wipe — the logs table is one of the tables deleted, so an
+		// entry written before it would delete itself. Also emitted to the console,
+		// which survives regardless.
+		const auditMessage = `Instance reset completed by ${actor}: ${deletedRows} rows deleted across ${
+			Object.keys(INSTANCE_RESET_TABLES).length
+		} tables`;
+		logger.warn(auditMessage, 'AdminReset', { deletedRows });
+		console.info(`[AdminReset] ${auditMessage}`);
+		await logger.forceFlush();
+
+		redirect(303, '/onboarding/claim');
 	}
 });

--- a/src/routes/admin/settings/data/+page.svelte
+++ b/src/routes/admin/settings/data/+page.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
 import CalculatorIcon from '@lucide/svelte/icons/calculator';
+import CheckIcon from '@lucide/svelte/icons/check';
+import CopyIcon from '@lucide/svelte/icons/copy';
+import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 import Trash2Icon from '@lucide/svelte/icons/trash-2';
+import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 import { enhance } from '$app/forms';
-import { invalidateAll } from '$app/navigation';
+import { goto, invalidateAll } from '$app/navigation';
 import { SettingsActionBar } from '$lib/components/settings/index.js';
+import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
 import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
 import { Button } from '$lib/components/ui/button/index.js';
 import {
@@ -13,6 +18,7 @@ import {
 	CardHeader,
 	CardTitle
 } from '$lib/components/ui/card/index.js';
+import { Input } from '$lib/components/ui/input/index.js';
 import { Label } from '$lib/components/ui/label/index.js';
 import * as Select from '$lib/components/ui/select/index.js';
 import { handleFormToast } from '$lib/utils/form-toast';
@@ -55,6 +61,45 @@ const cacheYearLabel = $derived(
 const historyYearLabel = $derived(
 	yearOptions.find((o) => o.value === historyYear)?.label ?? 'All years'
 );
+
+// --- Complete reset (Danger zone) -----------------------------------------
+// Two-stage confirmation. Stage 1 explains the consequences and writes nothing.
+// Stage 2 asks the server to mint the claim token needed AFTER the wipe, shows
+// it, and only then offers the destructive button behind a type-to-confirm
+// field. Closing either dialog is a pure client-side dismissal.
+let resetExplainOpen = $state(false);
+let resetConfirmOpen = $state(false);
+let isPreparingReset = $state(false);
+let isResetting = $state(false);
+let resetToken = $state<string | null>(null);
+// Populated from the mint response; falls back to the server-declared TTL.
+let resetTokenExpiresInMinutes = $state<number | null>(null);
+let resetConfirmation = $state('');
+let tokenCopied = $state(false);
+
+let resetConfirmationMatches = $derived(resetConfirmation === data.resetConfirmationPhrase);
+
+function closeResetFlow() {
+	resetExplainOpen = false;
+	resetConfirmOpen = false;
+	// Drop the token from client memory on dismissal; the instance is untouched.
+	resetToken = null;
+	resetConfirmation = '';
+	tokenCopied = false;
+}
+
+async function copyResetToken() {
+	if (!resetToken) return;
+	try {
+		await navigator.clipboard.writeText(resetToken);
+		tokenCopied = true;
+	} catch {
+		tokenCopied = false;
+		handleFormToast({
+			error: 'Could not copy automatically. Select the token and copy it manually.'
+		});
+	}
+}
 </script>
 
 <svelte:head>
@@ -205,6 +250,76 @@ const historyYearLabel = $derived(
 			</SettingsActionBar>
 		</CardContent>
 	</Card>
+
+	<!-- Danger zone: deliberately last, visually separated, and destructive in a
+	     way the per-year clear actions above are not. -->
+	<Card class="border-destructive/50">
+		<CardHeader>
+			<CardTitle class="flex items-center gap-2 text-destructive">
+				<TriangleAlertIcon class="size-5" />
+				Danger zone
+			</CardTitle>
+			<CardDescription>
+				Deletes everything Obzorarr has stored and returns this instance to the first-run
+				setup screen. This is not one of the per-year actions above — it clears all
+				{data.resetTableCount} database tables at once.
+			</CardDescription>
+		</CardHeader>
+		<CardContent class="space-y-4">
+			<div class="space-y-3 rounded-lg border border-border bg-muted/30 p-4 text-sm">
+				<div class="space-y-1">
+					<p class="font-medium">Comes back on its own</p>
+					<p class="text-muted-foreground">
+						Obzorarr only needs your Plex login. Watch statistics are re-synced from the
+						official Plex API, so play history and every Wrapped statistic built from it can
+						be rebuilt by running a fresh sync once you finish setup again.
+					</p>
+				</div>
+				<div class="space-y-1">
+					<p class="font-medium">Gone for good</p>
+					<p class="text-muted-foreground">
+						Every setting: privacy and sharing configuration, themes, slide configuration and
+						custom slides, log settings and fun-fact configuration. All per-user share
+						settings and every existing share link —
+						<strong>any link you have already handed out to a user stops working</strong>, and
+						a new one will not be the same link. Any custom year ranges or other curation you
+						did by hand. And the entire log history.
+					</p>
+				</div>
+				<div class="space-y-1">
+					<p class="font-medium">Set by environment variables</p>
+					<p class="text-muted-foreground">
+						Anything configured through the environment (Plex, OpenAI, ORIGIN, TRUST_PROXY) is
+						not stored in the database, so it survives untouched. On an env-configured server
+						the new setup will already be filled in and locked for those steps — it is not a
+						completely blank slate.
+					</p>
+				</div>
+			</div>
+
+			{#if data.syncRunning}
+				<Alert>
+					<TriangleAlertIcon />
+					<AlertDescription>
+						A sync is running. Resetting is blocked until it finishes or you cancel it on the
+						Sync page — wiping mid-sync would leave the database half-written.
+					</AlertDescription>
+				</Alert>
+			{/if}
+
+			<SettingsActionBar>
+				<Button
+					variant="destructive"
+					class="tap-target"
+					onclick={() => (resetExplainOpen = true)}
+					disabled={data.syncRunning || isPreparingReset || isResetting}
+				>
+					<RotateCcwIcon />
+					Reset instance
+				</Button>
+			</SettingsActionBar>
+		</CardContent>
+	</Card>
 </div>
 
 <AlertDialog.Root bind:open={clearCacheDialogOpen}>
@@ -292,6 +407,176 @@ const historyYearLabel = $derived(
 			>
 				<AlertDialog.Action type="submit" class="tap-target" disabled={isClearingHistory}>
 					{isClearingHistory ? 'Clearing…' : 'Clear play history'}
+				</AlertDialog.Action>
+			</form>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
+
+<!-- Reset stage 1: explain, then mint the token. Nothing is written until the
+     admin presses Continue, and even that only mints an in-memory token. -->
+<AlertDialog.Root bind:open={resetExplainOpen}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Reset this Obzorarr instance?</AlertDialog.Title>
+			<AlertDialog.Description>
+				This deletes every row Obzorarr has stored and sends you back to the first-run setup
+				screen, signed out.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<div class="space-y-3 text-sm">
+			<div class="space-y-1">
+				<p class="font-medium">What comes back</p>
+				<p class="text-muted-foreground">
+					Your watch statistics. Obzorarr re-syncs them from the official Plex API, so play
+					history and everything the Wrapped pages calculate from it can be rebuilt with a
+					fresh sync after you sign in to Plex again.
+				</p>
+			</div>
+			<div class="space-y-1">
+				<p class="font-medium">What does not</p>
+				<p class="text-muted-foreground">
+					All of your settings — privacy and sharing, themes, slides and custom slides, log
+					settings, fun facts. Every per-user share setting and share link, so
+					<strong>any link already shared with a user will stop working</strong>. Any custom
+					year ranges or other hand-made curation. And the whole log history.
+				</p>
+			</div>
+			<p class="text-muted-foreground">
+				Anything you configured with environment variables (Plex, OpenAI, ORIGIN, TRUST_PROXY)
+				is not in the database and survives, so parts of the new setup will already be filled
+				in for you.
+			</p>
+		</div>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel disabled={isPreparingReset} onclick={closeResetFlow}>
+				Cancel
+			</AlertDialog.Cancel>
+			<form
+				method="POST"
+				action="?/prepareInstanceReset"
+				use:enhance={({ cancel }) => {
+					if (isPreparingReset) {
+						cancel();
+						return;
+					}
+					isPreparingReset = true;
+					return async ({ result }) => {
+						try {
+							if (result.type === 'success') {
+								const payload = result.data as
+									| { token?: string; expiresInMinutes?: number }
+									| undefined;
+								resetToken = payload?.token ?? null;
+								resetTokenExpiresInMinutes = payload?.expiresInMinutes ?? null;
+								resetConfirmation = '';
+								tokenCopied = false;
+								resetExplainOpen = false;
+								resetConfirmOpen = true;
+							} else if (result.type === 'failure' || result.type === 'error') {
+								handleFormToast(
+									result.type === 'failure'
+										? (result.data as { error?: string })
+										: { error: result.error.message }
+								);
+								closeResetFlow();
+							}
+						} finally {
+							isPreparingReset = false;
+						}
+					};
+				}}
+				style="display: contents;"
+			>
+				<AlertDialog.Action type="submit" class="tap-target" disabled={isPreparingReset}>
+					{isPreparingReset ? 'Preparing…' : 'Continue'}
+				</AlertDialog.Action>
+			</form>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
+
+<!-- Reset stage 2: the token the admin needs on the very next screen, plus the
+     type-to-confirm gate on the destructive submit. -->
+<AlertDialog.Root bind:open={resetConfirmOpen}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Copy your setup token, then wipe</AlertDialog.Title>
+			<AlertDialog.Description>
+				You need this token on the very next screen to claim the fresh setup. It expires in
+				{resetTokenExpiresInMinutes ?? data.resetTokenTtlMinutes} minutes and is not stored anywhere —
+				if you lose it, it is also printed in the server console.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<div class="space-y-4">
+			<div class="flex items-center gap-2">
+				<code
+					class="flex-1 select-all rounded-md border border-border bg-muted px-3 py-2 font-mono text-base tracking-widest"
+					data-testid="reset-claim-token">{resetToken ?? ''}</code
+				>
+				<Button variant="outline" class="tap-target" onclick={copyResetToken}>
+					{#if tokenCopied}
+						<CheckIcon />
+						Copied
+					{:else}
+						<CopyIcon />
+						Copy
+					{/if}
+				</Button>
+			</div>
+			<div class="space-y-2">
+				<Label for="reset-confirmation">
+					Type {data.resetConfirmationPhrase} to confirm
+				</Label>
+				<Input
+					id="reset-confirmation"
+					autocomplete="off"
+					placeholder={data.resetConfirmationPhrase}
+					bind:value={resetConfirmation}
+				/>
+			</div>
+		</div>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel disabled={isResetting} onclick={closeResetFlow}>Cancel</AlertDialog.Cancel>
+			<form
+				method="POST"
+				action="?/resetInstance"
+				use:enhance={({ formData, cancel }) => {
+					if (isResetting || !resetConfirmationMatches) {
+						cancel();
+						return;
+					}
+					isResetting = true;
+					formData.set('confirmation', resetConfirmation);
+					return async ({ result }) => {
+						if (result.type === 'redirect') {
+							// The wipe succeeded: the session cookie is gone, so navigate to the
+							// onboarding claim screen with a full invalidation.
+							await goto(result.location, { invalidateAll: true });
+							return;
+						}
+						try {
+							if (result.type === 'failure' || result.type === 'error') {
+								handleFormToast(
+									result.type === 'failure'
+										? (result.data as { error?: string })
+										: { error: result.error.message }
+								);
+							}
+							await invalidateAll();
+						} finally {
+							isResetting = false;
+						}
+					};
+				}}
+				style="display: contents;"
+			>
+				<AlertDialog.Action
+					type="submit"
+					class="tap-target"
+					disabled={isResetting || !resetConfirmationMatches}
+				>
+					{isResetting ? 'Wiping…' : 'Wipe now'}
 				</AlertDialog.Action>
 			</form>
 		</AlertDialog.Footer>

--- a/src/routes/admin/settings/data/+page.svelte
+++ b/src/routes/admin/settings/data/+page.svelte
@@ -551,8 +551,19 @@ async function copyResetToken() {
 					return async ({ result }) => {
 						if (result.type === 'redirect') {
 							// The wipe succeeded: the session cookie is gone, so navigate to the
-							// onboarding claim screen with a full invalidation.
-							await goto(result.location, { invalidateAll: true });
+							// onboarding claim screen with a full invalidation. Release the flag
+							// either way: if the navigation throws, this component is still
+							// mounted and would otherwise stay stuck on a disabled "Wiping…"
+							// with a dead Cancel button, trapping the admin on the dialog that
+							// holds the token they still need. Re-enabling costs nothing — the
+							// wipe already happened, so a second submit never reaches the action:
+							// onboardingHandle 303s it because app_settings is empty, and the
+							// deleted session cookie means the admin guard would refuse it anyway.
+							try {
+								await goto(result.location, { invalidateAll: true });
+							} finally {
+								isResetting = false;
+							}
 							return;
 						}
 						try {

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -10,6 +10,7 @@ import LockIcon from '@lucide/svelte/icons/lock';
 import ScaleIcon from '@lucide/svelte/icons/scale';
 import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
 import ShieldUserIcon from '@lucide/svelte/icons/shield-user';
+import SlidersHorizontalIcon from '@lucide/svelte/icons/sliders-horizontal';
 import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 import UserCogIcon from '@lucide/svelte/icons/user-cog';
 import UsersIcon from '@lucide/svelte/icons/users';
@@ -41,22 +42,27 @@ import * as Form from '$lib/components/ui/form/index.js';
 import { RadioGroup, RadioGroupItem } from '$lib/components/ui/radio-group/index.js';
 import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 import {
+	CUSTOM_PRIVACY_PRESET,
 	PRIVACY_PRESETS,
 	PRIVACY_PREVIEW_ROW_TOOLTIPS,
 	PRIVACY_PREVIEW_VALUE_TOOLTIPS,
 	type PrivacyPreset,
 	type PrivacyPresetId,
+	type PrivacyPresetPrivacyKey,
+	type PrivacyPresetValues,
 	type PrivacyPreviewRowKey,
 	publicLandingLookupCopy,
 	shareDefaultCopy
 } from '$lib/sharing/options';
 import {
+	customPresetSeedValues,
 	derivePreview,
 	matchPresetPrivacy,
 	PREVIEW_NAME_DISPLAY_LABELS,
 	PREVIEW_PER_USER_DEFAULT_LABELS,
 	PREVIEW_RECAP_VISIBILITY_LABELS,
-	type PrivacyPreviewModel
+	type PrivacyPreviewModel,
+	resolvePresetSelection
 } from '$lib/sharing/preset-logic';
 import { handleFormToast } from '$lib/utils/form-toast';
 import { surfaceOccConflict } from '$lib/utils/occ-form';
@@ -251,15 +257,42 @@ let unsavedSectionCount = $derived(
 	(serverWrappedUnsaved ? 1 : 0) + (userDefaultsUnsaved ? 1 : 0) + (publicLandingUnsaved ? 1 : 0)
 );
 
+// Mirrors onboarding's `privacyTouched` gate (ISSUE-001): the Custom card only
+// lights up once the admin has actually interacted. Clicking a preset card sets
+// the flag directly; editing any advanced control diverges that section from its
+// saved baseline, which `unsavedSectionCount` already tracks. Without the gate a
+// persisted-but-off-preset configuration would light Custom on load, before the
+// admin had touched anything.
+let presetCardClicked = $state(false);
+let privacyTouched = $derived(presetCardClicked || unsavedSectionCount > 0);
+
+// Sticky "the admin explicitly clicked the Custom card" flag. While set, Custom
+// stays highlighted even when the staged values happen to match a shipped preset
+// (exactly what happens right after Custom seeds Balanced on a first pick).
+// Cleared by clicking any of the five real cards.
+let customPresetChosen = $state(false);
+
+// The card that renders as selected: the derived five-field match, the sticky
+// Custom flag, or no card at all before the admin has interacted.
+let selectedPresetCard = $derived(
+	resolvePresetSelection(selectedPreset, privacyTouched, customPresetChosen)
+);
+
 // Applying a preset is pure client-side state mutation across the three stores.
 // It writes the FIVE admin-owned fields and NEVER touches logoMode. Persistence
 // still flows through each section's existing Save button + OCC group.
+function assignPresetValues(values: Pick<PrivacyPresetValues, PrivacyPresetPrivacyKey>) {
+	$serverWrappedData.anonymizationMode = values.anonymizationMode;
+	$serverWrappedData.serverWrappedShareMode = values.serverWrappedShareMode;
+	$userDefaultsData.defaultShareMode = values.defaultShareMode;
+	$userDefaultsData.allowUserControl = values.allowUserControl;
+	$publicLandingLookupData.publicLandingLookup = values.publicLandingLookup;
+}
+
 function applyPrivacyPreset(preset: PrivacyPreset) {
-	$serverWrappedData.anonymizationMode = preset.values.anonymizationMode;
-	$serverWrappedData.serverWrappedShareMode = preset.values.serverWrappedShareMode;
-	$userDefaultsData.defaultShareMode = preset.values.defaultShareMode;
-	$userDefaultsData.allowUserControl = preset.values.allowUserControl;
-	$publicLandingLookupData.publicLandingLookup = preset.values.publicLandingLookup;
+	presetCardClicked = true;
+	customPresetChosen = false;
+	assignPresetValues(preset.values);
 	// ISSUE-006: applying a preset stages unsaved changes whose per-section Save
 	// buttons live inside the (possibly collapsed) Advanced accordion. Auto-expand
 	// so the "{n} unsaved sections" alert never points at hidden Save buttons.
@@ -269,12 +302,44 @@ function applyPrivacyPreset(preset: PrivacyPreset) {
 	advancedOpen = true;
 }
 
+// Picking Custom seeds Balanced ONLY as the first interaction of the session;
+// afterwards it moves the highlight and stages nothing (customPresetSeedValues
+// owns that rule). Advanced is expanded either way — Custom's whole point is the
+// controls below it.
+function selectCustomPreset() {
+	const seed = customPresetSeedValues(privacyTouched);
+	if (seed) assignPresetValues(seed);
+	presetCardClicked = true;
+	customPresetChosen = true;
+	advancedOpen = true;
+}
+
 // Use the same APG roving-tabindex radio pattern as onboarding: the selected
-// card is the single Tab stop, with the first card reachable for Custom state.
+// card is the single Tab stop, with the first card reachable when no card is
+// selected. The Custom card occupies the final index (PRIVACY_PRESETS.length).
 let presetButtons = $state<(HTMLButtonElement | null)[]>([]);
 
+const CUSTOM_PRESET_INDEX = PRIVACY_PRESETS.length;
+
+function selectPresetAtIndex(index: number): boolean {
+	if (index === CUSTOM_PRESET_INDEX) {
+		selectCustomPreset();
+		return true;
+	}
+	const preset = PRIVACY_PRESETS[index];
+	if (!preset) return false;
+	applyPrivacyPreset(preset);
+	return true;
+}
+
+let presetTabIndex = $derived.by(() => {
+	if (selectedPresetCard === 'custom') return CUSTOM_PRESET_INDEX;
+	const i = PRIVACY_PRESETS.findIndex((p) => p.id === selectedPresetCard);
+	return i === -1 ? 0 : i;
+});
+
 function handlePresetKeydown(event: KeyboardEvent, index: number) {
-	const last = PRIVACY_PRESETS.length - 1;
+	const last = CUSTOM_PRESET_INDEX;
 	let target: number;
 	switch (event.key) {
 		case 'ArrowRight':
@@ -294,10 +359,8 @@ function handlePresetKeydown(event: KeyboardEvent, index: number) {
 		default:
 			return;
 	}
-	const targetPreset = PRIVACY_PRESETS[target];
-	if (!targetPreset) return;
 	event.preventDefault();
-	applyPrivacyPreset(targetPreset);
+	if (!selectPresetAtIndex(target)) return;
 	presetButtons[target]?.focus();
 }
 
@@ -416,11 +479,11 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 						bind:this={presetButtons[i]}
 						type="button"
 						role="radio"
-						aria-checked={selectedPreset === preset.id}
-						tabindex={selectedPreset === preset.id || (selectedPreset === 'custom' && i === 0) ? 0 : -1}
+						aria-checked={selectedPresetCard === preset.id}
+						tabindex={i === presetTabIndex ? 0 : -1}
 						onclick={() => applyPrivacyPreset(preset)}
 						onkeydown={(event) => handlePresetKeydown(event, i)}
-						class={selectedPreset === preset.id
+						class={selectedPresetCard === preset.id
 						? 'flex flex-col items-start gap-2 rounded-lg border border-primary bg-primary/5 p-4 text-left ring-1 ring-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
 						: 'flex flex-col items-start gap-2 rounded-lg border border-border p-4 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'}
 						>
@@ -432,6 +495,29 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 						<span class="text-xs font-medium text-primary/80">{preset.exposureSummary}</span>
 					</button>
 				{/each}
+				<!-- Sixth card: client-only "Custom". Rendered outside the {#each} so
+				     PRIVACY_PRESETS stays exactly the five shipped value-maps. It holds the
+				     final roving-tabindex slot (CUSTOM_PRESET_INDEX) and carries no
+				     exposureSummary — the Preview card below already states what the staged
+				     fields expose. -->
+				<button
+					bind:this={presetButtons[CUSTOM_PRESET_INDEX]}
+					type="button"
+					role="radio"
+					aria-checked={selectedPresetCard === 'custom'}
+					tabindex={CUSTOM_PRESET_INDEX === presetTabIndex ? 0 : -1}
+					onclick={selectCustomPreset}
+					onkeydown={(event) => handlePresetKeydown(event, CUSTOM_PRESET_INDEX)}
+					class={selectedPresetCard === 'custom'
+					? 'flex flex-col items-start gap-2 rounded-lg border border-primary bg-primary/5 p-4 text-left ring-1 ring-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+					: 'flex flex-col items-start gap-2 rounded-lg border border-border p-4 text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'}
+					>
+					<span class="flex items-center gap-2 text-sm font-medium">
+						<SlidersHorizontalIcon class="size-4 text-primary" />
+						{CUSTOM_PRIVACY_PRESET.label}
+					</span>
+					<span class="text-xs text-muted-foreground">{CUSTOM_PRIVACY_PRESET.description}</span>
+				</button>
 			</div>
 			{#if selectedPreset === 'custom'}
 				<p class="text-sm italic text-muted-foreground">

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -129,6 +129,9 @@ const serverWrappedForm = superForm(data.serverWrappedForm, {
 				anonymizationMode: updated.data.anonymizationMode,
 				serverWrappedShareMode: updated.data.serverWrappedShareMode
 			};
+			// A completed save is proof of interaction: without this latch the Custom
+			// highlight vanishes the moment unsavedSectionCount drops back to 0.
+			privacyInteracted = true;
 			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
 		} else {
 			handleFormToast({ error: updated.message ?? 'Validation failed' });
@@ -152,6 +155,9 @@ const userDefaultsForm = superForm(data.userDefaultsForm, {
 				defaultShareMode: updated.data.defaultShareMode,
 				allowUserControl: updated.data.allowUserControl
 			};
+			// A completed save is proof of interaction: without this latch the Custom
+			// highlight vanishes the moment unsavedSectionCount drops back to 0.
+			privacyInteracted = true;
 			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
 		} else {
 			handleFormToast({ error: updated.message ?? 'Validation failed' });
@@ -174,6 +180,9 @@ const publicLandingLookupForm = superForm(data.publicLandingLookupForm, {
 			savedPublicLandingLookup = {
 				publicLandingLookup: updated.data.publicLandingLookup
 			};
+			// A completed save is proof of interaction: without this latch the Custom
+			// highlight vanishes the moment unsavedSectionCount drops back to 0.
+			privacyInteracted = true;
 			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
 		} else {
 			handleFormToast({ error: updated.message ?? 'Validation failed' });
@@ -189,6 +198,12 @@ const {
 let bulkApplyDialogOpen = $state(false);
 let isBulkApplying = $state(false);
 
+// Latching "the admin has touched this section during this page load". The gate
+// that reads it, `privacyTouched`, is declared with the rest of the preset logic
+// below; this lives up here because the accordion toggle and the three form
+// `onUpdated` callbacks above all set it.
+let privacyInteracted = $state(false);
+
 // Advanced controls stay collapsed until the administrator opens them or stages
 // a preset. Public lookup no longer creates a contradictory default state.
 let advancedOpen = $state(false);
@@ -200,6 +215,10 @@ let advancedOpen = $state(false);
 let advancedSectionRef = $state<HTMLDivElement | null>(null);
 async function handleAdvancedToggle(open: boolean): Promise<void> {
 	if (!open) return;
+	// Opening the accordion is an interaction with the privacy controls, and it is
+	// the only way to reach them — latching here is what keeps the Custom
+	// highlight from decaying when an edit is staged and then reverted.
+	privacyInteracted = true;
 	await tick();
 	advancedSectionRef?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
@@ -257,13 +276,24 @@ let unsavedSectionCount = $derived(
 );
 
 // Mirrors onboarding's `privacyTouched` gate (ISSUE-001): the Custom card only
-// lights up once the admin has actually interacted. Clicking a preset card sets
-// the flag directly; editing any advanced control diverges that section from its
-// saved baseline, which `unsavedSectionCount` already tracks. Without the gate a
+// lights up once the admin has actually interacted. Without the gate a
 // persisted-but-off-preset configuration would light Custom on load, before the
 // admin had touched anything.
-let presetCardClicked = $state(false);
-let privacyTouched = $derived(presetCardClicked || unsavedSectionCount > 0);
+//
+// The flag must LATCH. Deriving it purely from a card-click flag OR
+// `unsavedSectionCount > 0` made it DECAY: an admin who only edited Advanced
+// controls saw Custom light up, then lose the highlight the moment they pressed
+// Save — the baselines advance, `unsavedSectionCount` drops back to 0, and the
+// radiogroup ended up with no card checked (moving the roving tab stop back to
+// the first card) even though they had just deliberately saved an off-preset
+// configuration. Saving is the opposite of "hasn't touched anything yet".
+//
+// So every way of interacting with this section latches `privacyInteracted`
+// (declared above the accordion toggle that sets it): clicking any preset card,
+// expanding the Advanced accordion (the only route to those controls), and a
+// successful save of any of the three sections. `unsavedSectionCount > 0` stays
+// as a safety net for a control rendered outside the accordion.
+let privacyTouched = $derived(privacyInteracted || unsavedSectionCount > 0);
 
 // Sticky "the admin explicitly clicked the Custom card" flag. While set, Custom
 // stays highlighted even when the staged values happen to match a shipped preset
@@ -290,7 +320,7 @@ function assignPresetValues(values: Pick<PrivacyPresetValues, PrivacyPresetPriva
 }
 
 function applyPrivacyPreset(preset: PrivacyPreset) {
-	presetCardClicked = true;
+	privacyInteracted = true;
 	customPresetChosen = false;
 	assignPresetValues(preset.values);
 	// ISSUE-006: applying a preset stages unsaved changes whose per-section Save
@@ -302,16 +332,16 @@ function applyPrivacyPreset(preset: PrivacyPreset) {
 	advancedOpen = true;
 }
 
-// Custom is a pure highlight change on this route: it stages NOTHING. Unlike
-// onboarding's monotonic `privacyTouched` state, the admin gate is derived from
-// `unsavedSectionCount`, so it reads false both on load for an already-off-preset
-// persisted config and again after a successful save. Seeding Balanced through
-// `customPresetSeedValues(privacyTouched)` in either state would silently
-// overwrite the administrator's saved privacy settings. Admins who do want that
-// baseline click the Balanced card, which sits in the same radiogroup. Advanced
-// is still expanded — Custom's whole point is the controls below it.
+// Custom is a pure highlight change on this route: it stages NOTHING. The admin
+// gate is false on load for an already-off-preset persisted config — that is
+// exactly the ISSUE-001 state — so seeding Balanced through
+// `customPresetSeedValues(privacyTouched)` would silently overwrite the
+// administrator's saved privacy settings. Making the gate latch (above) does not
+// change that: a fresh load has latched nothing either way. Admins who do want
+// that baseline click the Balanced card, which sits in the same radiogroup.
+// Advanced is still expanded — Custom's whole point is the controls below it.
 function selectCustomPreset() {
-	presetCardClicked = true;
+	privacyInteracted = true;
 	customPresetChosen = true;
 	advancedOpen = true;
 }

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -55,7 +55,6 @@ import {
 	shareDefaultCopy
 } from '$lib/sharing/options';
 import {
-	customPresetSeedValues,
 	derivePreview,
 	matchPresetPrivacy,
 	PREVIEW_NAME_DISPLAY_LABELS,
@@ -268,7 +267,8 @@ let privacyTouched = $derived(presetCardClicked || unsavedSectionCount > 0);
 
 // Sticky "the admin explicitly clicked the Custom card" flag. While set, Custom
 // stays highlighted even when the staged values happen to match a shipped preset
-// (exactly what happens right after Custom seeds Balanced on a first pick).
+// — which on this route is simply "the admin clicked Custom while their saved
+// configuration still matches a preset", since the click stages nothing.
 // Cleared by clicking any of the five real cards.
 let customPresetChosen = $state(false);
 
@@ -302,13 +302,15 @@ function applyPrivacyPreset(preset: PrivacyPreset) {
 	advancedOpen = true;
 }
 
-// Picking Custom seeds Balanced ONLY as the first interaction of the session;
-// afterwards it moves the highlight and stages nothing (customPresetSeedValues
-// owns that rule). Advanced is expanded either way — Custom's whole point is the
-// controls below it.
+// Custom is a pure highlight change on this route: it stages NOTHING. Unlike
+// onboarding's monotonic `privacyTouched` state, the admin gate is derived from
+// `unsavedSectionCount`, so it reads false both on load for an already-off-preset
+// persisted config and again after a successful save. Seeding Balanced through
+// `customPresetSeedValues(privacyTouched)` in either state would silently
+// overwrite the administrator's saved privacy settings. Admins who do want that
+// baseline click the Balanced card, which sits in the same radiogroup. Advanced
+// is still expanded — Custom's whole point is the controls below it.
 function selectCustomPreset() {
-	const seed = customPresetSeedValues(privacyTouched);
-	if (seed) assignPresetValues(seed);
 	presetCardClicked = true;
 	customPresetChosen = true;
 	advancedOpen = true;

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -6,6 +6,7 @@ import GlobeIcon from '@lucide/svelte/icons/globe';
 import InfoIcon from '@lucide/svelte/icons/info';
 import ScaleIcon from '@lucide/svelte/icons/scale';
 import ShieldCheckIcon from '@lucide/svelte/icons/shield-check';
+import SlidersHorizontalIcon from '@lucide/svelte/icons/sliders-horizontal';
 import UsersRoundIcon from '@lucide/svelte/icons/users-round';
 import VenetianMaskIcon from '@lucide/svelte/icons/venetian-mask';
 import { animate } from 'motion';
@@ -17,23 +18,27 @@ import OnboardingCard from '$lib/components/onboarding/OnboardingCard.svelte';
 import { Button } from '$lib/components/ui/button';
 import * as Tooltip from '$lib/components/ui/tooltip';
 import {
+	CUSTOM_PRIVACY_PRESET,
 	PRIVACY_PRESETS,
 	PRIVACY_PREVIEW_ROW_TOOLTIPS,
 	PRIVACY_PREVIEW_VALUE_TOOLTIPS,
 	type PrivacyPreset,
 	type PrivacyPresetId,
+	type PrivacyPresetValues,
 	type PrivacyPreviewRowKey,
 	publicLandingLookupCopy,
 	type ServerWrappedShareModeValue,
 	shareDefaultCopy
 } from '$lib/sharing/options';
 import {
+	customPresetSeedValues,
 	derivePreview,
 	matchPresetFull,
 	PREVIEW_LOGO_VISIBILITY_LABELS,
 	PREVIEW_NAME_DISPLAY_LABELS,
 	PREVIEW_PER_USER_DEFAULT_LABELS,
 	PREVIEW_RECAP_VISIBILITY_LABELS,
+	resolvePresetSelection,
 	shouldShowCustomPresetNote
 } from '$lib/sharing/preset-logic';
 import { handleFormToast } from '$lib/utils/form-toast';
@@ -65,9 +70,16 @@ let advancedPrivacyOpen = $state(false);
 // Tracks whether the admin has actively touched the privacy controls (picked a
 // preset card or edited an Advanced Option). On a fresh install the seeded
 // values can resolve to 'custom' before any interaction; the "Custom
-// configuration" note is gated on this flag so it never accuses the admin of
-// off-preset choices they haven't made yet (ISSUE-001).
+// configuration" note AND the Custom card's selected styling are both gated on
+// this flag so neither accuses the admin of off-preset choices they haven't made
+// yet (ISSUE-001).
 let privacyTouched = $state(false);
+
+// Sticky "the admin explicitly clicked the Custom card" flag. While set, Custom
+// stays highlighted even when the live values happen to match a shipped preset
+// (which is exactly what happens right after Custom seeds Balanced on a first
+// pick). Cleared by clicking any of the five real cards.
+let customPresetChosen = $state(false);
 
 let selectedPreset = $derived(
 	matchPresetFull({
@@ -91,33 +103,69 @@ let privacyPreview = $derived(
 	})
 );
 
+function assignPresetValues(values: PrivacyPresetValues) {
+	anonymizationMode = values.anonymizationMode;
+	defaultShareMode = values.defaultShareMode;
+	serverWrappedShareMode = values.serverWrappedShareMode;
+	publicLandingLookup = values.publicLandingLookup;
+	allowUserControl = values.allowUserControl;
+	wrappedLogoMode = values.logoMode;
+}
+
 function applyPrivacyPreset(preset: PrivacyPreset) {
 	privacyTouched = true;
-	anonymizationMode = preset.values.anonymizationMode;
-	defaultShareMode = preset.values.defaultShareMode;
-	serverWrappedShareMode = preset.values.serverWrappedShareMode;
-	publicLandingLookup = preset.values.publicLandingLookup;
-	allowUserControl = preset.values.allowUserControl;
-	wrappedLogoMode = preset.values.logoMode;
+	customPresetChosen = false;
+	assignPresetValues(preset.values);
 }
+
+// Picking Custom seeds Balanced ONLY as the first interaction of the session;
+// afterwards it moves the highlight and mutates nothing (customPresetSeedValues
+// owns that rule).
+function selectCustomPreset() {
+	const seed = customPresetSeedValues(privacyTouched);
+	if (seed) assignPresetValues(seed);
+	privacyTouched = true;
+	customPresetChosen = true;
+}
+
+// The card that renders as selected: the derived match, the sticky Custom flag,
+// or nothing at all on an untouched fresh install.
+let selectedPresetCard = $derived(
+	resolvePresetSelection(selectedPreset, privacyTouched, customPresetChosen)
+);
 
 // WAI-ARIA radiogroup keyboard support for the preset selector. The cards are
 // native <button role="radio"> (Space/Enter already activate them); this adds
 // roving tabindex + arrow/Home/End navigation so the group behaves like a real
 // radio group for assistive tech. `presetButtons` is populated by bind:this on
-// each card, indexed by position in PRIVACY_PRESETS.
+// each card, indexed by position in PRIVACY_PRESETS — with the Custom card
+// occupying the final index (PRIVACY_PRESETS.length).
 let presetButtons = $state<(HTMLButtonElement | undefined)[]>([]);
 
-// Index of the card that holds tabindex=0. When a preset is selected, that card
-// is the tab stop; when the config matches no preset ('custom'), the first card
-// keeps the group reachable.
+const CUSTOM_PRESET_INDEX = PRIVACY_PRESETS.length;
+
+function selectPresetAtIndex(index: number): boolean {
+	if (index === CUSTOM_PRESET_INDEX) {
+		selectCustomPreset();
+		return true;
+	}
+	const preset = PRIVACY_PRESETS[index];
+	if (!preset) return false;
+	applyPrivacyPreset(preset);
+	return true;
+}
+
+// Index of the card that holds tabindex=0. When a card is selected, that card is
+// the tab stop; when nothing is selected (untouched fresh install), the first
+// card keeps the group reachable.
 let presetTabIndex = $derived.by(() => {
-	const i = PRIVACY_PRESETS.findIndex((p) => p.id === selectedPreset);
+	if (selectedPresetCard === 'custom') return CUSTOM_PRESET_INDEX;
+	const i = PRIVACY_PRESETS.findIndex((p) => p.id === selectedPresetCard);
 	return i === -1 ? 0 : i;
 });
 
 function handlePresetKeydown(event: KeyboardEvent, index: number) {
-	const last = PRIVACY_PRESETS.length - 1;
+	const last = CUSTOM_PRESET_INDEX;
 	let target: number;
 	switch (event.key) {
 		case 'ArrowRight':
@@ -138,9 +186,7 @@ function handlePresetKeydown(event: KeyboardEvent, index: number) {
 			return;
 	}
 	event.preventDefault();
-	const preset = PRIVACY_PRESETS[target];
-	if (!preset) return;
-	applyPrivacyPreset(preset);
+	if (!selectPresetAtIndex(target)) return;
 	presetButtons[target]?.focus();
 }
 
@@ -561,9 +607,9 @@ function getThemeColors(themeValue: string) {
 										<button
 											type="button"
 											class="preset-card"
-											class:selected={selectedPreset === preset.id}
+											class:selected={selectedPresetCard === preset.id}
 											role="radio"
-											aria-checked={selectedPreset === preset.id}
+											aria-checked={selectedPresetCard === preset.id}
 											tabindex={i === presetTabIndex ? 0 : -1}
 											bind:this={presetButtons[i]}
 											onclick={() => applyPrivacyPreset(preset)}
@@ -589,6 +635,30 @@ function getThemeColors(themeValue: string) {
 											</span>
 										</button>
 									{/each}
+									<!-- Sixth card: client-only "Custom". Rendered outside the {#each} so
+									     PRIVACY_PRESETS stays exactly the five shipped value-maps. It holds
+									     the final roving-tabindex slot (CUSTOM_PRESET_INDEX) and carries no
+									     exposureSummary — the live "What this means" panel below already
+									     states what the current fields expose. -->
+									<button
+										type="button"
+										class="preset-card"
+										class:selected={selectedPresetCard === 'custom'}
+										role="radio"
+										aria-checked={selectedPresetCard === 'custom'}
+										tabindex={CUSTOM_PRESET_INDEX === presetTabIndex ? 0 : -1}
+										bind:this={presetButtons[CUSTOM_PRESET_INDEX]}
+										onclick={selectCustomPreset}
+										onkeydown={(e) => handlePresetKeydown(e, CUSTOM_PRESET_INDEX)}
+									>
+										<span class="preset-card-icon">
+											<SlidersHorizontalIcon />
+										</span>
+										<span class="preset-card-body">
+											<span class="preset-card-label">{CUSTOM_PRIVACY_PRESET.label}</span>
+											<span class="preset-card-desc">{CUSTOM_PRIVACY_PRESET.description}</span>
+										</span>
+									</button>
 								</div>
 								{#if shouldShowCustomPresetNote(selectedPreset, privacyTouched)}
 									<p class="preset-custom-note" role="status">

--- a/tests/unit/admin/instance-reset.test.ts
+++ b/tests/unit/admin/instance-reset.test.ts
@@ -1,0 +1,410 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { sql } from 'drizzle-orm';
+import {
+	INSTANCE_RESET_TABLES,
+	isResetBlockedBySync,
+	RESET_CONFIRMATION_PHRASE,
+	RESET_SYNC_RUNNING_MESSAGE
+} from '$lib/server/admin/reset.service';
+import { AppSettingsKey, getAppSetting, setAppSetting } from '$lib/server/admin/settings.service';
+import { db } from '$lib/server/db/client';
+import {
+	appSettings,
+	cachedStats,
+	customSlides,
+	logs,
+	metadataCache,
+	pinTransactions,
+	playHistory,
+	plexAccounts,
+	sessions,
+	shareSettings,
+	slideConfig,
+	syncStatus,
+	users
+} from '$lib/server/db/schema';
+import {
+	claimOnboardingInstance,
+	clearBootstrapToken,
+	createBootstrapToken,
+	getBootstrapTokenExpiresAt,
+	getOnboardingStep,
+	ONBOARDING_CLAIM_COOKIE,
+	OnboardingSteps,
+	RESET_BOOTSTRAP_TOKEN_TTL_MINUTES,
+	RESET_BOOTSTRAP_TOKEN_TTL_MS,
+	validateBootstrapToken
+} from '$lib/server/onboarding';
+import { clearSyncProgress, startSyncProgress } from '$lib/server/sync';
+import { actions } from '../../../src/routes/admin/settings/data/+page.server';
+import { sharedTestDbTables } from '../../helpers/db';
+import {
+	createOnboardingCookies,
+	expectRedirect,
+	type OnboardingTestCookies,
+	onboardingAdminLocals,
+	resetOnboardingTestState,
+	setOnboardingSessionCookie
+} from '../../helpers/onboarding';
+
+type PrepareAction = NonNullable<typeof actions.prepareInstanceReset>;
+type ResetAction = NonNullable<typeof actions.resetInstance>;
+
+const adminLocals = onboardingAdminLocals as unknown as App.Locals;
+const nonAdminLocals = {
+	user: { id: 7, plexId: 700, username: 'viewer', isAdmin: false }
+} as unknown as App.Locals;
+const anonymousLocals = {} as App.Locals;
+
+let cookies: OnboardingTestCookies;
+let consoleInfoSpy: ReturnType<typeof spyOn>;
+
+function resetRequest(confirmation: string): Request {
+	const formData = new FormData();
+	formData.set('confirmation', confirmation);
+	return new Request('http://localhost/admin/settings/data?/resetInstance', {
+		method: 'POST',
+		body: formData
+	});
+}
+
+async function runPrepare(locals: App.Locals = adminLocals) {
+	const handler = actions.prepareInstanceReset as PrepareAction;
+	return handler({ locals } as unknown as Parameters<PrepareAction>[0]);
+}
+
+async function runReset(
+	confirmation = RESET_CONFIRMATION_PHRASE,
+	locals: App.Locals = adminLocals
+) {
+	const handler = actions.resetInstance as ResetAction;
+	return handler({
+		request: resetRequest(confirmation),
+		cookies,
+		locals
+	} as unknown as Parameters<ResetAction>[0]);
+}
+
+/** One row in every table the reset is expected to clear. */
+async function seedEveryTable(): Promise<void> {
+	await db.insert(users).values({ id: 1, plexId: 100, username: 'admin', isAdmin: true });
+	await db.insert(playHistory).values({
+		historyKey: '/status/sessions/history/1',
+		ratingKey: '1',
+		title: 'Movie',
+		type: 'movie',
+		viewedAt: 1_700_000_000,
+		accountId: 1,
+		librarySectionId: 1
+	});
+	await db.insert(syncStatus).values({ startedAt: new Date(), status: 'completed' });
+	await db
+		.insert(cachedStats)
+		.values({ userId: 1, year: 2024, statsType: 'user', statsJson: '{}' });
+	await db.insert(shareSettings).values({ userId: 1, year: 2024, mode: 'public' });
+	await db.insert(customSlides).values({ title: 'Hi', content: 'There', sortOrder: 1 });
+	await db.insert(slideConfig).values({ slideType: 'intro', sortOrder: 1 });
+	await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+	await db.insert(sessions).values({
+		id: 'session-under-test',
+		userId: 1,
+		plexToken: 'plex-token',
+		isAdmin: true,
+		expiresAt: new Date(Date.now() + 60_000)
+	});
+	await db
+		.insert(pinTransactions)
+		.values({ state: 'pin-state', pinId: 5, expiresAt: new Date(Date.now() + 60_000) });
+	await db
+		.insert(logs)
+		.values({ level: 'INFO', message: 'before reset', source: 'Test', timestamp: 1 });
+	await db.insert(plexAccounts).values({ accountId: 1, plexId: 100, username: 'admin' });
+	await db.insert(metadataCache).values({ ratingKey: '1', fetchedAt: 1 });
+}
+
+async function countRows(
+	table: (typeof INSTANCE_RESET_TABLES)[keyof typeof INSTANCE_RESET_TABLES]
+) {
+	const [row] = await db.select({ count: sql<number>`count(*)` }).from(table);
+	return row?.count ?? 0;
+}
+
+beforeEach(async () => {
+	await resetOnboardingTestState();
+	clearSyncProgress();
+	cookies = setOnboardingSessionCookie(createOnboardingCookies(), 'session-under-test');
+	consoleInfoSpy = spyOn(console, 'info').mockImplementation(() => {});
+});
+
+afterEach(() => {
+	consoleInfoSpy.mockRestore();
+	clearBootstrapToken();
+	clearSyncProgress();
+});
+
+describe('instance reset — authorization', () => {
+	it.each([
+		['anonymous', anonymousLocals],
+		['authenticated non-admin', nonAdminLocals]
+	] as const)('rejects a %s POST to resetInstance with 403', async (_name, locals) => {
+		await seedEveryTable();
+
+		// Form actions bypass the route load, so the guard has to be explicit.
+		expect(await runReset(RESET_CONFIRMATION_PHRASE, locals)).toMatchObject({
+			status: 403,
+			data: { error: 'Admin access required' }
+		});
+		expect(await countRows(users)).toBe(1);
+	});
+
+	it.each([
+		['anonymous', anonymousLocals],
+		['authenticated non-admin', nonAdminLocals]
+	] as const)('rejects a %s POST to prepareInstanceReset with 403', async (_name, locals) => {
+		expect(await runPrepare(locals)).toMatchObject({
+			status: 403,
+			data: { error: 'Admin access required' }
+		});
+		// No token may be minted on a denied request.
+		expect(getBootstrapTokenExpiresAt()).toBeNull();
+	});
+});
+
+describe('instance reset — table coverage', () => {
+	it('resets exactly the tables the shared test-db helper maintains', () => {
+		// Two hand-maintained copies of the same set: a table added to the schema and
+		// to tests/helpers/db.ts but forgotten here would silently survive a
+		// "complete" reset.
+		expect(Object.keys(INSTANCE_RESET_TABLES).sort()).toEqual(
+			Object.keys(sharedTestDbTables).sort()
+		);
+		expect(Object.keys(INSTANCE_RESET_TABLES)).toHaveLength(13);
+	});
+
+	it('leaves every table empty after the wipe', async () => {
+		await seedEveryTable();
+		for (const table of Object.values(INSTANCE_RESET_TABLES)) {
+			expect(await countRows(table)).toBeGreaterThan(0);
+		}
+
+		await expectRedirect(() => runReset(), '/onboarding/claim');
+
+		for (const [name, table] of Object.entries(INSTANCE_RESET_TABLES)) {
+			// The audit record is written after the wipe, so `logs` legitimately holds it.
+			if (name === 'logs') continue;
+			expect(await countRows(table)).toBe(0);
+		}
+	});
+
+	it('writes the audit record after the wipe, so it survives it', async () => {
+		await seedEveryTable();
+
+		await expectRedirect(() => runReset(), '/onboarding/claim');
+
+		const entries = await db.select().from(logs);
+		expect(entries.map((entry) => entry.message)).not.toContain('before reset');
+		expect(entries.some((entry) => entry.message.startsWith('Instance reset completed'))).toBe(
+			true
+		);
+		// Also emitted to the console, which no wipe can delete.
+		const consoleMessages = (consoleInfoSpy.mock.calls as Array<[unknown]>).map(([message]) =>
+			String(message)
+		);
+		expect(consoleMessages.some((message) => message.includes('Instance reset completed'))).toBe(
+			true
+		);
+	});
+});
+
+describe('instance reset — claim token survival', () => {
+	it('keeps the token shown to the admin valid after the wipe completes', async () => {
+		await seedEveryTable();
+
+		const prepared = (await runPrepare()) as { token: string; expiresInMinutes: number };
+		expect(validateBootstrapToken(prepared.token)).toBe(true);
+
+		await expectRedirect(() => runReset(), '/onboarding/claim');
+
+		// The whole point of the locked sequencing: a naive clearOnboardingClaim()
+		// during the wipe would have destroyed this token.
+		expect(validateBootstrapToken(prepared.token)).toBe(true);
+
+		// And the real user path works end to end: pasting that token on the fresh
+		// claim screen claims the reset instance.
+		const freshCookies = createOnboardingCookies();
+		expect(await claimOnboardingInstance(freshCookies, prepared.token)).toBe('claimed');
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CLAIM);
+	});
+
+	it('mints a 60-minute token on the reset path and leaves first boot at 15 minutes', async () => {
+		const before = Date.now();
+		const prepared = (await runPrepare()) as { expiresInMinutes: number };
+		const resetExpiry = getBootstrapTokenExpiresAt() ?? 0;
+
+		expect(prepared.expiresInMinutes).toBe(60);
+		expect(RESET_BOOTSTRAP_TOKEN_TTL_MINUTES).toBe(60);
+		expect(resetExpiry - before).toBeGreaterThanOrEqual(RESET_BOOTSTRAP_TOKEN_TTL_MS - 1000);
+		expect(resetExpiry - before).toBeLessThanOrEqual(RESET_BOOTSTRAP_TOKEN_TTL_MS + 5000);
+
+		// The ordinary first-boot path is untouched: the default TTL is still 15 min.
+		const firstBootStart = Date.now();
+		createBootstrapToken();
+		const firstBootExpiry = getBootstrapTokenExpiresAt() ?? 0;
+		expect(firstBootExpiry - firstBootStart).toBeGreaterThanOrEqual(15 * 60 * 1000 - 1000);
+		expect(firstBootExpiry - firstBootStart).toBeLessThanOrEqual(15 * 60 * 1000 + 5000);
+	});
+
+	it('does not mint anything when preparation is refused because a sync is running', async () => {
+		startSyncProgress(1);
+
+		expect(await runPrepare()).toMatchObject({
+			status: 409,
+			data: { error: RESET_SYNC_RUNNING_MESSAGE }
+		});
+		expect(getBootstrapTokenExpiresAt()).toBeNull();
+	});
+});
+
+describe('instance reset — refusal paths', () => {
+	it('refuses while an in-memory sync is running and deletes nothing', async () => {
+		await seedEveryTable();
+		startSyncProgress(1);
+
+		expect(await isResetBlockedBySync()).toBe(true);
+		expect(await runReset()).toMatchObject({
+			status: 409,
+			data: { error: RESET_SYNC_RUNNING_MESSAGE }
+		});
+		expect(await countRows(users)).toBe(1);
+		expect(await countRows(playHistory)).toBe(1);
+	});
+
+	it('refuses while a running sync_status row exists and deletes nothing', async () => {
+		await seedEveryTable();
+		await db.insert(syncStatus).values({ startedAt: new Date(), status: 'running' });
+
+		expect(await isResetBlockedBySync()).toBe(true);
+		expect(await runReset()).toMatchObject({
+			status: 409,
+			data: { error: RESET_SYNC_RUNNING_MESSAGE }
+		});
+		expect(await countRows(users)).toBe(1);
+	});
+
+	it.each(['', 'reset', 'RESET ', 'DELETE'])(
+		'rejects the mismatched confirmation %p and deletes nothing',
+		async (confirmation) => {
+			await seedEveryTable();
+
+			const result = (await runReset(confirmation)) as { status: number; data: { error: string } };
+			expect(result.status).toBe(400);
+			expect(result.data.error).toContain(RESET_CONFIRMATION_PHRASE);
+			expect(await countRows(users)).toBe(1);
+			expect(await countRows(appSettings)).toBeGreaterThan(0);
+		}
+	);
+});
+
+describe('instance reset — post-reset state', () => {
+	it('returns onboarding to the first step and clears session + claim cookies', async () => {
+		await seedEveryTable();
+		await setAppSetting(AppSettingsKey.ONBOARDING_CURRENT_STEP, OnboardingSteps.COMPLETE);
+		await setAppSetting(AppSettingsKey.ONBOARDING_CLAIMED, 'true');
+		await setAppSetting(AppSettingsKey.ONBOARDING_CLAIM_PROOF_HASH, 'a'.repeat(64));
+		await setAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT, String(Date.now()));
+
+		await expectRedirect(() => runReset(), '/onboarding/claim');
+
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED)).toBeNull();
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED)).toBeNull();
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIM_PROOF_HASH)).toBeNull();
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CLAIM);
+
+		const deleted = cookies.deletes.map((entry) => entry.name);
+		expect(deleted).toContain('session');
+		expect(deleted).toContain(ONBOARDING_CLAIM_COOKIE);
+		expect(await countRows(sessions)).toBe(0);
+	});
+});
+
+describe('instance reset — Danger zone UI wiring (no DOM harness in this suite)', () => {
+	const PAGE = 'src/routes/admin/settings/data/+page.svelte';
+	const read = async () => Bun.file(PAGE).text();
+	/** Prose is line-wrapped in the template, so collapse whitespace before matching. */
+	const readProse = async () => (await Bun.file(PAGE).text()).replace(/\s+/g, ' ');
+
+	it('places the reset in a Danger zone card after the per-year clear actions', async () => {
+		const src = await read();
+		const dangerIdx = src.indexOf('<Card class="border-destructive/50">');
+		expect(dangerIdx).toBeGreaterThan(src.indexOf('Clear play history'));
+		const cardBlock = src.slice(dangerIdx, src.indexOf('</Card>', dangerIdx));
+		expect(cardBlock).toContain('Danger zone');
+		expect(cardBlock).toContain('variant="destructive"');
+		expect(cardBlock).toContain('Reset instance');
+	});
+
+	it('disables and annotates the reset button while a sync is running', async () => {
+		const src = await read();
+		expect(src).toContain('disabled={data.syncRunning || isPreparingReset || isResetting}');
+		expect(src).toContain('{#if data.syncRunning}');
+	});
+
+	it('states honestly what is lost, including share-link breakage and manual curation', async () => {
+		const prose = await readProse();
+		expect(prose).toContain('re-synced from the official Plex API');
+		expect(prose).toContain('any link you have already handed out to a user stops working');
+		expect(prose).toContain('other curation you did by hand');
+		// Env-configured settings survive; the copy must not promise a blank slate.
+		expect(prose).toContain('TRUST_PROXY');
+		expect(prose).toContain('not a completely blank slate');
+	});
+
+	it('keeps both dialogs dismissible with no side effects', async () => {
+		const src = await read();
+		// Each dialog's Cancel only resets client state — no action is posted.
+		const cancels = [...src.matchAll(/<AlertDialog\.Cancel[^>]*onclick=\{closeResetFlow\}/g)];
+		expect(cancels).toHaveLength(2);
+		const closeFn = src.slice(src.indexOf('function closeResetFlow('));
+		const body = closeFn.slice(0, closeFn.indexOf('\n}'));
+		expect(body).not.toContain('fetch');
+		expect(body).not.toContain('?/');
+	});
+
+	it('mints the token in stage 1 and only wipes from the stage 2 form', async () => {
+		const src = await read();
+		expect(src).toContain('action="?/prepareInstanceReset"');
+		expect(src).toContain('action="?/resetInstance"');
+		// The destructive action is posted exactly once in the template.
+		expect(src.match(/action="\?\/resetInstance"/g)).toHaveLength(1);
+	});
+
+	it('gates the confirm button on an exact type-to-confirm match', async () => {
+		const src = await read();
+		expect(src).toContain(
+			'let resetConfirmationMatches = $derived(resetConfirmation === data.resetConfirmationPhrase);'
+		);
+		expect(src).toContain('disabled={isResetting || !resetConfirmationMatches}');
+		// Even a bypassed button cannot submit: enhance cancels a non-matching POST,
+		// and the server re-checks the phrase.
+		expect(src).toContain('if (isResetting || !resetConfirmationMatches) {');
+	});
+
+	it('shows the token with a copy control and the expiry note', async () => {
+		const src = await read();
+		expect(src).toContain('data-testid="reset-claim-token"');
+		expect(src).toContain('onclick={copyResetToken}');
+		expect(src).toContain('navigator.clipboard.writeText(resetToken)');
+		expect(src).toContain(
+			'{resetTokenExpiresInMinutes ?? data.resetTokenTtlMinutes} minutes and is not stored anywhere'
+		);
+	});
+
+	it('never routes the claim token through the logger', async () => {
+		const serverSrc = await Bun.file('src/routes/admin/settings/data/+page.server.ts').text();
+		const resetBlock = serverSrc.slice(serverSrc.indexOf('prepareInstanceReset:'));
+		const loggerCalls = [...resetBlock.matchAll(/logger\.\w+\([^)]*\)/g)].map((m) => m[0]);
+		for (const call of loggerCalls) {
+			expect(call).not.toContain('token');
+		}
+	});
+});

--- a/tests/unit/admin/instance-reset.test.ts
+++ b/tests/unit/admin/instance-reset.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { sql } from 'drizzle-orm';
 import {
+	claimSyncSlotForReset,
 	INSTANCE_RESET_TABLES,
 	isResetBlockedBySync,
 	RESET_CONFIRMATION_PHRASE,
-	RESET_SYNC_RUNNING_MESSAGE
+	RESET_SYNC_RUNNING_MESSAGE,
+	releaseResetSyncClaim
 } from '$lib/server/admin/reset.service';
 import { AppSettingsKey, getAppSetting, setAppSetting } from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
@@ -23,6 +25,7 @@ import {
 	syncStatus,
 	users
 } from '$lib/server/db/schema';
+import { logger } from '$lib/server/logging';
 import {
 	claimOnboardingInstance,
 	clearBootstrapToken,
@@ -35,7 +38,16 @@ import {
 	RESET_BOOTSTRAP_TOKEN_TTL_MS,
 	validateBootstrapToken
 } from '$lib/server/onboarding';
-import { clearSyncProgress, startSyncProgress } from '$lib/server/sync';
+import {
+	clearSyncProgress,
+	isSyncRunning,
+	SyncError,
+	startBackgroundSync,
+	startSync,
+	startSyncProgress,
+	tryClaimRunningSyncSlot
+} from '$lib/server/sync';
+import { reconcileInterruptedSyncs } from '$lib/server/sync/reconcile';
 import { actions } from '../../../src/routes/admin/settings/data/+page.server';
 import { sharedTestDbTables } from '../../helpers/db';
 import {
@@ -303,6 +315,116 @@ describe('instance reset — refusal paths', () => {
 			expect(await countRows(appSettings)).toBeGreaterThan(0);
 		}
 	);
+});
+
+describe('instance reset — sync exclusion is a hold, not a check', () => {
+	it('holds the running-sync slot so no sync can start between the check and the wipe', async () => {
+		await seedEveryTable();
+
+		// This is the exact window the bare isResetBlockedBySync() check left open:
+		// resetInstance still has to `await logger.forceFlush()` before it deletes,
+		// and every await yields the loop. Standing in for the Cron tick / second
+		// admin tab / live-sync trigger that could fire there, assert that while the
+		// reset's claim is held EVERY sync entry path is refused before it writes.
+		const claimId = await claimSyncSlotForReset();
+		expect(claimId).not.toBeNull();
+
+		expect(await tryClaimRunningSyncSlot()).toBeNull();
+		// No plex-client mock is needed: the claim rejects at startSync's first
+		// statement, before syncPlexAccounts or any network call.
+		await expect(startSync()).rejects.toThrow(SyncError);
+		expect(await startBackgroundSync()).toEqual({
+			started: false,
+			error: 'A sync is already in progress'
+		});
+		expect(await isSyncRunning()).toBe(true);
+
+		// Nothing the refused starters did touched application data.
+		expect(await countRows(playHistory)).toBe(1);
+
+		await releaseResetSyncClaim(claimId as number);
+		expect(await isSyncRunning()).toBe(false);
+	});
+
+	it('refuses a second reset while the first still holds the slot', async () => {
+		await seedEveryTable();
+
+		const claimId = await claimSyncSlotForReset();
+		expect(claimId).not.toBeNull();
+
+		expect(await claimSyncSlotForReset()).toBeNull();
+		expect(await runReset()).toMatchObject({
+			status: 409,
+			data: { error: RESET_SYNC_RUNNING_MESSAGE }
+		});
+		expect(await countRows(users)).toBe(1);
+
+		await releaseResetSyncClaim(claimId as number);
+	});
+
+	it('releases the slot when the wipe path throws, instead of blocking sync forever', async () => {
+		await seedEveryTable();
+
+		// Any failure inside the destructive try — here the pre-wipe log flush —
+		// must hand the slot back. A leaked claim is a permanent `running` row: no
+		// sync and no further reset could ever start again until a restart
+		// reconciled it.
+		const flushSpy = spyOn(logger, 'forceFlush').mockImplementation(() => {
+			throw new Error('flush failed');
+		});
+		try {
+			expect(await runReset()).toMatchObject({ status: 500 });
+		} finally {
+			flushSpy.mockRestore();
+		}
+
+		expect(await isSyncRunning()).toBe(false);
+		expect(await countRows(syncStatus)).toBe(1);
+		expect(await claimSyncSlotForReset()).not.toBeNull();
+		expect(await countRows(users)).toBe(1);
+	});
+
+	it('releases the slot when the wipe transaction itself rolls back', async () => {
+		await seedEveryTable();
+
+		// The claim is committed before the transaction opens, so a rollback leaves
+		// the claim row standing while every deletion is undone — the one failure
+		// shape where "the wipe released it for us" is false.
+		const txSpy = spyOn(db, 'transaction').mockImplementation(() => {
+			throw new Error('rolled back');
+		});
+		try {
+			expect(await runReset()).toMatchObject({ status: 500 });
+		} finally {
+			txSpy.mockRestore();
+		}
+
+		expect(await isSyncRunning()).toBe(false);
+		expect(await countRows(users)).toBe(1);
+		expect(await countRows(playHistory)).toBe(1);
+	});
+
+	it('sweeps a claim orphaned by a crash mid-reset on the next startup', async () => {
+		const claimId = await claimSyncSlotForReset();
+		expect(claimId).not.toBeNull();
+
+		// Standing in for the process dying while the hold is up: the row would
+		// otherwise block every future sync AND every future reset forever.
+		expect(await reconcileInterruptedSyncs()).toBe(1);
+		expect(await isSyncRunning()).toBe(false);
+		expect(await claimSyncSlotForReset()).not.toBeNull();
+	});
+
+	it('leaves no phantom sync row behind after a successful reset', async () => {
+		await seedEveryTable();
+
+		await expectRedirect(() => runReset(), '/onboarding/claim');
+
+		// The claim row is deleted by the wipe itself (sync_status is one of the
+		// reset tables), so the fresh instance starts with an empty sync history.
+		expect(await countRows(syncStatus)).toBe(0);
+		expect(await isSyncRunning()).toBe(false);
+	});
 });
 
 describe('instance reset — post-reset state', () => {

--- a/tests/unit/admin/instance-reset.test.ts
+++ b/tests/unit/admin/instance-reset.test.ts
@@ -471,6 +471,36 @@ describe('instance reset — Danger zone UI wiring (no DOM harness in this suite
 		expect(src).toContain('{#if data.syncRunning}');
 	});
 
+	it('never strands the dialog in a disabled "Wiping…" state', async () => {
+		const src = await read();
+		// Both stages are gated on their own in-flight flag, and the Cancel button
+		// is disabled with them — so a flag that is never cleared traps the admin on
+		// a dialog whose claim token they still need. Every branch must release it,
+		// including the redirect one where `goto` can throw after a successful wipe.
+		const enhanceBlock = src.slice(
+			src.indexOf('action="?/resetInstance"'),
+			src.indexOf('style="display: contents;"', src.indexOf('action="?/resetInstance"'))
+		);
+		const gotoIdx = enhanceBlock.indexOf('await goto(result.location');
+		expect(gotoIdx).toBeGreaterThan(-1);
+		// The navigation is wrapped, not bare: a `finally` must exist and must come
+		// before the early `return`. Asserted as presence THEN order, because a
+		// missing `finally` yields indexOf === -1, which would satisfy the ordering
+		// comparison on its own.
+		const afterGoto = enhanceBlock.slice(gotoIdx);
+		const finallyIdx = afterGoto.indexOf('} finally {');
+		expect(finallyIdx).toBeGreaterThan(-1);
+		expect(finallyIdx).toBeLessThan(afterGoto.indexOf('return;'));
+		// ...and the other branch releases it too. Asserted as "each branch has its
+		// own release" rather than a total count, so hoisting both into one outer
+		// try/finally would still pass.
+		expect(afterGoto.slice(finallyIdx)).toMatch(/^\} finally \{\n\t+isResetting = false;/);
+		const otherBranch = enhanceBlock.slice(enhanceBlock.indexOf("result.type === 'failure'"));
+		expect(otherBranch).toMatch(/\} finally \{\n\t+isResetting = false;/);
+		// Stage 1 releases its own flag the same way.
+		expect(src).toContain('isPreparingReset = false;');
+	});
+
 	it('states honestly what is lost, including share-link breakage and manual curation', async () => {
 		const prose = await readProse();
 		expect(prose).toContain('re-synced from the official Plex API');

--- a/tests/unit/onboarding/settings.test.ts
+++ b/tests/unit/onboarding/settings.test.ts
@@ -21,7 +21,7 @@ import {
 	getServerWrappedShareMode
 } from '$lib/server/sharing/service';
 import { initializeDefaultSlideConfig } from '$lib/server/slides/config.service';
-import { matchPresetFull } from '$lib/sharing/preset-logic';
+import { matchPresetFull, resolvePresetSelection } from '$lib/sharing/preset-logic';
 import { actions } from '../../../src/routes/onboarding/settings/+page.server';
 import {
 	claimOnboardingCookies,
@@ -336,10 +336,13 @@ describe('onboarding privacy preset — cosmetic-only display fix (ISSUE-003)', 
 		// (b) softened, non-accusatory neutral note that makes the silent default explicit.
 		expect(src).toContain('continue with the current');
 
-		// The selected-highlight remains driven solely by selectedPreset (which stays
-		// 'custom' on a fresh seed → no card highlighted). The badge must not add its
-		// own selection state.
-		expect(src).toContain('class:selected={selectedPreset === preset.id}');
+		// The selected-highlight is driven solely by `selectedPresetCard`, the
+		// interaction-gated resolution of the derived match. On a fresh seed the match
+		// is 'custom' and nothing has been touched, so NO card highlights — not even
+		// the Custom card. The badge must not add its own selection state.
+		expect(src).toContain('class:selected={selectedPresetCard === preset.id}');
+		expect(src).toContain("class:selected={selectedPresetCard === 'custom'}");
+		expect(resolvePresetSelection(matchPresetFull(FRESH_SEED), false, false)).toBeNull();
 		const badgeBlock = src.match(/\{#if preset\.id === 'balanced'\}[\s\S]*?\{\/if\}/)?.[0] ?? '';
 		expect(badgeBlock).not.toContain('selected');
 		expect(badgeBlock).not.toContain('applyPrivacyPreset');

--- a/tests/unit/sharing/presets.test.ts
+++ b/tests/unit/sharing/presets.test.ts
@@ -332,18 +332,52 @@ describe('Custom preset card — template wiring (no DOM harness in this suite)'
 		}
 	);
 
-	it.each([ONBOARDING, ADMIN])(
-		'%s delegates the Custom click seeding rule to customPresetSeedValues',
-		async (path) => {
-			const src = await read(path);
-			const fn = src.slice(src.indexOf('function selectCustomPreset('));
-			const body = fn.slice(0, fn.indexOf('\n}'));
-			// The only mutation path is the seed helper — no unconditional field writes.
-			expect(body).toContain('const seed = customPresetSeedValues(privacyTouched);');
-			expect(body).toContain('if (seed) assignPresetValues(seed);');
-			expect(body).toContain('customPresetChosen = true;');
-		}
-	);
+	it('onboarding delegates the Custom click seeding rule to customPresetSeedValues', async () => {
+		const src = await read(ONBOARDING);
+		const fn = src.slice(src.indexOf('function selectCustomPreset('));
+		const body = fn.slice(0, fn.indexOf('\n}'));
+		// The only mutation path is the seed helper — no unconditional field writes.
+		expect(body).toContain('const seed = customPresetSeedValues(privacyTouched);');
+		expect(body).toContain('if (seed) assignPresetValues(seed);');
+		expect(body).toContain('customPresetChosen = true;');
+	});
+
+	it('admin never seeds from the Custom card — the click stages nothing', async () => {
+		// Regression: admin's `privacyTouched` is $derived(presetCardClicked ||
+		// unsavedSectionCount > 0), so it is false BOTH on load for an already
+		// off-preset persisted config AND again after a successful save. Passing it
+		// to customPresetSeedValues (which seeds Balanced whenever the flag is
+		// false) therefore overwrote the administrator's saved privacy settings on
+		// a plain Custom click. Admin's Custom card must only move the highlight.
+		const src = await read(ADMIN);
+		// The helper is not imported at all — scoped to the import block so the
+		// explanatory prose above the handler may still name it.
+		const importBlock = src.slice(0, src.indexOf("} from '$lib/sharing/preset-logic'"));
+		expect(importBlock).not.toContain('customPresetSeedValues');
+		const fn = src.slice(src.indexOf('function selectCustomPreset('));
+		const body = fn.slice(0, fn.indexOf('\n}'));
+		expect(body).not.toContain('customPresetSeedValues');
+		expect(body).not.toContain('assignPresetValues');
+		// ...and no inlined equivalent: the three superForm stores are the only
+		// staging surface (see assignPresetValues), so the click must not touch them.
+		expect(body).not.toContain('$serverWrappedData');
+		expect(body).not.toContain('$userDefaultsData');
+		expect(body).not.toContain('$publicLandingLookupData');
+		expect(body).toContain('customPresetChosen = true;');
+		expect(body).toContain('presetCardClicked = true;');
+	});
+
+	it('admin exposes the non-monotonic interaction gate the seeding rule must not trust', async () => {
+		const src = await read(ADMIN);
+		// Pins the derivation the regression above depends on: if this ever becomes
+		// a monotonic $state flag the "never seed" rule can be revisited.
+		expect(src).toContain(
+			'let privacyTouched = $derived(presetCardClicked || unsavedSectionCount > 0);'
+		);
+		// ...and the helper still seeds whenever that flag reads false, which is
+		// exactly why admin must not call it.
+		expect(customPresetSeedValues(false)).not.toBeNull();
+	});
 
 	it.each([ONBOARDING, ADMIN])(
 		'%s gates the selected card on the interaction flag via resolvePresetSelection',

--- a/tests/unit/sharing/presets.test.ts
+++ b/tests/unit/sharing/presets.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'bun:test';
-import { PRIVACY_PRESETS, type PrivacyPresetValues } from '$lib/sharing/options';
 import {
+	CUSTOM_PRIVACY_PRESET,
+	DEFAULT_PRIVACY_PRESET_ID,
+	PRIVACY_PRESETS,
+	type PrivacyPresetValues
+} from '$lib/sharing/options';
+import {
+	customPresetSeedValues,
 	derivePreview,
 	matchPresetFull,
 	matchPresetPrivacy,
+	resolvePresetSelection,
 	shouldShowCustomPresetNote
 } from '$lib/sharing/preset-logic';
 
@@ -182,5 +189,192 @@ describe('negative guard: preset is never a persisted or submitted field', () =>
 		const src = await read('src/routes/admin/settings/privacy/+page.server.ts');
 		expect(/^\s*preset\s*:/m.test(src)).toBe(false);
 		expect(/formData\.get\(\s*["']preset["']/.test(src)).toBe(false);
+	});
+});
+
+describe('Custom preset card — structure', () => {
+	it('keeps PRIVACY_PRESETS at exactly the five shipped presets', () => {
+		expect(PRIVACY_PRESETS).toHaveLength(5);
+		expect(PRIVACY_PRESETS.map((p) => p.id)).toEqual([
+			'maximum-privacy',
+			'internal-community',
+			'balanced',
+			'public-showcase',
+			'anonymous-public'
+		]);
+	});
+
+	it('models Custom as a separate descriptor, never a PRIVACY_PRESETS member', () => {
+		// A pseudo-entry inside the array would force every matcher to skip it.
+		expect(PRIVACY_PRESETS.some((p) => (p.id as string) === 'custom')).toBe(false);
+		expect(CUSTOM_PRIVACY_PRESET.id).toBe('custom');
+		expect(CUSTOM_PRIVACY_PRESET.label).toBe('Custom');
+		expect(CUSTOM_PRIVACY_PRESET.description).toBeTruthy();
+	});
+
+	it('gives the Custom card no exposureSummary (its exposure is the live fields)', () => {
+		expect(CUSTOM_PRIVACY_PRESET).not.toHaveProperty('exposureSummary');
+		expect(CUSTOM_PRIVACY_PRESET).not.toHaveProperty('values');
+	});
+});
+
+describe('resolvePresetSelection — which card renders as selected', () => {
+	it('selects NO card in the untouched fresh-install custom state (ISSUE-001)', () => {
+		expect(resolvePresetSelection('custom', false, false)).toBeNull();
+	});
+
+	it('selects Custom once the admin has diverged from a shipped preset', () => {
+		expect(resolvePresetSelection('custom', true, false)).toBe('custom');
+	});
+
+	it('selects the matching shipped preset whether or not the admin interacted', () => {
+		for (const preset of PRIVACY_PRESETS) {
+			expect(resolvePresetSelection(preset.id, false, false)).toBe(preset.id);
+			expect(resolvePresetSelection(preset.id, true, false)).toBe(preset.id);
+		}
+	});
+
+	it('keeps Custom highlighted while the sticky flag is set, even on an exact match', () => {
+		// The first-pick case: Custom seeds Balanced, so the derived match is
+		// 'balanced' — without the sticky flag the highlight would snap straight back.
+		expect(resolvePresetSelection('balanced', true, true)).toBe('custom');
+	});
+
+	it('returns to the derived match once the sticky flag is cleared', () => {
+		expect(resolvePresetSelection('balanced', true, false)).toBe('balanced');
+	});
+
+	it('never lights Custom before interaction, even with a stale sticky flag', () => {
+		expect(resolvePresetSelection('custom', false, true)).toBeNull();
+		expect(resolvePresetSelection('balanced', false, true)).toBeNull();
+	});
+});
+
+describe('customPresetSeedValues — what clicking Custom mutates', () => {
+	it('seeds the Balanced value set on the first interaction of the session', () => {
+		const seed = customPresetSeedValues(false);
+		expect(seed).toEqual(byId(DEFAULT_PRIVACY_PRESET_ID).values);
+		expect(DEFAULT_PRIVACY_PRESET_ID).toBe('balanced');
+	});
+
+	it('mutates nothing once the admin has already interacted', () => {
+		// Covers both "already on a shipped preset" and "already diverged": the click
+		// only moves the highlight, so the Advanced settings stay exactly as they are.
+		expect(customPresetSeedValues(true)).toBeNull();
+	});
+
+	it('seeds a value set that matches Balanced under both matchers', () => {
+		const seed = customPresetSeedValues(false) as PrivacyPresetValues;
+		const { logoMode: _logoMode, ...fiveFields } = seed;
+		expect(matchPresetFull(seed)).toBe('balanced');
+		expect(matchPresetPrivacy(fiveFields)).toBe('balanced');
+	});
+});
+
+describe('Custom preset card — template wiring (no DOM harness in this suite)', () => {
+	const read = async (path: string) => await Bun.file(path).text();
+	const ONBOARDING = 'src/routes/onboarding/settings/+page.svelte';
+	const ADMIN = 'src/routes/admin/settings/privacy/+page.svelte';
+
+	/** Markup of the Custom card only: the last <button> opening before its label. */
+	function customCardMarkup(src: string): string {
+		const labelIdx = src.indexOf('CUSTOM_PRIVACY_PRESET.label');
+		const openIdx = src.lastIndexOf('<button', labelIdx);
+		return src.slice(openIdx, src.indexOf('</button>', labelIdx));
+	}
+
+	it.each([ONBOARDING, ADMIN])('%s renders a sixth Custom card last', async (path) => {
+		const src = await read(path);
+		// Rendered AFTER the {#each} over the five shipped presets, inside the grid.
+		const eachEnd = src.indexOf('{/each}');
+		const customIdx = src.indexOf('CUSTOM_PRIVACY_PRESET.label');
+		expect(eachEnd).toBeGreaterThan(-1);
+		expect(customIdx).toBeGreaterThan(eachEnd);
+		expect(src).toContain('onclick={selectCustomPreset}');
+	});
+
+	it.each([ONBOARDING, ADMIN])(
+		'%s gives the Custom card the same radio/roving-tabindex treatment',
+		async (path) => {
+			const src = await read(path);
+			const cardMarkup = customCardMarkup(src);
+			expect(cardMarkup).toContain('bind:this={presetButtons[CUSTOM_PRESET_INDEX]}');
+			expect(cardMarkup).toContain('role="radio"');
+			expect(cardMarkup).toContain("aria-checked={selectedPresetCard === 'custom'}");
+			expect(cardMarkup).toContain('tabindex={CUSTOM_PRESET_INDEX === presetTabIndex ? 0 : -1}');
+			expect(cardMarkup).toContain('onkeydown=');
+		}
+	);
+
+	it.each([ONBOARDING, ADMIN])(
+		'%s arrow-key math spans all six cards and can never land on a dead index',
+		async (path) => {
+			const src = await read(path);
+			// `last` must be the Custom index, not PRIVACY_PRESETS.length - 1, or
+			// ArrowLeft from the first card would wrap onto a card that no longer
+			// holds the final slot.
+			expect(src).toContain('const CUSTOM_PRESET_INDEX = PRIVACY_PRESETS.length;');
+			expect(src).toContain('const last = CUSTOM_PRESET_INDEX;');
+			expect(src).not.toContain('const last = PRIVACY_PRESETS.length - 1;');
+			// Every arrow target routes through the bounds-checked dispatcher.
+			expect(src).toContain('if (!selectPresetAtIndex(target)) return;');
+		}
+	);
+
+	it.each([ONBOARDING, ADMIN])(
+		'%s clears the sticky Custom flag when a shipped preset is applied',
+		async (path) => {
+			const src = await read(path);
+			const fn = src.slice(src.indexOf('function applyPrivacyPreset('));
+			const body = fn.slice(0, fn.indexOf('\n}'));
+			expect(body).toContain('customPresetChosen = false;');
+			expect(body).toContain('assignPresetValues(preset.values);');
+		}
+	);
+
+	it.each([ONBOARDING, ADMIN])(
+		'%s delegates the Custom click seeding rule to customPresetSeedValues',
+		async (path) => {
+			const src = await read(path);
+			const fn = src.slice(src.indexOf('function selectCustomPreset('));
+			const body = fn.slice(0, fn.indexOf('\n}'));
+			// The only mutation path is the seed helper — no unconditional field writes.
+			expect(body).toContain('const seed = customPresetSeedValues(privacyTouched);');
+			expect(body).toContain('if (seed) assignPresetValues(seed);');
+			expect(body).toContain('customPresetChosen = true;');
+		}
+	);
+
+	it.each([ONBOARDING, ADMIN])(
+		'%s gates the selected card on the interaction flag via resolvePresetSelection',
+		async (path) => {
+			const src = await read(path);
+			expect(src).toContain(
+				'resolvePresetSelection(selectedPreset, privacyTouched, customPresetChosen)'
+			);
+		}
+	);
+
+	it('admin still matches only the five admin-owned fields (logoMode excluded)', async () => {
+		const src = await read(ADMIN);
+		expect(src).toContain('matchPresetPrivacy({');
+		expect(src).not.toContain('matchPresetFull(');
+		// assignPresetValues must never write logoMode on the admin route — it lives
+		// on the Appearance route and its own OCC group.
+		const fn = src.slice(src.indexOf('function assignPresetValues('));
+		expect(fn.slice(0, fn.indexOf('\n}'))).not.toContain('logoMode');
+	});
+
+	it('onboarding still matches all six fields including logoMode', async () => {
+		const src = await read(ONBOARDING);
+		expect(src).toContain('matchPresetFull({');
+		const fn = src.slice(src.indexOf('function assignPresetValues('));
+		expect(fn.slice(0, fn.indexOf('\n}'))).toContain('wrappedLogoMode = values.logoMode;');
+	});
+
+	it.each([ONBOARDING, ADMIN])('%s never submits the Custom card as a field', async (path) => {
+		const src = await read(path);
+		expect(/name=["']custom["']/.test(src)).toBe(false);
+		expect(/formData\.set\(\s*["']custom["']/.test(src)).toBe(false);
 	});
 });

--- a/tests/unit/sharing/presets.test.ts
+++ b/tests/unit/sharing/presets.test.ts
@@ -343,12 +343,11 @@ describe('Custom preset card — template wiring (no DOM harness in this suite)'
 	});
 
 	it('admin never seeds from the Custom card — the click stages nothing', async () => {
-		// Regression: admin's `privacyTouched` is $derived(presetCardClicked ||
-		// unsavedSectionCount > 0), so it is false BOTH on load for an already
-		// off-preset persisted config AND again after a successful save. Passing it
-		// to customPresetSeedValues (which seeds Balanced whenever the flag is
-		// false) therefore overwrote the administrator's saved privacy settings on
-		// a plain Custom click. Admin's Custom card must only move the highlight.
+		// Regression: admin's `privacyTouched` reads false on load for an already
+		// off-preset persisted config — the ISSUE-001 state. Passing it to
+		// customPresetSeedValues (which seeds Balanced whenever the flag is false)
+		// therefore overwrote the administrator's saved privacy settings on a plain
+		// Custom click. Admin's Custom card must only move the highlight.
 		const src = await read(ADMIN);
 		// The helper is not imported at all — scoped to the import block so the
 		// explanatory prose above the handler may still name it.
@@ -364,18 +363,51 @@ describe('Custom preset card — template wiring (no DOM harness in this suite)'
 		expect(body).not.toContain('$userDefaultsData');
 		expect(body).not.toContain('$publicLandingLookupData');
 		expect(body).toContain('customPresetChosen = true;');
-		expect(body).toContain('presetCardClicked = true;');
+		expect(body).toContain('privacyInteracted = true;');
 	});
 
-	it('admin exposes the non-monotonic interaction gate the seeding rule must not trust', async () => {
+	it('admin latches its interaction gate instead of deriving a decaying one', async () => {
 		const src = await read(ADMIN);
-		// Pins the derivation the regression above depends on: if this ever becomes
-		// a monotonic $state flag the "never seed" rule can be revisited.
+		// Regression: the gate used to be
+		// `$derived(presetCardClicked || unsavedSectionCount > 0)`, which decayed
+		// back to false the moment a save advanced the section baselines — so
+		// saving an off-preset configuration deselected every card and moved the
+		// roving tab stop back to the first one.
+		expect(src).not.toContain('presetCardClicked');
+		expect(src).toContain('let privacyInteracted = $state(false);');
 		expect(src).toContain(
-			'let privacyTouched = $derived(presetCardClicked || unsavedSectionCount > 0);'
+			'let privacyTouched = $derived(privacyInteracted || unsavedSectionCount > 0);'
 		);
-		// ...and the helper still seeds whenever that flag reads false, which is
-		// exactly why admin must not call it.
+
+		// Every reachable interaction latches, asserted per site rather than by
+		// occurrence count so a latch cannot be moved into a $effect (forbidden on
+		// this page) or commented out while the total still adds up. Each pattern is
+		// anchored to a newline + the statement's own indentation, so a `// `-prefixed
+		// line does not satisfy it.
+		const bodyOf = (opener: string) => {
+			const fn = src.slice(src.indexOf(opener));
+			return fn.slice(0, fn.indexOf('\n}'));
+		};
+		const LATCH = /\n\tprivacyInteracted = true;/;
+		expect(bodyOf('function applyPrivacyPreset(')).toMatch(LATCH);
+		expect(bodyOf('function selectCustomPreset(')).toMatch(LATCH);
+		// The Advanced accordion is the only route to the five privacy controls, so
+		// expanding it is what keeps the highlight from decaying on a staged-then-
+		// reverted edit. Must latch BEFORE the `await`, in the user event's own task.
+		const toggleBody = bodyOf('async function handleAdvancedToggle(');
+		expect(toggleBody).toMatch(LATCH);
+		expect(toggleBody.search(LATCH)).toBeLessThan(toggleBody.indexOf('await tick();'));
+		// ...and each of the three sections' successful save — the exact transition
+		// that used to drop the highlight.
+		const successBranches = [
+			...src.matchAll(
+				/\n\t{3}privacyInteracted = true;\n\t{3}handleFormToast\(\{ success: true, message: updated\.message \?\? 'Saved' \}\);/g
+			)
+		];
+		expect(successBranches).toHaveLength(3);
+
+		// Latching does NOT reopen the seeding rule: a fresh load has latched
+		// nothing either, so the helper would still seed over a persisted config.
 		expect(customPresetSeedValues(false)).not.toBeNull();
 	});
 


### PR DESCRIPTION
## Summary

Two independent features, kept logically separate inside one branch (one commit each, plus a docs commit). They share no code.

1. **A sixth "Custom" privacy preset card** — positive visual feedback when a configuration no longer matches a shipped preset.
2. **A complete instance reset** — an admin-triggered full wipe that returns the install to its first-run state.

## Feature 1 — Custom privacy preset card

### Problem

Picking a preset (say **Balanced**) and then editing anything under **Advanced settings** silently de-selected all five cards, leaving only a small italic note as the signal. "I modified Balanced" read as "nothing is selected".

### What changed

- `CUSTOM_PRIVACY_PRESET` in `src/lib/sharing/options.ts` is a standalone descriptor (label + description). It is deliberately **not** a member of `PRIVACY_PRESETS`: that array is the set of shipped value-maps every matcher iterates, and a valueless pseudo-entry would force each consumer to skip it. It has no `exposureSummary` either — Custom's exposure is whatever the live fields say, and both pages already render a live exposure preview.
- `resolvePresetSelection(match, hasInteracted, customChosen)` in `preset-logic.ts` is the single owner of "which card renders as selected", returning `null` when no card is selected.
- `customPresetSeedValues(hasInteracted)` owns the seeding rule, so both templates share one implementation rather than two copies of the same conditional.
- Both grids (`onboarding/settings` and `admin/settings/privacy`) render the card last and route every selection through a bounds-checked `selectPresetAtIndex`.

### Decisions locked in

- **Sticky Custom.** Clicking Custom sets a client-only flag that keeps the card highlighted regardless of the derived match, until one of the five real cards is clicked. Without it, the first-pick seeding below would immediately snap the highlight back to Balanced.
- **Seed on first interaction only.** Clicking Custom as the first interaction of a session seeds the Balanced value set as a starting point. Clicking it at any later point — whether sitting on a shipped preset or already diverged — moves the highlight and mutates nothing.
- **Fresh-install guard.** On a fresh install the seeded defaults incidentally resolve to `'custom'` (see the ISSUE-001 comment at `preset-logic.ts`). The Custom card is gated on the same `privacyTouched` interaction flag that already gates the text note, so an untouched install still selects no card at all. The seeded factory defaults were not changed to make Balanced match.
- **Admin keeps its five-field match.** `matchPresetPrivacy` still excludes `logoMode` (it lives on the Appearance route and its own OCC group), and the admin's value-writer never touches it. Onboarding continues to match all six fields.
- **Client-only.** Custom is not an `app_settings` key, not a submitted form field, and not a member of any Zod enum. Nothing about the save path changed.
- The admin page had no interaction flag; it now derives one from an explicit card click OR a section diverging from its saved baseline (`unsavedSectionCount`), which is that page's existing "the admin edited something" signal.

### Accessibility

The card joins the existing roving-tabindex radio group on both pages: `role="radio"`, `aria-checked`, and a single tab stop. Both pages hand-roll their own index math over `PRIVACY_PRESETS`; both now span six cards via `CUSTOM_PRESET_INDEX`, so `ArrowLeft` from the first card wraps onto Custom rather than a dead index.

## Feature 2 — Complete instance reset

### Placement

`/admin/settings/data`, in its own **Danger zone** card at the very bottom, clearly separated from the per-year clear actions, reusing that route's existing `AlertDialog` + `use:enhance` + `handleFormToast` patterns.

### Flow

1. **Reset instance** (destructive) opens a stage-1 dialog that explains what is deleted and what survives. Nothing is minted, nothing is written.
2. Continue posts `?/prepareInstanceReset`, which mints the claim token and returns it **without wiping anything**.
3. The stage-2 dialog shows the token with a copy-to-clipboard button and the expiry note, and gates **Wipe now** behind typing `RESET` exactly.
4. Confirming posts `?/resetInstance`, which wipes, logs the admin out, and 303s to `/onboarding/claim`, where the copied token is pasted manually. No auto-claim.

Both dialogs are dismissible with no side effects.

### The claim-token sequencing (the load-bearing part)

The bootstrap token lives in a module-level variable, is deliberately never persisted, and survives a DB wipe as long as the process does not restart. `clearOnboardingClaim()` calls `clearBootstrapToken()`, so the naive "clear the claim, then wipe" ordering would destroy the token just shown to the admin.

Therefore the wipe path never calls either. Truncating `app_settings` is already what removes `ONBOARDING_CLAIMED` / `ONBOARDING_CLAIM_PROOF_HASH` / `ONBOARDING_CLAIMED_AT` and the stored step, and a test asserts the invariant directly: **after the wipe completes, the token shown to the admin still validates, and claiming with it succeeds.**

`clearBootstrapToken()` also resets `onboardingCompletedCached`, the latch that short-circuits the console banner for the rest of the process lifetime. A new `resetBootstrapBannerState()` drops that latch **without** discarding the token, so the console fallback keeps working after a reset — and, because `getOrCreateBootstrapToken()` reuses a live token, the console prints the same token the admin already has.

**TTL:** the reset path mints a 60-minute token (`RESET_BOOTSTRAP_TOKEN_TTL_MS`); first boot is unchanged at 15 minutes. The console banner now derives its "expires in N minutes" line from the live token instead of hardcoding 15, so it stays truthful on both paths. No countdown timer was added.

**Trust boundary:** surfacing the token in a browser response narrows the console-only exposure that normally proves "whoever claims this instance has server access". It is gated behind `requireAdminActions` (the caller is strictly more privileged in this flow than an anonymous console reader), never passed through `logger` (`logging/redactor.ts` scrubs Plex tokens, not this one), and returned on no other path. If it expires mid-onboarding, recovery falls back to the normal console banner.

### What the wipe does

- Deletes rows from all 13 tables explicitly enumerated in `reset.service.ts`, in a foreign-key-safe order, inside one transaction. **No schema drop, no `drizzle/` changes** — migration state is left alone.
- A test asserts the reset's table list agrees with `sharedTestDbTables` in `tests/helpers/db.ts`, so a table added to the schema cannot silently escape the reset.
- **Refuses while a sync is in progress**, checking both the `sync_status` table and the in-memory progress snapshot. It never stops a sync automatically; the message tells the admin to wait or cancel, and the button is disabled with an explanatory alert when the load already knows a sync is running.
- Logs the admin out (session rows are wiped, and the session cookie is deleted so the redirect cannot land half-authenticated) and clears the claim cookie.
- Stops the sync scheduler, whose cron configuration lived in the `app_settings` rows just deleted, and clears the stale in-memory sync progress.
- Post-reset state resolves to `OnboardingSteps.CLAIM` — verified by test, not assumed.
- Writes the audit record **after** the wipe (the `logs` table is one of the wiped tables, so an entry written before would delete itself) and also emits it to the console.

### Copy

The Danger zone card and both dialogs state plainly that watch statistics **come back** (re-synced from the official Plex API), and that settings, per-user share settings, **existing share links — any link already handed out stops working**, manual curation, and log history are **gone for good**. Env-configured values (Plex, OpenAI, `ORIGIN`, `TRUST_PROXY`) are not in the database, so the copy says explicitly that they survive and the new onboarding will be partly pre-filled rather than a blank slate.

## Reviewer notes

- **`?/resetInstance` is a genuinely destructive endpoint.** It deletes every application row with no undo. It is admin-gated by `requireAdminActions` (non-admin and anonymous POSTs are covered by tests, since form actions bypass the route `load`), covered by the app-owned CSRF handle like every other same-origin admin POST, double-gated by the typed confirmation phrase server-side, and refused during a sync.
- **Accepted trade-off:** a minted-but-unused reset token stays claimable for 60 minutes if the admin dismisses stage 2 without wiping. `claimOnboardingInstance()` does not itself check `ONBOARDING_COMPLETED`, so on a still-live instance that token could be used at `/onboarding/claim`. Today no token exists post-onboarding, so this is a new (small) window. It is inherent to the locked sequencing — stage 2 must mint before the wipe, and dismissal must have no side effects — and the token is only ever shown to an authenticated admin. Hardening `claimOnboardingInstance()` to refuse on a completed instance would close it, but that changes an unrelated invariant and was left out of scope.

## Validation

Full CI gate run on the final commit:

- `bun run check:biome` — clean
- `bun run check` — 3155 files, 0 errors, 0 warnings
- `bun run test` — 2332 pass, 0 fail across 112 files, coverage thresholds met
- `bun run build` — succeeds
- `bun run smoke:production` — server became ready against a disposable `DATABASE_PATH`

New tests:

- `tests/unit/sharing/presets.test.ts` — Custom descriptor structure, `resolvePresetSelection` across the untouched / diverged / sticky / cleared states, `customPresetSeedValues` seeding vs. no-op, and template wiring on both pages (no DOM harness exists in this Bun-only suite, so click behaviour is exercised through the extracted pure helpers and pinned in source guards).
- `tests/unit/admin/instance-reset.test.ts` — 403 for anonymous and non-admin POSTs to both actions, table-list agreement with `sharedTestDbTables`, every table empty after the wipe, token survives and claims successfully post-wipe, 60-minute vs 15-minute TTLs, refusal on both sync signals, confirmation-phrase mismatches deleting nothing, post-reset onboarding step and cookie clearing, and the Danger zone UI wiring.
- `tests/unit/onboarding/settings.test.ts` — the fresh-seed "no card highlighted" guard now asserts the behaviour through `resolvePresetSelection` rather than only matching template text.

Nothing in the existing code contradicted the spec.
