### PR TITLE
fix(admin): persist privacy presets atomically and re-pass the instance-reset section

### DIFF
--- a/src/lib/server/admin/settings.service.ts
+++ b/src/lib/server/admin/settings.service.ts
@@ -272,6 +272,117 @@ export function nextOccVersionDate(dbFloorMs: number): Date {
 export type OccWriteResult = { status: 'ok'; version: Date } | { status: 'conflict' };
 
 /**
+ * A drizzle transaction handle as produced by `db.transaction(...)`. Named so the
+ * in-transaction OCC gate and row writers below can be shared between the
+ * single-group `set*Atomic` writers and the cross-group `setPrivacyPresetAtomic`.
+ */
+type SettingsTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * The OCC gate every atomic settings write runs INSIDE its transaction: read
+ * `max(updatedAt)` over `keys`, reject a stale/blank `submittedVersion`, and
+ * return the strictly-advancing timestamp the caller must stamp its rows with.
+ *
+ * Extracted so a multi-group write can gate several key groups against one
+ * transaction snapshot. Semantics are byte-for-byte the ones the three
+ * single-group writers used inline before:
+ *   - a missing/blank/unparseable `submittedVersion` is a conflict regardless of
+ *     row count (closes the fresh-install/all-cleared loophole where a row-count
+ *     gate would silently skip OCC);
+ *   - with rows present, `submittedMs < maxMs` is a conflict;
+ *   - the write timestamp comes from `nextOccVersionDate(maxMs)`, so it shares
+ *     the DB floor the check just read and `max(updatedAt)` strictly advances.
+ */
+async function occGateInTx(
+	tx: SettingsTx,
+	keys: readonly string[],
+	submittedVersion: string
+): Promise<OccWriteResult> {
+	const rows = await tx
+		.select({ updatedAt: appSettings.updatedAt })
+		.from(appSettings)
+		.where(inArray(appSettings.key, keys as unknown as string[]));
+
+	const submittedMs = submittedVersion ? Date.parse(submittedVersion) : Number.NaN;
+	if (Number.isNaN(submittedMs)) {
+		return { status: 'conflict' };
+	}
+	let maxMs = 0;
+	for (const row of rows) {
+		const t = row.updatedAt.getTime();
+		if (t > maxMs) maxMs = t;
+	}
+	if (rows.length > 0 && submittedMs < maxMs) {
+		return { status: 'conflict' };
+	}
+
+	return { status: 'ok', version: nextOccVersionDate(maxMs) };
+}
+
+/** Upsert a single `app_settings` row inside `tx` at the OCC-issued timestamp. */
+async function upsertSettingInTx(
+	tx: SettingsTx,
+	key: string,
+	value: string,
+	now: Date
+): Promise<void> {
+	await tx
+		.insert(appSettings)
+		.values({ key, value, updatedAt: now })
+		.onConflictDoUpdate({ target: appSettings.key, set: { value, updatedAt: now } });
+}
+
+/** The two `SERVER_WRAPPED_SETTINGS_KEYS` rows. */
+async function writeServerWrappedRowsInTx(
+	tx: SettingsTx,
+	opts: { anonymizationMode: AnonymizationModeType; serverWrappedShareMode: string },
+	now: Date
+): Promise<void> {
+	await upsertSettingInTx(tx, AppSettingsKey.ANONYMIZATION_MODE, opts.anonymizationMode, now);
+	await upsertSettingInTx(
+		tx,
+		ShareSettingsKey.SERVER_WRAPPED_SHARE_MODE,
+		opts.serverWrappedShareMode,
+		now
+	);
+}
+
+/**
+ * The two `USER_DEFAULTS_SETTINGS_KEYS` rows, plus the private-link token purge
+ * that has always been part of this write (see `setUserDefaultsAtomic` below for
+ * why it does NOT fan out to explicit per-user overrides).
+ */
+async function writeUserDefaultsRowsInTx(
+	tx: SettingsTx,
+	opts: { defaultShareMode: string; allowUserControl: boolean },
+	now: Date
+): Promise<void> {
+	await upsertSettingInTx(tx, ShareSettingsKey.DEFAULT_SHARE_MODE, opts.defaultShareMode, now);
+	await upsertSettingInTx(
+		tx,
+		ShareSettingsKey.ALLOW_USER_CONTROL,
+		String(opts.allowUserControl),
+		now
+	);
+
+	if (opts.defaultShareMode !== ShareMode.PRIVATE_LINK) {
+		await tx
+			.update(shareSettings)
+			.set({ shareToken: null })
+			.where(eq(shareSettings.modeSource, ShareModeSource.DEFAULT));
+	}
+}
+
+/** The single `PUBLIC_LANDING_LOOKUP_SETTINGS_KEYS` row. */
+async function writePublicLandingLookupRowInTx(
+	tx: SettingsTx,
+	enabled: boolean,
+	now: Date
+): Promise<void> {
+	await upsertSettingInTx(tx, AppSettingsKey.PUBLIC_LANDING_LOOKUP, String(enabled), now);
+}
+
+/**
  * Atomically validates that the "Server-wide Wrapped" settings (anonymization
  * mode + server-wide share mode) have not changed since `submittedVersion`
  * and, if so, writes both values in a single SQLite transaction. Returns
@@ -283,57 +394,11 @@ export async function setServerWrappedSettingsAtomic(opts: {
 	submittedVersion: string;
 }): Promise<OccWriteResult> {
 	return db.transaction(async (tx) => {
-		const rows = await tx
-			.select({ updatedAt: appSettings.updatedAt })
-			.from(appSettings)
-			.where(inArray(appSettings.key, SERVER_WRAPPED_SETTINGS_KEYS as unknown as string[]));
+		const gate = await occGateInTx(tx, SERVER_WRAPPED_SETTINGS_KEYS, opts.submittedVersion);
+		if (gate.status === 'conflict') return gate;
 
-		// Treat a missing/blank submittedVersion as a stale tab regardless of row
-		// count — defends against the fresh-install/all-cleared loophole where the
-		// row-count gate would silently skip OCC.
-		const submittedMs = opts.submittedVersion ? Date.parse(opts.submittedVersion) : Number.NaN;
-		if (Number.isNaN(submittedMs)) {
-			return { status: 'conflict' };
-		}
-		// Compute `maxMs` over the existing rows so the OCC check and the write
-		// timestamp share the same DB floor. With no rows, `maxMs = 0` is fine —
-		// `Date.now()` dominates inside `nextOccVersionDate`.
-		let maxMs = 0;
-		for (const row of rows) {
-			const t = row.updatedAt.getTime();
-			if (t > maxMs) maxMs = t;
-		}
-		if (rows.length > 0 && submittedMs < maxMs) {
-			return { status: 'conflict' };
-		}
-
-		const now = nextOccVersionDate(maxMs);
-
-		await tx
-			.insert(appSettings)
-			.values({
-				key: AppSettingsKey.ANONYMIZATION_MODE,
-				value: opts.anonymizationMode,
-				updatedAt: now
-			})
-			.onConflictDoUpdate({
-				target: appSettings.key,
-				set: { value: opts.anonymizationMode, updatedAt: now }
-			});
-
-		await tx
-			.insert(appSettings)
-			.values({
-				key: ShareSettingsKey.SERVER_WRAPPED_SHARE_MODE,
-				value: opts.serverWrappedShareMode,
-				updatedAt: now
-			})
-			.onConflictDoUpdate({
-				target: appSettings.key,
-				set: { value: opts.serverWrappedShareMode, updatedAt: now }
-			});
-
-		return { status: 'ok', version: now };
+		await writeServerWrappedRowsInTx(tx, opts, gate.version);
+		return gate;
 	});
 }
 
@@ -359,63 +424,11 @@ export async function setUserDefaultsAtomic(opts: {
 	submittedVersion: string;
 }): Promise<OccWriteResult> {
 	return db.transaction(async (tx) => {
-		const rows = await tx
-			.select({ updatedAt: appSettings.updatedAt })
-			.from(appSettings)
-			.where(inArray(appSettings.key, USER_DEFAULTS_SETTINGS_KEYS as unknown as string[]));
+		const gate = await occGateInTx(tx, USER_DEFAULTS_SETTINGS_KEYS, opts.submittedVersion);
+		if (gate.status === 'conflict') return gate;
 
-		// Treat a missing/blank submittedVersion as a stale tab regardless of row
-		// count — defends against the fresh-install/all-cleared loophole.
-		const submittedMs = opts.submittedVersion ? Date.parse(opts.submittedVersion) : Number.NaN;
-		if (Number.isNaN(submittedMs)) {
-			return { status: 'conflict' };
-		}
-		// Compute `maxMs` over the existing rows so the OCC check and the write
-		// timestamp share the same DB floor. With no rows, `maxMs = 0` is fine —
-		// `Date.now()` dominates inside `nextOccVersionDate`.
-		let maxMs = 0;
-		for (const row of rows) {
-			const t = row.updatedAt.getTime();
-			if (t > maxMs) maxMs = t;
-		}
-		if (rows.length > 0 && submittedMs < maxMs) {
-			return { status: 'conflict' };
-		}
-
-		const now = nextOccVersionDate(maxMs);
-
-		await tx
-			.insert(appSettings)
-			.values({
-				key: ShareSettingsKey.DEFAULT_SHARE_MODE,
-				value: opts.defaultShareMode,
-				updatedAt: now
-			})
-			.onConflictDoUpdate({
-				target: appSettings.key,
-				set: { value: opts.defaultShareMode, updatedAt: now }
-			});
-
-		await tx
-			.insert(appSettings)
-			.values({
-				key: ShareSettingsKey.ALLOW_USER_CONTROL,
-				value: String(opts.allowUserControl),
-				updatedAt: now
-			})
-			.onConflictDoUpdate({
-				target: appSettings.key,
-				set: { value: String(opts.allowUserControl), updatedAt: now }
-			});
-
-		if (opts.defaultShareMode !== ShareMode.PRIVATE_LINK) {
-			await tx
-				.update(shareSettings)
-				.set({ shareToken: null })
-				.where(eq(shareSettings.modeSource, ShareModeSource.DEFAULT));
-		}
-
-		return { status: 'ok', version: now };
+		await writeUserDefaultsRowsInTx(tx, opts, gate.version);
+		return gate;
 	});
 }
 
@@ -1595,41 +1608,121 @@ export async function setPublicLandingLookupEnabledAtomic(opts: {
 	submittedVersion: string;
 }): Promise<OccWriteResult> {
 	return db.transaction(async (tx) => {
-		const rows = await tx
-			.select({ updatedAt: appSettings.updatedAt })
-			.from(appSettings)
-			.where(inArray(appSettings.key, PUBLIC_LANDING_LOOKUP_SETTINGS_KEYS as unknown as string[]));
+		const gate = await occGateInTx(tx, PUBLIC_LANDING_LOOKUP_SETTINGS_KEYS, opts.submittedVersion);
+		if (gate.status === 'conflict') return gate;
 
-		// Treat a missing/blank submittedVersion as a stale tab regardless of row
-		// count — defends against the fresh-install/all-cleared loophole.
-		const submittedMs = opts.submittedVersion ? Date.parse(opts.submittedVersion) : Number.NaN;
-		if (Number.isNaN(submittedMs)) {
-			return { status: 'conflict' };
+		await writePublicLandingLookupRowInTx(tx, opts.enabled, gate.version);
+		return gate;
+	});
+}
+
+/**
+ * The three OCC key groups a privacy preset spans, in the order they appear on
+ * the admin Privacy route. Used as the conflict discriminator by
+ * {@link setPrivacyPresetAtomic}.
+ */
+export const PRIVACY_PRESET_SECTIONS = {
+	SERVER_WRAPPED: 'serverWrapped',
+	USER_DEFAULTS: 'userDefaults',
+	PUBLIC_LANDING_LOOKUP: 'publicLandingLookup'
+} as const;
+
+export type PrivacyPresetSection =
+	(typeof PRIVACY_PRESET_SECTIONS)[keyof typeof PRIVACY_PRESET_SECTIONS];
+
+/**
+ * Result of {@link setPrivacyPresetAtomic}. On success it carries the single
+ * `updatedAt` the transaction stamped on all three OCC groups, so the calling
+ * action can hand every section a fresh `settingsVersion` without a post-write
+ * re-read (see `OccWriteResult` for why that re-read is a TOCTOU hole). On
+ * conflict it names every stale group, so the client can say which sections moved
+ * underneath it — and, because the write is all-or-nothing, nothing was applied.
+ */
+export type PrivacyPresetWriteResult =
+	| { status: 'ok'; version: Date }
+	| { status: 'conflict'; staleSections: PrivacyPresetSection[] };
+
+/**
+ * Atomically applies a privacy preset across all THREE OCC groups the admin
+ * Privacy route splits its controls into (server-wide wrapped, user sharing
+ * defaults, public landing lookup) in a single SQLite transaction.
+ *
+ * Why this exists rather than three sequential `set*Atomic` calls: a preset is
+ * one coherent privacy posture, and three separate transactions can leave a
+ * half-applied configuration behind when the third group turns out to be stale —
+ * e.g. names already anonymized while public lookup stayed on. Gating all three
+ * groups against ONE transaction snapshot and writing only if every gate passes
+ * makes a partial apply unreachable, so "partial conflict" collapses to "the
+ * whole apply was refused, and here is every section that moved".
+ *
+ * The write reuses the same in-transaction OCC gate and row writers as the
+ * single-group writers above, so there is exactly one implementation of each
+ * rule — including the private-link share-token purge inside
+ * `writeUserDefaultsRowsInTx`.
+ *
+ * `logoMode` is deliberately NOT written: it lives on the Appearance route and
+ * its own OCC group, and the admin preset match covers only the five fields this
+ * route owns.
+ */
+export async function setPrivacyPresetAtomic(opts: {
+	anonymizationMode: AnonymizationModeType;
+	serverWrappedShareMode: string;
+	defaultShareMode: string;
+	allowUserControl: boolean;
+	publicLandingLookup: boolean;
+	submittedVersions: Record<PrivacyPresetSection, string>;
+}): Promise<PrivacyPresetWriteResult> {
+	return db.transaction(async (tx) => {
+		const gates = [
+			{
+				section: PRIVACY_PRESET_SECTIONS.SERVER_WRAPPED,
+				gate: await occGateInTx(
+					tx,
+					SERVER_WRAPPED_SETTINGS_KEYS,
+					opts.submittedVersions.serverWrapped
+				)
+			},
+			{
+				section: PRIVACY_PRESET_SECTIONS.USER_DEFAULTS,
+				gate: await occGateInTx(
+					tx,
+					USER_DEFAULTS_SETTINGS_KEYS,
+					opts.submittedVersions.userDefaults
+				)
+			},
+			{
+				section: PRIVACY_PRESET_SECTIONS.PUBLIC_LANDING_LOOKUP,
+				gate: await occGateInTx(
+					tx,
+					PUBLIC_LANDING_LOOKUP_SETTINGS_KEYS,
+					opts.submittedVersions.publicLandingLookup
+				)
+			}
+		];
+
+		const staleSections = gates
+			.filter(({ gate }) => gate.status === 'conflict')
+			.map(({ section }) => section);
+		if (staleSections.length > 0) {
+			// All-or-nothing: return before ANY write, so a stale group can never
+			// leave the other two applied.
+			return { status: 'conflict', staleSections };
 		}
-		// Compute `maxMs` over the existing rows so the OCC check and the write
-		// timestamp share the same DB floor. With no rows, `maxMs = 0` is fine —
-		// `Date.now()` dominates inside `nextOccVersionDate`.
-		let maxMs = 0;
-		for (const row of rows) {
-			const t = row.updatedAt.getTime();
-			if (t > maxMs) maxMs = t;
-		}
-		if (rows.length > 0 && submittedMs < maxMs) {
-			return { status: 'conflict' };
-		}
 
-		const now = nextOccVersionDate(maxMs);
-		const value = String(opts.enabled);
+		// One shared version across all three groups. Each gate's own
+		// `nextOccVersionDate` value already clears that group's floor, so the
+		// maximum of the three clears all of them — and one preset apply then reads
+		// as one version rather than three near-identical ones. The `: 0` arm is
+		// unreachable: the guard above returned on any conflicting gate.
+		const version = new Date(
+			Math.max(...gates.map(({ gate }) => (gate.status === 'ok' ? gate.version.getTime() : 0)))
+		);
 
-		await tx
-			.insert(appSettings)
-			.values({ key: AppSettingsKey.PUBLIC_LANDING_LOOKUP, value, updatedAt: now })
-			.onConflictDoUpdate({
-				target: appSettings.key,
-				set: { value, updatedAt: now }
-			});
+		await writeServerWrappedRowsInTx(tx, opts, version);
+		await writeUserDefaultsRowsInTx(tx, opts, version);
+		await writePublicLandingLookupRowInTx(tx, opts.publicLandingLookup, version);
 
-		return { status: 'ok', version: now };
+		return { status: 'ok', version };
 	});
 }
 

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -273,17 +273,25 @@ export const PRIVACY_PREVIEW_VALUE_TOOLTIPS: PrivacyPreviewValueTooltips = {
 };
 
 /**
- * Privacy preset identifiers. A preset bundles a recommended combination of the
- * existing privacy/sharing fields behind one visual card. Presets are NEVER a
- * persisted field — selecting one just mutates the existing form state; the
- * active preset is recomputed from field values on load (see `preset-logic.ts`).
+ * Privacy preset identifiers, as a tuple so the admin route's Zod enum is built
+ * from the same source the preset cards iterate — a new preset cannot become
+ * clickable without also becoming submittable.
+ *
+ * A preset is never a persisted FIELD: no `app_settings` row stores an id. The
+ * admin "apply preset" action submits an id purely as a discriminator, resolves
+ * it to a {@link PrivacyPreset} server-side, and writes only the ordinary
+ * privacy/sharing values. The active preset is still recomputed from field values
+ * on load (see `preset-logic.ts`).
  */
-export type PrivacyPresetId =
-	| 'maximum-privacy'
-	| 'internal-community'
-	| 'balanced'
-	| 'public-showcase'
-	| 'anonymous-public';
+export const PRIVACY_PRESET_IDS = [
+	'maximum-privacy',
+	'internal-community',
+	'balanced',
+	'public-showcase',
+	'anonymous-public'
+] as const;
+
+export type PrivacyPresetId = (typeof PRIVACY_PRESET_IDS)[number];
 
 /**
  * The exact set of fields a preset configures. EXACTLY six keys, mirroring the

--- a/src/lib/utils/occ-form.ts
+++ b/src/lib/utils/occ-form.ts
@@ -28,6 +28,32 @@ export function isOccConflict(data: unknown): boolean {
 }
 
 /**
+ * Whether an action `failure` payload is a POST-VALIDATION failure, i.e. one the
+ * action returned after `superValidate` already passed.
+ *
+ * Such a payload hands back a form that is still `valid`, so superForm's
+ * `onUpdated` takes its SUCCESS branch — the trap behind ISSUE-006, where a
+ * discarded stale write fired a "Saved" toast. Status codes do not discriminate
+ * it: an action can `fail(400, { form, error })` semantically on a payload that
+ * satisfied its schema (`applyPrivacyPreset`'s `!preset` guard does exactly that,
+ * because `presetId` is `.optional()`), while a genuine schema failure carries
+ * `form.valid === false` and must be left to `onUpdated`'s field-error branch.
+ *
+ * ORDERING CONTRACT: an OCC conflict returned after the pre-write check is ALSO a
+ * post-validation failure, so a caller that runs {@link surfaceOccConflict} must
+ * early-return on `isOccConflict(result.data)` before consulting this predicate.
+ * `surfaceOccConflict` cancels but does not stop the caller, so skipping that
+ * early return toasts every 409 twice.
+ *
+ * Kept next to {@link isOccConflict} because both inspect the same failure payload
+ * and both are consumed at the `onUpdate` layer.
+ */
+export function isPostValidationFailure(data: unknown): boolean {
+	const d = data as { form?: { valid?: boolean } } | undefined;
+	return d?.form?.valid === true;
+}
+
+/**
  * superForm `onUpdate` guard for OCC stale-writes.
  *
  * An OCC stale-write returns `fail(409, { form, conflict, error })` AFTER

--- a/src/routes/admin/settings/data/+page.svelte
+++ b/src/routes/admin/settings/data/+page.svelte
@@ -8,8 +8,9 @@ import TriangleAlertIcon from '@lucide/svelte/icons/triangle-alert';
 import { enhance } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
 import { SettingsActionBar } from '$lib/components/settings/index.js';
-import { Alert, AlertDescription } from '$lib/components/ui/alert/index.js';
+import { Alert, AlertDescription, AlertTitle } from '$lib/components/ui/alert/index.js';
 import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
+import { Badge } from '$lib/components/ui/badge/index.js';
 import { Button } from '$lib/components/ui/button/index.js';
 import {
 	Card,
@@ -251,32 +252,38 @@ async function copyResetToken() {
 		</CardContent>
 	</Card>
 
-	<!-- Danger zone: deliberately last, visually separated, and destructive in a
-	     way the per-year clear actions above are not. -->
+	<!-- The only irreversible action on this page. The severity badge carries the
+	     alarm so the title is free to say plainly WHAT the action does, and the
+	     three blocks below use the same three labels as the confirm dialog — an
+	     admin must never read two vocabularies for the same three facts. -->
 	<Card class="border-destructive/50">
 		<CardHeader>
-			<CardTitle class="flex items-center gap-2 text-destructive">
-				<TriangleAlertIcon class="size-5" />
+			<Badge variant="destructive" class="mb-1">
+				<TriangleAlertIcon />
 				Danger zone
-			</CardTitle>
+			</Badge>
+			<CardTitle class="text-destructive">Reset this Obzorarr instance</CardTitle>
 			<CardDescription>
-				Deletes everything Obzorarr has stored and returns this instance to the first-run
-				setup screen. This is not one of the per-year actions above — it clears all
-				{data.resetTableCount} database tables at once.
+				Clears all {data.resetTableCount} database tables at once and returns this instance to the
+				first-run setup screen. This is not one of the per-year actions above, and it cannot be
+				undone.
 			</CardDescription>
 		</CardHeader>
 		<CardContent class="space-y-4">
 			<div class="space-y-3 rounded-lg border border-border bg-muted/30 p-4 text-sm">
+				<p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+					Where your data ends up
+				</p>
 				<div class="space-y-1">
-					<p class="font-medium">Comes back on its own</p>
+					<p class="font-medium">What comes back</p>
 					<p class="text-muted-foreground">
-						Obzorarr only needs your Plex login. Watch statistics are re-synced from the
-						official Plex API, so play history and every Wrapped statistic built from it can
-						be rebuilt by running a fresh sync once you finish setup again.
+						Your watch statistics. Obzorarr only needs your Plex login, and play history is
+						re-synced from the official Plex API — so play history and every Wrapped statistic
+						built from it can be rebuilt by running a fresh sync once you finish setup again.
 					</p>
 				</div>
 				<div class="space-y-1">
-					<p class="font-medium">Gone for good</p>
+					<p class="font-medium">What does not</p>
 					<p class="text-muted-foreground">
 						Every setting: privacy and sharing configuration, themes, slide configuration and
 						custom slides, log settings and fun-fact configuration. All per-user share
@@ -287,11 +294,11 @@ async function copyResetToken() {
 					</p>
 				</div>
 				<div class="space-y-1">
-					<p class="font-medium">Set by environment variables</p>
+					<p class="font-medium">What is untouched</p>
 					<p class="text-muted-foreground">
 						Anything configured through the environment (Plex, OpenAI, ORIGIN, TRUST_PROXY) is
-						not stored in the database, so it survives untouched. On an env-configured server
-						the new setup will already be filled in and locked for those steps — it is not a
+						not stored in the database, so it survives. On an env-configured server the new
+						setup will already be filled in and locked for those steps — it is not a
 						completely blank slate.
 					</p>
 				</div>
@@ -300,14 +307,19 @@ async function copyResetToken() {
 			{#if data.syncRunning}
 				<Alert>
 					<TriangleAlertIcon />
+					<AlertTitle>Reset is on hold while a sync runs</AlertTitle>
 					<AlertDescription>
-						A sync is running. Resetting is blocked until it finishes or you cancel it on the
-						Sync page — wiping mid-sync would leave the database half-written.
+						Wiping mid-sync would leave the database half-written. Wait for the sync to finish, or
+						cancel it on the <a href="/admin/sync">Sync</a> page.
 					</AlertDescription>
 				</Alert>
 			{/if}
 
-			<SettingsActionBar>
+			<SettingsActionBar align="between">
+				<p class="text-xs text-muted-foreground">
+					Takes three steps: you read what is lost, copy a fresh setup token, then type
+					{data.resetConfirmationPhrase} to confirm.
+				</p>
 				<Button
 					variant="destructive"
 					class="tap-target"
@@ -332,7 +344,10 @@ async function copyResetToken() {
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
-			<AlertDialog.Cancel disabled={isClearingCache}>Cancel</AlertDialog.Cancel>
+			<!-- `tap-target` on BOTH footer buttons: the 44px min-size utility on the
+			     Action alone made it visibly taller than a bare 36px Cancel. Cancel and
+			     the confirm button are equal-weight siblings, so they size identically. -->
+			<AlertDialog.Cancel class="tap-target" disabled={isClearingCache}>Cancel</AlertDialog.Cancel>
 			<form
 				method="POST"
 				action="?/clearCache"
@@ -378,7 +393,7 @@ async function copyResetToken() {
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
-			<AlertDialog.Cancel disabled={isClearingHistory}>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Cancel class="tap-target" disabled={isClearingHistory}>Cancel</AlertDialog.Cancel>
 			<form
 				method="POST"
 				action="?/clearPlayHistory"
@@ -425,6 +440,9 @@ async function copyResetToken() {
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<div class="space-y-3 text-sm">
+			<p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+				Where your data ends up
+			</p>
 			<div class="space-y-1">
 				<p class="font-medium">What comes back</p>
 				<p class="text-muted-foreground">
@@ -442,14 +460,21 @@ async function copyResetToken() {
 					year ranges or other hand-made curation. And the whole log history.
 				</p>
 			</div>
-			<p class="text-muted-foreground">
-				Anything you configured with environment variables (Plex, OpenAI, ORIGIN, TRUST_PROXY)
-				is not in the database and survives, so parts of the new setup will already be filled
-				in for you.
-			</p>
+			<div class="space-y-1">
+				<p class="font-medium">What is untouched</p>
+				<p class="text-muted-foreground">
+					Anything you configured with environment variables (Plex, OpenAI, ORIGIN, TRUST_PROXY)
+					is not in the database and survives, so parts of the new setup will already be filled
+					in for you.
+				</p>
+			</div>
 		</div>
 		<AlertDialog.Footer>
-			<AlertDialog.Cancel disabled={isPreparingReset} onclick={closeResetFlow}>
+			<AlertDialog.Cancel
+				class="tap-target"
+				disabled={isPreparingReset}
+				onclick={closeResetFlow}
+			>
 				Cancel
 			</AlertDialog.Cancel>
 			<form
@@ -537,7 +562,9 @@ async function copyResetToken() {
 			</div>
 		</div>
 		<AlertDialog.Footer>
-			<AlertDialog.Cancel disabled={isResetting} onclick={closeResetFlow}>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Cancel class="tap-target" disabled={isResetting} onclick={closeResetFlow}>
+				Cancel
+			</AlertDialog.Cancel>
 			<form
 				method="POST"
 				action="?/resetInstance"

--- a/src/routes/admin/settings/data/+page.svelte
+++ b/src/routes/admin/settings/data/+page.svelte
@@ -374,7 +374,15 @@ async function copyResetToken() {
 				}}
 				style="display: contents;"
 			>
-				<AlertDialog.Action type="submit" class="tap-target" disabled={isClearingCache}>
+				<!-- Destructive variant to match the trigger that opened this dialog: the
+				     confirm button must not read as a friendlier action than the button
+				     the admin just pressed. -->
+				<AlertDialog.Action
+					type="submit"
+					variant="destructive"
+					class="tap-target"
+					disabled={isClearingCache}
+				>
 					{isClearingCache ? 'Clearing…' : 'Clear cache'}
 				</AlertDialog.Action>
 			</form>
@@ -420,7 +428,12 @@ async function copyResetToken() {
 				}}
 				style="display: contents;"
 			>
-				<AlertDialog.Action type="submit" class="tap-target" disabled={isClearingHistory}>
+				<AlertDialog.Action
+					type="submit"
+					variant="destructive"
+					class="tap-target"
+					disabled={isClearingHistory}
+				>
 					{isClearingHistory ? 'Clearing…' : 'Clear play history'}
 				</AlertDialog.Action>
 			</form>
@@ -609,8 +622,11 @@ async function copyResetToken() {
 				}}
 				style="display: contents;"
 			>
+				<!-- The one irreversible submit on the page reads destructive. Stage 1's
+				     Continue stays primary on purpose: it only mints a token. -->
 				<AlertDialog.Action
 					type="submit"
+					variant="destructive"
 					class="tap-target"
 					disabled={isResetting || !resetConfirmationMatches}
 				>

--- a/src/routes/admin/settings/privacy/+page.server.ts
+++ b/src/routes/admin/settings/privacy/+page.server.ts
@@ -12,8 +12,11 @@ import {
 	getAnonymizationMode,
 	getAppSettingsUpdatedAt,
 	getPublicLandingLookupEnabled,
+	PRIVACY_PRESET_SECTIONS,
+	type PrivacyPresetSection,
 	PUBLIC_LANDING_LOOKUP_SETTINGS_KEYS,
 	SERVER_WRAPPED_SETTINGS_KEYS,
+	setPrivacyPresetAtomic,
 	setPublicLandingLookupEnabledAtomic,
 	setServerWrappedSettingsAtomic,
 	setUserDefaultsAtomic,
@@ -29,6 +32,9 @@ import {
 } from '$lib/server/sharing/service';
 import {
 	anonymizationOptions,
+	DEFAULT_PRIVACY_PRESET_ID,
+	PRIVACY_PRESET_IDS,
+	PRIVACY_PRESETS,
 	serverWrappedShareModeOptions,
 	shareModeOptions
 } from '$lib/sharing/options';
@@ -119,6 +125,53 @@ const PublicLandingLookupSchema = z.object({
 	settingsVersion: z.string().min(1, 'Missing settings version (reload the page)')
 });
 
+/**
+ * Human-readable section names for the cross-group conflict message. Match the
+ * card titles on the route so an admin can find the section that moved.
+ */
+const PRESET_SECTION_LABELS: Record<PrivacyPresetSection, string> = {
+	serverWrapped: 'Server-wide wrapped sharing',
+	userDefaults: 'User sharing defaults',
+	publicLandingLookup: 'Public landing lookup'
+};
+
+/**
+ * Conflict copy for `applyPrivacyPreset`. Keeps `OCC_CONFLICT_MESSAGE` intact as
+ * the leading sentinel (`surfaceOccConflict` surfaces `error` verbatim, and the
+ * suite asserts the sentinel), then states the two things a generic OCC message
+ * cannot: that the apply is all-or-nothing so NOTHING was written, and which
+ * sections changed underneath the tab.
+ */
+function presetConflictMessage(staleSections: readonly PrivacyPresetSection[]): string {
+	const names = staleSections.map((section) => PRESET_SECTION_LABELS[section]).join(', ');
+	return `${OCC_CONFLICT_MESSAGE} Nothing was applied — changed since this page loaded: ${names}.`;
+}
+
+/**
+ * OCC strategy: THREE INLINE versions, one per group the preset spans. A preset is
+ * one coherent privacy posture written across all three sections at once, so the
+ * form carries `serverWrappedVersion` / `userDefaultsVersion` /
+ * `publicLandingLookupVersion` and the action refuses the WHOLE apply if any one
+ * of them is stale — `setPrivacyPresetAtomic` gates all three inside a single
+ * transaction and writes nothing on conflict, so a partial apply is unreachable.
+ *
+ * `presetId` is the shipped-preset enum only. The client-only `custom` card has no
+ * value-map by definition, so it can never reach this action; a POST claiming it
+ * fails validation as a 400.
+ *
+ * The enum is `.optional()` on purpose. Superforms infers a required enum's default
+ * as its FIRST member, so a POST that simply omits `presetId` would otherwise pass
+ * validation and silently apply Maximum Privacy — a missing discriminator must
+ * never pick a privacy posture. Optional makes both an absent field and an empty
+ * value arrive as `undefined`, which the action rejects with a 400 before any write.
+ */
+const PrivacyPresetApplySchema = z.object({
+	presetId: z.enum(PRIVACY_PRESET_IDS).optional(),
+	serverWrappedVersion: z.string().min(1, 'Missing settings version (reload the page)'),
+	userDefaultsVersion: z.string().min(1, 'Missing settings version (reload the page)'),
+	publicLandingLookupVersion: z.string().min(1, 'Missing settings version (reload the page)')
+});
+
 export const load: PageServerLoad = async () => {
 	const [
 		anonymizationMode,
@@ -173,6 +226,22 @@ export const load: PageServerLoad = async () => {
 		{ id: 'publicLandingLookup' }
 	);
 
+	// Submission channel for the "apply preset" write. `presetId` is seeded with the
+	// shipped default only so the enum validates on load; the value that is actually
+	// submitted is the highlighted card, rendered into the form's hidden input. The
+	// three version fields mirror the sections' own `settingsVersion` values, so one
+	// submit can gate all three OCC groups.
+	const presetForm = await superValidate(
+		{
+			presetId: DEFAULT_PRIVACY_PRESET_ID,
+			serverWrappedVersion: serverWrappedSettingsVersion,
+			userDefaultsVersion: userDefaultsSettingsVersion,
+			publicLandingLookupVersion: publicLandingLookupSettingsVersion
+		},
+		zod4(PrivacyPresetApplySchema),
+		{ id: 'privacyPreset' }
+	);
+
 	return {
 		anonymizationMode,
 		// Option copy is sourced from the shared module so onboarding and settings
@@ -190,7 +259,8 @@ export const load: PageServerLoad = async () => {
 		publicLandingLookupSettingsVersion,
 		serverWrappedForm,
 		userDefaultsForm,
-		publicLandingLookupForm
+		publicLandingLookupForm,
+		presetForm
 	};
 };
 
@@ -349,6 +419,115 @@ export const actions: Actions = requireAdminActions({
 			const message = error instanceof Error ? error.message : String(error);
 			logger.error(`Failed to update public landing lookup: ${message}`, 'Privacy');
 			return fail(500, { form, error: 'Failed to update public landing lookup' });
+		}
+	},
+
+	/**
+	 * Applies one shipped privacy preset across ALL THREE sections in a single
+	 * atomic write.
+	 *
+	 * Why this action exists: a preset spans three independently-saved OCC groups
+	 * (`updateServerWrappedSettings`, `updatePublicLandingLookup`,
+	 * `updateUserDefaults`). Clicking a preset card used to only stage client-side
+	 * values, so Balanced → Custom → Balanced looked applied while the section that
+	 * actually changed stayed unsaved until the admin found its own Save button.
+	 *
+	 * Partial-conflict policy: the whole apply is refused, and nothing is written.
+	 * The pre-write `inlineOccCheck`s below and the second gate inside
+	 * `setPrivacyPresetAtomic` both evaluate all three groups before any row is
+	 * touched, so there is no state in which one section applied and another did
+	 * not. The 409 names every section that changed underneath the tab.
+	 *
+	 * `logoMode` is not in scope: it lives on the Appearance route and its own OCC
+	 * group, and admin preset matching covers only the five fields this route owns.
+	 */
+	applyPrivacyPreset: async ({ request }) => {
+		const form = await superValidate(request, zod4(PrivacyPresetApplySchema), {
+			id: 'privacyPreset'
+		});
+		if (!form.valid) {
+			const versionErrors = [
+				form.errors.serverWrappedVersion,
+				form.errors.userDefaultsVersion,
+				form.errors.publicLandingLookupVersion
+			];
+			if (versionErrors.some((errors) => errors?.length)) {
+				return fail(409, {
+					form,
+					conflict: true,
+					error: OCC_CONFLICT_MESSAGE
+				});
+			}
+			return fail(400, { form, error: 'Invalid input' });
+		}
+
+		const preset = PRIVACY_PRESETS.find((candidate) => candidate.id === form.data.presetId);
+		if (!preset) {
+			// Reached when `presetId` is absent or empty (see the schema's `.optional()`
+			// note), and it would also catch an id added to PRIVACY_PRESET_IDS without a
+			// matching value-map — failing loudly instead of writing undefined values.
+			return fail(400, { form, error: 'Invalid input' });
+		}
+
+		const submittedVersions: Record<PrivacyPresetSection, string> = {
+			serverWrapped: form.data.serverWrappedVersion,
+			userDefaults: form.data.userDefaultsVersion,
+			publicLandingLookup: form.data.publicLandingLookupVersion
+		};
+
+		const preChecks = await Promise.all([
+			inlineOccCheck(submittedVersions.serverWrapped, SERVER_WRAPPED_SETTINGS_KEYS),
+			inlineOccCheck(submittedVersions.userDefaults, USER_DEFAULTS_SETTINGS_KEYS),
+			inlineOccCheck(submittedVersions.publicLandingLookup, PUBLIC_LANDING_LOOKUP_SETTINGS_KEYS)
+		]);
+		const sections: PrivacyPresetSection[] = [
+			PRIVACY_PRESET_SECTIONS.SERVER_WRAPPED,
+			PRIVACY_PRESET_SECTIONS.USER_DEFAULTS,
+			PRIVACY_PRESET_SECTIONS.PUBLIC_LANDING_LOOKUP
+		];
+		const staleBeforeWrite = sections.filter(
+			(_section, index) => preChecks[index]?.status === 'conflict'
+		);
+		if (staleBeforeWrite.length > 0) {
+			return fail(409, {
+				form,
+				conflict: true,
+				error: presetConflictMessage(staleBeforeWrite)
+			});
+		}
+
+		try {
+			const result = await setPrivacyPresetAtomic({
+				anonymizationMode: preset.values.anonymizationMode as AnonymizationModeType,
+				serverWrappedShareMode: preset.values.serverWrappedShareMode,
+				defaultShareMode: preset.values.defaultShareMode,
+				allowUserControl: preset.values.allowUserControl,
+				publicLandingLookup: preset.values.publicLandingLookup,
+				submittedVersions
+			});
+			if (result.status === 'conflict') {
+				return fail(409, {
+					form,
+					conflict: true,
+					error: presetConflictMessage(result.staleSections)
+				});
+			}
+			// ISSUE-004: hand every section the version the transaction actually wrote,
+			// so each one's own Save button still works afterwards without a reload.
+			// One shared timestamp — the write covered all three groups at once.
+			const version = settingsVersionISO(result.version);
+			form.data.serverWrappedVersion = version;
+			form.data.userDefaultsVersion = version;
+			form.data.publicLandingLookupVersion = version;
+			return {
+				form,
+				success: true,
+				message: `Applied the ${preset.label} preset`
+			};
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			logger.error(`Failed to apply privacy preset: ${message}`, 'Privacy');
+			return fail(500, { form, error: 'Failed to apply the privacy preset' });
 		}
 	},
 

--- a/src/routes/admin/settings/privacy/+page.server.ts
+++ b/src/routes/admin/settings/privacy/+page.server.ts
@@ -466,7 +466,12 @@ export const actions: Actions = requireAdminActions({
 			// Reached when `presetId` is absent or empty (see the schema's `.optional()`
 			// note), and it would also catch an id added to PRIVACY_PRESET_IDS without a
 			// matching value-map — failing loudly instead of writing undefined values.
-			return fail(400, { form, error: 'Invalid input' });
+			//
+			// This 400 is SEMANTIC: the payload satisfied the schema, so the returned form
+			// is still `valid` and the client's `guardSettingsUpdate` surfaces this exact
+			// string. It therefore says what happened rather than reusing the generic
+			// schema-failure copy above.
+			return fail(400, { form, error: 'No preset selected' });
 		}
 
 		const submittedVersions: Record<PrivacyPresetSection, string> = {

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -195,6 +195,58 @@ const {
 	submitting: publicLandingLookupSubmitting
 } = publicLandingLookupForm;
 
+// Fourth form: the "apply preset" write. It owns no controls of its own — the
+// preset cards and the Apply button both submit it — and it spans all THREE OCC
+// groups, so a successful apply advances every section's baseline AND its
+// settingsVersion. See `applyPrivacyPreset` in +page.server.ts for the
+// all-or-nothing partial-conflict policy behind the shared version.
+// svelte-ignore state_referenced_locally
+const presetForm = superForm(data.presetForm, {
+	resetForm: false,
+	invalidateAll: false,
+	onUpdate: guardSettingsUpdate,
+	onUpdated({ form: updated }) {
+		if (!updated.valid) {
+			handleFormToast({ error: updated.message ?? 'Validation failed' });
+			return;
+		}
+		const applied = PRIVACY_PRESETS.find((candidate) => candidate.id === updated.data.presetId);
+		if (!applied) {
+			handleFormToast({ error: 'Unknown preset' });
+			return;
+		}
+		// The server wrote all three groups in one transaction, so the staged values
+		// ARE the saved values now: advance the stores, the three settingsVersions
+		// and all three baselines together. That is what makes the Advanced sections
+		// below read as saved rather than staged.
+		assignPresetValues(applied.values);
+		$serverWrappedData.settingsVersion = updated.data.serverWrappedVersion;
+		$userDefaultsData.settingsVersion = updated.data.userDefaultsVersion;
+		$publicLandingLookupData.settingsVersion = updated.data.publicLandingLookupVersion;
+		savedServerWrapped = {
+			anonymizationMode: applied.values.anonymizationMode,
+			serverWrappedShareMode: applied.values.serverWrappedShareMode
+		};
+		savedUserDefaults = {
+			defaultShareMode: applied.values.defaultShareMode,
+			allowUserControl: applied.values.allowUserControl
+		};
+		savedPublicLandingLookup = { publicLandingLookup: applied.values.publicLandingLookup };
+		customPresetChosen = false;
+		privacyInteracted = true;
+		// The action keeps its name through the whole flow: the button says "Apply
+		// Balanced", so the toast says "Applied the Balanced preset" — not a generic
+		// "Saved" that gives no hint which of six cards actually landed.
+		handleFormToast({ success: true, message: `Applied the ${applied.label} preset` });
+	}
+});
+const { enhance: presetEnhance, submitting: presetSubmitting } = presetForm;
+
+// The <form> the preset cards submit programmatically. Its hidden inputs are
+// rendered from the highlighted card and the three sections' live
+// settingsVersions, so a submit always carries current values.
+let presetFormEl = $state<HTMLFormElement | null>(null);
+
 let bulkApplyDialogOpen = $state(false);
 let isBulkApplying = $state(false);
 
@@ -308,9 +360,8 @@ let selectedPresetCard = $derived(
 	resolvePresetSelection(selectedPreset, privacyTouched, customPresetChosen)
 );
 
-// Applying a preset is pure client-side state mutation across the three stores.
-// It writes the FIVE admin-owned fields and NEVER touches logoMode. Persistence
-// still flows through each section's existing Save button + OCC group.
+// Staging the five admin-owned fields across the three stores. NEVER touches
+// logoMode — that lives on the Appearance route and its own OCC group.
 function assignPresetValues(values: Pick<PrivacyPresetValues, PrivacyPresetPrivacyKey>) {
 	$serverWrappedData.anonymizationMode = values.anonymizationMode;
 	$serverWrappedData.serverWrappedShareMode = values.serverWrappedShareMode;
@@ -319,17 +370,30 @@ function assignPresetValues(values: Pick<PrivacyPresetValues, PrivacyPresetPriva
 	$publicLandingLookupData.publicLandingLookup = values.publicLandingLookup;
 }
 
-function applyPrivacyPreset(preset: PrivacyPreset) {
+/**
+ * Whether a preset interaction also PERSISTS.
+ *
+ * `persist` is what a card click (mouse, Enter, Space) and the explicit Apply
+ * button use: one `?/applyPrivacyPreset` POST writes all five fields across the
+ * three OCC groups atomically, so nothing is left staged.
+ *
+ * `stage-only` is what the roving-tabindex ARROW keys use. An APG radiogroup moves
+ * its selection as focus moves, and firing one three-section write per ArrowRight
+ * would be absurd; the arrows stage, and the Apply button commits what they landed
+ * on. That is also why the button is not redundant with the cards.
+ */
+type PresetCommit = 'persist' | 'stage-only';
+
+async function applyPrivacyPreset(preset: PrivacyPreset, commit: PresetCommit = 'persist') {
 	privacyInteracted = true;
 	customPresetChosen = false;
 	assignPresetValues(preset.values);
-	// ISSUE-006: applying a preset stages unsaved changes whose per-section Save
-	// buttons live inside the (possibly collapsed) Advanced accordion. Auto-expand
-	// so the "{n} unsaved sections" alert never points at hidden Save buttons.
-	// Only ever opens — never force-collapses — and both the card click and the
-	// keyboard arrow handler route through here. (No state-in-$effect: this is an
-	// explicit user action, respecting the file's no-effect-writes rule.)
-	advancedOpen = true;
+	if (commit === 'stage-only' || $presetSubmitting) return;
+	// Let the staged values reach `presetIdToSubmit`'s hidden input before the
+	// native submit reads the form. (No state-in-$effect: this is an explicit user
+	// action, respecting the file's no-effect-writes rule.)
+	await tick();
+	presetFormEl?.requestSubmit();
 }
 
 // Custom is a pure highlight change on this route: it stages NOTHING. The admin
@@ -339,7 +403,9 @@ function applyPrivacyPreset(preset: PrivacyPreset) {
 // administrator's saved privacy settings. Making the gate latch (above) does not
 // change that: a fresh load has latched nothing either way. Admins who do want
 // that baseline click the Balanced card, which sits in the same radiogroup.
-// Advanced is still expanded — Custom's whole point is the controls below it.
+// Advanced is still expanded — Custom's whole point is the controls below it, and
+// the only way to reach an off-preset configuration is to edit them and save that
+// section. Custom therefore also has nothing for the Apply button to write.
 function selectCustomPreset() {
 	privacyInteracted = true;
 	customPresetChosen = true;
@@ -353,6 +419,9 @@ let presetButtons = $state<(HTMLButtonElement | null)[]>([]);
 
 const CUSTOM_PRESET_INDEX = PRIVACY_PRESETS.length;
 
+// Called by the roving-tabindex ARROW keys only, so every branch stages without
+// writing: `applyPrivacyPreset(preset, 'stage-only')` for a shipped preset and
+// `selectCustomPreset()` — which stages nothing at all — for the Custom slot.
 function selectPresetAtIndex(index: number): boolean {
 	if (index === CUSTOM_PRESET_INDEX) {
 		selectCustomPreset();
@@ -360,9 +429,53 @@ function selectPresetAtIndex(index: number): boolean {
 	}
 	const preset = PRIVACY_PRESETS[index];
 	if (!preset) return false;
-	applyPrivacyPreset(preset);
+	applyPrivacyPreset(preset, 'stage-only');
 	return true;
 }
+
+// What the explicit Apply button would write: the highlighted card resolved to a
+// shipped preset. `null` for the Custom card (no value-map by definition) and
+// before the admin has interacted at all, which is exactly when there is nothing
+// to apply.
+let applicablePreset = $derived(
+	PRIVACY_PRESETS.find((preset) => preset.id === selectedPresetCard) ?? null
+);
+
+// Whether the highlighted preset is ALREADY what is persisted. Read from the
+// per-section saved baselines, not the staged stores, so the button is enabled
+// exactly when applying would change something on the server — which is what keeps
+// it from feeling like a duplicate of the card click that just persisted.
+let applicablePresetIsSaved = $derived(
+	applicablePreset !== null &&
+		matchPresetPrivacy({
+			anonymizationMode: savedServerWrapped.anonymizationMode,
+			defaultShareMode: savedUserDefaults.defaultShareMode,
+			serverWrappedShareMode: savedServerWrapped.serverWrappedShareMode,
+			publicLandingLookup: savedPublicLandingLookup.publicLandingLookup,
+			allowUserControl: savedUserDefaults.allowUserControl
+		}) === applicablePreset.id
+);
+
+let canApplyPreset = $derived(
+	applicablePreset !== null && !applicablePresetIsSaved && !$presetSubmitting
+);
+
+// The submitted preset id. Empty for Custom and for "no card highlighted", both of
+// which also disable the button — the action's Zod enum rejects either anyway.
+let presetIdToSubmit = $derived(applicablePreset?.id ?? '');
+
+// One line that states the truth about the selection relative to what is saved.
+// This is the whole reason the Apply button reads as deliberate rather than
+// redundant: it always says why it is or is not available.
+let presetApplyStatus = $derived.by(() => {
+	if ($presetSubmitting) return 'Applying to all three sections…';
+	if (selectedPresetCard === 'custom') {
+		return 'Custom has no values of its own. Set the controls in Advanced options, then save that section.';
+	}
+	if (!applicablePreset) return 'Pick a preset to save it across all three sections at once.';
+	if (applicablePresetIsSaved) return `${applicablePreset.label} is the saved configuration.`;
+	return `${applicablePreset.label} is selected but not saved yet.`;
+});
 
 let presetTabIndex = $derived.by(() => {
 	if (selectedPresetCard === 'custom') return CUSTOM_PRESET_INDEX;
@@ -494,9 +607,10 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 		<CardHeader>
 			<CardTitle>Privacy presets</CardTitle>
 			<CardDescription>
-				Pick a recommended starting point, then save each affected section below. These presets
-				stage five privacy fields here; the full onboarding presets also set the Wrapped logo to
-				Always Show.
+				A preset is one privacy posture. Picking a card saves all five fields it owns across the
+				three sections below in one write — the Save buttons down there are only for
+				hand-editing a single field. The full onboarding presets also set the Wrapped logo to
+				Always Show; this page does not.
 			</CardDescription>
 		</CardHeader>
 		<CardContent class="space-y-4">
@@ -556,6 +670,53 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 					Custom configuration — your settings don’t match a preset.
 				</p>
 			{/if}
+			<!-- The commit surface. A card click already submits this form; the button is
+			     the deliberate, visible route for the keyboard path (arrow keys move the
+			     radiogroup selection without writing) and for re-applying after an
+			     Advanced edit landed on a preset. Its status line states why it is or is
+			     not available, so the two affordances never read as duplicates. -->
+			<form
+				method="POST"
+				action="?/applyPrivacyPreset"
+				bind:this={presetFormEl}
+				use:presetEnhance
+			>
+				<input type="hidden" name="presetId" value={presetIdToSubmit} />
+				<input
+					type="hidden"
+					name="serverWrappedVersion"
+					value={$serverWrappedData.settingsVersion}
+				/>
+				<input type="hidden" name="userDefaultsVersion" value={$userDefaultsData.settingsVersion} />
+				<input
+					type="hidden"
+					name="publicLandingLookupVersion"
+					value={$publicLandingLookupData.settingsVersion}
+				/>
+				<SettingsActionBar align="between">
+					<!-- Described-by rather than a live region: the status changes on every
+					     arrow-key move through the radiogroup, and an aria-live line would
+					     talk over the card being announced. As a description it instead
+					     gives the (often disabled) button its reason. -->
+					<p id="preset-apply-status" class="text-xs text-muted-foreground">
+						{presetApplyStatus}
+					</p>
+					<Button
+						type="submit"
+						class="tap-target"
+						disabled={!canApplyPreset}
+						aria-describedby="preset-apply-status"
+					>
+						{#if $presetSubmitting}
+							Applying…
+						{:else if applicablePreset}
+							Apply {applicablePreset.label}
+						{:else}
+							Apply preset
+						{/if}
+					</Button>
+				</SettingsActionBar>
+			</form>
 			<div class="flex items-start gap-2 rounded-lg border border-border bg-muted/30 p-3 text-sm">
 				<ImageIcon class="mt-0.5 size-4 shrink-0 text-muted-foreground" />
 				<div class="space-y-1">
@@ -586,7 +747,13 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 					<TriangleAlertIcon />
 					<AlertDescription>
 						{unsavedSectionCount} unsaved section{unsavedSectionCount === 1 ? '' : 's'} — staged changes
-						aren't live until you save each section below.
+						aren't live yet.
+						{#if applicablePreset}
+							Apply {applicablePreset.label} above to save all of them at once, or save each section
+							below.
+						{:else}
+							Save each section below.
+						{/if}
 					</AlertDescription>
 				</Alert>
 			{/if}
@@ -885,7 +1052,9 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
-			<AlertDialog.Cancel disabled={isBulkApplying}>Cancel</AlertDialog.Cancel>
+			<!-- `tap-target` on BOTH footer buttons: the 44px min-size utility on the
+			     Action alone made it visibly taller than a bare 36px Cancel. -->
+			<AlertDialog.Cancel class="tap-target" disabled={isBulkApplying}>Cancel</AlertDialog.Cancel>
 			<form
 				method="POST"
 				action="?/bulkApplyShareDefaults"

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -375,7 +375,9 @@ function assignPresetValues(values: Pick<PrivacyPresetValues, PrivacyPresetPriva
  *
  * `persist` is what a card click (mouse, Enter, Space) and the explicit Apply
  * button use: one `?/applyPrivacyPreset` POST writes all five fields across the
- * three OCC groups atomically, so nothing is left staged.
+ * three OCC groups atomically, so nothing is left staged. The POST is still
+ * skipped when it would write values that are already persisted — see
+ * `presetMatchesSaved` below.
  *
  * `stage-only` is what the roving-tabindex ARROW keys use. An APG radiogroup moves
  * its selection as focus moves, and firing one three-section write per ArrowRight
@@ -384,11 +386,47 @@ function assignPresetValues(values: Pick<PrivacyPresetValues, PrivacyPresetPriva
  */
 type PresetCommit = 'persist' | 'stage-only';
 
+/**
+ * Whether `preset` is EXACTLY what the three per-section baselines already hold,
+ * i.e. whether applying it would write values that are already persisted.
+ *
+ * Read from the saved baselines rather than the staged stores, so a card that
+ * has only staged still counts as "not saved yet". Shared by the Apply button's
+ * enablement and by the card-click path, because those two must never disagree
+ * about whether there is anything to write.
+ */
+function presetMatchesSaved(preset: PrivacyPreset): boolean {
+	return (
+		matchPresetPrivacy({
+			anonymizationMode: savedServerWrapped.anonymizationMode,
+			defaultShareMode: savedUserDefaults.defaultShareMode,
+			serverWrappedShareMode: savedServerWrapped.serverWrappedShareMode,
+			publicLandingLookup: savedPublicLandingLookup.publicLandingLookup,
+			allowUserControl: savedUserDefaults.allowUserControl
+		}) === preset.id
+	);
+}
+
 async function applyPrivacyPreset(preset: PrivacyPreset, commit: PresetCommit = 'persist') {
+	// The in-flight guard comes BEFORE any mutation. An apply already writing all
+	// three groups rewrites the stores and clears `customPresetChosen` from its own
+	// response, so staging another card underneath it only flickers the highlight
+	// and the "After you save" preview before snapping back to what that apply
+	// wrote — a click that visibly did nothing.
+	if ($presetSubmitting) return;
 	privacyInteracted = true;
 	customPresetChosen = false;
 	assignPresetValues(preset.values);
-	if (commit === 'stage-only' || $presetSubmitting) return;
+	if (commit === 'stage-only') return;
+	// A card click on the preset that is ALREADY persisted has nothing to write.
+	// Submitting anyway would stamp a strictly-advancing `updatedAt` on all three
+	// OCC groups (see `setPrivacyPresetAtomic`), 409-ing every other admin tab over
+	// a write that changed no value. This is the same condition the Apply button
+	// disables itself on, and `presetApplyStatus` already says "… is the saved
+	// configuration", so the skip is explained rather than silent. The staging
+	// above still ran, which is what reverts unsaved Advanced edits back to the
+	// card the admin just clicked.
+	if (presetMatchesSaved(preset)) return;
 	// Let the staged values reach `presetIdToSubmit`'s hidden input before the
 	// native submit reads the form. (No state-in-$effect: this is an explicit user
 	// action, respecting the file's no-effect-writes rule.)
@@ -407,6 +445,10 @@ async function applyPrivacyPreset(preset: PrivacyPreset, commit: PresetCommit = 
 // the only way to reach an off-preset configuration is to edit them and save that
 // section. Custom therefore also has nothing for the Apply button to write.
 function selectCustomPreset() {
+	// Same in-flight rule as the shipped cards: a running apply clears
+	// `customPresetChosen` in its own `onUpdated`, so highlighting Custom
+	// underneath it would only be undone.
+	if ($presetSubmitting) return;
 	privacyInteracted = true;
 	customPresetChosen = true;
 	advancedOpen = true;
@@ -422,7 +464,12 @@ const CUSTOM_PRESET_INDEX = PRIVACY_PRESETS.length;
 // Called by the roving-tabindex ARROW keys only, so every branch stages without
 // writing: `applyPrivacyPreset(preset, 'stage-only')` for a shipped preset and
 // `selectCustomPreset()` — which stages nothing at all — for the Custom slot.
+//
+// Returns false while an apply is in flight, because both of those refuse to move
+// the selection then. Reporting that refusal keeps the roving tab stop on the
+// still-selected card instead of letting focus desync from `aria-checked`.
 function selectPresetAtIndex(index: number): boolean {
+	if ($presetSubmitting) return false;
 	if (index === CUSTOM_PRESET_INDEX) {
 		selectCustomPreset();
 		return true;
@@ -446,14 +493,7 @@ let applicablePreset = $derived(
 // exactly when applying would change something on the server — which is what keeps
 // it from feeling like a duplicate of the card click that just persisted.
 let applicablePresetIsSaved = $derived(
-	applicablePreset !== null &&
-		matchPresetPrivacy({
-			anonymizationMode: savedServerWrapped.anonymizationMode,
-			defaultShareMode: savedUserDefaults.defaultShareMode,
-			serverWrappedShareMode: savedServerWrapped.serverWrappedShareMode,
-			publicLandingLookup: savedPublicLandingLookup.publicLandingLookup,
-			allowUserControl: savedUserDefaults.allowUserControl
-		}) === applicablePreset.id
+	applicablePreset !== null && presetMatchesSaved(applicablePreset)
 );
 
 let canApplyPreset = $derived(
@@ -614,10 +654,15 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 			</CardDescription>
 		</CardHeader>
 		<CardContent class="space-y-4">
+			<!-- `aria-busy` rather than `disabled` on the cards: every handler below
+			     refuses to move the selection while an apply is in flight, and the
+			     native attribute would drop the card out of the tab order and break
+			     the single roving tab stop `presetTabIndex` maintains. -->
 			<div
 				class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3"
 				role="radiogroup"
 				aria-label="Privacy preset"
+				aria-busy={$presetSubmitting}
 			>
 				{#each PRIVACY_PRESETS as preset, i (preset.id)}
 					{@const PresetIcon = presetIcons[preset.id]}

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -64,7 +64,7 @@ import {
 	resolvePresetSelection
 } from '$lib/sharing/preset-logic';
 import { handleFormToast } from '$lib/utils/form-toast';
-import { surfaceOccConflict } from '$lib/utils/occ-form';
+import { isOccConflict, isPostValidationFailure, surfaceOccConflict } from '$lib/utils/occ-form';
 import type { PageData } from './$types';
 
 interface Props {
@@ -73,24 +73,35 @@ interface Props {
 
 let { data }: Props = $props();
 
-// superForm `onUpdate` guard for the three settings forms. Runs the shared OCC
-// stale-write guard first (cancels on fail(409,{conflict:true}) — ISSUE-006),
-// then also cancels on a *server-side* failure whose form is still schema-valid:
-// the actions return `fail(500, { form, error })` from their catch blocks AFTER
-// validation, so `onUpdated`'s `form.valid` stays true and would otherwise fire a
-// false "Saved" toast + advance the saved baseline even though nothing persisted.
-// fail(400) validation failures have `form.valid === false` and are left alone so
-// they still reach `onUpdated`'s else branch to render field errors. (Locally
-// scoped — the shared occ-form helper is intentionally not generalised here.)
+// superForm `onUpdate` guard for the four forms on this route. Runs the shared
+// OCC stale-write guard first (cancels on fail(409,{conflict:true}) — ISSUE-006),
+// then cancels every OTHER post-validation failure.
+//
+// The discriminator is the RETURNED FORM's own `valid` flag, not the status code.
+// An action that fails AFTER `superValidate` passed hands back a form that is
+// still `valid`, so `onUpdated` takes its success branch and would fire a false
+// "Saved" toast and advance the saved baseline even though nothing persisted.
+// That covers both the `fail(500, { form, error })` catch blocks and
+// `applyPrivacyPreset`'s semantic `fail(400, { form, error: 'Invalid input' })`,
+// which is schema-valid because `presetId` is `.optional()` — a status-only test
+// let that one through to `onUpdated`, where it surfaced the client's own
+// "Unknown preset" instead of the action's message.
+//
+// Schema failures are still left alone: they carry `form.valid === false` and must
+// reach `onUpdated`'s else branch, which renders the field errors. The two
+// predicates live in `$lib/utils/occ-form` because they classify a failure PAYLOAD,
+// which is not route-specific; the toast/cancel policy assembled from them is what
+// stays local to this page.
 function guardSettingsUpdate(event: { result: ActionResult; cancel: () => void }): void {
 	surfaceOccConflict(event);
 	const { result } = event;
-	if (result.type === 'failure' && result.status >= 500) {
-		const message =
-			(result.data as { error?: string } | undefined)?.error ?? 'Failed to save. Please try again.';
-		handleFormToast({ error: message });
-		event.cancel();
-	}
+	if (result.type !== 'failure') return;
+	// Already surfaced and cancelled above; a second toast would double up.
+	if (isOccConflict(result.data)) return;
+	if (!isPostValidationFailure(result.data)) return;
+	const failure = result.data as { error?: string } | undefined;
+	handleFormToast({ error: failure?.error ?? 'Failed to save. Please try again.' });
+	event.cancel();
 }
 
 // Per-section "last saved" baselines. Each advances ONLY after its own section
@@ -210,6 +221,11 @@ const presetForm = superForm(data.presetForm, {
 			handleFormToast({ error: updated.message ?? 'Validation failed' });
 			return;
 		}
+		// Unreachable since `guardSettingsUpdate` began cancelling post-validation
+		// failures: reaching here with a valid form means the result was a `success`,
+		// which proves the action's own `PRIVACY_PRESETS.find` matched. Retained
+		// deliberately — the action anticipates an id added to `PRIVACY_PRESET_IDS`
+		// without a value-map, and a toast beats `assignPresetValues(undefined)`.
 		const applied = PRIVACY_PRESETS.find((candidate) => candidate.id === updated.data.presetId);
 		if (!applied) {
 			handleFormToast({ error: 'Unknown preset' });

--- a/tests/unit/admin/instance-reset.test.ts
+++ b/tests/unit/admin/instance-reset.test.ts
@@ -603,4 +603,78 @@ describe('instance reset — Danger zone UI wiring (no DOM harness in this suite
 			expect(call).not.toContain('token');
 		}
 	});
+
+	it('titles the card with what the action does and keeps severity as a badge eyebrow', async () => {
+		// "Danger zone" alone signals severity but never says what the button does.
+		// The retitle must not trade the severity signal away to gain the "what".
+		const src = await read();
+		const dangerIdx = src.indexOf('<Card class="border-destructive/50">');
+		const cardBlock = src.slice(dangerIdx, src.indexOf('</Card>', dangerIdx));
+		expect(cardBlock).toContain(
+			'<CardTitle class="text-destructive">Reset this Obzorarr instance</CardTitle>'
+		);
+		const badgeIdx = cardBlock.indexOf('<Badge');
+		const badge = cardBlock.slice(badgeIdx, cardBlock.indexOf('</Badge>'));
+		expect(badge).toContain('variant="destructive"');
+		expect(badge).toContain('Danger zone');
+		expect(badge).toContain('<TriangleAlertIcon />');
+		// Eyebrow, so it reads above the title rather than replacing it.
+		expect(badgeIdx).toBeLessThan(cardBlock.indexOf('<CardTitle'));
+	});
+
+	it('frames the three-way data classification with a lead-in', async () => {
+		// The box used to open on a bare "Comes back on its own" — meaningless read
+		// cold, because nothing above it said what the three blocks classify.
+		const prose = await readProse();
+		expect(prose).toContain('Where your data ends up');
+		expect(prose).not.toContain('Comes back on its own');
+		expect(prose).not.toContain('Gone for good');
+		expect(prose).not.toContain('Set by environment variables');
+	});
+
+	it('uses one vocabulary for the three facts in the card and the confirm dialog', async () => {
+		// The card and the stage-1 dialog state the same three facts. They must not
+		// label them differently, or an admin reads two vocabularies for one truth.
+		const src = await read();
+		const labels = ['What comes back', 'What does not', 'What is untouched'];
+		const cardIdx = src.indexOf('<Card class="border-destructive/50">');
+		const cardBlock = src.slice(cardIdx, src.indexOf('</Card>', cardIdx));
+		const prepareIdx = src.indexOf('action="?/prepareInstanceReset"');
+		const dialogBlock = src.slice(src.lastIndexOf('<AlertDialog.Root', prepareIdx), prepareIdx);
+		for (const surface of [cardBlock, dialogBlock]) {
+			expect(surface).toContain('Where your data ends up');
+			let cursor = -1;
+			for (const label of labels) {
+				const at = surface.indexOf(`<p class="font-medium">${label}</p>`);
+				expect(at).toBeGreaterThan(cursor);
+				cursor = at;
+			}
+		}
+	});
+
+	it('sizes Cancel and the confirm button identically in every dialog on the page', async () => {
+		// `.tap-target` is the 44px WCAG min-size utility. It used to sit on the
+		// Action only — which lives inside a <form>, so the omission on the bare
+		// 36px Cancel was easy to miss — and the pair rendered visibly mismatched.
+		const src = await read();
+		const footers = src.split('<AlertDialog.Footer>').slice(1);
+		expect(footers).toHaveLength(4);
+		for (const raw of footers) {
+			const footer = raw.slice(0, raw.indexOf('</AlertDialog.Footer>'));
+			for (const tag of ['<AlertDialog.Cancel', '<AlertDialog.Action']) {
+				const start = footer.indexOf(tag);
+				expect(start).toBeGreaterThan(-1);
+				expect(footer.slice(start, footer.indexOf('>', start))).toContain('tap-target');
+			}
+		}
+	});
+
+	it('names the sync-blocked state and where to clear it', async () => {
+		const src = await read();
+		const start = src.indexOf('{#if data.syncRunning}');
+		const block = src.slice(start, src.indexOf('{/if}', start));
+		expect(block).toContain('<AlertTitle>');
+		// The copy tells the admin where to go, not just that they cannot proceed.
+		expect(block).toContain('href="/admin/sync"');
+	});
 });

--- a/tests/unit/admin/privacy-preset-apply.test.ts
+++ b/tests/unit/admin/privacy-preset-apply.test.ts
@@ -289,9 +289,30 @@ describe('privacy nested route — applyPrivacyPreset rejects non-presets', () =
 		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid input' } });
 	});
 
-	it('rejects a missing presetId as a 400', async () => {
+	it('rejects a missing presetId as a 400 that names the actual problem', async () => {
 		const result = await runApply({ ...versionsAt(EPOCH) });
-		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid input' } });
+		// Distinct from the generic schema-failure copy: this 400 is the one the client
+		// surfaces verbatim, so it has to say what happened.
+		expect(result).toMatchObject({ status: 400, data: { error: 'No preset selected' } });
+	});
+
+	it('splits the two 400 shapes on form.valid, which is what the client keys on', async () => {
+		// `presetId` is `.optional()`, so an ABSENT field passes the schema and is only
+		// refused afterwards by the `!preset` guard: the returned form is still valid,
+		// so superForm's `onUpdated` would take its SUCCESS branch. The client's
+		// `guardSettingsUpdate` therefore cancels on `form.valid`, not on the status.
+		const missing = (await runApply({ ...versionsAt(EPOCH) })) as {
+			data: { form: { valid: boolean } };
+		};
+		expect(missing.data.form.valid).toBe(true);
+
+		// A value the enum rejects fails validation instead, and MUST stay valid ===
+		// false so it reaches `onUpdated`'s field-error branch rather than a toast.
+		const unknown = (await runApply({
+			presetId: 'ultra-private',
+			...versionsAt(EPOCH)
+		})) as { data: { form: { valid: boolean } } };
+		expect(unknown.data.form.valid).toBe(false);
 	});
 });
 
@@ -331,6 +352,26 @@ describe('privacy preset apply — client wiring (no DOM harness in this suite)'
 		const form = src.slice(src.indexOf('const presetForm = superForm('));
 		expect(form.slice(0, form.indexOf('\n});'))).toContain('onUpdate: guardSettingsUpdate');
 		expect(src).toContain('surfaceOccConflict(event);');
+	});
+
+	it('cancels every post-validation failure instead of testing the status code', async () => {
+		const src = await read();
+		// `applyPrivacyPreset` returns fail(400, { form, error }) from its `!preset`
+		// guard on a payload that PASSED the schema (`presetId` is `.optional()`), so
+		// the returned form is still `valid` and `onUpdated` took its success branch —
+		// surfacing the client's own "Unknown preset" instead of the action's message.
+		// A `status >= 500` test cannot see that.
+		const guard = bodyOf(src, 'function guardSettingsUpdate(');
+		expect(guard).toContain('if (!isPostValidationFailure(result.data)) return;');
+		// No status arithmetic left anywhere in the guard, spelled or destructured.
+		expect(guard).not.toContain('result.status');
+		expect(guard).not.toContain('status');
+		// The OCC 409 is already surfaced and cancelled by surfaceOccConflict; falling
+		// through would toast twice, since a post-write 409 is post-validation too.
+		const surfaceAt = guard.indexOf('surfaceOccConflict(event);');
+		const occReturnAt = guard.indexOf('if (isOccConflict(result.data)) return;');
+		expect(surfaceAt).toBeGreaterThan(-1);
+		expect(occReturnAt).toBeGreaterThan(surfaceAt);
 	});
 
 	it('persists on a card click and only stages on the arrow keys', async () => {

--- a/tests/unit/admin/privacy-preset-apply.test.ts
+++ b/tests/unit/admin/privacy-preset-apply.test.ts
@@ -1,0 +1,412 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import {
+	getAnonymizationMode,
+	getPublicLandingLookupEnabled
+} from '$lib/server/admin/settings.service';
+import {
+	getGlobalAllowUserControl,
+	getGlobalDefaultShareMode,
+	getServerWrappedShareMode
+} from '$lib/server/sharing/service';
+import { PRIVACY_PRESETS } from '$lib/sharing/options';
+import { matchPresetPrivacy } from '$lib/sharing/preset-logic';
+import { actions } from '../../../src/routes/admin/settings/privacy/+page.server';
+import { resetSharedTestDb } from '../../helpers/db';
+
+type ApplyPresetAction = NonNullable<typeof actions.applyPrivacyPreset>;
+type UpdatePublicLandingLookupAction = NonNullable<typeof actions.updatePublicLandingLookup>;
+type UpdateUserDefaultsAction = NonNullable<typeof actions.updateUserDefaults>;
+
+const adminLocals = {
+	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
+} as unknown as App.Locals;
+
+const EPOCH = new Date(0).toISOString();
+const OCC_MESSAGE = 'Settings changed in another tab. Please reload.';
+
+function makeRequest(action: string, fields: Record<string, string>): Request {
+	const formData = new FormData();
+	for (const [k, v] of Object.entries(fields)) formData.set(k, v);
+	return new Request(`http://localhost/admin/settings/privacy?/${action}`, {
+		method: 'POST',
+		body: formData
+	});
+}
+
+function presetById(id: string) {
+	const preset = PRIVACY_PRESETS.find((candidate) => candidate.id === id);
+	if (!preset) throw new Error(`Unknown preset ${id}`);
+	return preset;
+}
+
+/** Every version field at the given value — the "nothing has been written yet" shape. */
+function versionsAt(version: string) {
+	return {
+		serverWrappedVersion: version,
+		userDefaultsVersion: version,
+		publicLandingLookupVersion: version
+	};
+}
+
+async function runApply(fields: Record<string, string>) {
+	const handler = actions.applyPrivacyPreset as ApplyPresetAction;
+	return handler({
+		request: makeRequest('applyPrivacyPreset', fields),
+		locals: adminLocals
+	} as Parameters<ApplyPresetAction>[0]);
+}
+
+async function runPublicLookup(fields: Record<string, string>) {
+	const handler = actions.updatePublicLandingLookup as UpdatePublicLandingLookupAction;
+	return handler({
+		request: makeRequest('updatePublicLandingLookup', fields),
+		locals: adminLocals
+	} as Parameters<UpdatePublicLandingLookupAction>[0]);
+}
+
+async function runUserDefaults(fields: Record<string, string>) {
+	const handler = actions.updateUserDefaults as UpdateUserDefaultsAction;
+	return handler({
+		request: makeRequest('updateUserDefaults', fields),
+		locals: adminLocals
+	} as Parameters<UpdateUserDefaultsAction>[0]);
+}
+
+/** The five admin-owned fields as currently persisted. */
+async function readPersistedPrivacy() {
+	const [
+		anonymizationMode,
+		defaultShareMode,
+		serverWrappedShareMode,
+		publicLandingLookup,
+		allowUserControl
+	] = await Promise.all([
+		getAnonymizationMode(),
+		getGlobalDefaultShareMode(),
+		getServerWrappedShareMode(),
+		getPublicLandingLookupEnabled(),
+		getGlobalAllowUserControl()
+	]);
+	return {
+		anonymizationMode,
+		defaultShareMode,
+		serverWrappedShareMode,
+		publicLandingLookup,
+		allowUserControl
+	};
+}
+
+describe('privacy nested route — applyPrivacyPreset persists every section', () => {
+	beforeEach(resetSharedTestDb);
+
+	it.each(PRIVACY_PRESETS.map((preset) => preset.id))(
+		'writes all five admin-owned fields for %s in one request',
+		async (id) => {
+			const preset = presetById(id);
+			const result = await runApply({ presetId: id, ...versionsAt(EPOCH) });
+			expect(result).toMatchObject({
+				success: true,
+				message: `Applied the ${preset.label} preset`
+			});
+
+			const persisted = await readPersistedPrivacy();
+			expect(persisted).toEqual({
+				anonymizationMode: preset.values.anonymizationMode,
+				defaultShareMode: preset.values.defaultShareMode,
+				serverWrappedShareMode: preset.values.serverWrappedShareMode,
+				publicLandingLookup: preset.values.publicLandingLookup,
+				allowUserControl: preset.values.allowUserControl
+			});
+			// ...and the persisted configuration reads back as that exact preset, so the
+			// card highlight after a reload is not "Custom".
+			expect(matchPresetPrivacy(persisted)).toBe(id);
+		}
+	);
+
+	it('advances all three settingsVersions so each section can still save afterwards', async () => {
+		const applied = (await runApply({ presetId: 'balanced', ...versionsAt(EPOCH) })) as {
+			form: {
+				data: {
+					serverWrappedVersion: string;
+					userDefaultsVersion: string;
+					publicLandingLookupVersion: string;
+				};
+			};
+			success?: boolean;
+		};
+		expect(applied).toMatchObject({ success: true });
+		const { serverWrappedVersion, userDefaultsVersion, publicLandingLookupVersion } =
+			applied.form.data;
+		for (const version of [serverWrappedVersion, userDefaultsVersion, publicLandingLookupVersion]) {
+			expect(version).not.toBe(EPOCH);
+		}
+
+		// A section save reusing the version the apply handed back must NOT false-409.
+		const followUp = await runUserDefaults({
+			defaultShareMode: 'private-link',
+			allowUserControl: 'false',
+			settingsVersion: userDefaultsVersion
+		});
+		expect(followUp).toMatchObject({ success: true });
+		expect(await getGlobalDefaultShareMode()).toBe('private-link');
+	});
+
+	it('round-trips Balanced → Custom → Balanced without touching a section Save button', async () => {
+		// The reported bug: going back to Balanced looked applied but only re-staged
+		// client-side values, leaving the section that actually changed (public
+		// landing lookup) unsaved until the admin found its own Save button.
+		const balanced = presetById('balanced');
+		const first = (await runApply({ presetId: 'balanced', ...versionsAt(EPOCH) })) as {
+			form: { data: { publicLandingLookupVersion: string } };
+		};
+		expect(await getPublicLandingLookupEnabled()).toBe(balanced.values.publicLandingLookup);
+
+		// Diverge into Custom by flipping exactly one field through its own section.
+		const diverged = (await runPublicLookup({
+			publicLandingLookup: 'true',
+			settingsVersion: first.form.data.publicLandingLookupVersion
+		})) as { form: { data: { settingsVersion: string } } };
+		expect(await getPublicLandingLookupEnabled()).toBe(true);
+		expect(matchPresetPrivacy(await readPersistedPrivacy())).toBe('custom');
+
+		// Back to Balanced: one apply must persist the flipped field again.
+		const second = await runApply({
+			presetId: 'balanced',
+			serverWrappedVersion: diverged.form.data.settingsVersion,
+			userDefaultsVersion: diverged.form.data.settingsVersion,
+			publicLandingLookupVersion: diverged.form.data.settingsVersion
+		});
+		expect(second).toMatchObject({ success: true });
+		expect(await getPublicLandingLookupEnabled()).toBe(false);
+		expect(matchPresetPrivacy(await readPersistedPrivacy())).toBe('balanced');
+	});
+});
+
+describe('privacy nested route — applyPrivacyPreset OCC', () => {
+	beforeEach(resetSharedTestDb);
+
+	/** Apply Public Showcase, then return the version every group now holds. */
+	async function seedPublicShowcase(): Promise<string> {
+		const result = (await runApply({ presetId: 'public-showcase', ...versionsAt(EPOCH) })) as {
+			form: { data: { serverWrappedVersion: string } };
+			success?: boolean;
+		};
+		expect(result).toMatchObject({ success: true });
+		return result.form.data.serverWrappedVersion;
+	}
+
+	it.each([
+		['serverWrappedVersion', 'Server-wide wrapped sharing'],
+		['userDefaultsVersion', 'User sharing defaults'],
+		['publicLandingLookupVersion', 'Public landing lookup']
+	])('409s on a stale %s and names the section that moved', async (field, label) => {
+		const fresh = await seedPublicShowcase();
+		const before = await readPersistedPrivacy();
+
+		const result = (await runApply({
+			presetId: 'maximum-privacy',
+			...versionsAt(fresh),
+			[field]: EPOCH
+		})) as { status: number; data: { conflict?: boolean; error?: string } };
+
+		expect(result).toMatchObject({ status: 409, data: { conflict: true } });
+		// Sentinel preserved so `surfaceOccConflict` still keys on it and offers Reload.
+		expect(result.data.error).toContain(OCC_MESSAGE);
+		expect(result.data.error).toContain(label);
+		// Partial-conflict policy: the whole apply is refused, so NOTHING moved.
+		expect(await readPersistedPrivacy()).toEqual(before);
+	});
+
+	it('names every stale section when more than one moved', async () => {
+		const fresh = await seedPublicShowcase();
+		const result = (await runApply({
+			presetId: 'balanced',
+			serverWrappedVersion: EPOCH,
+			userDefaultsVersion: EPOCH,
+			publicLandingLookupVersion: fresh
+		})) as { status: number; data: { error?: string } };
+		expect(result.status).toBe(409);
+		expect(result.data.error).toContain('Server-wide wrapped sharing');
+		expect(result.data.error).toContain('User sharing defaults');
+		expect(result.data.error).not.toContain('Public landing lookup');
+		expect(result.data.error).toContain('Nothing was applied');
+	});
+
+	it.each(['serverWrappedVersion', 'userDefaultsVersion', 'publicLandingLookupVersion'])(
+		'rejects a blank %s as a 409 conflict',
+		async (field) => {
+			const result = await runApply({
+				presetId: 'balanced',
+				...versionsAt(EPOCH),
+				[field]: ''
+			});
+			expect(result).toMatchObject({
+				status: 409,
+				data: { conflict: true, error: OCC_MESSAGE }
+			});
+			// Nothing was written, so the five fields still read as factory defaults.
+			expect(await getPublicLandingLookupEnabled()).toBe(false);
+		}
+	);
+
+	it('does not false-409 two consecutive applies in the same page load', async () => {
+		const first = (await runApply({ presetId: 'balanced', ...versionsAt(EPOCH) })) as {
+			form: {
+				data: {
+					serverWrappedVersion: string;
+					userDefaultsVersion: string;
+					publicLandingLookupVersion: string;
+				};
+			};
+		};
+		await new Promise<void>((resolve) => setTimeout(resolve, 10));
+		const second = await runApply({
+			presetId: 'anonymous-public',
+			serverWrappedVersion: first.form.data.serverWrappedVersion,
+			userDefaultsVersion: first.form.data.userDefaultsVersion,
+			publicLandingLookupVersion: first.form.data.publicLandingLookupVersion
+		});
+		expect(second).toMatchObject({ success: true });
+		expect(matchPresetPrivacy(await readPersistedPrivacy())).toBe('anonymous-public');
+	});
+});
+
+describe('privacy nested route — applyPrivacyPreset rejects non-presets', () => {
+	beforeEach(resetSharedTestDb);
+
+	it('rejects the client-only Custom card as a 400 and writes nothing', async () => {
+		// Custom has no value-map by definition. It must never reach a write path —
+		// seeding Balanced from it would silently overwrite an off-preset config
+		// (ISSUE-001), which is exactly why the client keeps it a pure highlight.
+		const result = await runApply({ presetId: 'custom', ...versionsAt(EPOCH) });
+		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid input' } });
+		expect(await getAnonymizationMode()).toBe('hybrid');
+		expect(await getPublicLandingLookupEnabled()).toBe(false);
+	});
+
+	it('rejects an unknown presetId as a 400', async () => {
+		const result = await runApply({ presetId: 'ultra-private', ...versionsAt(EPOCH) });
+		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid input' } });
+	});
+
+	it('rejects a missing presetId as a 400', async () => {
+		const result = await runApply({ ...versionsAt(EPOCH) });
+		expect(result).toMatchObject({ status: 400, data: { error: 'Invalid input' } });
+	});
+});
+
+describe('privacy preset apply — client wiring (no DOM harness in this suite)', () => {
+	const PAGE = 'src/routes/admin/settings/privacy/+page.svelte';
+	const read = async () => Bun.file(PAGE).text();
+	const bodyOf = (src: string, opener: string) => {
+		const fn = src.slice(src.indexOf(opener));
+		return fn.slice(0, fn.indexOf('\n}'));
+	};
+
+	it('submits the apply action from the presets card, carrying all three versions', async () => {
+		const src = await read();
+		expect(src).toContain('action="?/applyPrivacyPreset"');
+		for (const field of [
+			'presetId',
+			'serverWrappedVersion',
+			'userDefaultsVersion',
+			'publicLandingLookupVersion'
+		]) {
+			expect(src).toContain(`name="${field}"`);
+		}
+		// Versions are rendered from the sections' own live stores, so a submit can
+		// never carry a version the admin's page has already advanced past.
+		expect(src).toContain(
+			'name="serverWrappedVersion"\n\t\t\t\t\tvalue={$serverWrappedData.settingsVersion}'
+		);
+		expect(src).toContain('name="userDefaultsVersion" value={$userDefaultsData.settingsVersion}');
+		expect(src).toContain(
+			'name="publicLandingLookupVersion"\n\t\t\t\t\tvalue={$publicLandingLookupData.settingsVersion}'
+		);
+	});
+
+	it('routes the preset form through the shared OCC guard', async () => {
+		const src = await read();
+		// Without surfaceOccConflict a stale 409 renders a success toast (ISSUE-006).
+		const form = src.slice(src.indexOf('const presetForm = superForm('));
+		expect(form.slice(0, form.indexOf('\n});'))).toContain('onUpdate: guardSettingsUpdate');
+		expect(src).toContain('surfaceOccConflict(event);');
+	});
+
+	it('persists on a card click and only stages on the arrow keys', async () => {
+		const src = await read();
+		// The card click is the persist path.
+		expect(src).toContain('onclick={() => applyPrivacyPreset(preset)}');
+		const apply = bodyOf(src, 'async function applyPrivacyPreset(');
+		expect(apply).toContain("if (commit === 'stage-only' || $presetSubmitting) return;");
+		expect(apply).toContain('presetFormEl?.requestSubmit();');
+		// Arrow keys must NOT fire one three-section write per keypress.
+		const dispatch = bodyOf(src, 'function selectPresetAtIndex(');
+		expect(dispatch).toContain("applyPrivacyPreset(preset, 'stage-only');");
+		expect(dispatch).not.toContain('applyPrivacyPreset(preset);');
+	});
+
+	it('offers an explicit Apply button that is enabled only when it would change something', async () => {
+		const src = await read();
+		const applyForm = src.slice(src.indexOf('action="?/applyPrivacyPreset"'));
+		const button = applyForm.slice(applyForm.indexOf('<Button'), applyForm.indexOf('</Button>'));
+		expect(button).toContain('type="submit"');
+		expect(button).toContain('class="tap-target"');
+		expect(button).toContain('disabled={!canApplyPreset}');
+		// The status line is the button's accessible description, so a disabled button
+		// still explains itself instead of being a dead end.
+		expect(button).toContain('aria-describedby="preset-apply-status"');
+		expect(src).toContain('Apply {applicablePreset.label}');
+		expect(src).toContain(
+			'let canApplyPreset = $derived(\n\tapplicablePreset !== null && !applicablePresetIsSaved && !$presetSubmitting\n);'
+		);
+		// "Already saved" is measured against the per-section saved baselines, not the
+		// staged stores, or the button would disable itself the moment a card staged.
+		const saved = src.slice(src.indexOf('let applicablePresetIsSaved = $derived('));
+		const savedBlock = saved.slice(0, saved.indexOf('\n);'));
+		expect(savedBlock).toContain('savedServerWrapped.anonymizationMode');
+		expect(savedBlock).toContain('savedUserDefaults.defaultShareMode');
+		expect(savedBlock).toContain('savedPublicLandingLookup.publicLandingLookup');
+		expect(savedBlock).not.toContain('$serverWrappedData');
+	});
+
+	it('never submits the Custom card and never stages from it', async () => {
+		const src = await read();
+		// presetIdToSubmit is empty for Custom, so the enum can never see it.
+		expect(src).toContain("let presetIdToSubmit = $derived(applicablePreset?.id ?? '');");
+		const custom = bodyOf(src, 'function selectCustomPreset(');
+		expect(custom).not.toContain('assignPresetValues');
+		expect(custom).not.toContain('requestSubmit');
+		expect(custom).toContain('advancedOpen = true;');
+	});
+
+	it('advances all three saved baselines and versions on a successful apply', async () => {
+		const src = await read();
+		const form = src.slice(src.indexOf('const presetForm = superForm('));
+		const block = form.slice(0, form.indexOf('\n});'));
+		// Without these the Advanced sections below would still read as "staged" and
+		// the unsaved-sections banner would linger after a successful write.
+		expect(block).toContain('savedServerWrapped = {');
+		expect(block).toContain('savedUserDefaults = {');
+		expect(block).toContain('savedPublicLandingLookup = {');
+		expect(block).toContain(
+			'$serverWrappedData.settingsVersion = updated.data.serverWrappedVersion;'
+		);
+		expect(block).toContain(
+			'$userDefaultsData.settingsVersion = updated.data.userDefaultsVersion;'
+		);
+		expect(block).toContain(
+			'$publicLandingLookupData.settingsVersion = updated.data.publicLandingLookupVersion;'
+		);
+	});
+
+	it('drops the stale ISSUE-006 force-expand workaround', async () => {
+		const src = await read();
+		// The accordion was force-opened so the "{n} unsaved sections" alert never
+		// pointed at hidden Save buttons. Applying now persists, so there is nothing
+		// to point at — and the comment claiming otherwise would be a lie.
+		const apply = bodyOf(src, 'async function applyPrivacyPreset(');
+		expect(apply).not.toContain('advancedOpen = true;');
+		expect(src).not.toContain('ISSUE-006: applying a preset stages unsaved changes');
+	});
+});

--- a/tests/unit/admin/privacy-preset-apply.test.ts
+++ b/tests/unit/admin/privacy-preset-apply.test.ts
@@ -338,12 +338,72 @@ describe('privacy preset apply — client wiring (no DOM harness in this suite)'
 		// The card click is the persist path.
 		expect(src).toContain('onclick={() => applyPrivacyPreset(preset)}');
 		const apply = bodyOf(src, 'async function applyPrivacyPreset(');
-		expect(apply).toContain("if (commit === 'stage-only' || $presetSubmitting) return;");
+		expect(apply).toContain("if (commit === 'stage-only') return;");
 		expect(apply).toContain('presetFormEl?.requestSubmit();');
 		// Arrow keys must NOT fire one three-section write per keypress.
 		const dispatch = bodyOf(src, 'function selectPresetAtIndex(');
 		expect(dispatch).toContain("applyPrivacyPreset(preset, 'stage-only');");
 		expect(dispatch).not.toContain('applyPrivacyPreset(preset);');
+	});
+
+	it('skips the submit when the clicked card is already the saved configuration', async () => {
+		const src = await read();
+		// A redundant apply is not free: `setPrivacyPresetAtomic` stamps a
+		// strictly-advancing `updatedAt` on all three OCC groups, so a no-op card
+		// click would 409 every other admin tab without changing a single value.
+		const apply = bodyOf(src, 'async function applyPrivacyPreset(');
+		expect(apply).toContain('if (presetMatchesSaved(preset)) return;');
+		// The skip must be decided BEFORE the submit and AFTER staging, so clicking
+		// the saved card still reverts unsaved Advanced edits back to that preset.
+		const stageAt = apply.indexOf('assignPresetValues(preset.values);');
+		const skipAt = apply.indexOf('if (presetMatchesSaved(preset)) return;');
+		const submitAt = apply.indexOf('presetFormEl?.requestSubmit();');
+		expect(stageAt).toBeGreaterThan(-1);
+		expect(skipAt).toBeGreaterThan(stageAt);
+		expect(submitAt).toBeGreaterThan(skipAt);
+		// One implementation of "is this preset already persisted", shared with the
+		// Apply button, or the click path and the button could disagree.
+		expect(src).toContain(
+			'let applicablePresetIsSaved = $derived(\n\tapplicablePreset !== null && presetMatchesSaved(applicablePreset)\n);'
+		);
+	});
+
+	it('refuses every radiogroup mutation while an apply is in flight', async () => {
+		const src = await read();
+		// The guard has to precede the staging call: the in-flight apply rewrites the
+		// stores from its own response, so staging underneath it flickers the
+		// highlight and the "After you save" preview and is then silently undone.
+		const apply = bodyOf(src, 'async function applyPrivacyPreset(');
+		const guardAt = apply.indexOf('if ($presetSubmitting) return;');
+		const stageAt = apply.indexOf('assignPresetValues(preset.values);');
+		expect(guardAt).toBeGreaterThan(-1);
+		expect(stageAt).toBeGreaterThan(guardAt);
+		expect(apply.indexOf('privacyInteracted = true;')).toBeGreaterThan(guardAt);
+		expect(apply.indexOf('customPresetChosen = false;')).toBeGreaterThan(guardAt);
+		// Pinned as the FIRST statement rather than merely ahead of today's three
+		// mutations, so a fourth one added above the guard cannot re-open the defect.
+		const firstStatement = apply
+			.split('\n')
+			.slice(1)
+			.map((line) => line.trim())
+			.find((line) => line.length > 0 && !line.startsWith('//'));
+		expect(firstStatement).toBe('if ($presetSubmitting) return;');
+		// Custom mutates only the highlight, but `onUpdated` clears
+		// `customPresetChosen`, so it would be undone just the same.
+		const custom = bodyOf(src, 'function selectCustomPreset(');
+		const customGuardAt = custom.indexOf('if ($presetSubmitting) return;');
+		expect(customGuardAt).toBeGreaterThan(-1);
+		expect(custom.indexOf('customPresetChosen = true;')).toBeGreaterThan(customGuardAt);
+		// Reporting the refusal keeps the roving tab stop on the still-selected card
+		// instead of moving focus to a card that never became aria-checked.
+		const dispatch = bodyOf(src, 'function selectPresetAtIndex(');
+		expect(dispatch).toContain('if ($presetSubmitting) return false;');
+		// The refusal is total, so the group has to say it is busy. Not the native
+		// `disabled` attribute: that drops the card out of the tab order and breaks
+		// the single roving tab stop.
+		const group = src.slice(src.indexOf('role="radiogroup"'));
+		expect(group.slice(0, group.indexOf('>'))).toContain('aria-busy={$presetSubmitting}');
+		expect(src).not.toContain('disabled={$presetSubmitting}');
 	});
 
 	it('offers an explicit Apply button that is enabled only when it would change something', async () => {
@@ -362,8 +422,7 @@ describe('privacy preset apply — client wiring (no DOM harness in this suite)'
 		);
 		// "Already saved" is measured against the per-section saved baselines, not the
 		// staged stores, or the button would disable itself the moment a card staged.
-		const saved = src.slice(src.indexOf('let applicablePresetIsSaved = $derived('));
-		const savedBlock = saved.slice(0, saved.indexOf('\n);'));
+		const savedBlock = bodyOf(src, 'function presetMatchesSaved(');
 		expect(savedBlock).toContain('savedServerWrapped.anonymizationMode');
 		expect(savedBlock).toContain('savedUserDefaults.defaultShareMode');
 		expect(savedBlock).toContain('savedPublicLandingLookup.publicLandingLookup');

--- a/tests/unit/core-contracts.test.ts
+++ b/tests/unit/core-contracts.test.ts
@@ -20,7 +20,7 @@ import pkg from '../../package.json';
 import { match as matchYear } from '../../src/params/year';
 import { sharedTestDbTables } from '../helpers/db';
 
-const { isOccConflict } = await import('$lib/utils/occ-form');
+const { isOccConflict, isPostValidationFailure } = await import('$lib/utils/occ-form');
 const envAny = env as Record<string, string | undefined>;
 
 const REAL_CHROME_UA =
@@ -262,6 +262,28 @@ describe('core client/server utility contracts', () => {
 			[null, false]
 		] as const)('isOccConflict(%p) -> %s', (payload, expected) => {
 			expect(isOccConflict(payload)).toBe(expected);
+		});
+
+		// The discriminator a page-local `onUpdate` guard needs: a failure whose
+		// returned form is still `valid` slipped past validation, so `onUpdated` would
+		// take its SUCCESS branch. Status codes do not answer that question — see
+		// `applyPrivacyPreset`'s semantic `fail(400, { form, error })`. Note the true
+		// row that also carries `conflict: true`: an OCC 409 is post-validation too,
+		// which is why the caller must early-return on `isOccConflict` first.
+		it.each([
+			[{ form: { valid: true } }, true],
+			[{ form: { valid: true }, error: 'Invalid input' }, true],
+			[{ form: { valid: true }, conflict: true, error: 'reload' }, true],
+			[{ form: { valid: false } }, false],
+			[{ form: { valid: false }, error: 'Invalid input' }, false],
+			[{ form: {} }, false],
+			[{ form: null }, false],
+			[{ error: 'Failed to save' }, false],
+			[{}, false],
+			[undefined, false],
+			[null, false]
+		] as const)('isPostValidationFailure(%p) -> %s', (payload, expected) => {
+			expect(isPostValidationFailure(payload)).toBe(expected);
 		});
 	});
 

--- a/tests/unit/sharing/presets.test.ts
+++ b/tests/unit/sharing/presets.test.ts
@@ -164,7 +164,7 @@ describe('shouldShowCustomPresetNote (ISSUE-001: gate the "Custom configuration"
 	});
 });
 
-describe('negative guard: preset is never a persisted or submitted field', () => {
+describe('negative guard: a preset is never a persisted field', () => {
 	const read = async (path: string) => await Bun.file(path).text();
 
 	it('onboarding +page.svelte never submits a "preset" form field', async () => {
@@ -189,6 +189,39 @@ describe('negative guard: preset is never a persisted or submitted field', () =>
 		const src = await read('src/routes/admin/settings/privacy/+page.server.ts');
 		expect(/^\s*preset\s*:/m.test(src)).toBe(false);
 		expect(/formData\.get\(\s*["']preset["']/.test(src)).toBe(false);
+	});
+
+	it('submits a preset id only as a discriminator, and stores no row for it', async () => {
+		// The admin "apply preset" action DOES receive an id (`presetId`) so one
+		// request can write all three sections atomically. It resolves that id to a
+		// PRIVACY_PRESETS entry server-side and writes only ordinary privacy values:
+		// no app_settings key exists for a preset, and the active preset is still
+		// recomputed from field values on load.
+		const server = await read('src/routes/admin/settings/privacy/+page.server.ts');
+		expect(server).toContain('presetId: z.enum(PRIVACY_PRESET_IDS).optional()');
+		expect(server).toContain(
+			'PRIVACY_PRESETS.find((candidate) => candidate.id === form.data.presetId)'
+		);
+
+		// No app_settings key stores a preset, so nothing can persist one.
+		const settingsService = await read('src/lib/server/admin/settings.service.ts');
+		const keyTable = settingsService.slice(
+			settingsService.indexOf('export const AppSettingsKey = {'),
+			settingsService.indexOf(
+				'} as const;',
+				settingsService.indexOf('export const AppSettingsKey = {')
+			)
+		);
+		expect(keyTable.toLowerCase()).not.toContain('preset');
+
+		// The atomic writer takes the resolved VALUES, never an id.
+		const writer = settingsService.slice(
+			settingsService.indexOf('export async function setPrivacyPresetAtomic(')
+		);
+		const signature = writer.slice(0, writer.indexOf('}): Promise'));
+		expect(signature).not.toContain('presetId');
+		expect(signature).toContain('anonymizationMode');
+		expect(signature).toContain('publicLandingLookup');
 	});
 });
 


### PR DESCRIPTION
## Summary

Two related admin-settings problems, both UI/UX-facing.

1. **`/admin/settings/data`** — the destructive-reset card was titled only "Danger zone", so it signalled severity without ever saying what the action does, its explanatory box opened on a bare "Comes back on its own" heading, and its dialog footers rendered Cancel and the confirm button at visibly different sizes.
2. **`/admin/settings/privacy`** — clicking a privacy preset only *staged* client-side values across three independently-saved sections. Going Balanced → Custom → Balanced looked applied but was not persisted until the admin hunted down the Save button in whichever section actually changed.

---

## 1. Instance-reset section re-pass

A full design pass over the destructive surface, not a string patch.

**Title and severity.** The card is now titled **"Reset this Obzorarr instance"** with a destructive `Badge` eyebrow carrying "Danger zone" and the warning triangle above it. The badge holds the alarm so the title is free to state the action plainly; the destructive card border and destructive trigger button keep the severity unmistakable.

**The explanatory box has a lead-in and one vocabulary.** The box opens on a "Where your data ends up" eyebrow, and its three blocks are relabelled to the parallel set the confirm dialog already used:

| Before (card) | After (card and dialog) |
| --- | --- |
| Comes back on its own | What comes back |
| Gone for good | What does not |
| Set by environment variables | What is untouched |

The stage-1 dialog gains the same lead-in and promotes its trailing environment-variable paragraph to the third labelled block, so the card and the dialog now state the same three facts in the same words and the same order.

**Footer button sizing.** `.tap-target` is the repo's 44px WCAG minimum-size utility. It sat on `AlertDialog.Action` only — which lives inside a `<form>`, so the omission was easy to miss — leaving `AlertDialog.Cancel` at the bare 36px button height. All four dialogs on the page (Clear stats cache, Clear play history, both reset stages) now carry it on both footer buttons. Verified in the browser: both buttons render 44px tall at the same vertical offset on desktop, and full-width equal siblings at 390px.

**Coherence of the whole surface.**
- The sync-blocked state gets an `AlertTitle` ("Reset is on hold while a sync runs") and links to the Sync page instead of only stating that reset is blocked.
- The action row uses `align="between"` with a note stating the three-step consequence next to the button.
- Destructive dialog confirms now use the destructive button variant, so a confirm never reads friendlier than the trigger that opened it. Stage 1's "Continue" deliberately stays primary: it only mints a token.

**Security model untouched.** Nothing is written until Continue, the token is still minted in memory, and the sync-running hold is unchanged. This commit is presentation and copy only.

---

## 2. Privacy presets now persist

### Server

**`setPrivacyPresetAtomic`** (`admin/settings.service.ts`) applies a preset across all three OCC groups in a single SQLite transaction. It gates every group against **one** transaction snapshot and writes only if all three pass, so a half-applied posture — names already anonymized while public lookup stayed on — is unreachable.

To avoid a second implementation of the OCC rules, the shared in-transaction gate (`occGateInTx`) and the per-group row writers were extracted out of the existing `set*Atomic` writers, which now compose them. Behaviour of the three existing writers is unchanged, including the private-link share-token purge inside the user-defaults write. The full suite was run against the refactor before the new action was added.

**`?/applyPrivacyPreset`** carries three inline `settingsVersion` values, runs `inlineOccCheck` per group before any write, and wraps in the existing `requireAdminActions`. On success it hands every section the timestamp the transaction actually wrote — never a post-write re-read, which would be a TOCTOU hole — so each section's own Save button still works afterwards without a reload.

**Partial-conflict policy: the whole apply is refused and nothing is written.** The 409 keeps `OCC_CONFLICT_MESSAGE` as its leading sentinel, so `surfaceOccConflict` still keys on it and still offers Reload, then appends what a generic OCC message cannot say:

> Settings changed in another tab. Please reload. Nothing was applied — changed since this page loaded: Server-wide wrapped sharing, User sharing defaults, Public landing lookup.

**A missing `presetId` can no longer pick a posture.** `presetId` is `z.enum(PRIVACY_PRESET_IDS).optional()`. Superforms infers a required enum's default as its *first* member, so a POST that simply omitted `presetId` would otherwise have passed validation and silently applied Maximum Privacy. Optional makes both an absent field and an empty value arrive as `undefined`, which the action rejects with a 400 before any write.

`PRIVACY_PRESET_IDS` is now the single tuple both the preset cards and the Zod enum read, so a new preset cannot become clickable without also becoming submittable.

### Client

A fourth `superForm` owns the apply write and routes through the page's shared `guardSettingsUpdate`, which runs `surfaceOccConflict` first. On success it advances the three stores, the three `settingsVersion` values and all three saved baselines together — which is what makes the Advanced sections read as saved rather than staged and clears the unsaved-sections banner.

**How the two affordances coexist without redundancy:**

- **Card click** (mouse, Enter, Space) stages and persists in one request, confirmed by one toast: "Applied the Balanced preset". The action keeps its name through the flow, so the button that says "Apply Balanced" produces that toast rather than a generic "Saved".
- **Arrow keys** stage only. An APG radiogroup moves its selection as focus moves, and firing one three-section write per ArrowRight would be absurd.
- **The explicit Apply button** commits whatever the arrows landed on, and also commits an Advanced edit that happened to land on a preset. It is enabled *exactly* when applying would change something on the server, measured against the per-section saved baselines rather than the staged stores. Its status line always states why it is or is not available:
  - `Balanced is the saved configuration.` (disabled — this is the confirmation after a card click)
  - `Balanced is selected but not saved yet.` (enabled)
  - `Custom has no values of its own. Set the controls in Advanced options, then save that section.` (disabled)
  - `Pick a preset to save it across all three sections at once.` (disabled)

  The status line is the button's `aria-describedby` rather than an `aria-live` region: it changes on every arrow-key move and a live region would talk over the card being announced.

The unsaved-sections banner now points at the Apply button when the staged configuration matches a preset, and only at the section Save buttons when it does not.

### Not regressed

- **`Custom` stays a no-op highlight.** It stages nothing, writes nothing, only highlights itself and expands Advanced, and stays auto-selected when the persisted configuration matches no shipped preset. The `ISSUE-001` protection is intact: seeding Balanced from Custom would silently overwrite an admin's saved off-preset configuration. `presetIdToSubmit` is empty for Custom, and the server enum rejects it as a 400 regardless.
- **Preset matching still covers the five admin-owned fields only.** `logoMode` is neither matched nor written; it lives on the Appearance route and its own OCC group.
- **Onboarding is untouched.** `src/lib/sharing/preset-logic.ts` and its consumers are unchanged apart from `PrivacyPresetId` now being derived from the new tuple.
- The stale `ISSUE-006` comment and its force-expand workaround are gone. Applying persists, so there are no hidden Save buttons left to point at.

---

## Validation

```
bun run check:biome   Checked 653 files. No fixes applied.
bun run check         COMPLETED 3157 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
bun run test          2384 pass, 0 fail — 90.30% funcs / 87.57% lines (thresholds 80/80)
```

**New — `tests/unit/admin/privacy-preset-apply.test.ts` (25 cases):**
- Each of the five presets writes all five admin-owned fields in one request, and the persisted result reads back as that exact preset.
- All three `settingsVersion` values advance, and a following section save reusing one of them does not false-409.
- The reported round-trip: Balanced → diverge via the public-lookup section → Balanced, persisting without touching a section Save button.
- Per-section and multi-section 409s, each asserting the section names, the `Nothing was applied` phrase, the OCC sentinel, and that no field moved.
- Blank versions, two consecutive applies, and rejection of `custom`, an unknown id, and a missing id — each verifying nothing was written.
- Client wiring source guards: form action and hidden fields, `surfaceOccConflict` reaching the preset form, card-click-persists vs arrow-keys-stage, the Apply button's enable rule and description, Custom staging nothing, baseline/version advancement, and the removal of the `ISSUE-006` workaround.

**Extended — `tests/unit/admin/instance-reset.test.ts` (+5 cases):** title/badge pairing, the box lead-in, card-and-dialog vocabulary parity in order, footer button size parity across all four dialogs, and the blocked-state copy.

**Updated — `tests/unit/sharing/presets.test.ts`:** the "never persisted or submitted" guard is retitled and extended. A preset id is now submitted as a discriminator, so the test pins the honest invariant instead: the id resolves to values server-side, no `AppSettingsKey` mentions a preset, and `setPrivacyPresetAtomic`'s signature takes values rather than an id.

**Browser verification** (`bun run dev` against a disposable database, so no developer state was touched):
- Reset section: card hierarchy and copy, the three labelled blocks, both dialog footers measured at 44px equal height on desktop and equal full-width siblings at 390px.
- Privacy: fresh install selects no card and disables Apply; a Balanced card click writes all five rows with one shared timestamp; toggling public lookup drops to Custom with Apply correctly disabled; clicking Balanced again persists and survives a page reload; arrow keys stage without writing, confirmed against the database; the Apply button then commits; and a genuinely stale second tab receives the conflict toast naming all three sections with no false success and no write.
