### PR TITLE
fix(onboarding): refuse setup claims on an already-onboarded instance

### DIFF
--- a/src/lib/server/onboarding/bootstrap.ts
+++ b/src/lib/server/onboarding/bootstrap.ts
@@ -7,6 +7,7 @@ import {
 	getCsrfOrigin,
 	setAppSetting
 } from '$lib/server/admin/settings.service';
+import { logger } from '$lib/server/logging';
 
 const BOOTSTRAP_TOKEN_TTL_MS = 15 * 60 * 1000;
 /**
@@ -278,11 +279,52 @@ export async function requireActiveOnboardingClaim(
 	}
 }
 
+/**
+ * Claim the single onboarding setup session, or report why the claim was refused.
+ *
+ * The first statement is a completion guard, and it exists because of the admin
+ * instance reset. A bootstrap token normally only exists on an un-onboarded
+ * instance, but `prepareInstanceReset` (stage 2 of `/admin/settings/data`) mints
+ * one on a fully live instance and hands it straight to the browser, before any
+ * wipe — the token lives in module state, so minting after the wipe is not an
+ * option. Dismissing that dialog is deliberately side-effect-free, which leaves a
+ * valid 60-minute token in memory on a running install. Nothing upstream notices:
+ * `/onboarding` sits in `onboardingHandle`'s skipPaths, and a form action bypasses
+ * the layout `load` that would otherwise redirect. So completion has to be checked
+ * here or the dismissal is not side-effect-free after all.
+ *
+ * It sits ABOVE the renew branch on purpose: `renewOnboardingClaim()` writes
+ * ONBOARDING_CLAIMED_AT, so guarding below it would leave a live `app_settings`
+ * mutation path — half the residue this removes.
+ *
+ * It refuses and never clears. Burning the token here would turn any reachable
+ * POST into a way to strand a reset mid-flight (mint, attacker posts garbage,
+ * token dead, admin wipes and cannot claim). Refusing is enough: this is the only
+ * caller of `validateBootstrapToken()`, so while the flag is set the token has no
+ * capability surface at all. After the wipe the key reads back `null` and the very
+ * same token claims normally.
+ *
+ * The flag is read with a raw `getAppSetting` rather than `isOnboardingComplete()`
+ * because `status.ts` imports `clearOnboardingClaim` from this module and the
+ * back-import would close a cycle (`printBootstrapBanner()` reads it directly for
+ * the same reason). It is NOT read from the `onboardingCompletedCached` latch:
+ * that is a console-banner optimisation which `resetBootstrapBannerState()`
+ * deliberately drops mid-reset, and it must never be load-bearing for an
+ * authorization decision.
+ */
 export async function claimOnboardingInstance(
 	cookies: Cookies,
 	token: string,
 	context: OnboardingClaimCookieContext = {}
 ): Promise<'claimed' | 'renewed' | 'already-claimed' | 'invalid-token'> {
+	if ((await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED)) === 'true') {
+		// No token, prefix or length in this message: logging/redactor.ts scrubs Plex
+		// tokens, not bootstrap tokens, so anything passed here lands unredacted in
+		// the `logs` table.
+		logger.warn('Onboarding claim refused: instance already onboarded', 'Onboarding');
+		return 'invalid-token';
+	}
+
 	if (await renewOnboardingClaim(cookies, context)) {
 		return 'renewed';
 	}

--- a/tests/unit/admin/instance-reset.test.ts
+++ b/tests/unit/admin/instance-reset.test.ts
@@ -70,6 +70,7 @@ const anonymousLocals = {} as App.Locals;
 
 let cookies: OnboardingTestCookies;
 let consoleInfoSpy: ReturnType<typeof spyOn>;
+let consoleWarnSpy: ReturnType<typeof spyOn>;
 
 function resetRequest(confirmation: string): Request {
 	const formData = new FormData();
@@ -146,12 +147,19 @@ beforeEach(async () => {
 	clearSyncProgress();
 	cookies = setOnboardingSessionCookie(createOnboardingCookies(), 'session-under-test');
 	consoleInfoSpy = spyOn(console, 'info').mockImplementation(() => {});
+	// The claim guard warns on every refusal; silence it so the suite output stays
+	// readable.
+	consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
 });
 
-afterEach(() => {
+afterEach(async () => {
 	consoleInfoSpy.mockRestore();
+	consoleWarnSpy.mockRestore();
 	clearBootstrapToken();
 	clearSyncProgress();
+	// Drain the buffered guard warning instead of leaving its 100ms timer to fire
+	// during a later test file's `logs` assertions.
+	await logger.forceFlush();
 });
 
 describe('instance reset — authorization', () => {
@@ -235,6 +243,15 @@ describe('instance reset — claim token survival', () => {
 		const prepared = (await runPrepare()) as { token: string; expiresInMinutes: number };
 		expect(validateBootstrapToken(prepared.token)).toBe(true);
 
+		// Before the wipe the very same token buys nothing: claimOnboardingInstance()
+		// refuses outright while ONBOARDING_COMPLETED is set (seedEveryTable() sets
+		// it), which is what makes dismissing this dialog genuinely side-effect-free.
+		// Asserted here so refuse-before and claim-after are pinned by one token —
+		// this fails loudly if anyone makes the guard burn the token instead.
+		expect(await claimOnboardingInstance(createOnboardingCookies(), prepared.token)).toBe(
+			'invalid-token'
+		);
+
 		await expectRedirect(() => runReset(), '/onboarding/claim');
 
 		// The whole point of the locked sequencing: a naive clearOnboardingClaim()
@@ -246,6 +263,33 @@ describe('instance reset — claim token survival', () => {
 		const freshCookies = createOnboardingCookies();
 		expect(await claimOnboardingInstance(freshCookies, prepared.token)).toBe('claimed');
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.CLAIM);
+	});
+
+	it('leaves the token unusable when the admin dismisses the prepare dialog instead of resetting', async () => {
+		await seedEveryTable();
+
+		const prepared = (await runPrepare()) as { token: string; expiresInMinutes: number };
+
+		// Dismissal posts nothing, so the token really is still live in module memory
+		// for its full 60 minutes — that is the documented behaviour, not the bug.
+		expect(validateBootstrapToken(prepared.token)).toBe(true);
+
+		// The bug was that this token could then be spent against the running
+		// instance: /onboarding is in onboardingHandle's skipPaths and a form action
+		// bypasses the layout load, so nothing upstream refuses the POST.
+		expect(await claimOnboardingInstance(createOnboardingCookies(), prepared.token)).toBe(
+			'invalid-token'
+		);
+
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED)).toBeNull();
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIM_PROOF_HASH)).toBeNull();
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT)).toBeNull();
+		// The raw row, not getOnboardingStep(): that helper defaults to CLAIM when the
+		// row is missing and so cannot tell "never written" from "written then wiped".
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CURRENT_STEP)).toBeNull();
+		// And the live instance is untouched.
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED)).toBe('true');
+		expect(await countRows(users)).toBe(1);
 	});
 
 	it('mints a 60-minute token on the reset path and leaves first boot at 15 minutes', async () => {

--- a/tests/unit/onboarding/bootstrap.test.ts
+++ b/tests/unit/onboarding/bootstrap.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import type { Cookies } from '@sveltejs/kit';
-import { AppSettingsKey, getAppSetting, setAppSetting } from '$lib/server/admin/settings.service';
+import {
+	AppSettingsKey,
+	deleteAppSetting,
+	getAppSetting,
+	setAppSetting
+} from '$lib/server/admin/settings.service';
 import { db } from '$lib/server/db/client';
 import { appSettings } from '$lib/server/db/schema';
+import { logger } from '$lib/server/logging';
 import {
 	claimOnboardingInstance,
 	clearBootstrapToken,
@@ -13,6 +19,7 @@ import {
 	isBootstrapTokenExpired,
 	ONBOARDING_CLAIM_COOKIE,
 	printOnboardingBootstrapBanner,
+	RESET_BOOTSTRAP_TOKEN_TTL_MS,
 	renewOnboardingClaim,
 	validateBootstrapToken
 } from '$lib/server/onboarding/bootstrap';
@@ -178,6 +185,97 @@ describe('onboarding bootstrap token and claim', () => {
 		expect(await claimOnboardingInstance(second as unknown as Cookies, token)).toBe(
 			'already-claimed'
 		);
+	});
+
+	// The admin instance reset (PR #168) mints a 60-minute bootstrap token on a
+	// LIVE instance — stage 2 hands it to the browser before anything is wiped,
+	// because the token lives in module state and minting after the wipe is not an
+	// option. Dismissing that dialog is deliberately side-effect-free, so the token
+	// stays valid in memory on a fully onboarded install, and nothing upstream
+	// notices: /onboarding sits in onboardingHandle's skipPaths and form actions
+	// bypass the layout load. These pin the completion guard that makes such a
+	// token inert until the wipe actually happens.
+	describe('refuses claims on an already-onboarded instance (dismissed instance reset)', () => {
+		let consoleWarnSpy: ReturnType<typeof spyOn>;
+
+		beforeEach(() => {
+			consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+		});
+
+		afterEach(async () => {
+			consoleWarnSpy.mockRestore();
+			// The refusal warning is buffered behind a 100ms timer; drain it here so it
+			// cannot flush into a later file's `logs` assertions.
+			await logger.forceFlush();
+		});
+
+		async function claimKeys(): Promise<Array<string | null>> {
+			return Promise.all([
+				getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED),
+				getAppSetting(AppSettingsKey.ONBOARDING_CLAIM_PROOF_HASH),
+				getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT)
+			]);
+		}
+
+		it('refuses a live bootstrap token while onboarding is already complete, writing nothing', async () => {
+			await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+			const cookies = createCookies();
+			const token = createBootstrapToken(RESET_BOOTSTRAP_TOKEN_TTL_MS);
+
+			expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe(
+				'invalid-token'
+			);
+
+			expect(await claimKeys()).toEqual([null, null, null]);
+			expect(cookies.values.get(ONBOARDING_CLAIM_COOKIE)).toBeUndefined();
+		});
+
+		it('refuses without burning the token, so the same token claims once the wipe clears the flag', async () => {
+			await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+			const cookies = createCookies();
+			const token = createBootstrapToken(RESET_BOOTSTRAP_TOKEN_TTL_MS);
+
+			expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe(
+				'invalid-token'
+			);
+			// Refuse only, never burn: burning would turn any reachable POST into a way
+			// to strand a reset mid-flight, leaving the admin unable to claim after
+			// their own wipe.
+			expect(validateBootstrapToken(token)).toBe(true);
+
+			// Standing in for the wipe, which deletes the key outright.
+			await deleteAppSetting(AppSettingsKey.ONBOARDING_COMPLETED);
+
+			expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
+		});
+
+		it('suppresses renewal too: an active claim cookie cannot renew on a completed instance', async () => {
+			const cookies = createCookies();
+			const token = createBootstrapToken();
+			expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
+			const claimedAt = await getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT);
+
+			// A live claim alongside the completed flag is only reachable in production
+			// inside completeOnboarding()'s own await window (it sets the flag, then
+			// clears the claim). It still matters, because renewOnboardingClaim()
+			// WRITES ONBOARDING_CLAIMED_AT — a byte-identical value after the refusal
+			// is what proves the guard sits above that branch.
+			await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+
+			expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe(
+				'invalid-token'
+			);
+			expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT)).toBe(claimedAt);
+		});
+
+		it('treats only the exact string "true" as complete', async () => {
+			await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'false');
+			const cookies = createCookies();
+			const token = createBootstrapToken();
+
+			// Guards against a refactor to truthiness: 'false' is a stored string.
+			expect(await claimOnboardingInstance(cookies as unknown as Cookies, token)).toBe('claimed');
+		});
 	});
 
 	it('clears claim state', async () => {

--- a/tests/unit/onboarding/claim-action.test.ts
+++ b/tests/unit/onboarding/claim-action.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { AppSettingsKey, getAppSetting, setAppSetting } from '$lib/server/admin/settings.service';
+import { logger } from '$lib/server/logging';
+import {
+	createBootstrapToken,
+	getOnboardingStep,
+	ONBOARDING_CLAIM_COOKIE,
+	OnboardingSteps,
+	RESET_BOOTSTRAP_TOKEN_TTL_MS,
+	setOnboardingStep
+} from '$lib/server/onboarding';
+import { actions, load } from '../../../src/routes/onboarding/claim/+page.server';
+import {
+	claimOnboardingCookies,
+	createOnboardingCookies,
+	expectRedirect,
+	type OnboardingTestCookies,
+	resetOnboardingTestState
+} from '../../helpers/onboarding';
+
+type ClaimAction = NonNullable<typeof actions.claimInstance>;
+
+const ALREADY_CLAIMED_MESSAGE =
+	'Setup is already claimed in another browser. Wait for the claim to expire and try again.';
+
+let cookies: OnboardingTestCookies;
+let consoleWarnSpy: ReturnType<typeof spyOn>;
+
+function claimRequest(token: string): Request {
+	const formData = new FormData();
+	formData.set('token', token);
+	return new Request('http://localhost/onboarding/claim?/claimInstance', {
+		method: 'POST',
+		body: formData
+	});
+}
+
+async function runClaim(token: string, jar: OnboardingTestCookies = cookies) {
+	const handler = actions.claimInstance as ClaimAction;
+	const request = claimRequest(token);
+	return handler({
+		request,
+		cookies: jar,
+		url: new URL(request.url)
+	} as unknown as Parameters<ClaimAction>[0]);
+}
+
+/** The three keys a successful claim writes, read raw. */
+async function claimKeys(): Promise<Array<string | null>> {
+	return Promise.all([
+		getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED),
+		getAppSetting(AppSettingsKey.ONBOARDING_CLAIM_PROOF_HASH),
+		getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED_AT)
+	]);
+}
+
+beforeEach(async () => {
+	await resetOnboardingTestState();
+	cookies = createOnboardingCookies();
+	consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(async () => {
+	consoleWarnSpy.mockRestore();
+	// The refusal warning is buffered behind a 100ms timer; drain it here so it
+	// cannot flush into a later file's `logs` assertions.
+	await logger.forceFlush();
+});
+
+describe('onboarding claim route', () => {
+	it('delegates load to the onboarding layout parent', async () => {
+		const parentData = { currentStep: OnboardingSteps.CLAIM };
+
+		const result = await load({
+			parent: async () => parentData
+		} as unknown as Parameters<typeof load>[0]);
+
+		expect(result).toBe(parentData);
+	});
+
+	it('does not export a default action alongside claimInstance', () => {
+		expect('default' in actions).toBe(false);
+		expect(actions.default).toBeUndefined();
+		expect(typeof actions.claimInstance).toBe('function');
+	});
+
+	it('claims with a valid token, advances the step, and sets the claim cookie', async () => {
+		const token = createBootstrapToken();
+
+		await expectRedirect(() => runClaim(token), '/onboarding/csrf');
+
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED)).toBe('true');
+		expect(cookies.sets.map((entry) => entry.name)).toContain(ONBOARDING_CLAIM_COOKIE);
+	});
+
+	it('trims surrounding whitespace from a pasted token', async () => {
+		const token = createBootstrapToken();
+
+		await expectRedirect(() => runClaim(`  ${token}\n`), '/onboarding/csrf');
+
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CLAIMED)).toBe('true');
+	});
+
+	it('renews an existing claim and redirects, even with a junk token in the form', async () => {
+		await claimOnboardingCookies(cookies);
+		await setOnboardingStep(OnboardingSteps.PLEX);
+
+		// The renew branch runs before token validation, so this proves the POST took
+		// it. Documenting, not endorsing: the route sets CSRF unconditionally, so a
+		// re-POST from a browser already further along is bumped back a step. That is
+		// pre-existing behaviour and out of scope here.
+		await expectRedirect(() => runClaim('not-a-real-token'), '/onboarding/csrf');
+
+		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);
+	});
+
+	it('returns 409 with the browser-conflict message for a competing claimant', async () => {
+		await claimOnboardingCookies(createOnboardingCookies());
+		// A live token in a second browser: the claim slot, not the token, is what
+		// refuses here.
+		const token = createBootstrapToken();
+
+		expect(await runClaim(token)).toEqual({
+			status: 409,
+			data: { error: ALREADY_CLAIMED_MESSAGE }
+		});
+		expect(cookies.sets).toHaveLength(0);
+	});
+
+	it('returns 400 for an invalid token without writing anything', async () => {
+		expect(await runClaim('bogus-token-1')).toEqual({
+			status: 400,
+			data: { error: 'Invalid or expired bootstrap token' }
+		});
+
+		expect(await claimKeys()).toEqual([null, null, null]);
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CURRENT_STEP)).toBeNull();
+		expect(cookies.sets).toHaveLength(0);
+	});
+
+	it('refuses a reset-minted token at the exact seam the layout load cannot cover', async () => {
+		// This is the whole bug in one test. The onboarding layout `load` would 303 an
+		// already-onboarded visitor away, but a form action never runs it, and
+		// /onboarding is in onboardingHandle's skipPaths — so before the guard existed
+		// this POST claimed a live instance with a token the admin had merely been
+		// shown by a dismissed instance-reset dialog.
+		await setAppSetting(AppSettingsKey.ONBOARDING_COMPLETED, 'true');
+		const token = createBootstrapToken(RESET_BOOTSTRAP_TOKEN_TTL_MS);
+
+		expect(await runClaim(token)).toEqual({
+			status: 400,
+			data: { error: 'Invalid or expired bootstrap token' }
+		});
+
+		expect(await claimKeys()).toEqual([null, null, null]);
+		// The raw row, not getOnboardingStep(): that helper defaults to CLAIM when the
+		// row is missing, so only the raw read proves setOnboardingStep(CSRF) was
+		// never reached.
+		expect(await getAppSetting(AppSettingsKey.ONBOARDING_CURRENT_STEP)).toBeNull();
+		expect(cookies.sets).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

`prepareInstanceReset` (stage 2 of the complete instance reset added in #168) mints a 60-minute bootstrap token and returns it to the browser without writing anything; stage 3 does the wipe. That ordering is forced: the token lives in a module-level variable in `src/lib/server/onboarding/bootstrap.ts`, and the usual reset path, `clearOnboardingClaim()`, would destroy the token the admin was just handed.

The consequence, flagged in #168 rather than silently closed: dismissing stage 2 leaves a valid 60-minute token in memory on a live, fully-onboarded instance. `claimOnboardingInstance()` never checked `ONBOARDING_COMPLETED`, `/onboarding` is in `onboardingHandle`'s `skipPaths`, and SvelteKit form actions bypass the layout `load` — so a POST to `/onboarding/claim?/claimInstance` with that token succeeded on a running instance, writing `ONBOARDING_CLAIMED`, `ONBOARDING_CLAIM_PROOF_HASH`, `ONBOARDING_CLAIMED_AT` and `ONBOARDING_CURRENT_STEP='csrf'`.

This adds the completion guard so the token minted in stage 2 stays inert until the wipe actually happens, making the side-effect-free dismissal genuinely side-effect-free.

## Severity: defense-in-depth, not privilege escalation

Worth stating precisely, because the fix is small and the framing matters for anyone reading this later.

Every downstream onboarding action independently re-checks completion (`isOnboardingCsrfStep()` in `src/routes/onboarding/csrf/+page.server.ts` is `!done && step === CSRF`; proxy-trust mirrors it) or requires `locals.user.isAdmin`, and the Plex OAuth path branches on `requiresOnboarding()` rather than the claim (`src/lib/server/auth/login-completion.ts`). A leaked token therefore bought an anonymous party exactly two things: seizing the single claim slot (renewable, and it would make the admin's own post-wipe claim return `already-claimed`) and moving the step pointer. Both are inert on a live instance and erased by any later wipe. It also required the token to leak off an authenticated admin's screen in the first place. No advisory is warranted.

## Changes

### `src/lib/server/onboarding/bootstrap.ts`

`claimOnboardingInstance()` now begins with:

```ts
if ((await getAppSetting(AppSettingsKey.ONBOARDING_COMPLETED)) === 'true') {
	logger.warn('Onboarding claim refused: instance already onboarded', 'Onboarding');
	return 'invalid-token';
}
```

Four decisions worth calling out, each also recorded in a JSDoc block on the function so they survive a future "simplification":

- **Return `'invalid-token'` rather than a new variant.** Accurate (the token genuinely has no authority against a completed instance), no change to the exhaustive switch in `claim/+page.server.ts`, and it removes an existing information leak: today a prober can distinguish instance states via `already-claimed` (409) versus `invalid-token` (400). Collapsing both to 400 matches the repo's uniform-denial posture for public endpoints.
- **Placed above the renew branch.** `renewOnboardingClaim()` writes `ONBOARDING_CLAIMED_AT`. Guarding below it would leave a live `app_settings` mutation path — half the residue being removed. Behaviour-preserving: `completeOnboarding()` calls `clearOnboardingClaim()`, so the `'renewed'` branch is already unreachable once the flag is set outside that function's own await window.
- **Refuse only; never clear the token.** Burning it would turn any reachable POST into a remote way to strand a reset mid-flight: mint, attacker posts garbage, token dead, admin wipes and cannot claim — recoverable only via the console banner. There is no security gain, because `validateBootstrapToken()` has exactly one caller, so refusing already removes the token's entire capability surface while the flag is set.
- **Raw `getAppSetting`, not `isOnboardingComplete()` and not the module latch.** `status.ts` imports `clearOnboardingClaim` from `bootstrap.ts`, so importing the helper back would close a cycle; `printBootstrapBanner()` reads the key directly for the same reason. The `onboardingCompletedCached` latch is a console-banner optimisation that `resetBootstrapBannerState()` deliberately drops mid-reset, so it must never be load-bearing for an authorization decision.

The log message deliberately carries no token, no prefix and no length: `logging/redactor.ts` scrubs Plex tokens, not bootstrap tokens, so anything passed would land unredacted in the `logs` table. The client response stays the uniform `fail(400, ...)`. Flood-safe, since `POST /onboarding/claim` is capped at 5 requests per 5 minutes and `rateLimitHandle` runs first in the hook chain.

Verified non-risks: `getAppSetting` is an uncached `db.select()`, so there is no stale read that could strand the admin post-wipe; the only writer of `ONBOARDING_COMPLETED='true'` in the tree is `completeOnboarding()`, which needs both an active claim and an admin session, neither of which survives a wipe.

### `tests/unit/onboarding/bootstrap.test.ts`

New nested describe covering the guard:

- refuses a live reset-minted token while onboarding is complete, with all three claim keys `null` and no claim cookie set;
- refuses without burning the token, then claims successfully with that same token after the flag is deleted (the load-bearing test — it pins refuse-only and the guard together);
- suppresses the renew branch too, asserted via a byte-identical `ONBOARDING_CLAIMED_AT`, which is what proves the guard sits above that write;
- treats only the exact string `'true'` as complete, so a refactor to truthiness fails.

### `tests/unit/onboarding/claim-action.test.ts` (new)

`src/routes/onboarding/claim/+page.server.ts` was the only onboarding route with no coverage, and the seam this bug exploited is precisely "the action bypasses the `load`" — only a route-level test expresses that. The file covers `load` delegation to the layout parent, all four result branches, `.trim()` on a pasted token, the absence of a default action, and the refusal of a reset-minted token with `ONBOARDING_CURRENT_STEP` asserted as a raw row (the assertion the service-level tests cannot make, since it proves `setOnboardingStep(CSRF)` was never reached). The route is now at 100% line and function coverage.

One note so nobody reads a new test as an intentional spec: the `renewed` test documents rather than endorses pre-existing behaviour. The route sets `CSRF` unconditionally, so a re-POST from a browser already on step `plex` is bumped back. Out of scope here.

### `tests/unit/admin/instance-reset.test.ts`

`keeps the token shown to the admin valid after the wipe completes` now asserts a pre-wipe refusal against a fresh cookie jar, so a single token pins both refuse-before and claim-after and the test fails loudly if anyone makes the guard burn the token. A new sibling test, `leaves the token unusable when the admin dismisses the prepare dialog instead of resetting`, walks the reported scenario end to end: prepare, no reset, token still valid in memory, claim refused, all three claim keys and the raw `ONBOARDING_CURRENT_STEP` row `null`, `ONBOARDING_COMPLETED` still `'true'`, and the user row intact.

The suite's `afterEach` now drains the logger buffer and silences `console.warn`, so the guard's buffered refusal warning cannot flush into a later test file's `logs` assertions.

## Deliberately not done

- **A `cancelInstanceReset` action that burns the token on dismiss.** It contradicts the documented side-effect-free dismissal, is asserted against by the existing "keeps both dialogs dismissible with no side effects" test, and cannot cover a closed tab, a navigate-away or a browser crash — so the server-side guard would still be required. Strictly additive complexity.
- **A hook-level block on `/onboarding/*` POSTs when onboarding is complete.** It closes marginally more (the two-await window inside `completeOnboarding()`), but reintroduces a `requiresOnboarding()` DB read on a deliberately-skipped hot path, changes the denial shape from a typed `fail(400)` to a hook 303/403 (a split this repo treats as deliberate), and is invisible from `bootstrap.ts` where a reader needs it. That window is also self-healing.
- **A guard inside `validateBootstrapToken()`.** One production caller, closes zero extra holes, and forcing it async would silently break eight synchronous `expect(validateBootstrapToken(t)).toBe(true)` assertions by comparing a Promise to `true`.

## Validation

```
bun run check:biome        # clean, 652 files
bun run check              # 3156 files, 0 errors, 0 warnings
bun run test               # 2353 pass, 0 fail across 113 files, coverage thresholds met
bun run build             # production build succeeds
```

Regression watch, verified rather than assumed: the four suites that claim in `beforeEach` and expect `'claimed'` (`tests/unit/auth/lifecycle.test.ts`, `tests/unit/onboarding/csrf-actions.test.ts`, `tests/unit/onboarding/proxy-trust-actions.test.ts`, `tests/unit/onboarding/routing-and-guards.test.ts`) all pass untouched — 114 tests — because they claim against a DB cleared by `resetSharedTestDb()`.

The `curl`-level scenario from the report is covered by `refuses a reset-minted token at the exact seam the layout load cannot cover` in the new route test, which drives the real form action with the real completion flag set and asserts that nothing at all was written.
