### PR TITLE
fix(admin): derive the privacy preset highlight from the saved values

### DIFF
--- a/src/lib/sharing/preset-logic.ts
+++ b/src/lib/sharing/preset-logic.ts
@@ -43,31 +43,58 @@ export function shouldShowCustomPresetNote(
 }
 
 /**
- * Which preset card renders as SELECTED, or `null` when no card is selected.
+ * Which preset card renders as SELECTED for a flow whose field values come from
+ * PERSISTED settings — i.e. the admin privacy route. Always returns a card.
  *
- * Three inputs, because the visual selection is not simply the derived match:
+ * The selection is a pure function of what the live fields currently say:
  *
- * - `match` — what the live field values resolve to ('custom' when they match no
- *   shipped preset).
- * - `hasInteracted` — the `privacyTouched` gate. On a fresh install the seeded
- *   defaults can incidentally resolve to `'custom'` before the admin touches
- *   anything (ISSUE-001, see {@link shouldShowCustomPresetNote}); the Custom card
- *   must not light up there either, so an untouched `'custom'` selects NO card —
- *   exactly the pre-Custom-card behaviour.
+ * - `match` — what those values resolve to ('custom' when they match no shipped
+ *   preset). An off-preset combination on this route is a real configuration an
+ *   administrator saved, so Custom is simply the honest answer, on the first
+ *   paint of a fresh load exactly as much as mid-session.
  * - `customChosen` — the sticky "admin explicitly clicked Custom" flag. It wins
  *   over `match` so the highlight does not immediately snap back to a shipped
- *   preset: in onboarding because clicking Custom seeds the Balanced values, and
- *   on the admin route because the saved configuration may already match a preset
- *   while the click itself stages nothing. Clicking any of the five real cards
- *   clears it.
+ *   preset when the click itself stages nothing (the saved configuration may
+ *   already match one). Clicking any of the five real cards clears it.
+ *
+ * Deliberately NOT interaction-gated. Suppressing an untouched `'custom'` is an
+ * onboarding-only rule about unseeded fresh-install defaults (ISSUE-001, see
+ * {@link resolvePresetSelection}); applying it here meant a session-scoped "has
+ * the admin touched anything yet" flag decided the highlight, so every page load
+ * of a saved off-preset configuration selected NO card and left `aria-checked`
+ * false on all six.
+ */
+export function resolvePersistedPresetSelection(
+	match: PrivacyPresetMatch,
+	customChosen: boolean
+): PrivacyPresetMatch {
+	return customChosen ? 'custom' : match;
+}
+
+/**
+ * {@link resolvePersistedPresetSelection} plus ONBOARDING's untouched-state
+ * guard, returning `null` when no card is selected.
+ *
+ * On a fresh install the seeded values can incidentally resolve to `'custom'`
+ * (the raw defaults match no shipped preset) before the admin touches anything
+ * (ISSUE-001, see {@link shouldShowCustomPresetNote}). The Custom card must not
+ * light up there, so an untouched `'custom'` selection collapses to NO card —
+ * exactly the pre-Custom-card behaviour. Every other selection, including a live
+ * `'custom'` reached by editing an Advanced Option, resolves the same way it does
+ * on the admin route.
+ *
+ * ONBOARDING-ONLY. The admin privacy route calls
+ * {@link resolvePersistedPresetSelection} directly: its values are persisted
+ * settings, not fresh-install seeds, so it has no untouched state to protect.
  */
 export function resolvePresetSelection(
 	match: PrivacyPresetMatch,
 	hasInteracted: boolean,
 	customChosen: boolean
 ): PrivacyPresetMatch | null {
-	if (match !== 'custom' && !customChosen) return match;
-	return hasInteracted ? 'custom' : null;
+	const selected = resolvePersistedPresetSelection(match, customChosen);
+	if (selected === 'custom' && !hasInteracted) return null;
+	return selected;
 }
 
 /**
@@ -83,11 +110,11 @@ export function resolvePresetSelection(
  * `hasInteracted` is only ever a "has the admin touched anything THIS SESSION"
  * flag, so it necessarily reads false on a fresh page load. That is harmless in
  * onboarding, where a fresh load has no persisted configuration to destroy, and
- * destructive on the admin privacy route, where it always does: the untouched
- * `'custom'` state there is a real configuration the admin saved (ISSUE-001, see
- * {@link resolvePresetSelection}), and seeding would silently replace it with
- * Balanced. Admin consequently never calls this helper — its Custom card stages
- * nothing, and its own gate latching on interaction does not change that.
+ * destructive on the admin privacy route, where it always does: an off-preset
+ * state there is a real configuration the admin saved, and seeding would
+ * silently replace it with Balanced. Admin consequently never calls this helper
+ * — its Custom card stages nothing and only moves the highlight (see
+ * {@link resolvePersistedPresetSelection}).
  */
 export function customPresetSeedValues(hasInteracted: boolean): PrivacyPresetValues | null {
 	if (hasInteracted) return null;

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -61,7 +61,7 @@ import {
 	PREVIEW_PER_USER_DEFAULT_LABELS,
 	PREVIEW_RECAP_VISIBILITY_LABELS,
 	type PrivacyPreviewModel,
-	resolvePresetSelection
+	resolvePersistedPresetSelection
 } from '$lib/sharing/preset-logic';
 import { handleFormToast } from '$lib/utils/form-toast';
 import { isOccConflict, isPostValidationFailure, surfaceOccConflict } from '$lib/utils/occ-form';
@@ -140,9 +140,6 @@ const serverWrappedForm = superForm(data.serverWrappedForm, {
 				anonymizationMode: updated.data.anonymizationMode,
 				serverWrappedShareMode: updated.data.serverWrappedShareMode
 			};
-			// A completed save is proof of interaction: without this latch the Custom
-			// highlight vanishes the moment unsavedSectionCount drops back to 0.
-			privacyInteracted = true;
 			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
 		} else {
 			handleFormToast({ error: updated.message ?? 'Validation failed' });
@@ -166,9 +163,6 @@ const userDefaultsForm = superForm(data.userDefaultsForm, {
 				defaultShareMode: updated.data.defaultShareMode,
 				allowUserControl: updated.data.allowUserControl
 			};
-			// A completed save is proof of interaction: without this latch the Custom
-			// highlight vanishes the moment unsavedSectionCount drops back to 0.
-			privacyInteracted = true;
 			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
 		} else {
 			handleFormToast({ error: updated.message ?? 'Validation failed' });
@@ -191,9 +185,6 @@ const publicLandingLookupForm = superForm(data.publicLandingLookupForm, {
 			savedPublicLandingLookup = {
 				publicLandingLookup: updated.data.publicLandingLookup
 			};
-			// A completed save is proof of interaction: without this latch the Custom
-			// highlight vanishes the moment unsavedSectionCount drops back to 0.
-			privacyInteracted = true;
 			handleFormToast({ success: true, message: updated.message ?? 'Saved' });
 		} else {
 			handleFormToast({ error: updated.message ?? 'Validation failed' });
@@ -249,7 +240,6 @@ const presetForm = superForm(data.presetForm, {
 		};
 		savedPublicLandingLookup = { publicLandingLookup: applied.values.publicLandingLookup };
 		customPresetChosen = false;
-		privacyInteracted = true;
 		// The action keeps its name through the whole flow: the button says "Apply
 		// Balanced", so the toast says "Applied the Balanced preset" — not a generic
 		// "Saved" that gives no hint which of six cards actually landed.
@@ -266,12 +256,6 @@ let presetFormEl = $state<HTMLFormElement | null>(null);
 let bulkApplyDialogOpen = $state(false);
 let isBulkApplying = $state(false);
 
-// Latching "the admin has touched this section during this page load". The gate
-// that reads it, `privacyTouched`, is declared with the rest of the preset logic
-// below; this lives up here because the accordion toggle and the three form
-// `onUpdated` callbacks above all set it.
-let privacyInteracted = $state(false);
-
 // Advanced controls stay collapsed until the administrator opens them or stages
 // a preset. Public lookup no longer creates a contradictory default state.
 let advancedOpen = $state(false);
@@ -283,10 +267,6 @@ let advancedOpen = $state(false);
 let advancedSectionRef = $state<HTMLDivElement | null>(null);
 async function handleAdvancedToggle(open: boolean): Promise<void> {
 	if (!open) return;
-	// Opening the accordion is an interaction with the privacy controls, and it is
-	// the only way to reach them — latching here is what keeps the Custom
-	// highlight from decaying when an edit is staged and then reverted.
-	privacyInteracted = true;
 	await tick();
 	advancedSectionRef?.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
@@ -343,26 +323,6 @@ let unsavedSectionCount = $derived(
 	(serverWrappedUnsaved ? 1 : 0) + (userDefaultsUnsaved ? 1 : 0) + (publicLandingUnsaved ? 1 : 0)
 );
 
-// Mirrors onboarding's `privacyTouched` gate (ISSUE-001): the Custom card only
-// lights up once the admin has actually interacted. Without the gate a
-// persisted-but-off-preset configuration would light Custom on load, before the
-// admin had touched anything.
-//
-// The flag must LATCH. Deriving it purely from a card-click flag OR
-// `unsavedSectionCount > 0` made it DECAY: an admin who only edited Advanced
-// controls saw Custom light up, then lose the highlight the moment they pressed
-// Save — the baselines advance, `unsavedSectionCount` drops back to 0, and the
-// radiogroup ended up with no card checked (moving the roving tab stop back to
-// the first card) even though they had just deliberately saved an off-preset
-// configuration. Saving is the opposite of "hasn't touched anything yet".
-//
-// So every way of interacting with this section latches `privacyInteracted`
-// (declared above the accordion toggle that sets it): clicking any preset card,
-// expanding the Advanced accordion (the only route to those controls), and a
-// successful save of any of the three sections. `unsavedSectionCount > 0` stays
-// as a safety net for a control rendered outside the accordion.
-let privacyTouched = $derived(privacyInteracted || unsavedSectionCount > 0);
-
 // Sticky "the admin explicitly clicked the Custom card" flag. While set, Custom
 // stays highlighted even when the staged values happen to match a shipped preset
 // — which on this route is simply "the admin clicked Custom while their saved
@@ -370,10 +330,19 @@ let privacyTouched = $derived(privacyInteracted || unsavedSectionCount > 0);
 // Cleared by clicking any of the five real cards.
 let customPresetChosen = $state(false);
 
-// The card that renders as selected: the derived five-field match, the sticky
-// Custom flag, or no card at all before the admin has interacted.
+// The card that renders as selected: the sticky Custom flag, otherwise the
+// five-field match over the live store values. Always a card.
+//
+// NOT interaction-gated. This route used to reuse onboarding's resolver together
+// with a session-scoped "has the admin touched anything yet" flag, so an
+// untouched `'custom'` selected nothing at all — and on the admin route
+// "untouched" means "this is the configuration the administrator saved". Every
+// page load of an off-preset configuration therefore rendered six cards with
+// `aria-checked="false"`, and the roving tab stop fell back to the first card.
+// Suppressing an untouched `'custom'` is an onboarding-only rule about
+// fresh-install seeds (ISSUE-001); see `resolvePersistedPresetSelection`.
 let selectedPresetCard = $derived(
-	resolvePresetSelection(selectedPreset, privacyTouched, customPresetChosen)
+	resolvePersistedPresetSelection(selectedPreset, customPresetChosen)
 );
 
 // Staging the five admin-owned fields across the three stores. NEVER touches
@@ -430,7 +399,6 @@ async function applyPrivacyPreset(preset: PrivacyPreset, commit: PresetCommit = 
 	// and the "After you save" preview before snapping back to what that apply
 	// wrote — a click that visibly did nothing.
 	if ($presetSubmitting) return;
-	privacyInteracted = true;
 	customPresetChosen = false;
 	assignPresetValues(preset.values);
 	if (commit === 'stage-only') return;
@@ -450,13 +418,12 @@ async function applyPrivacyPreset(preset: PrivacyPreset, commit: PresetCommit = 
 	presetFormEl?.requestSubmit();
 }
 
-// Custom is a pure highlight change on this route: it stages NOTHING. The admin
-// gate is false on load for an already-off-preset persisted config — that is
-// exactly the ISSUE-001 state — so seeding Balanced through
-// `customPresetSeedValues(privacyTouched)` would silently overwrite the
-// administrator's saved privacy settings. Making the gate latch (above) does not
-// change that: a fresh load has latched nothing either way. Admins who do want
-// that baseline click the Balanced card, which sits in the same radiogroup.
+// Custom is a pure highlight change on this route: it stages NOTHING. Seeding
+// Balanced through `customPresetSeedValues` — onboarding's rule — would silently
+// overwrite the administrator's saved privacy settings, because on this route an
+// off-preset configuration is real persisted state rather than an untouched
+// fresh-install seed. Admins who do want that baseline click the Balanced card,
+// which sits in the same radiogroup.
 // Advanced is still expanded — Custom's whole point is the controls below it, and
 // the only way to reach an off-preset configuration is to edit them and save that
 // section. Custom therefore also has nothing for the Apply button to write.
@@ -465,14 +432,15 @@ function selectCustomPreset() {
 	// `customPresetChosen` in its own `onUpdated`, so highlighting Custom
 	// underneath it would only be undone.
 	if ($presetSubmitting) return;
-	privacyInteracted = true;
 	customPresetChosen = true;
 	advancedOpen = true;
 }
 
 // Use the same APG roving-tabindex radio pattern as onboarding: the selected
-// card is the single Tab stop, with the first card reachable when no card is
-// selected. The Custom card occupies the final index (PRIVACY_PRESETS.length).
+// card is the single Tab stop. A card is always selected on this route (the
+// selection is derived straight from the live values), so the group's tab stop
+// always lands on it. The Custom card occupies the final index
+// (PRIVACY_PRESETS.length).
 let presetButtons = $state<(HTMLButtonElement | null)[]>([]);
 
 const CUSTOM_PRESET_INDEX = PRIVACY_PRESETS.length;
@@ -497,9 +465,8 @@ function selectPresetAtIndex(index: number): boolean {
 }
 
 // What the explicit Apply button would write: the highlighted card resolved to a
-// shipped preset. `null` for the Custom card (no value-map by definition) and
-// before the admin has interacted at all, which is exactly when there is nothing
-// to apply.
+// shipped preset. `null` for the Custom card, which has no value-map by
+// definition and therefore nothing to apply.
 let applicablePreset = $derived(
 	PRIVACY_PRESETS.find((preset) => preset.id === selectedPresetCard) ?? null
 );
@@ -516,8 +483,8 @@ let canApplyPreset = $derived(
 	applicablePreset !== null && !applicablePresetIsSaved && !$presetSubmitting
 );
 
-// The submitted preset id. Empty for Custom and for "no card highlighted", both of
-// which also disable the button — the action's Zod enum rejects either anyway.
+// The submitted preset id. Empty for Custom, which also disables the button —
+// the action's Zod enum rejects it anyway.
 let presetIdToSubmit = $derived(applicablePreset?.id ?? '');
 
 // One line that states the truth about the selection relative to what is saved.
@@ -528,6 +495,9 @@ let presetApplyStatus = $derived.by(() => {
 	if (selectedPresetCard === 'custom') {
 		return 'Custom has no values of its own. Set the controls in Advanced options, then save that section.';
 	}
+	// Unreachable: `selectedPresetCard` is always a card, and the 'custom' arm
+	// returned above. Kept because `.find()` is typed `| undefined` and the two
+	// lines below read `applicablePreset.label`.
 	if (!applicablePreset) return 'Pick a preset to save it across all three sections at once.';
 	if (applicablePresetIsSaved) return `${applicablePreset.label} is the saved configuration.`;
 	return `${applicablePreset.label} is selected but not saved yet.`;
@@ -536,6 +506,8 @@ let presetApplyStatus = $derived.by(() => {
 let presetTabIndex = $derived.by(() => {
 	if (selectedPresetCard === 'custom') return CUSTOM_PRESET_INDEX;
 	const i = PRIVACY_PRESETS.findIndex((p) => p.id === selectedPresetCard);
+	// `-1` is unreachable — a non-'custom' selection is always a shipped id — but
+	// falling back to the first card keeps the group Tab-reachable regardless.
 	return i === -1 ? 0 : i;
 });
 

--- a/tests/unit/admin/privacy-preset-apply.test.ts
+++ b/tests/unit/admin/privacy-preset-apply.test.ts
@@ -419,10 +419,9 @@ describe('privacy preset apply — client wiring (no DOM harness in this suite)'
 		const stageAt = apply.indexOf('assignPresetValues(preset.values);');
 		expect(guardAt).toBeGreaterThan(-1);
 		expect(stageAt).toBeGreaterThan(guardAt);
-		expect(apply.indexOf('privacyInteracted = true;')).toBeGreaterThan(guardAt);
 		expect(apply.indexOf('customPresetChosen = false;')).toBeGreaterThan(guardAt);
-		// Pinned as the FIRST statement rather than merely ahead of today's three
-		// mutations, so a fourth one added above the guard cannot re-open the defect.
+		// Pinned as the FIRST statement rather than merely ahead of today's
+		// mutations, so a new one added above the guard cannot re-open the defect.
 		const firstStatement = apply
 			.split('\n')
 			.slice(1)

--- a/tests/unit/sharing/presets.test.ts
+++ b/tests/unit/sharing/presets.test.ts
@@ -3,6 +3,7 @@ import {
 	CUSTOM_PRIVACY_PRESET,
 	DEFAULT_PRIVACY_PRESET_ID,
 	PRIVACY_PRESETS,
+	type PrivacyPresetPrivacyKey,
 	type PrivacyPresetValues
 } from '$lib/sharing/options';
 import {
@@ -10,6 +11,7 @@ import {
 	derivePreview,
 	matchPresetFull,
 	matchPresetPrivacy,
+	resolvePersistedPresetSelection,
 	resolvePresetSelection,
 	shouldShowCustomPresetNote
 } from '$lib/sharing/preset-logic';
@@ -251,7 +253,44 @@ describe('Custom preset card — structure', () => {
 	});
 });
 
-describe('resolvePresetSelection — which card renders as selected', () => {
+describe('resolvePersistedPresetSelection — admin, derived purely from the live values', () => {
+	it('selects Custom for an off-preset combination with no interaction at all', () => {
+		// THE REGRESSION. The admin route's values come from persisted app_settings,
+		// so an off-preset combination is a configuration an administrator saved —
+		// not an untouched fresh-install seed. Routing this through onboarding's
+		// interaction-gated resolver made every page load of such a configuration
+		// select NO card (see the contrast assertion below).
+		expect(resolvePersistedPresetSelection('custom', false)).toBe('custom');
+		expect(resolvePresetSelection('custom', false, false)).toBeNull();
+	});
+
+	it('selects the matching shipped preset for an exact match', () => {
+		for (const preset of PRIVACY_PRESETS) {
+			expect(resolvePersistedPresetSelection(preset.id, false)).toBe(preset.id);
+		}
+	});
+
+	it('keeps Custom highlighted while the sticky flag is set, even on an exact match', () => {
+		// Admin's Custom click stages nothing, so the derived match is still whatever
+		// is saved; the sticky flag is the only thing holding the highlight.
+		expect(resolvePersistedPresetSelection('balanced', true)).toBe('custom');
+		expect(resolvePersistedPresetSelection('custom', true)).toBe('custom');
+	});
+
+	it('returns to the derived match once the sticky flag is cleared', () => {
+		expect(resolvePersistedPresetSelection('balanced', false)).toBe('balanced');
+	});
+
+	it('never returns null — a card is always selected on this route', () => {
+		for (const match of [...PRIVACY_PRESETS.map((p) => p.id), 'custom' as const]) {
+			for (const sticky of [false, true]) {
+				expect(resolvePersistedPresetSelection(match, sticky)).not.toBeNull();
+			}
+		}
+	});
+});
+
+describe('resolvePresetSelection — onboarding, the same resolution plus the untouched guard', () => {
 	it('selects NO card in the untouched fresh-install custom state (ISSUE-001)', () => {
 		expect(resolvePresetSelection('custom', false, false)).toBeNull();
 	});
@@ -376,11 +415,12 @@ describe('Custom preset card — template wiring (no DOM harness in this suite)'
 	});
 
 	it('admin never seeds from the Custom card — the click stages nothing', async () => {
-		// Regression: admin's `privacyTouched` reads false on load for an already
-		// off-preset persisted config — the ISSUE-001 state. Passing it to
-		// customPresetSeedValues (which seeds Balanced whenever the flag is false)
-		// therefore overwrote the administrator's saved privacy settings on a plain
-		// Custom click. Admin's Custom card must only move the highlight.
+		// Regression: `customPresetSeedValues` seeds Balanced whenever its
+		// "has interacted" flag is false, and on the admin route that flag reads
+		// false on every fresh load — including loads of an already off-preset
+		// persisted config. Wiring the helper up there overwrote the
+		// administrator's saved privacy settings on a plain Custom click. Admin's
+		// Custom card must only move the highlight.
 		const src = await read(ADMIN);
 		// The helper is not imported at all — scoped to the import block so the
 		// explanatory prose above the handler may still name it.
@@ -396,63 +436,72 @@ describe('Custom preset card — template wiring (no DOM harness in this suite)'
 		expect(body).not.toContain('$userDefaultsData');
 		expect(body).not.toContain('$publicLandingLookupData');
 		expect(body).toContain('customPresetChosen = true;');
-		expect(body).toContain('privacyInteracted = true;');
 	});
 
-	it('admin latches its interaction gate instead of deriving a decaying one', async () => {
+	it('admin carries NO interaction gate — the highlight is a function of the values', async () => {
 		const src = await read(ADMIN);
-		// Regression: the gate used to be
-		// `$derived(presetCardClicked || unsavedSectionCount > 0)`, which decayed
-		// back to false the moment a save advanced the section baselines — so
-		// saving an off-preset configuration deselected every card and moved the
-		// roving tab stop back to the first one.
+		// THE REGRESSION. Admin used to mirror onboarding's ISSUE-001 gate with a
+		// session-scoped flag (`presetCardClicked`, then a latching
+		// `privacyInteracted`). Both are wrong in kind, not just in decay
+		// behaviour: the flag necessarily reads false on every fresh page load, so
+		// a SAVED off-preset configuration rendered six cards with
+		// `aria-checked="false"` and dropped the roving tab stop back to the first
+		// card. On this route the persisted values are the whole truth.
 		expect(src).not.toContain('presetCardClicked');
-		expect(src).toContain('let privacyInteracted = $state(false);');
-		expect(src).toContain(
-			'let privacyTouched = $derived(privacyInteracted || unsavedSectionCount > 0);'
-		);
+		expect(src).not.toContain('privacyInteracted');
+		expect(src).not.toContain('privacyTouched');
+		expect(src).toContain('resolvePersistedPresetSelection(selectedPreset, customPresetChosen)');
+		// The onboarding-gated resolver must not come back in through the import.
+		const importBlock = src.slice(0, src.indexOf("} from '$lib/sharing/preset-logic'"));
+		expect(importBlock).not.toContain('resolvePresetSelection');
+		expect(importBlock).toContain('resolvePersistedPresetSelection');
 
-		// Every reachable interaction latches, asserted per site rather than by
-		// occurrence count so a latch cannot be moved into a $effect (forbidden on
-		// this page) or commented out while the total still adds up. Each pattern is
-		// anchored to a newline + the statement's own indentation, so a `// `-prefixed
-		// line does not satisfy it.
+		// Nothing else was folded into the removal: the accordion toggle keeps its
+		// scroll-into-view behaviour, and the three saves keep their toasts.
+		const toggleBody = (() => {
+			const fn = src.slice(src.indexOf('async function handleAdvancedToggle('));
+			return fn.slice(0, fn.indexOf('\n}'));
+		})();
+		expect(toggleBody).toContain('if (!open) return;');
+		expect(toggleBody).toContain('await tick();');
+		expect(toggleBody).toContain("advancedSectionRef?.scrollIntoView({ behavior: 'smooth'");
+		const savedToasts = [
+			...src.matchAll(
+				/\n\t{3}handleFormToast\(\{ success: true, message: updated\.message \?\? 'Saved' \}\);/g
+			)
+		];
+		expect(savedToasts).toHaveLength(3);
+	});
+
+	it('onboarding keeps its untouched-initial-state gate', async () => {
+		const src = await read(ONBOARDING);
+		expect(src).toContain('let privacyTouched = $state(false);');
+		expect(src).toContain(
+			'resolvePresetSelection(selectedPreset, privacyTouched, customPresetChosen)'
+		);
+	});
+
+	it('onboarding latches privacyTouched on every route to a privacy value', async () => {
+		// Live detection in onboarding depends on the gate flipping the moment ANY
+		// Advanced control moves — otherwise an off-preset edit would resolve to
+		// 'custom' and still light no card.
+		const src = await read(ONBOARDING);
 		const bodyOf = (opener: string) => {
 			const fn = src.slice(src.indexOf(opener));
 			return fn.slice(0, fn.indexOf('\n}'));
 		};
-		const LATCH = /\n\tprivacyInteracted = true;/;
-		expect(bodyOf('function applyPrivacyPreset(')).toMatch(LATCH);
-		expect(bodyOf('function selectCustomPreset(')).toMatch(LATCH);
-		// The Advanced accordion is the only route to the five privacy controls, so
-		// expanding it is what keeps the highlight from decaying on a staged-then-
-		// reverted edit. Must latch BEFORE the `await`, in the user event's own task.
-		const toggleBody = bodyOf('async function handleAdvancedToggle(');
-		expect(toggleBody).toMatch(LATCH);
-		expect(toggleBody.search(LATCH)).toBeLessThan(toggleBody.indexOf('await tick();'));
-		// ...and each of the three sections' successful save — the exact transition
-		// that used to drop the highlight.
-		const successBranches = [
-			...src.matchAll(
-				/\n\t{3}privacyInteracted = true;\n\t{3}handleFormToast\(\{ success: true, message: updated\.message \?\? 'Saved' \}\);/g
-			)
-		];
-		expect(successBranches).toHaveLength(3);
-
-		// Latching does NOT reopen the seeding rule: a fresh load has latched
-		// nothing either, so the helper would still seed over a persisted config.
-		expect(customPresetSeedValues(false)).not.toBeNull();
+		expect(bodyOf('function applyPrivacyPreset(')).toContain('privacyTouched = true;');
+		expect(bodyOf('function selectCustomPreset(')).toContain('privacyTouched = true;');
+		// The five radio groups have no per-input handler; a single delegated
+		// `change` listener on the Advanced panel covers all of them.
+		expect(src).toContain(
+			'<div class="advanced-content" onchange={() => (privacyTouched = true)}>'
+		);
+		// The two switches are <button type="button">, which emit no `change`, so
+		// each latches for itself.
+		const toggleHandlers = [...src.matchAll(/onclick=\{\(\) => \{\n\t+privacyTouched = true;\n/g)];
+		expect(toggleHandlers).toHaveLength(2);
 	});
-
-	it.each([ONBOARDING, ADMIN])(
-		'%s gates the selected card on the interaction flag via resolvePresetSelection',
-		async (path) => {
-			const src = await read(path);
-			expect(src).toContain(
-				'resolvePresetSelection(selectedPreset, privacyTouched, customPresetChosen)'
-			);
-		}
-	);
 
 	it('admin still matches only the five admin-owned fields (logoMode excluded)', async () => {
 		const src = await read(ADMIN);
@@ -475,5 +524,182 @@ describe('Custom preset card — template wiring (no DOM harness in this suite)'
 		const src = await read(path);
 		expect(/name=["']custom["']/.test(src)).toBe(false);
 		expect(/formData\.set\(\s*["']custom["']/.test(src)).toBe(false);
+	});
+});
+
+/**
+ * DOM-free models of the two privacy-preset selectors. Each mirrors exactly what
+ * its page composes from the shared helpers — nothing else — so the flows below
+ * exercise the real selection pipeline rather than a paraphrase of it:
+ *
+ *   admin      selectedPresetCard = resolvePersistedPresetSelection(
+ *                                     matchPresetPrivacy(<5 staged fields>),
+ *                                     customPresetChosen)
+ *   onboarding selectedPresetCard = resolvePresetSelection(
+ *                                     matchPresetFull(<6 live fields>),
+ *                                     privacyTouched, customPresetChosen)
+ */
+type AdminFields = Pick<PrivacyPresetValues, PrivacyPresetPrivacyKey>;
+
+const fiveOf = ({ logoMode: _logoMode, ...five }: PrivacyPresetValues): AdminFields => five;
+
+/** The admin privacy page: three superForm stores + three saved baselines. */
+function adminPage(persisted: AdminFields) {
+	let staged: AdminFields = { ...persisted };
+	let saved: AdminFields = { ...persisted };
+	let customPresetChosen = false;
+	return {
+		card: () => resolvePersistedPresetSelection(matchPresetPrivacy(staged), customPresetChosen),
+		/** Edit an Advanced control (stages only — the section Save button persists). */
+		edit(patch: Partial<AdminFields>) {
+			staged = { ...staged, ...patch };
+		},
+		/** Press one section's Save button: that section's baseline advances. */
+		save() {
+			saved = { ...staged };
+		},
+		/** Click one of the five shipped cards. */
+		clickPreset(id: string) {
+			customPresetChosen = false;
+			staged = { ...staged, ...fiveOf(byId(id).values) };
+		},
+		/** Click the sixth Custom card: highlight only, stages nothing. */
+		clickCustom() {
+			customPresetChosen = true;
+		},
+		/** Reload the route: every session flag resets, values come from the DB. */
+		reload: () => adminPage(saved)
+	};
+}
+
+/** The onboarding privacy step: six local runes, no persistence until submit. */
+function onboardingStep(seed: PrivacyPresetValues) {
+	let values: PrivacyPresetValues = { ...seed };
+	let privacyTouched = false;
+	let customPresetChosen = false;
+	return {
+		card: () => resolvePresetSelection(matchPresetFull(values), privacyTouched, customPresetChosen),
+		edit(patch: Partial<PrivacyPresetValues>) {
+			privacyTouched = true;
+			values = { ...values, ...patch };
+		},
+		clickPreset(id: string) {
+			privacyTouched = true;
+			customPresetChosen = false;
+			values = { ...byId(id).values };
+		}
+	};
+}
+
+describe('admin privacy page — live Custom detection across the real state transitions', () => {
+	const BALANCED = fiveOf(byId('balanced').values);
+	/** Balanced with the recap flipped public: matches no shipped preset. */
+	const OFF_PRESET: AdminFields = { ...BALANCED, serverWrappedShareMode: 'public' };
+
+	it('1. built-in preset values select the matching built-in card', () => {
+		for (const preset of PRIVACY_PRESETS) {
+			expect(adminPage(fiveOf(preset.values)).card()).toBe(preset.id);
+		}
+	});
+
+	it('2. an off-preset edit selects Custom immediately, before any save', () => {
+		const page = adminPage(BALANCED);
+		expect(page.card()).toBe('balanced');
+		page.edit({ serverWrappedShareMode: 'public' });
+		expect(page.card()).toBe('custom');
+	});
+
+	it('3. saving that section keeps Custom, and a fresh load still resolves Custom', () => {
+		const page = adminPage(BALANCED);
+		page.edit({ serverWrappedShareMode: 'public' });
+		page.save();
+		expect(page.card()).toBe('custom');
+		// The transition that used to lose the highlight: no session flag survives a
+		// reload, so the selection has to come from the persisted values alone.
+		expect(page.reload().card()).toBe('custom');
+		expect(page.reload().reload().card()).toBe('custom');
+	});
+
+	it('4. editing into an exact match for another preset selects THAT preset', () => {
+		const page = adminPage(BALANCED);
+		page.edit({ serverWrappedShareMode: 'public' });
+		expect(page.card()).toBe('custom');
+		// Balanced -> Public Showcase differs in three of the five fields.
+		page.edit(fiveOf(byId('public-showcase').values));
+		expect(page.card()).toBe('public-showcase');
+		page.save();
+		expect(page.reload().card()).toBe('public-showcase');
+	});
+
+	it('reverting an off-preset edit restores the shipped preset highlight', () => {
+		const page = adminPage(BALANCED);
+		page.edit({ serverWrappedShareMode: 'public' });
+		expect(page.card()).toBe('custom');
+		page.edit({ serverWrappedShareMode: 'private-oauth' });
+		expect(page.card()).toBe('balanced');
+	});
+
+	it('an explicit Custom click sticks without overwriting the saved configuration', () => {
+		const page = adminPage(BALANCED);
+		page.clickCustom();
+		expect(page.card()).toBe('custom');
+		// The click staged nothing, so the underlying values are untouched: clicking a
+		// shipped card clears the sticky flag and the derived match is still Balanced.
+		page.clickPreset('balanced');
+		expect(page.card()).toBe('balanced');
+		expect(page.reload().card()).toBe('balanced');
+	});
+
+	it('a saved off-preset configuration is Custom on FIRST paint, with no interaction', () => {
+		expect(adminPage(OFF_PRESET).card()).toBe('custom');
+	});
+
+	it('logoMode is not part of the admin match — Appearance cannot force Custom', () => {
+		// The admin model has no logoMode field at all; the five-field match is what
+		// the page feeds the resolver.
+		expect(Object.keys(adminPage(BALANCED))).not.toContain('logoMode');
+		expect(matchPresetPrivacy(BALANCED)).toBe('balanced');
+	});
+});
+
+describe('onboarding privacy step — live detection with the untouched-seed guard intact', () => {
+	// The genuine fresh-install seed: matches no shipped preset (see the
+	// seed-divergence pin in tests/unit/onboarding/settings.test.ts).
+	const FRESH_SEED: PrivacyPresetValues = {
+		anonymizationMode: 'hybrid',
+		defaultShareMode: 'public',
+		serverWrappedShareMode: 'private-oauth',
+		publicLandingLookup: false,
+		allowUserControl: false,
+		logoMode: 'always_show'
+	};
+
+	it('5a. shows NO card for the untouched fresh seed even though it matches no preset', () => {
+		expect(matchPresetFull(FRESH_SEED)).toBe('custom');
+		expect(onboardingStep(FRESH_SEED).card()).toBeNull();
+	});
+
+	it('5b. a preset click selects that card, and an off-preset edit selects Custom', () => {
+		const step = onboardingStep(FRESH_SEED);
+		step.clickPreset('balanced');
+		expect(step.card()).toBe('balanced');
+		step.edit({ logoMode: 'always_hide' });
+		expect(step.card()).toBe('custom');
+	});
+
+	it('5c. editing into an exact match for a different preset selects that preset', () => {
+		const step = onboardingStep(FRESH_SEED);
+		step.clickPreset('balanced');
+		step.edit(byId('anonymous-public').values);
+		expect(step.card()).toBe('anonymous-public');
+	});
+
+	it('5d. the very first Advanced edit is enough to reveal Custom', () => {
+		// No preset click first: the seed already resolves to 'custom', and touching
+		// any control is what makes that honest rather than accusatory.
+		const step = onboardingStep(FRESH_SEED);
+		expect(step.card()).toBeNull();
+		step.edit({ anonymizationMode: 'anonymous' });
+		expect(step.card()).toBe('custom');
 	});
 });


### PR DESCRIPTION
## Problem

On **Settings → Privacy** (`/admin/settings/privacy`) the active preset card is supposed to be derived from the current privacy-setting values, so that any combination which no longer matches a shipped preset selects **Custom**. It did not do that reliably.

The admin page reused onboarding's `resolvePresetSelection`, which deliberately suppresses an untouched `'custom'` match:

```ts
if (match !== 'custom' && !customChosen) return match;
return hasInteracted ? 'custom' : null;
```

That suppression exists for a real onboarding problem (ISSUE-001): on a fresh install the seeded defaults incidentally match no shipped preset, and the step must not accuse the administrator of off-preset choices they have not made yet.

It is wrong in kind on the admin route. There the field values come from persisted `app_settings`, so an off-preset combination *is* a configuration an administrator saved. The `hasInteracted` input can only ever be a session-scoped "has anything been touched during this page load" flag, which by definition reads `false` on every fresh load — so the resolver collapsed a legitimate `'custom'` to `null`.

Reproduced against the pre-fix code by replaying the admin page's own composition:

```
on load                 : balanced
after off-preset edit   : custom
after saving the section: custom
after a page reload     : null   (match = custom)
```

The state transition that breaks it is the page load itself. Concretely:

- A saved off-preset configuration rendered all six cards with `aria-checked="false"` — nothing selected, no accessible selection exposed.
- With no card selected, `presetTabIndex` fell back to `0`, moving the radiogroup's single roving tab stop to Maximum Privacy rather than the active configuration.
- The session flag had already been made to latch (card click, accordion expand, successful save) in an earlier pass, which papered over the mid-session symptom but could not fix the load-time one — a fresh load has latched nothing either way.

The onboarding privacy step was verified rather than assumed: its `privacyTouched` rune is latched by a preset click, by the delegated `change` listener on the Advanced panel (covering all five radio groups), and by each of the two toggle switches individually. Live detection there is correct and unchanged.

## Change

`src/lib/sharing/preset-logic.ts` gains `resolvePersistedPresetSelection(match, customChosen)` — the same sticky-Custom resolution, without the untouched guard — and `resolvePresetSelection` is re-expressed on top of it:

```ts
export function resolvePersistedPresetSelection(match, customChosen) {
	return customChosen ? 'custom' : match;
}

export function resolvePresetSelection(match, hasInteracted, customChosen) {
	const selected = resolvePersistedPresetSelection(match, customChosen);
	if (selected === 'custom' && !hasInteracted) return null;
	return selected;
}
```

`resolvePresetSelection`'s behaviour is unchanged for every input, so onboarding keeps its untouched-initial-state guard verbatim.

`src/routes/admin/settings/privacy/+page.svelte` calls the new resolver, and the session interaction flag is removed along with the gate it existed to feed (`privacyInteracted`, its four latch sites, and the `privacyTouched` derived). Everything that flag was not responsible for is untouched: the accordion toggle keeps its ISSUE-007 scroll-into-view, each section keeps its save toast and baseline advance, and `unsavedSectionCount` still drives the unsaved-sections banner and the "After you save" preview.

Constraints held:

- No second source of truth and no persisted preset identifier. The highlight is still `matchPresetPrivacy` over the **five** admin-owned fields; `logoMode` stays excluded because it belongs to Appearance and its own OCC group.
- Onboarding still matches all **six** fields through `matchPresetFull`.
- Explicitly clicking **Custom** on the admin page still stages nothing and still cannot overwrite persisted settings — `customPresetSeedValues` remains unimported there, which is exactly why the seeding rule could not simply be reused.
- Keyboard navigation, focus handling, OCC (inline per section plus the three-version preset apply), form submission, and preset-application behaviour are unchanged. A card is now always selected, so the roving tab stop always lands on the active configuration instead of falling back to the first card.

## Tests

`tests/unit/sharing/presets.test.ts` adds DOM-free models of both selectors, composed from exactly what each page composes, and replays the real transitions:

1. Built-in preset values select the matching built-in card (all five).
2. An off-preset edit selects **Custom** immediately, before any save.
3. Saving that section keeps **Custom**, and a fresh load — and a second one — still resolves **Custom**.
4. Editing into an exact match for a different preset selects that preset, and survives save plus reload.
5. Onboarding shows no card for the untouched fresh seed, then does live detection identically once anything is touched.

Plus: reverting an off-preset edit restores the shipped highlight; an explicit Custom click sticks without mutating the saved configuration; a saved off-preset configuration is Custom on first paint; the resolver never returns `null` on the admin route.

The template-wiring guards are re-pointed at the new composition — the admin page must contain no interaction gate at all, must import `resolvePersistedPresetSelection` and not the onboarding-gated resolver, and must keep the accordion's scroll behaviour and the three save toasts. A companion guard pins onboarding's gate in place, including the delegated `change` listener and the two per-toggle latches.

Both directions of the regression were confirmed:

- Reverting `src/` while keeping the tests: the suite fails to load (the new export does not exist).
- Reverting only the admin page: `admin carries NO interaction gate — the highlight is a function of the values` fails, 68 pass / 1 fail.

## Validation

| Command | Result |
| --- | --- |
| `bun test --env-file=.env.test tests/unit/sharing/presets.test.ts` | 69 pass, 0 fail |
| targeted privacy/onboarding suites (`privacy-preset-apply`, `privacy-actions`, `privacy-occ-409`, `onboarding/settings`, `dogfood-ui-invariants`) | 107 pass, 0 fail |
| `bun run check:biome` | clean |
| `bun run check` | 3157 files, 0 errors, 0 warnings |
| `bun run test` | 2416 pass, 0 fail, coverage thresholds met |
| `bun run build` | succeeded |
