### PR TITLE
refactor(copy): audit and revise user-facing prose across the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Obzorarr is a **"Wrapped for Plex"** application that syncs viewing history from
 - **Plex OAuth** — Secure authentication with your Plex account
 - **Automatic Sync** — Scheduled background sync of viewing history, with live progress
 - **Reverse-Proxy Diagnostic** — Compares what your browser sees, what the proxy forwards, and what Obzorarr uses
-- **AI Fun Facts** — Optional AI-generated personalized insights (falls back to built-in templates)
+- **AI Fun Facts** — Optional AI-written fun facts, with the built-in templates as the fallback
 
 ## Issues & Support
 
@@ -327,11 +327,11 @@ a fresh claim token to paste on the next screen — that one lasts 60 minutes, s
 in to Plex, reconfigure, and sync again. It is also printed to the console as usual, so losing the
 tab is recoverable.
 
-Your watch statistics come back: they re-sync from Plex. Everything else does not — all settings,
-every per-user share setting, and **every share link you have already handed out stops working**,
-along with any manual curation and the log history. Anything configured through environment
-variables (Plex, OpenAI, `ORIGIN`, `TRUST_PROXY`) is not in the database, so it survives and the new
-setup arrives partly pre-filled. Resetting is refused while a sync is running.
+Your watch statistics come back: they re-sync from Plex. Everything else does not. That covers all
+settings, every per-user share setting, and **every share link you have already handed out stops
+working**, along with any manual curation and the log history. Anything configured through
+environment variables (Plex, OpenAI, `ORIGIN`, `TRUST_PROXY`) is not in the database, so it survives
+and the new setup arrives partly pre-filled. Obzorarr refuses to reset while a sync is running.
 
 ## Running Behind a Reverse Proxy
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -299,7 +299,7 @@ export const handleError: HandleServerError = async ({ error, event }) => {
 	logger.error(`Unexpected error: ${error}`, 'ErrorHandler', metadata);
 
 	return {
-		message: 'An unexpected error occurred'
+		message: 'Something went wrong. Try again.'
 	};
 };
 

--- a/src/lib/client/plex-login.ts
+++ b/src/lib/client/plex-login.ts
@@ -202,7 +202,7 @@ async function fetchPin(redirectUrl?: string): Promise<PinResponse> {
 		const errData = (await response.json().catch(() => ({}))) as {
 			message?: string;
 		};
-		throw new Error(errData.message || 'Failed to initiate login');
+		throw new Error(errData.message || 'Could not start login');
 	}
 	return (await response.json()) as PinResponse;
 }
@@ -267,7 +267,7 @@ export function resolveRedirectPinData(
 			pinData = JSON.parse(storedData) as StoredRedirectPinData;
 		} catch {
 			removeStoredRedirectPinData(storage);
-			throw new Error('Invalid authentication data. Please try again.');
+			throw new Error('Invalid authentication data. Try again.');
 		}
 
 		if (
@@ -276,13 +276,13 @@ export function resolveRedirectPinData(
 			(pinData.context !== 'landing' && pinData.context !== 'onboarding')
 		) {
 			removeStoredRedirectPinData(storage);
-			throw new Error('Invalid authentication data. Please try again.');
+			throw new Error('Invalid authentication data. Try again.');
 		}
 
 		const pinAge = now - pinData.createdAt;
 		if (pinAge > PIN_MAX_AGE_MS) {
 			removeStoredRedirectPinData(storage);
-			throw new Error('Authentication session expired. Please try again.');
+			throw new Error('Authentication session expired. Sign in again.');
 		}
 
 		return pinData;
@@ -291,7 +291,7 @@ export function resolveRedirectPinData(
 	if (serverPinFallback) {
 		const expiresAt = Date.parse(serverPinFallback.expiresAt);
 		if (!Number.isFinite(expiresAt) || expiresAt <= now) {
-			throw new Error('Authentication session expired. Please try again.');
+			throw new Error('Authentication session expired. Sign in again.');
 		}
 
 		return {
@@ -301,7 +301,7 @@ export function resolveRedirectPinData(
 		};
 	}
 
-	throw new Error('No pending authentication found. Please try again.');
+	throw new Error('No pending sign-in found. Start again.');
 }
 
 export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginController {
@@ -353,7 +353,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 			opts.onPopupBlocked(pinId, authUrl);
 		} catch {
 			if (cancelled) return;
-			opts.onError('Unable to prepare redirect. Please try again.');
+			opts.onError('Could not prepare the redirect. Try again.');
 		}
 	};
 
@@ -399,14 +399,14 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 						if (pollResponse.status === 401) {
 							pinExpired = true;
 							cleanup();
-							opts.onError('Authentication expired. Please try again.');
+							opts.onError('Sign-in expired. Try again.');
 							return;
 						}
 						const errData = (await pollResponse.json().catch(() => ({}))) as {
 							message?: string;
 						};
 						cleanup();
-						opts.onError(errData.message || 'Login failed. Please try again.');
+						opts.onError(errData.message || 'Login failed. Try again.');
 						return;
 					}
 
@@ -442,7 +442,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 					// cancel so the landing page can surface feedback (ISSUE-015).
 					if (popupClosed) {
 						cleanup();
-						opts.onError('Sign-in cancelled. You can try again.');
+						opts.onError('Sign-in cancelled.');
 						return;
 					}
 				} catch (err) {
@@ -484,7 +484,7 @@ export function startPlexLoginPopup(opts: PlexLoginPopupOptions): PlexLoginContr
 				if (finished) return;
 				timedOut = true;
 				cleanup();
-				opts.onError('Authentication timed out. Please try again.');
+				opts.onError('Sign-in timed out. Try again.');
 			}, LOGIN_TIMEOUT_MS);
 		} catch (err) {
 			if (cancelled) return;
@@ -517,7 +517,7 @@ export async function startPlexLoginRedirect(opts: PlexLoginRedirectOptions): Pr
 		storePinForRedirect(pinId, opts.context, storage);
 		location.href = authUrl;
 	} catch (err) {
-		opts.onError(err instanceof Error ? err.message : 'Failed to initiate login');
+		opts.onError(err instanceof Error ? err.message : 'Could not start login');
 	}
 }
 
@@ -530,7 +530,7 @@ export function commitRedirectFromPopupBlocked(
 		storePinForRedirect(pinId, context);
 	} catch {
 		throw new Error(
-			'Unable to save login state. Storage may be blocked. Please enable cookies/storage for this site.'
+			'Could not save login state. Enable cookies and storage for this site, then try again.'
 		);
 	}
 	window.location.href = authUrl;

--- a/src/lib/components/auth/PopupBlockedModal.svelte
+++ b/src/lib/components/auth/PopupBlockedModal.svelte
@@ -79,8 +79,8 @@ function handleCancel(): void {
 				</svg>
 			</div>
 			<p>
-				Continue in this window instead. You'll be redirected to Plex to sign in, then back here
-				automatically.
+				Continue in this window instead. Obzorarr sends you to Plex to sign in and brings you back
+				here.
 			</p>
 		</div>
 

--- a/src/lib/components/security/CsrfWarningBanner.svelte
+++ b/src/lib/components/security/CsrfWarningBanner.svelte
@@ -54,8 +54,8 @@ async function handlePermanentDismiss() {
 			<ShieldAlert class="icon" />
 		</div>
 		<div class="banner-text">
-			<strong>Security Warning:</strong> CSRF protection is not configured. Your application may be vulnerable
-			to cross-site request forgery attacks.
+			<strong>Security Warning:</strong> CSRF protection is not configured, so Obzorarr accepts form
+			posts from any origin.
 		</div>
 		<div class="banner-actions">
 			<a href="/admin/settings?tab=security" class="configure-button">
@@ -82,16 +82,14 @@ async function handlePermanentDismiss() {
 			</div>
 			<AlertDialog.Title>Dismiss Security Warning?</AlertDialog.Title>
 			<AlertDialog.Description>
-				CSRF (Cross-Site Request Forgery) protection helps prevent malicious websites from making
-				unauthorized requests on behalf of your users. Without it, attackers could potentially
-				perform actions as authenticated users.
+				CSRF (Cross-Site Request Forgery) protection stops other websites from making requests on
+				behalf of your users. Without it, an attacker can act as a signed-in user.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 
 		<div class="warning-card">
 			<p>
-				By dismissing this warning, you acknowledge that you understand the security implications
-				and accept the associated risks.
+				Dismissing this warning means you accept that risk.
 			</p>
 		</div>
 
@@ -110,10 +108,9 @@ async function handlePermanentDismiss() {
 			<div class="dialog-icon danger">
 				<ShieldAlert class="icon" />
 			</div>
-			<AlertDialog.Title>Are You Absolutely Sure?</AlertDialog.Title>
+			<AlertDialog.Title>Dismiss the warning for good?</AlertDialog.Title>
 			<AlertDialog.Description>
-				This will permanently dismiss the CSRF security warning. The warning will not appear again
-				unless you manually reset it in the admin settings.
+				The CSRF security warning will not appear again unless you reset it in the admin settings.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 

--- a/src/lib/components/slides/DecadeSlide.svelte
+++ b/src/lib/components/slides/DecadeSlide.svelte
@@ -180,7 +180,7 @@ $effect(() => {
 			<div class="no-data">
 				<span class="no-data-icon">📅</span>
 				<p class="empty-message">No release year data available</p>
-				<p class="empty-hint">Release year data will be available after the next sync</p>
+				<p class="empty-hint">Release years appear after the next sync</p>
 			</div>
 		{/if}
 

--- a/src/lib/components/slides/GenresSlide.svelte
+++ b/src/lib/components/slides/GenresSlide.svelte
@@ -205,7 +205,7 @@ $effect(() => {
 			</Tooltip.Provider>
 		{:else}
 			<p class="empty-message">No genre data available</p>
-			<p class="empty-hint">Genre information will be available in a future update</p>
+			<p class="empty-hint">Obzorarr does not collect genre data yet</p>
 		{/if}
 
 		{#if children}

--- a/src/lib/components/slides/PercentileSlide.svelte
+++ b/src/lib/components/slides/PercentileSlide.svelte
@@ -29,7 +29,7 @@ const isTopPerformer = $derived(topPercentage <= 10);
 const message = $derived.by(() => {
 	if (topPercentage <= 1) return "You're the #1 viewer!";
 	if (topPercentage <= 5) return "You're in the top 5%!";
-	if (topPercentage <= 10) return "You're a super fan!";
+	if (topPercentage <= 10) return "You're in the top 10%!";
 	if (topPercentage <= 25) return "You're in the top quarter!";
 	if (topPercentage <= 50) return 'You watch more than most!';
 	return 'Keep watching!';

--- a/src/lib/components/slides/RewatchSlide.svelte
+++ b/src/lib/components/slides/RewatchSlide.svelte
@@ -159,7 +159,7 @@ $effect(() => {
 			{/if}
 		{:else}
 			<p class="empty-message">No rewatches this year</p>
-			<p class="empty-hint">Looks like you're always exploring new content!</p>
+			<p class="empty-hint">Every play this year was something new.</p>
 		{/if}
 
 		{#if children}

--- a/src/lib/components/slides/StreakSlide.svelte
+++ b/src/lib/components/slides/StreakSlide.svelte
@@ -32,7 +32,7 @@ const streakEmoji = $derived.by(() => {
 
 const streakMessage = $derived.by(() => {
 	if (!watchStreak) return '';
-	if (watchStreak.longestStreak >= 30) return 'Incredible dedication!';
+	if (watchStreak.longestStreak >= 30) return 'A month or more!';
 	if (watchStreak.longestStreak >= 14) return 'Two weeks strong!';
 	if (watchStreak.longestStreak >= 7) return 'A full week!';
 	if (watchStreak.longestStreak >= 3) return 'Building momentum!';

--- a/src/lib/components/wrapped/ShareModal.svelte
+++ b/src/lib/components/wrapped/ShareModal.svelte
@@ -375,7 +375,7 @@ $effect(() => {
 						<path d="M7 11V7a5 5 0 0 1 10 0v4" />
 					</svg>
 					<p class="members-only-text">
-						Visible to Plex server members only — recipients must sign in with their Plex
+						Visible to Plex server members only. Recipients must sign in with their Plex
 						account to open this Wrapped.
 					</p>
 				</div>
@@ -398,8 +398,8 @@ $effect(() => {
 						<path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
 					</svg>
 					<p class="members-only-text">
-						Shared via private link — anyone with this link can open this Wrapped without
-						signing in. Treat the link like a password and only share it with people you trust.
+						Shared via private link. Anyone with this link can open this Wrapped without
+						signing in, so treat it like a password and share it only with people you trust.
 					</p>
 				</div>
 			{/if}
@@ -476,8 +476,8 @@ $effect(() => {
 												>
 													Privacy settings
 												</a>
-												to self-share — note this lowers the floor for
-												<strong>all users</strong> server-wide, not just you.
+												to self-share. That lowers the floor for
+												<strong>all users</strong> on the server, not only you.
 											{:else}
 												Contact your admin to change the server-wide floor.
 											{/if}

--- a/src/lib/components/wrapped/StoryMode.svelte
+++ b/src/lib/components/wrapped/StoryMode.svelte
@@ -387,7 +387,7 @@ function handleSlideAnimationComplete(): void {}
 	bind:this={container}
 	class="story-mode {klass}"
 	role="application"
-	aria-label="Story presentation - use arrow keys to navigate"
+	aria-label="Story presentation. Use the arrow keys to move between slides."
 	onclick={handleClick}
 	ontouchstart={handleTouchStart}
 	ontouchend={handleTouchEnd}

--- a/src/lib/server/admin/occ-helpers.ts
+++ b/src/lib/server/admin/occ-helpers.ts
@@ -8,7 +8,7 @@ import { getAppSettingsUpdatedAt } from './settings.service';
  *
  * The external-OCC path uses a different shape — see `OCC_CONFLICT_CODE`.
  */
-export const OCC_CONFLICT_MESSAGE = 'Settings changed in another tab. Please reload.';
+export const OCC_CONFLICT_MESSAGE = 'Settings changed in another tab. Reload and try again.';
 
 /**
  * Sentinel `code` discriminator for the external-OCC conflict shape.

--- a/src/lib/server/auth/login-completion.ts
+++ b/src/lib/server/auth/login-completion.ts
@@ -25,7 +25,7 @@ const COOKIE_OPTIONS = {
 };
 
 const ONBOARDING_OWNER_REQUIRED_MESSAGE =
-	'Only the server owner can configure Obzorarr. Please sign in with the server owner account.';
+	'Only the server owner can configure Obzorarr. Sign in with the owner account.';
 
 // SvelteKit throws a bare `Error` (no subclass/`.code`) when `cookies.set(...)` runs
 // after the response is generated, so this trailing substring of its message is the
@@ -179,7 +179,7 @@ export async function completePlexPinLogin(
 ): Promise<PinLoginResult> {
 	const transaction = await getPinTransactionForRequest(pinId, cookies);
 	if (!transaction) {
-		throw new PinExpiredError('Login session expired or invalid. Please try again.');
+		throw new PinExpiredError('Login session expired or invalid. Sign in again.');
 	}
 
 	if (!transaction.callbackVerified) {

--- a/src/lib/server/auth/membership.ts
+++ b/src/lib/server/auth/membership.ts
@@ -547,7 +547,7 @@ export function messageForMembershipFailure(membership: MembershipResult): strin
 			return `Temporary connection issue contacting your Plex server. Please try again${detail}. If this keeps happening, verify PLEX_SERVER_URL and PLEX_TOKEN are correct and the server is online.`;
 		}
 		case 'not_in_resources':
-			return 'The configured Plex server is not listed under your Plex.tv account. Please sign in with the server owner account.';
+			return 'The configured Plex server is not listed under your Plex.tv account. Sign in with the owner account.';
 		default:
 			return 'You are not a member of this Plex server.';
 	}

--- a/src/lib/server/auth/plex-oauth.ts
+++ b/src/lib/server/auth/plex-oauth.ts
@@ -147,7 +147,7 @@ export async function pollPinForToken(
 		await new Promise((resolve) => setTimeout(resolve, intervalMs));
 	}
 
-	throw new PinExpiredError('Login timed out. Please try again.');
+	throw new PinExpiredError('Login timed out. Try again.');
 }
 
 /** Validate Plex's external profile payload before onboarding/auth code trusts its identifiers. */

--- a/src/lib/server/auth/types.ts
+++ b/src/lib/server/auth/types.ts
@@ -25,14 +25,14 @@ export class NotServerMemberError extends AuthError {
 }
 
 export class PinExpiredError extends AuthError {
-	constructor(message = 'Login session expired. Please try again.') {
+	constructor(message = 'Login session expired. Sign in again.') {
 		super(message, 'PIN_EXPIRED');
 		this.name = 'PinExpiredError';
 	}
 }
 
 export class SessionExpiredError extends AuthError {
-	constructor(message = 'Your session has expired. Please log in again.') {
+	constructor(message = 'Your session expired. Sign in again.') {
 		super(message, 'SESSION_EXPIRED');
 		this.name = 'SessionExpiredError';
 	}

--- a/src/lib/server/funfacts/templates/achievement.ts
+++ b/src/lib/server/funfacts/templates/achievement.ts
@@ -58,7 +58,7 @@ export const ACHIEVEMENT_TEMPLATES = defineTemplateCategory('achievement', [
 	{
 		id: 'double-digit-movies',
 		factTemplate: '{Subject} watched {possessive} favorite movie {topMovieCount} times',
-		comparisonTemplate: '{Subject} really love that film!',
+		comparisonTemplate: '{Subject} love that film!',
 		icon: '🔁',
 		requiredStats: ['topMovieCount'],
 		minThresholds: { topMovieCount: 10 },

--- a/src/lib/server/funfacts/templates/behavioral-insight.ts
+++ b/src/lib/server/funfacts/templates/behavioral-insight.ts
@@ -38,7 +38,7 @@ export const BEHAVIORAL_TEMPLATES = defineTemplateCategory('behavioral-insight',
 	{
 		id: 'peak-month',
 		factTemplate: '{peakMonthName} was {possessive} biggest viewing month',
-		comparisonTemplate: '{Subject} really went all-in that month!',
+		comparisonTemplate: '{Subject} went all-in that month!',
 		icon: '📅',
 		requiredStats: ['peakMonth', 'plays'],
 		// Avoid declaring a "biggest month" from a token amount of viewing data.

--- a/src/lib/server/funfacts/templates/content-comparison.ts
+++ b/src/lib/server/funfacts/templates/content-comparison.ts
@@ -28,7 +28,7 @@ export const CONTENT_COMPARISON_TEMPLATES = defineTemplateCategory('content-comp
 	{
 		id: 'show-explorer',
 		factTemplate: '{Subject} jumped between {uniqueShows} different TV shows',
-		comparisonTemplate: 'A true explorer of the television landscape!',
+		comparisonTemplate: 'A true explorer of television!',
 		icon: '🔍',
 		requiredStats: ['uniqueShows'],
 		minThresholds: { uniqueShows: 5 }

--- a/src/lib/server/funfacts/templates/temporal-pattern.ts
+++ b/src/lib/server/funfacts/templates/temporal-pattern.ts
@@ -11,7 +11,7 @@ export const TEMPORAL_TEMPLATES = defineTemplateCategory('temporal-pattern', [
 	{
 		id: 'year-bookends',
 		factTemplate: 'From "{firstWatchTitle}" to "{lastWatchTitle}"',
-		comparisonTemplate: 'What a viewing journey this year has been!',
+		comparisonTemplate: 'What a year of watching!',
 		icon: '📖',
 		requiredStats: ['firstWatchTitle', 'lastWatchTitle']
 	},
@@ -25,7 +25,7 @@ export const TEMPORAL_TEMPLATES = defineTemplateCategory('temporal-pattern', [
 	{
 		id: 'year-participant',
 		factTemplate: '{Subject} were an active viewer in {year}',
-		comparisonTemplate: "Here's to another year of great content!",
+		comparisonTemplate: 'Bring on another year of great content!',
 		icon: '🎊',
 		requiredStats: [],
 		minThresholds: {}

--- a/src/lib/server/funfacts/test-connection.ts
+++ b/src/lib/server/funfacts/test-connection.ts
@@ -60,7 +60,7 @@ export async function testOpenAIConnection(
 		if (response.status === 401) {
 			return {
 				success: false,
-				error: appendErrorDetail('Authentication failed — check your API key', statusDetail)
+				error: appendErrorDetail('Authentication failed. Check your API key.', statusDetail)
 			};
 		}
 		if (response.status === 404) {
@@ -93,5 +93,5 @@ export async function testOpenAIConnection(
 }
 
 function appendErrorDetail(message: string, detail: string | null): string {
-	return detail ? `${message} — ${detail}` : message;
+	return detail ? `${message} (${detail})` : message;
 }

--- a/src/lib/server/plex/account-reconciliation.ts
+++ b/src/lib/server/plex/account-reconciliation.ts
@@ -342,9 +342,7 @@ export async function runPlexAccountReconciliation(): Promise<number> {
 		!isCanonicalPositiveAuthorityEpoch(beforeObservation.authorityEpoch) ||
 		!hasCurrentAuthorityDiscriminator(beforeObservation)
 	) {
-		throw new PlexAuthApiError(
-			'Plex authority is not configured. Please complete the onboarding process.'
-		);
+		throw new PlexAuthApiError('Plex authority is not configured. Finish onboarding first.');
 	}
 
 	const machineIdentifier = await getServerMachineIdentifier(beforeConfig);

--- a/src/lib/server/plex/server-identity.service.ts
+++ b/src/lib/server/plex/server-identity.service.ts
@@ -72,7 +72,7 @@ export async function fetchServerIdentity(
 			return {
 				identity: null,
 				errorReason:
-					'Authentication failed - the PLEX_TOKEN may be invalid or no longer authorized for this server'
+					'Authentication failed. The PLEX_TOKEN may be invalid or no longer authorized for this server.'
 			};
 		}
 

--- a/src/lib/server/security/error-sanitizer.ts
+++ b/src/lib/server/security/error-sanitizer.ts
@@ -31,13 +31,13 @@ export function sanitizeConnectionError(error: unknown): string {
 
 export function classifyConnectionError(error: Error): string {
 	if (error.name === 'AbortError') {
-		return 'Connection timed out - the server may be unreachable';
+		return 'Connection timed out. The server may be unreachable.';
 	}
 
 	const message = error.message;
 
 	if (message.includes('certificate') || message.includes('SSL') || message.includes('TLS')) {
-		return 'SSL certificate error - check your server configuration';
+		return 'SSL certificate error. Check your server configuration.';
 	}
 
 	if (
@@ -45,7 +45,7 @@ export function classifyConnectionError(error: Error): string {
 		message.includes('ECONNREFUSED') ||
 		message.includes('getaddrinfo')
 	) {
-		return 'Could not connect to server - check the URL and ensure the server is reachable';
+		return 'Could not connect to the server. Check the URL and make sure the server is reachable.';
 	}
 
 	return sanitizeConnectionError(error);

--- a/src/lib/server/security/rate-limit-handle.ts
+++ b/src/lib/server/security/rate-limit-handle.ts
@@ -85,7 +85,7 @@ export const rateLimitHandle: Handle = async ({ event, resolve }) => {
 						type: 'failure',
 						status: 429,
 						data: stringify({
-							error: `Too many requests. Please try again in ${retryAfterSeconds} second${retryAfterSeconds === 1 ? '' : 's'}.`,
+							error: `Too many requests. Try again in ${retryAfterSeconds} second${retryAfterSeconds === 1 ? '' : 's'}.`,
 							requiresAuth: false
 						})
 					}),

--- a/src/lib/server/sharing/access-control.ts
+++ b/src/lib/server/sharing/access-control.ts
@@ -117,10 +117,10 @@ export async function checkWrappedAccess(
 			case 'invalid_token':
 				throw new InvalidShareTokenError();
 			case 'not_authenticated':
-				throw new ShareAccessDeniedError('Sign in with your Plex account to view this wrapped.');
+				throw new ShareAccessDeniedError('Sign in with your Plex account to view this Wrapped.');
 			case 'mode_requires_auth':
 				throw new ShareAccessDeniedError(
-					'This wrapped is visible only to members of this Plex server. Sign in with your Plex account to view.'
+					'This Wrapped is visible only to members of this Plex server. Sign in with your Plex account to view it.'
 				);
 			default:
 				throw new ShareAccessDeniedError();
@@ -174,7 +174,7 @@ export async function checkTokenAccess(
 	if (ShareModePrivacyLevel[settings.mode] > ShareModePrivacyLevel[ShareMode.PRIVATE_LINK]) {
 		if (!currentUser) {
 			throw new ShareAccessDeniedError(
-				'This wrapped is visible only to members of this Plex server. Sign in with your Plex account to view.'
+				'This Wrapped is visible only to members of this Plex server. Sign in with your Plex account to view it.'
 			);
 		}
 		return {
@@ -201,7 +201,7 @@ export async function checkTokenAccess(
 		if (ShareModePrivacyLevel[effectiveMode] > ShareModePrivacyLevel[ShareMode.PRIVATE_LINK]) {
 			if (!currentUser) {
 				throw new ShareAccessDeniedError(
-					'This wrapped is visible only to members of this Plex server. Sign in with your Plex account to view.'
+					'This Wrapped is visible only to members of this Plex server. Sign in with your Plex account to view it.'
 				);
 			}
 			return {
@@ -255,10 +255,10 @@ export async function checkServerWrappedAccess(
 	if (!result.allowed) {
 		switch (result.denialReason) {
 			case 'not_authenticated':
-				throw new ShareAccessDeniedError('Sign in with your Plex account to view this wrapped.');
+				throw new ShareAccessDeniedError('Sign in with your Plex account to view this Wrapped.');
 			case 'mode_requires_auth':
 				throw new ShareAccessDeniedError(
-					'This wrapped is visible only to members of this Plex server. Sign in with your Plex account to view.'
+					'This Wrapped is visible only to members of this Plex server. Sign in with your Plex account to view it.'
 				);
 			default:
 				throw new ShareAccessDeniedError();

--- a/src/lib/server/sharing/service.ts
+++ b/src/lib/server/sharing/service.ts
@@ -569,7 +569,11 @@ export async function regenerateShareToken(userId: number, year: number): Promis
 	}
 
 	if (settings.mode !== ShareMode.PRIVATE_LINK) {
-		throw new ShareError('Can only regenerate token for private-link mode', 'INVALID_MODE', 400);
+		throw new ShareError(
+			'Switch to private-link mode before regenerating the token',
+			'INVALID_MODE',
+			400
+		);
 	}
 
 	// Defense-in-depth: if the server-wide floor is more restrictive than

--- a/src/lib/server/slides/renderer.ts
+++ b/src/lib/server/slides/renderer.ts
@@ -110,7 +110,7 @@ export function detectUnsafeHtml(content: string): UnsafeHtmlDetection {
 	if (/<script[^>]*>/i.test(content)) {
 		return {
 			unsafe: true,
-			reason: "Remove <script> tags — inline scripts aren't allowed in slide content."
+			reason: 'Remove <script> tags. Slide content cannot include inline scripts.'
 		};
 	}
 

--- a/src/lib/server/slides/types.ts
+++ b/src/lib/server/slides/types.ts
@@ -40,7 +40,7 @@ export function slideErrorToFail(err: unknown): SlideActionFail {
 				});
 				return {
 					status: 500,
-					body: { error: 'Slide could not be saved. Please try again.' }
+					body: { error: 'Could not save the slide. Try again.' }
 				};
 		}
 	}
@@ -53,5 +53,5 @@ export function slideErrorToFail(err: unknown): SlideActionFail {
 	logger.error(`Unexpected slide action error: ${detail}`, 'SlideError', {
 		code: err instanceof SlideError ? err.code : undefined
 	});
-	return { status: 500, body: { error: 'An unexpected error occurred' } };
+	return { status: 500, body: { error: 'Something went wrong. Try again.' } };
 }

--- a/src/lib/sharing/options.ts
+++ b/src/lib/sharing/options.ts
@@ -54,7 +54,7 @@ export const shareModeOptions: OptionCopy<ShareModeType>[] = [
 		value: ShareMode.PRIVATE_OAUTH,
 		label: 'Server Members Only',
 		description:
-			'Any signed-in Plex server member can view — including this person’s real name and full viewing history'
+			'Any signed-in Plex server member can view, including this person’s real name and full viewing history'
 	},
 	{
 		value: ShareMode.PRIVATE_LINK,
@@ -243,7 +243,7 @@ export const PRIVACY_PREVIEW_VALUE_TOOLTIPS: PrivacyPreviewValueTooltips = {
 	namesInStats: {
 		real: 'Wrapped recap output and leaderboards show each person’s actual Plex username.',
 		anonymous:
-			'Usernames are replaced with neutral placeholders like “User #1” everywhere except the admin dashboard — no one is identifiable in public stats.',
+			'Obzorarr replaces usernames with placeholders like “User #1” everywhere except the admin dashboard, so no one is identifiable in public stats.',
 		'hybrid-self-sees-own':
 			'A signed-in member sees their own real name, while everyone else stays anonymized as “User #1”.'
 	},

--- a/src/lib/sharing/preset-logic.ts
+++ b/src/lib/sharing/preset-logic.ts
@@ -259,7 +259,7 @@ export function derivePreview(
 export const PREVIEW_NAME_DISPLAY_LABELS: Record<PrivacyPreviewModel['nameDisplay'], string> = {
 	real: 'Real usernames',
 	anonymous: 'Anonymous (hidden)',
-	'hybrid-self-sees-own': 'Hybrid — each sees their own name'
+	'hybrid-self-sees-own': 'Hybrid: each sees their own name'
 };
 
 export const PREVIEW_RECAP_VISIBILITY_LABELS: Record<

--- a/src/lib/utils/form-toast.ts
+++ b/src/lib/utils/form-toast.ts
@@ -40,21 +40,21 @@ export function handleFormToast(form: FormShape): void {
 				const data = (form as Extract<ActionResult, { type: 'success' }>).data as
 					| { message?: string }
 					| undefined;
-				toast.success(data?.message ?? 'Operation completed successfully');
+				toast.success(data?.message ?? 'Saved');
 				return;
 			}
 			case 'failure': {
 				const data = (form as Extract<ActionResult, { type: 'failure' }>).data as
 					| { error?: string; message?: string }
 					| undefined;
-				toast.error(data?.error ?? data?.message ?? 'An unexpected error occurred');
+				toast.error(data?.error ?? data?.message ?? 'Something went wrong. Try again.');
 				return;
 			}
 			case 'error': {
 				const err = (form as Extract<ActionResult, { type: 'error' }>).error as
 					| { message?: string }
 					| undefined;
-				toast.error(err?.message ?? 'An unexpected error occurred');
+				toast.error(err?.message ?? 'Something went wrong. Try again.');
 				return;
 			}
 			case 'redirect':
@@ -69,11 +69,11 @@ export function handleFormToast(form: FormShape): void {
 			return;
 		}
 		if (form.warning) {
-			toast.warning(form.message ?? 'Please review the warning');
+			toast.warning(form.message ?? 'Review the warning');
 			return;
 		}
 		if (form.success) {
-			toast.success(form.message ?? 'Operation completed successfully');
+			toast.success(form.message ?? 'Saved');
 		}
 	}
 }

--- a/src/lib/utils/form-toast.ts
+++ b/src/lib/utils/form-toast.ts
@@ -26,6 +26,19 @@ function isLegacyResponse(value: object): value is LegacyFormResponse {
 }
 
 /**
+ * Fallback success text for a `{ success: true }` result that carries no
+ * `message`. Deliberately operation-neutral: this branch cannot know what the
+ * action did, and not every caller is a save. `admin/slides` toggles, reorders
+ * AND deletes through one `$effect` on the `form` prop, and `?/deleteCustom`
+ * returns a bare `{ success: true }` — a 'Saved' fallback announces the wrong
+ * outcome for a delete. Whoever DOES know the operation supplies the message:
+ * the action (`'Sync started'` from `?/startSync`) or the caller (`'Logs
+ * cleared'` in the logs enhance callback, `'Saved'` on the settings cards).
+ * Keep this string generic instead of guessing on their behalf.
+ */
+const GENERIC_SUCCESS_MESSAGE = 'Done';
+
+/**
  * Toast a form-action result. Accepts both the legacy `FormResponse` shape
  * (kept compatible during the Superforms incremental migration across
  * PR-2/3) and the Superforms-native `ActionResult` shape returned by
@@ -40,7 +53,7 @@ export function handleFormToast(form: FormShape): void {
 				const data = (form as Extract<ActionResult, { type: 'success' }>).data as
 					| { message?: string }
 					| undefined;
-				toast.success(data?.message ?? 'Saved');
+				toast.success(data?.message ?? GENERIC_SUCCESS_MESSAGE);
 				return;
 			}
 			case 'failure': {
@@ -73,7 +86,7 @@ export function handleFormToast(form: FormShape): void {
 			return;
 		}
 		if (form.success) {
-			toast.success(form.message ?? 'Saved');
+			toast.success(form.message ?? GENERIC_SUCCESS_MESSAGE);
 		}
 	}
 }

--- a/src/lib/utils/occ-form.ts
+++ b/src/lib/utils/occ-form.ts
@@ -68,7 +68,7 @@ export function surfaceOccConflict(event: { result: ActionResult; cancel: () => 
 	if (result.type === 'failure' && isOccConflict(result.data)) {
 		const message =
 			(result.data as { error?: string } | undefined)?.error ??
-			'Settings changed in another tab. Please reload.';
+			'Settings changed in another tab. Reload and try again.';
 		toast.error(message, { action: { label: 'Reload', onClick: () => window.location.reload() } });
 		event.cancel();
 	}

--- a/src/lib/utils/submit-action.ts
+++ b/src/lib/utils/submit-action.ts
@@ -34,7 +34,7 @@ export async function submitAction<T = unknown>(
 		// plain text, or the body was truncated). Map this to a typed error
 		// outcome so callers can rely on the `SubmitOutcome<T>` contract.
 		console.error('[submitAction] deserialize failed:', err);
-		return { type: 'error', error: { message: 'An unexpected error occurred' } };
+		return { type: 'error', error: { message: 'Something went wrong. Try again.' } };
 	}
 
 	if (result.type === 'success') {

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -26,11 +26,11 @@ const title = $derived.by(() => {
 
 const description = $derived.by(() => {
 	if (message) return message;
-	if (status === 404) return "We couldn't find the page you were looking for.";
+	if (status === 404) return "That page doesn't exist.";
 	if (status === 403) return "You don't have permission to view this page.";
-	if (status === 429) return 'Please slow down and try again in a moment.';
-	if (status >= 500) return 'An unexpected error occurred on the server.';
-	return 'An unexpected error occurred.';
+	if (status === 429) return 'Wait a moment, then try again.';
+	if (status >= 500) return 'The server hit an unexpected error.';
+	return 'Something went wrong.';
 });
 
 function goBack(): void {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -124,7 +124,7 @@ function handleContinueWithRedirect(): void {
 	try {
 		commitRedirectFromPopupBlocked(pendingPinId, pendingAuthUrl, 'landing');
 	} catch (err) {
-		oauthError = err instanceof Error ? err.message : 'Failed to initiate redirect login';
+		oauthError = err instanceof Error ? err.message : 'Could not start the redirect login';
 	}
 }
 
@@ -149,8 +149,7 @@ function handleCancelRedirect(): void {
 			</h1>
 
 			<p class="hero-description">
-				Discover your Plex viewing journey. Beautiful statistics, stunning animations, and shareable
-				summaries of your media consumption.
+				See what you watched on Plex this year, with stats and animated slides you can share.
 			</p>
 
 			{#if data.publicLookupEnabled}
@@ -210,11 +209,11 @@ function handleCancelRedirect(): void {
 							</SubmitButton>
 						</div>
 						<p id="username-help" class="lookup-help">
-							Search a Plex username. Eligible pages open without sign-in; unknown and opted-out users
-							receive the same response.
+							Search a Plex username. Eligible pages open without sign-in, and unknown or opted-out
+							usernames return the same response.
 						</p>
 						<p class="lookup-boundary">
-							This opens only a Wrapped page. Dashboards, settings, and admin controls remain protected.
+							This opens only a Wrapped page. Dashboards, settings, and admin controls still need sign-in.
 						</p>
 						<p class="lookup-status" role="status" aria-live="polite">
 							{isLookingUp ? 'Looking for that Wrapped…' : ''}
@@ -264,7 +263,7 @@ function handleCancelRedirect(): void {
 			{/if}
 
 			<div class="login-section">
-				<p class="login-prompt">Sign in to access your protected dashboard or change settings.</p>
+				<p class="login-prompt">Sign in to reach your dashboard or change your settings.</p>
 				<Button
 					type="button"
 					class="login-button secondary tap-target"

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -124,7 +124,7 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 </script>
 
 <svelte:head>
-	<title>Dashboard — Admin — Obzorarr</title>
+	<title>Dashboard - Admin - Obzorarr</title>
 </svelte:head>
 
 <div class="dashboard">
@@ -252,7 +252,7 @@ const lastSyncStatus = $derived(data.lastSync?.status ?? 'unknown');
 				{#if syncStatus === 'inactive'}
 					<div class="scheduler-cta">
 						<p class="scheduler-cta-text">
-							No automatic sync is scheduled. Set one up so your viewing history stays up to date.
+							No automatic sync is scheduled. Add one to keep viewing history current.
 						</p>
 						<a href="/admin/sync" class="scheduler-cta-link" onclick={handleAdminNavigation}>
 							<span>Configure schedule</span>

--- a/src/routes/admin/logs/+page.server.ts
+++ b/src/routes/admin/logs/+page.server.ts
@@ -148,7 +148,7 @@ export const actions: Actions = requireAdminActions({
 			const total = result.byAge + result.byCount;
 			const message =
 				total === 0
-					? 'Cleanup completed: no log entries needed to be removed'
+					? 'Cleanup finished with nothing to remove'
 					: `Cleanup completed: removed ${total} log ${total === 1 ? 'entry' : 'entries'} (${result.byAge} by age, ${result.byCount} by count)`;
 			return { success: true, message };
 		} catch (error) {

--- a/src/routes/admin/logs/+page.svelte
+++ b/src/routes/admin/logs/+page.svelte
@@ -344,7 +344,7 @@ $effect(() => {
 </script>
 
 <svelte:head>
-	<title>Logs — Admin — Obzorarr</title>
+	<title>Logs - Admin - Obzorarr</title>
 </svelte:head>
 
 <div class="logs-page">
@@ -648,7 +648,7 @@ $effect(() => {
 		<AlertDialog.Header>
 			<AlertDialog.Title>Clear all logs?</AlertDialog.Title>
 			<AlertDialog.Description>
-				This will permanently delete every log entry. This action cannot be undone.
+				Deletes every log entry. You cannot undo this.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
@@ -700,8 +700,8 @@ $effect(() => {
 		<AlertDialog.Header>
 			<AlertDialog.Title>Run cleanup now?</AlertDialog.Title>
 			<AlertDialog.Description>
-				Logs older than {data.settings.retentionDays} days will be deleted, and only the {data.settings.maxCount.toLocaleString()}
-				newest will be kept. This cannot be undone.
+				Deletes logs older than {data.settings.retentionDays} days and keeps only the {data.settings.maxCount.toLocaleString()}
+				newest. You cannot undo this.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -48,7 +48,7 @@ const sections = [
 </script>
 
 <svelte:head>
-	<title>Settings — Admin — Obzorarr</title>
+	<title>Settings - Admin - Obzorarr</title>
 </svelte:head>
 
 <div class="hub">

--- a/src/routes/admin/settings/appearance/+page.server.ts
+++ b/src/routes/admin/settings/appearance/+page.server.ts
@@ -246,7 +246,8 @@ export const actions: Actions = requireAdminActions({
 			);
 			return { form, success: true, message: 'Logo visibility mode updated' };
 		} catch (error) {
-			const message = error instanceof Error ? error.message : 'Failed to update mode';
+			const message =
+				error instanceof Error ? error.message : 'Failed to update the logo visibility mode';
 			return fail(500, { form, error: message });
 		}
 	}

--- a/src/routes/admin/settings/appearance/+page.svelte
+++ b/src/routes/admin/settings/appearance/+page.svelte
@@ -147,7 +147,7 @@ function getThemeDescription(theme: string): string {
 </script>
 
 <svelte:head>
-	<title>Appearance — Settings — Obzorarr</title>
+	<title>Appearance - Settings - Obzorarr</title>
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">

--- a/src/routes/admin/settings/connections/+page.server.ts
+++ b/src/routes/admin/settings/connections/+page.server.ts
@@ -270,7 +270,8 @@ export const actions: Actions = requireAdminActions({
 
 			return { success: true, message, apiConfigVersion: newApiConfigVersion };
 		} catch (error) {
-			const message = error instanceof Error ? error.message : 'Failed to update settings';
+			const message =
+				error instanceof Error ? error.message : 'Failed to update the connection settings';
 			return fail(500, { error: message });
 		}
 	},

--- a/src/routes/admin/settings/connections/+page.svelte
+++ b/src/routes/admin/settings/connections/+page.svelte
@@ -77,7 +77,7 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 </script>
 
 <svelte:head>
-	<title>Connections — Settings — Obzorarr</title>
+	<title>Connections - Settings - Obzorarr</title>
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">
@@ -85,11 +85,11 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 		<CardHeader>
 			<CardTitle>Plex server</CardTitle>
 			<CardDescription>
-				URL + auth token for the Plex Media Server obzorarr syncs from.
+				URL and auth token for the Plex Media Server Obzorarr syncs from.
 				{#if plexAnyLocked}
-					Locked fields are set via environment variables and can only be changed there.
-					Placeholder env values (e.g. the shipped <code>.env.example</code> defaults) are
-					ignored and leave the field editable here.
+					Environment variables set the locked fields, so change them there. Obzorarr ignores
+					placeholder env values (for example the shipped <code>.env.example</code> defaults) and
+					leaves those fields editable here.
 				{/if}
 			</CardDescription>
 		</CardHeader>
@@ -152,7 +152,7 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 						<Label for="plexToken">
 							Plex token
 							{#if settings.plexToken.hasValue}
-								<span class="text-xs text-muted-foreground">(stored — leave blank to keep)</span>
+								<span class="text-xs text-muted-foreground">(stored, leave blank to keep)</span>
 							{/if}
 						</Label>
 						{#if plexTokenLocked}
@@ -248,8 +248,8 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 		<CardHeader>
 			<CardTitle>OpenAI / fun facts</CardTitle>
 			<CardDescription>
-				API credentials for the optional OpenAI-driven fun-fact generator. Falls back to the
-				template generator when unset.
+				API credentials for the optional OpenAI fun-fact generator. Obzorarr uses the built-in
+				templates when these are empty.
 				<!-- DF-017: the AI persona (fun_facts_ai_persona) and per-slide config are
 				     DB-only by design — set once in the onboarding wizard. A post-install
 				     selector UI is a tracked follow-up; edit these directly in app_settings /
@@ -312,7 +312,7 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 						<Label for="openaiApiKey">
 							OpenAI API key
 							{#if settings.openaiApiKey.hasValue}
-								<span class="text-xs text-muted-foreground">(stored — leave blank to keep)</span>
+								<span class="text-xs text-muted-foreground">(stored, leave blank to keep)</span>
 							{/if}
 						</Label>
 						{#if openaiApiKeyLocked}
@@ -330,9 +330,8 @@ const showOpenaiKeyWarning = $derived(!data.hasEffectiveOpenAIKey && !openaiApiK
 					/>
 					{#if showOpenaiKeyWarning}
 						<p class="ai-key-warning" role="status">
-							No OpenAI API key is in effect, so AI fun facts will not run — the built-in
-							template generator is used instead. Enter a key above (or set
-							<code>OPENAI_API_KEY</code>) to enable AI-generated fun facts.
+							No OpenAI API key is in effect, so fun facts come from the built-in templates. Enter a
+							key above, or set <code>OPENAI_API_KEY</code>, for AI-generated fun facts.
 						</p>
 					{/if}
 				</div>

--- a/src/routes/admin/settings/data/+page.svelte
+++ b/src/routes/admin/settings/data/+page.svelte
@@ -97,14 +97,14 @@ async function copyResetToken() {
 	} catch {
 		tokenCopied = false;
 		handleFormToast({
-			error: 'Could not copy automatically. Select the token and copy it manually.'
+			error: 'Copy failed. Select the token and copy it yourself.'
 		});
 	}
 }
 </script>
 
 <svelte:head>
-	<title>Data — Settings — Obzorarr</title>
+	<title>Data - Settings - Obzorarr</title>
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">
@@ -112,8 +112,8 @@ async function copyResetToken() {
 		<CardHeader>
 			<CardTitle>Stats cache</CardTitle>
 			<CardDescription>
-				Counts and clears cached per-year wrapped statistics. Clearing the cache forces a
-				rebuild on next wrapped page view.
+				Counts and clears cached per-year Wrapped statistics. Clearing the cache forces a
+				rebuild the next time someone opens a Wrapped page.
 			</CardDescription>
 		</CardHeader>
 		<CardContent class="space-y-4">
@@ -277,9 +277,9 @@ async function copyResetToken() {
 				<div class="space-y-1">
 					<p class="font-medium">What comes back</p>
 					<p class="text-muted-foreground">
-						Your watch statistics. Obzorarr only needs your Plex login, and play history is
-						re-synced from the official Plex API — so play history and every Wrapped statistic
-						built from it can be rebuilt by running a fresh sync once you finish setup again.
+						Your watch statistics. Obzorarr only needs your Plex login, and it re-syncs play history
+						from the official Plex API, so a fresh sync after setup rebuilds play history and every
+						Wrapped statistic built from it.
 					</p>
 				</div>
 				<div class="space-y-1">
@@ -287,10 +287,10 @@ async function copyResetToken() {
 					<p class="text-muted-foreground">
 						Every setting: privacy and sharing configuration, themes, slide configuration and
 						custom slides, log settings and fun-fact configuration. All per-user share
-						settings and every existing share link —
+						settings and every existing share link, so
 						<strong>any link you have already handed out to a user stops working</strong>, and
 						a new one will not be the same link. Any custom year ranges or other curation you
-						did by hand. And the entire log history.
+						did by hand, plus the entire log history.
 					</p>
 				</div>
 				<div class="space-y-1">
@@ -298,8 +298,8 @@ async function copyResetToken() {
 					<p class="text-muted-foreground">
 						Anything configured through the environment (Plex, OpenAI, ORIGIN, TRUST_PROXY) is
 						not stored in the database, so it survives. On an env-configured server the new
-						setup will already be filled in and locked for those steps — it is not a
-						completely blank slate.
+						setup arrives with those steps already filled in and locked, so you do not start
+						from a blank slate.
 					</p>
 				</div>
 			</div>
@@ -339,8 +339,8 @@ async function copyResetToken() {
 		<AlertDialog.Header>
 			<AlertDialog.Title>Clear stats cache?</AlertDialog.Title>
 			<AlertDialog.Description>
-				Removes cached wrapped statistics for {cacheYearLabel.toLowerCase()}. Wrapped pages
-				will rebuild their stats from the play history on next view.
+				Removes cached Wrapped statistics for {cacheYearLabel.toLowerCase()}. Wrapped pages
+				rebuild their stats from the play history on the next view.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
@@ -395,9 +395,8 @@ async function copyResetToken() {
 		<AlertDialog.Header>
 			<AlertDialog.Title>Clear play history?</AlertDialog.Title>
 			<AlertDialog.Description>
-				Permanently deletes play history records for {historyYearLabel.toLowerCase()}. This
-				cannot be undone. Wrapped pages backed by deleted records will be empty until a
-				resync repopulates them.
+				Deletes the play history records for {historyYearLabel.toLowerCase()} for good. Wrapped
+				pages built from those records stay empty until a resync refills them.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
@@ -467,7 +466,7 @@ async function copyResetToken() {
 			<div class="space-y-1">
 				<p class="font-medium">What does not</p>
 				<p class="text-muted-foreground">
-					All of your settings — privacy and sharing, themes, slides and custom slides, log
+					All of your settings: privacy and sharing, themes, slides and custom slides, log
 					settings, fun facts. Every per-user share setting and share link, so
 					<strong>any link already shared with a user will stop working</strong>. Any custom
 					year ranges or other hand-made curation. And the whole log history.
@@ -542,8 +541,8 @@ async function copyResetToken() {
 			<AlertDialog.Title>Copy your setup token, then wipe</AlertDialog.Title>
 			<AlertDialog.Description>
 				You need this token on the very next screen to claim the fresh setup. It expires in
-				{resetTokenExpiresInMinutes ?? data.resetTokenTtlMinutes} minutes and is not stored anywhere —
-				if you lose it, it is also printed in the server console.
+				{resetTokenExpiresInMinutes ?? data.resetTokenTtlMinutes} minutes and Obzorarr stores it
+				nowhere. If you lose it, look for it in the server console.
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<div class="space-y-4">

--- a/src/routes/admin/settings/privacy/+page.server.ts
+++ b/src/routes/admin/settings/privacy/+page.server.ts
@@ -144,7 +144,7 @@ const PRESET_SECTION_LABELS: Record<PrivacyPresetSection, string> = {
  */
 function presetConflictMessage(staleSections: readonly PrivacyPresetSection[]): string {
 	const names = staleSections.map((section) => PRESET_SECTION_LABELS[section]).join(', ');
-	return `${OCC_CONFLICT_MESSAGE} Nothing was applied — changed since this page loaded: ${names}.`;
+	return `${OCC_CONFLICT_MESSAGE} Nothing was applied. Changed since this page loaded: ${names}.`;
 }
 
 /**

--- a/src/routes/admin/settings/privacy/+page.svelte
+++ b/src/routes/admin/settings/privacy/+page.svelte
@@ -547,7 +547,7 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 </script>
 
 <svelte:head>
-	<title>Privacy — Settings — Obzorarr</title>
+	<title>Privacy - Settings - Obzorarr</title>
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">
@@ -636,9 +636,9 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 			<CardTitle>Privacy presets</CardTitle>
 			<CardDescription>
 				A preset is one privacy posture. Picking a card saves all five fields it owns across the
-				three sections below in one write — the Save buttons down there are only for
-				hand-editing a single field. The full onboarding presets also set the Wrapped logo to
-				Always Show; this page does not.
+				three sections below in one write. The Save buttons down there are only for hand-editing a
+				single field. The full onboarding presets also set the Wrapped logo to Always Show; this
+				page does not.
 			</CardDescription>
 		</CardHeader>
 		<CardContent class="space-y-4">
@@ -700,7 +700,7 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 			</div>
 			{#if selectedPreset === 'custom'}
 				<p class="text-sm italic text-muted-foreground">
-					Custom configuration — your settings don’t match a preset.
+					Custom configuration: your settings don’t match a preset.
 				</p>
 			{/if}
 			<!-- The commit surface. A card click already submits this form; the button is
@@ -779,7 +779,7 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 				<Alert>
 					<TriangleAlertIcon />
 					<AlertDescription>
-						{unsavedSectionCount} unsaved section{unsavedSectionCount === 1 ? '' : 's'} — staged changes
+						{unsavedSectionCount} unsaved section{unsavedSectionCount === 1 ? '' : 's'}. Staged changes
 						aren't live yet.
 						{#if applicablePreset}
 							Apply {applicablePreset.label} above to save all of them at once, or save each section
@@ -825,8 +825,8 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 			<CardTitle>Server-wide wrapped sharing</CardTitle>
 			<CardDescription>
 				Controls anonymization and the share mode for the aggregate server-wide /wrapped recap
-				only. It does NOT change who can view individual users' personal Wrapped pages — that
-				is governed by the per-user default share mode below.
+				only. It does NOT change who can view individual users' personal Wrapped pages; the
+				per-user default share mode below does that.
 			</CardDescription>
 		</CardHeader>
 		<CardContent>
@@ -967,7 +967,7 @@ const presetIcons: Record<PrivacyPresetId, Component> = {
 			<CardDescription>
 				Default share mode for newly-created users, and whether users can change their own
 				share settings. This default is also the privacy floor for every user's personal
-				Wrapped page — raise or lower it here (not via the server-wide recap control above) to
+				Wrapped page. Raise or lower it here, not via the server-wide recap control above, to
 				change who can view personal Wrapped pages.
 			</CardDescription>
 		</CardHeader>

--- a/src/routes/admin/settings/security/+page.server.ts
+++ b/src/routes/admin/settings/security/+page.server.ts
@@ -193,7 +193,7 @@ export const actions: Actions = requireAdminActions({
 					requireConfirmation: true,
 					attemptedOrigin: normalizedOrigin,
 					requestOrigin,
-					csrfMismatchMessage: `Saving "${normalizedOrigin}" while loaded from "${requestOrigin}" will lock THIS browser out of admin POST operations until you reload the admin from "${normalizedOrigin}". To recover, open the admin at "${normalizedOrigin}" and update the CSRF origin again from this same page — no server restart or database edit is required. Confirm to proceed anyway.`
+					csrfMismatchMessage: `Saving "${normalizedOrigin}" while loaded from "${requestOrigin}" will lock THIS browser out of admin POST operations until you reload the admin from "${normalizedOrigin}". To recover, open the admin at "${normalizedOrigin}" and update the CSRF origin again from this same page. No server restart or database edit is required. Confirm to proceed anyway.`
 				});
 			}
 
@@ -203,7 +203,7 @@ export const actions: Actions = requireAdminActions({
 					return {
 						success: true,
 						warning: true,
-						message: `CSRF origin saved to "${normalizedOrigin}". Your current browser origin is "${requestOrigin}" — you may now be locked out.`
+						message: `CSRF origin saved to "${normalizedOrigin}". Your current browser origin is "${requestOrigin}", so you may now be locked out.`
 					};
 				}
 				return { success: true, message: 'CSRF origin updated' };
@@ -223,8 +223,8 @@ export const actions: Actions = requireAdminActions({
 		try {
 			await deleteAppSetting(AppSettingsKey.CSRF_ORIGIN);
 			const message = env.ORIGIN
-				? 'CSRF origin cleared. Application now uses environment variable.'
-				: 'CSRF origin cleared. CSRF protection is currently disabled — set ORIGIN env or re-add an origin.';
+				? 'CSRF origin cleared. Obzorarr now uses the ORIGIN environment variable.'
+				: 'CSRF origin cleared. CSRF protection is now off. Set the ORIGIN environment variable or add an origin again.';
 			return { success: true, message };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : 'Failed to clear CSRF origin';
@@ -249,7 +249,7 @@ export const actions: Actions = requireAdminActions({
 				return {
 					success: true,
 					message:
-						'CSRF origin skip enabled. CSRF origin validation is now relaxed — set a proper ORIGIN when possible.'
+						'CSRF origin skip enabled. Origin validation is now relaxed. Set a real ORIGIN when you can.'
 				};
 			}
 			const csrfConfig = await getCsrfConfigWithSource();
@@ -292,7 +292,8 @@ export const actions: Actions = requireAdminActions({
 		});
 		if (!parsed.success) {
 			return fail(400, {
-				diagnosticError: parsed.error.issues[0]?.message ?? 'Could not read browser origin safely'
+				diagnosticError:
+					parsed.error.issues[0]?.message ?? 'Could not read the browser origin safely'
 			});
 		}
 

--- a/src/routes/admin/settings/security/+page.svelte
+++ b/src/routes/admin/settings/security/+page.svelte
@@ -103,7 +103,7 @@ async function runDiagnostic({ userInitiated = false }: { userInitiated?: boolea
 	} catch {
 		if (myToken !== diagnosticRunToken) return;
 		diagnosticStatus = 'failure';
-		diagnosticError = 'Network error - could not complete diagnostic';
+		diagnosticError = 'Network error while running the diagnostic.';
 		if (userInitiated) toast.error(diagnosticError);
 	}
 }
@@ -153,7 +153,7 @@ const applicableProviderGuides = $derived(
 </script>
 
 <svelte:head>
-	<title>Security — Settings — Obzorarr</title>
+	<title>Security - Settings - Obzorarr</title>
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">
@@ -236,7 +236,7 @@ const applicableProviderGuides = $derived(
 				</form>
 			{:else}
 				<p class="text-sm text-muted-foreground">
-					CSRF origin is set via environment variable and cannot be changed here.
+					The <code>ORIGIN</code> environment variable sets the CSRF origin, so you cannot change it here.
 				</p>
 			{/if}
 
@@ -405,7 +405,7 @@ const applicableProviderGuides = $derived(
 							<div><span class="fact-label">Browser origin</span><span class="fact-value">{diagnostic.facts.browserOrigin.origin ?? 'not available'}</span></div>
 							<div><span class="fact-label">Effective app origin</span><span class="fact-value">{diagnostic.facts.origins.effectiveApp ?? 'not available'}</span></div>
 							<div><span class="fact-label">Forwarded origin</span><span class="fact-value">{diagnostic.facts.origins.forwardedPair ?? 'not available'}</span></div>
-							<div><span class="fact-label">TRUST_PROXY</span><span class="fact-value">{diagnostic.facts.trustProxy.enabled ? 'Enabled' : 'Disabled'} — {diagnostic.facts.trustProxy.source}{#if diagnostic.facts.trustProxy.isLocked} (locked){/if}</span></div>
+							<div><span class="fact-label">TRUST_PROXY</span><span class="fact-value">{diagnostic.facts.trustProxy.enabled ? 'Enabled' : 'Disabled'}, {diagnostic.facts.trustProxy.source}{#if diagnostic.facts.trustProxy.isLocked} (locked){/if}</span></div>
 						</div>
 						<p class="safety-note">{presentation.safetyNotice}</p>
 						{#if applicableProviderGuides.length > 0}
@@ -455,7 +455,7 @@ const applicableProviderGuides = $derived(
 
 			{#if security.trustProxyLocked}
 				<p class="text-sm text-muted-foreground">
-					Reverse-proxy header trust is managed via environment variable and cannot be changed here.
+					The <code>TRUST_PROXY</code> environment variable controls header trust, so you cannot change it here.
 				</p>
 			{:else if security.trustProxyValue}
 				<form

--- a/src/routes/admin/settings/system/+page.server.ts
+++ b/src/routes/admin/settings/system/+page.server.ts
@@ -129,7 +129,8 @@ export const actions: Actions = requireAdminActions({
 			form.data.settingsVersion = settingsVersionISO(new Date(maxWrittenMs));
 			return { form, success: true, message: 'Logging settings updated' };
 		} catch (error) {
-			const message = error instanceof Error ? error.message : 'Failed to update settings';
+			const message =
+				error instanceof Error ? error.message : 'Failed to update the logging settings';
 			return fail(500, { form, error: message });
 		}
 	}

--- a/src/routes/admin/settings/system/+page.svelte
+++ b/src/routes/admin/settings/system/+page.svelte
@@ -90,7 +90,7 @@ function formatUptime(seconds: number): string {
 </script>
 
 <svelte:head>
-	<title>System — Settings — Obzorarr</title>
+	<title>System - Settings - Obzorarr</title>
 </svelte:head>
 
 <div class="space-y-6 p-6 max-w-4xl">
@@ -138,7 +138,7 @@ function formatUptime(seconds: number): string {
 							/>
 						{/snippet}
 					</Form.Control>
-					<Form.Description>Older entries dropped once this ceiling is reached. Range 1,000–1,000,000.</Form.Description>
+					<Form.Description>Obzorarr drops older entries once the count reaches this ceiling. Range 1,000–1,000,000.</Form.Description>
 					<Form.FieldErrors />
 					{#if maxCountError}
 						<p class="text-sm text-destructive">{maxCountError}</p>
@@ -208,7 +208,7 @@ function formatUptime(seconds: number): string {
 				</div>
 				<div>
 					<dt class="text-muted-foreground">Bun</dt>
-					<dd class="font-mono">{data.systemInfo.bunVersion ?? '—'}</dd>
+					<dd class="font-mono">{data.systemInfo.bunVersion ?? 'Unknown'}</dd>
 				</div>
 			</dl>
 		</CardContent>

--- a/src/routes/admin/slides/+page.server.ts
+++ b/src/routes/admin/slides/+page.server.ts
@@ -339,7 +339,8 @@ export const actions: Actions = requireAdminActions({
 				funFactFrequency
 			};
 		} catch (error) {
-			const message = error instanceof Error ? error.message : 'Failed to update frequency';
+			const message =
+				error instanceof Error ? error.message : 'Failed to update the fun-fact frequency';
 			return fail(500, { error: message });
 		}
 	}

--- a/src/routes/admin/slides/+page.svelte
+++ b/src/routes/admin/slides/+page.svelte
@@ -291,7 +291,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 </script>
 
 <svelte:head>
-	<title>Slides — Admin — Obzorarr</title>
+	<title>Slides - Admin - Obzorarr</title>
 </svelte:head>
 
 <div class="admin-container">
@@ -306,8 +306,8 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 			<div class="section-title-content">
 				<h2>Slide Order</h2>
 				<p class="section-description">
-					Drag and drop, or use the move up/down buttons, to reorder. Toggle to enable or
-					disable slides.
+					Drag and drop, or use the move up/down buttons, to reorder. Toggle a row to enable or
+					disable that slide.
 				</p>
 			</div>
 			<Button type="button" class="add-button tap-target" onclick={openNewEditor}>
@@ -472,7 +472,7 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 	<section class="section">
 		<h2>Fun Fact Frequency</h2>
 		<p class="section-description">
-			Control how many fun facts appear interspersed throughout the wrapped presentation.
+			Choose how many fun facts appear between slides in the Wrapped presentation.
 		</p>
 
 		<!-- ISSUE-012: tell the admin whether fun facts are AI-generated (OpenAI key
@@ -480,14 +480,13 @@ function getCustomSlideForEdit(item: UnifiedSlideItem) {
 		{#if data.aiFunFactsActive}
 			<p class="ai-status ai-status-active" role="status">
 				<SparklesIcon class="ai-status-icon" aria-hidden="true" />
-				AI fun facts active — generated with your configured OpenAI key.
+				AI fun facts are active, generated with your OpenAI key.
 			</p>
 		{:else}
 			<p class="ai-status ai-status-fallback" role="status">
 				<SparklesIcon class="ai-status-icon" aria-hidden="true" />
-				Template fallback — no OpenAI key configured, so fun facts use the built-in
-				generator. Add a key in
-				<a href="/admin/settings/connections">Settings → Connections</a> to enable AI fun facts.
+				No OpenAI key configured, so fun facts come from the built-in templates. Add a key in
+				<a href="/admin/settings/connections">Settings → Connections</a> for AI fun facts.
 			</p>
 		{/if}
 

--- a/src/routes/admin/sync/+page.server.ts
+++ b/src/routes/admin/sync/+page.server.ts
@@ -175,7 +175,7 @@ export const actions: Actions = requireAdminActions({
 			await setAppSetting(AppSettingsKey.SYNC_CRON_EXPRESSION, parsed.data.cronExpression);
 			const isActive = isSchedulerConfigured();
 			const message = isActive
-				? 'Schedule updated successfully'
+				? 'Schedule updated'
 				: 'Schedule saved. Click "Initialize" to activate it.';
 			return { success: true, message, cronExpression: parsed.data.cronExpression };
 		} catch (error) {

--- a/src/routes/admin/sync/+page.svelte
+++ b/src/routes/admin/sync/+page.svelte
@@ -215,7 +215,7 @@ function formatRelativeTime(isoDate: string | null): string {
 
 function formatDuration(start: string, end: string | null, status?: string): string {
 	if (status === 'running') return 'In progress';
-	if (!end) return '—';
+	if (!end) return 'Unknown';
 	return formatDurationMs(new Date(end).getTime() - new Date(start).getTime());
 }
 
@@ -275,7 +275,7 @@ async function goToPage(page: number) {
 </script>
 
 <svelte:head>
-	<title>Sync — Admin — Obzorarr</title>
+	<title>Sync - Admin - Obzorarr</title>
 </svelte:head>
 
 <div class="sync-command-center">
@@ -288,8 +288,8 @@ async function goToPage(page: number) {
 				</svg>
 			</div>
 			<div class="header-text">
-				<h1>Sync Command</h1>
-				<p class="header-subtitle">Plex Data Synchronization Center</p>
+				<h1>Plex Sync</h1>
+				<p class="header-subtitle">Start a sync, manage the schedule, and review past runs</p>
 			</div>
 		</div>
 		<div class="header-stats">

--- a/src/routes/admin/users/+page.server.ts
+++ b/src/routes/admin/users/+page.server.ts
@@ -86,7 +86,8 @@ export const actions: Actions = requireAdminActions({
 
 			return { success: true, message: 'User permission updated' };
 		} catch (error) {
-			const message = error instanceof Error ? error.message : 'Failed to update permission';
+			const message =
+				error instanceof Error ? error.message : 'Failed to update the user permission';
 			return fail(500, { error: message });
 		}
 	}

--- a/src/routes/admin/users/+page.svelte
+++ b/src/routes/admin/users/+page.svelte
@@ -34,7 +34,7 @@ function markAvatarFailed(userId: number): void {
 </script>
 
 <svelte:head>
-	<title>Users — Admin — Obzorarr</title>
+	<title>Users - Admin - Obzorarr</title>
 </svelte:head>
 
 <div class="users-page">
@@ -90,15 +90,15 @@ function markAvatarFailed(userId: number): void {
 				synced {data.syncedViewerCount === 1 ? 'viewer' : 'viewers'}
 				(distinct Plex accounts seen in play history across all years) appear in server-wide stats.
 				Non-registered
-				viewers aren't listed individually here — their names on the server-wide Wrapped are
-				controlled by the global
+				viewers aren't listed individually here. Their names on the server-wide Wrapped come from
+				the global
 				<a href="/admin/settings/privacy" class="synced-viewers-link">anonymization setting</a>,
 				not per-user. Per-user share controls below apply only once you grant a user control.
 			</p>
 		</div>
 
 		{#if data.users.length === 0}
-			<p class="empty-message">No users found. Users will appear after authenticating via Plex.</p>
+			<p class="empty-message">No users yet. They appear here after signing in with Plex.</p>
 		{:else}
 			<div class="users-table-wrapper">
 				<table class="users-table">
@@ -326,7 +326,7 @@ function markAvatarFailed(userId: number): void {
 		<div class="legend-grid">
 			<div class="legend-item">
 				<span class="share-mode public">Public</span>
-				<span class="legend-desc">Anyone can view the wrapped page</span>
+				<span class="legend-desc">Anyone can view the Wrapped page</span>
 			</div>
 			<div class="legend-item">
 				<span class="share-mode oauth">OAuth</span>

--- a/src/routes/admin/wrapped/+page.svelte
+++ b/src/routes/admin/wrapped/+page.svelte
@@ -33,7 +33,7 @@ function handleConfigNavigation(event: MouseEvent): void {
 </script>
 
 <svelte:head>
-	<title>Wrapped — Admin — Obzorarr</title>
+	<title>Wrapped - Admin - Obzorarr</title>
 </svelte:head>
 
 <div class="wrapped-hub">
@@ -50,13 +50,13 @@ function handleConfigNavigation(event: MouseEvent): void {
 				<span class="year-display">{data.year}</span>
 				<span class="title-text">Wrapped</span>
 			</h1>
-			<p class="hero-subtitle">Discover viewing journeys and manage the wrapped experience</p>
+			<p class="hero-subtitle">Preview Wrapped pages and configure how they look</p>
 			{#if data.availableYears.length > 0}
 				<form method="GET" class="year-form">
 					<select
 						name="year"
 						class="year-selector"
-						aria-label="Select wrapped year"
+						aria-label="Select Wrapped year"
 						disabled={data.availableYears.length === 1}
 						title={data.availableYears.length === 1 ? 'Only one year of data available' : undefined}
 						onchange={(e) => e.currentTarget.form?.requestSubmit()}
@@ -97,7 +97,7 @@ function handleConfigNavigation(event: MouseEvent): void {
 						<div class="card-text">
 							<h2 class="card-title">My Wrapped</h2>
 							<p class="card-description">
-								Your personal viewing journey and stats for {data.year}
+								Your own viewing stats for {data.year}
 							</p>
 						</div>
 						<div class="card-cta">
@@ -118,10 +118,10 @@ function handleConfigNavigation(event: MouseEvent): void {
 					</div>
 					<div class="card-text">
 						<h2 class="card-title">Server Wrapped</h2>
-						<p class="card-description">Server-wide viewing stats and community highlights</p>
+						<p class="card-description">Combined viewing stats for everyone on the server</p>
 					</div>
 					<div class="card-cta">
-						<span class="cta-text">Explore together</span>
+						<span class="cta-text">View the recap</span>
 						<ArrowRight class="cta-arrow" />
 					</div>
 				</div>

--- a/src/routes/api/onboarding/select-server/+server.ts
+++ b/src/routes/api/onboarding/select-server/+server.ts
@@ -70,7 +70,7 @@ async function testConnection(url: string, accessToken: string): Promise<Connect
 		});
 
 		if (response.status === 401) {
-			return { success: false, error: 'Authentication failed - the access token may be invalid' };
+			return { success: false, error: 'Authentication failed. Check the access token.' };
 		}
 
 		if (!response.ok) {

--- a/src/routes/api/onboarding/servers/+server.ts
+++ b/src/routes/api/onboarding/servers/+server.ts
@@ -116,7 +116,7 @@ export const GET: RequestHandler = async ({ cookies, locals, url }) => {
 		if (err instanceof Error && 'code' in err) {
 			const authErr = err as { code: string };
 			if (authErr.code === 'PLEX_API_ERROR') {
-				error(502, 'Unable to connect to Plex. Please try again.');
+				error(502, 'Could not reach Plex. Try again.');
 			}
 		}
 

--- a/src/routes/api/onboarding/test-connection/+server.ts
+++ b/src/routes/api/onboarding/test-connection/+server.ts
@@ -113,7 +113,7 @@ export const POST: RequestHandler = async ({ request, locals, cookies, url }) =>
 				return json(
 					{
 						success: false,
-						error: 'Authentication failed - the access token may be invalid'
+						error: 'Authentication failed. Check the access token.'
 					},
 					{ status: 401 }
 				);
@@ -216,7 +216,7 @@ export const POST: RequestHandler = async ({ request, locals, cookies, url }) =>
 		return json(
 			{
 				success: false,
-				error: 'An unexpected error occurred'
+				error: 'Something went wrong. Try again.'
 			},
 			{ status: 500 }
 		);

--- a/src/routes/auth/plex/+server.ts
+++ b/src/routes/auth/plex/+server.ts
@@ -93,7 +93,7 @@ export const GET: RequestHandler = async ({ cookies, url, request, setHeaders })
 				endpoint: err.endpoint
 			});
 			error(502, {
-				message: 'Unable to connect to Plex. Please try again.'
+				message: 'Could not reach Plex. Try again.'
 			});
 		}
 
@@ -101,7 +101,7 @@ export const GET: RequestHandler = async ({ cookies, url, request, setHeaders })
 			errorType: err instanceof Error ? err.name : typeof err
 		});
 		error(500, {
-			message: 'An unexpected error occurred.'
+			message: 'Something went wrong. Try again.'
 		});
 	}
 };
@@ -138,7 +138,7 @@ export const POST: RequestHandler = async ({ request, cookies, url }) => {
 				endpoint: err.endpoint
 			});
 			error(502, {
-				message: 'Unable to connect to Plex. Please try again.'
+				message: 'Could not reach Plex. Try again.'
 			});
 		}
 
@@ -158,7 +158,7 @@ export const POST: RequestHandler = async ({ request, cookies, url }) => {
 			errorType: err instanceof Error ? err.name : typeof err
 		});
 		error(500, {
-			message: 'An unexpected error occurred.'
+			message: 'Something went wrong. Try again.'
 		});
 	}
 };

--- a/src/routes/auth/plex/callback/+server.ts
+++ b/src/routes/auth/plex/callback/+server.ts
@@ -50,12 +50,12 @@ export const POST: RequestHandler = async ({ request, cookies, url }) => {
 
 			if (err.statusCode === 401) {
 				error(401, {
-					message: 'Invalid or expired auth token. Please try again.'
+					message: 'Invalid or expired auth token. Sign in again.'
 				});
 			}
 
 			error(502, {
-				message: 'Unable to connect to Plex. Please try again.'
+				message: 'Could not reach Plex. Try again.'
 			});
 		}
 
@@ -63,7 +63,7 @@ export const POST: RequestHandler = async ({ request, cookies, url }) => {
 			errorType: err instanceof Error ? err.name : typeof err
 		});
 		error(500, {
-			message: 'An unexpected error occurred.'
+			message: 'Something went wrong. Try again.'
 		});
 	}
 };

--- a/src/routes/auth/plex/redirect/+page.svelte
+++ b/src/routes/auth/plex/redirect/+page.svelte
@@ -32,7 +32,7 @@ onMount(async () => {
 
 	if (!data.stateVerified) {
 		status = 'error';
-		errorMessage = 'Authentication session could not be verified. Please try again.';
+		errorMessage = 'Obzorarr could not verify this sign-in session. Try again.';
 		return;
 	}
 
@@ -141,15 +141,15 @@ function handleRetry(): void {
 			{#if status === 'loading'}
 				<LoaderCircleIcon class="size-12 text-primary animate-spin mx-auto" />
 				<Card.Title>Completing Authentication</Card.Title>
-				<Card.Description>Please wait while we verify your Plex account...</Card.Description>
+				<Card.Description>Verifying your Plex account…</Card.Description>
 			{:else if status === 'success'}
 				<CheckIcon class="size-12 text-success mx-auto" />
 				<Card.Title>Authentication Successful</Card.Title>
-				<Card.Description>Redirecting you now...</Card.Description>
+				<Card.Description>Redirecting…</Card.Description>
 			{:else if status === 'cancelled'}
 				<CircleXIcon class="size-12 text-muted-foreground mx-auto" />
 				<Card.Title>Authentication Cancelled</Card.Title>
-				<Card.Description>You cancelled the Plex authentication.</Card.Description>
+				<Card.Description>You cancelled the Plex sign-in.</Card.Description>
 			{:else if status === 'error'}
 				<CircleAlertIcon class="size-12 text-destructive mx-auto" />
 				<Card.Title>Authentication Error</Card.Title>

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -25,10 +25,10 @@ let { data }: Props = $props();
 			</div>
 			<h1 class="page-title">{data.user.username}</h1>
 			{#if data.wrappedHref}
-				<p class="page-subtitle">Your Plex Wrapped for {data.currentYear} is ready to explore</p>
+				<p class="page-subtitle">Your Plex Wrapped for {data.currentYear} is ready to view</p>
 			{:else}
 				<p class="page-subtitle">
-					No {data.currentYear} viewing history synced yet — your Wrapped will appear here once you have activity
+					No {data.currentYear} viewing history synced yet. Your Wrapped will appear here once you watch something
 				</p>
 			{/if}
 		</div>
@@ -48,7 +48,7 @@ let { data }: Props = $props();
 				<div class="card-content">
 					<h2 class="card-title">My Wrapped</h2>
 					<p class="card-description">
-						Discover your personal viewing journey - your top shows, movies, and more
+						Your top shows and movies for the year, plus how your viewing changed
 					</p>
 				</div>
 				<div class="card-action">
@@ -84,11 +84,11 @@ let { data }: Props = $props();
 			<div class="card-content">
 				<h2 class="card-title">Server Wrapped</h2>
 				<p class="card-description">
-					See how the entire server watched together - trending content and shared favorites
+					Trending titles and shared favorites from everyone on the server
 				</p>
 			</div>
 			<div class="card-action">
-				<span>Explore server stats</span>
+				<span>View server stats</span>
 				<ArrowRight class="card-arrow" />
 			</div>
 		</a>

--- a/src/routes/dashboard/settings/+page.server.ts
+++ b/src/routes/dashboard/settings/+page.server.ts
@@ -149,7 +149,8 @@ export const actions: Actions = requireUserActions({
 					currentMode
 				});
 			}
-			const message = error instanceof Error ? error.message : 'Failed to update settings';
+			const message =
+				error instanceof Error ? error.message : 'Could not save your sharing settings';
 			return fail(500, { error: message, action: 'updateShareMode', currentMode });
 		}
 	},
@@ -170,7 +171,7 @@ export const actions: Actions = requireUserActions({
 
 			if (shareSettings.mode !== 'private-link') {
 				return fail(400, {
-					error: 'Can only regenerate token when in private-link mode',
+					error: 'Switch to private-link mode before regenerating the token',
 					action: 'regenerateToken'
 				});
 			}
@@ -189,7 +190,8 @@ export const actions: Actions = requireUserActions({
 			if (error instanceof PermissionExceededError) {
 				return fail(403, { error: error.message, action: 'regenerateToken' });
 			}
-			const message = error instanceof Error ? error.message : 'Failed to regenerate token';
+			const message =
+				error instanceof Error ? error.message : 'Could not regenerate the share link';
 			return fail(500, { error: message, action: 'regenerateToken' });
 		}
 	},
@@ -224,7 +226,8 @@ export const actions: Actions = requireUserActions({
 				action: 'updateLogoPreference'
 			};
 		} catch (error) {
-			const message = error instanceof Error ? error.message : 'Failed to update preference';
+			const message =
+				error instanceof Error ? error.message : 'Could not save your logo preference';
 			return fail(500, { error: message, action: 'updateLogoPreference' });
 		}
 	}

--- a/src/routes/dashboard/settings/+page.svelte
+++ b/src/routes/dashboard/settings/+page.svelte
@@ -105,7 +105,7 @@ function getShareIcon(mode: string): string {
 }
 
 const shareModeDescriptions: Record<string, string> = {
-	public: 'Anyone can view your wrapped page',
+	public: 'Anyone can view your Wrapped page',
 	'private-oauth': 'Only Plex server members can view',
 	'private-link': 'Anyone with the special link can view'
 };
@@ -159,9 +159,9 @@ function formatRelativeDate(date: Date | null): string {
 function getLogoModeDescription(): string {
 	switch (data.wrappedLogoMode) {
 		case 'always_show':
-			return 'The logo is always shown on all wrapped pages (set by admin)';
+			return 'Your admin shows the logo on every Wrapped page';
 		case 'always_hide':
-			return 'The logo is always hidden on all wrapped pages (set by admin)';
+			return 'Your admin hides the logo on every Wrapped page';
 		default:
 			return '';
 	}
@@ -189,7 +189,7 @@ function getLogoModeDescription(): string {
 			<section class="section">
 				<h2>Sharing Settings</h2>
 				<p class="section-description">
-					Control who can view your {data.currentYear} Wrapped page.
+					Choose who can view your {data.currentYear} Wrapped page.
 				</p>
 
 				{#if data.shareSettings.canUserControl}
@@ -346,8 +346,8 @@ function getLogoModeDescription(): string {
 						{#if data.shareSettings.mode === 'private-link'}
 							<div class="token-actions">
 								<p class="token-hint">
-									This link contains a private token. Only people with this exact link can view your
-									wrapped page.
+									This link contains a private token. Only people with this exact link can open your
+									Wrapped page.
 								</p>
 								<button
 									type="button"
@@ -363,7 +363,7 @@ function getLogoModeDescription(): string {
 					<div class="info-banner" role="status" aria-live="polite">
 						<span class="info-icon">ℹ️</span>
 						<div class="info-content">
-							<strong>Sharing settings are managed by your server administrator</strong>
+							<strong>Your server administrator manages sharing settings</strong>
 							<p>
 								Your current sharing mode is: <span class="mode-badge"
 									>{getShareIcon(data.shareSettings.mode)}
@@ -434,7 +434,7 @@ function getLogoModeDescription(): string {
 			<section class="section">
 				<h2>Logo Visibility</h2>
 				<p class="section-description">
-					Control whether the Obzorarr logo appears on your wrapped page.
+					Choose whether the Obzorarr logo appears on your Wrapped page.
 				</p>
 
 				{#if data.canControlLogo}
@@ -457,7 +457,7 @@ function getLogoModeDescription(): string {
 						<div
 							class="privacy-card-grid two-col"
 							role="radiogroup"
-							aria-label="Logo visibility on your wrapped page"
+							aria-label="Logo visibility on your Wrapped page"
 						>
 							<label class="privacy-card" class:selected={selectedLogoPreference === 'show'}>
 								<input
@@ -470,7 +470,7 @@ function getLogoModeDescription(): string {
 								/>
 								<span class="card-icon" aria-hidden="true">✅</span>
 								<span class="card-title">Show logo</span>
-								<span class="card-desc">Display the Obzorarr logo on your wrapped page</span>
+								<span class="card-desc">Show the Obzorarr logo on your Wrapped page</span>
 							</label>
 
 							<label class="privacy-card" class:selected={selectedLogoPreference === 'hide'}>
@@ -484,7 +484,7 @@ function getLogoModeDescription(): string {
 								/>
 								<span class="card-icon" aria-hidden="true">🚫</span>
 								<span class="card-title">Hide logo</span>
-								<span class="card-desc">Hide the logo for a cleaner presentation</span>
+								<span class="card-desc">Hide the Obzorarr logo on your Wrapped page</span>
 							</label>
 						</div>
 
@@ -498,7 +498,7 @@ function getLogoModeDescription(): string {
 					<div class="info-banner">
 						<span class="info-icon">ℹ️</span>
 						<div class="info-content">
-							<strong>Logo visibility is managed by your server administrator</strong>
+							<strong>Your server administrator controls logo visibility</strong>
 							<p>{getLogoModeDescription()}</p>
 						</div>
 					</div>
@@ -582,8 +582,8 @@ function getLogoModeDescription(): string {
 			<AlertDialog.Header>
 				<AlertDialog.Title>Regenerate Share Link?</AlertDialog.Title>
 				<AlertDialog.Description>
-					This will create a new private link and invalidate the current one. Anyone using the old
-					link will no longer have access to your wrapped page.
+					A new private link replaces the current one. The old link stops working for everyone who
+					already has it.
 				</AlertDialog.Description>
 			</AlertDialog.Header>
 			<AlertDialog.Footer>
@@ -609,7 +609,7 @@ function getLogoModeDescription(): string {
 									}
 								} else if (result.type === 'error') {
 									handleFormToast({
-										error: result.error?.message ?? 'Failed to regenerate share link.'
+										error: result.error?.message ?? 'Could not regenerate the share link.'
 									});
 								}
 

--- a/src/routes/onboarding/+layout.svelte
+++ b/src/routes/onboarding/+layout.svelte
@@ -78,7 +78,7 @@ $effect(() => {
 		</main>
 
 		<footer class="onboarding-footer">
-			<p>Your Plex viewing history, beautifully wrapped.</p>
+			<p>Your Plex viewing history, wrapped for the year.</p>
 		</footer>
 	</div>
 </div>

--- a/src/routes/onboarding/complete/+page.server.ts
+++ b/src/routes/onboarding/complete/+page.server.ts
@@ -174,7 +174,7 @@ export function _deriveFunFactsSummary(
 		return formatFunFactFrequency(frequency);
 	}
 	if (aiKeyMissing) {
-		return 'Template mode — add an OpenAI key to enable AI';
+		return 'Template mode: add an OpenAI key for AI fun facts';
 	}
 	return 'Disabled';
 }

--- a/src/routes/onboarding/complete/+page.svelte
+++ b/src/routes/onboarding/complete/+page.svelte
@@ -126,7 +126,7 @@ const summaryItems = $derived([
 					</svg>
 					<span>
 						Fun facts use the built-in templates because you have not added an OpenAI key. Add one
-						in <strong>Admin → Settings → AI</strong> for AI-generated fun facts.
+						in <strong>Admin → Settings → Connections</strong> for AI-generated fun facts.
 					</span>
 				</div>
 			{/if}

--- a/src/routes/onboarding/complete/+page.svelte
+++ b/src/routes/onboarding/complete/+page.svelte
@@ -107,7 +107,7 @@ const summaryItems = $derived([
 
 			<div class="completion-header" class:visible={showContent}>
 				<h1 class="completion-title">Setup Complete!</h1>
-				<p class="completion-subtitle">Your Plex Wrapped is ready to go</p>
+				<p class="completion-subtitle">Your Plex Wrapped is ready</p>
 			</div>
 
 			{#if data.notice === 'ai-key-missing'}
@@ -125,8 +125,8 @@ const summaryItems = $derived([
 						<line x1="12" y1="16" x2="12.01" y2="16" />
 					</svg>
 					<span>
-						AI Fun Facts will use built-in templates because no OpenAI key was provided. Add a key
-						in <strong>Admin → Settings → AI</strong> to enable AI-generated fun facts.
+						Fun facts use the built-in templates because you have not added an OpenAI key. Add one
+						in <strong>Admin → Settings → AI</strong> for AI-generated fun facts.
 					</span>
 				</div>
 			{/if}

--- a/src/routes/onboarding/csrf/+page.server.ts
+++ b/src/routes/onboarding/csrf/+page.server.ts
@@ -123,7 +123,7 @@ async function saveCsrfOrigin({
 	const actualOrigin = getRequestOrigin(request);
 	if (!actualOrigin) {
 		return fail(400, {
-			error: 'Could not detect browser origin. Ensure you are accessing via HTTP/HTTPS.'
+			error: 'Could not detect the browser origin. Open Obzorarr over HTTP or HTTPS.'
 		});
 	}
 
@@ -177,7 +177,7 @@ export const actions: Actions = {
 		const actualOrigin = getRequestOrigin(request);
 		if (!actualOrigin) {
 			return fail(400, {
-				testError: 'Could not detect browser origin. Ensure you are accessing via HTTP/HTTPS.'
+				testError: 'Could not detect the browser origin. Open Obzorarr over HTTP or HTTPS.'
 			});
 		}
 

--- a/src/routes/onboarding/csrf/+page.svelte
+++ b/src/routes/onboarding/csrf/+page.svelte
@@ -69,7 +69,7 @@ async function runTest() {
 		}
 	} catch {
 		testResult = 'failure';
-		testError = 'Network error - could not complete test';
+		testError = 'Network error while testing the origin.';
 	}
 }
 
@@ -119,7 +119,7 @@ function useDetectedOrigin() {
 }
 </script>
 
-<OnboardingCard title="Security Settings" subtitle="Configure CSRF protection for your application">
+<OnboardingCard title="Security Settings" subtitle="Set the origin URL that CSRF checks accept">
 	<div class="csrf-content" bind:this={contentRef}>
 		<div class="icon-container" bind:this={iconRef}>
 			<div class="icon-wrapper">
@@ -230,8 +230,8 @@ function useDetectedOrigin() {
 			</div>
 
 			<p class="info-text animate-item">
-				CSRF protection is configured via the <code>ORIGIN</code> environment variable. This setting is
-				locked and cannot be changed here.
+				The <code>ORIGIN</code> environment variable sets CSRF protection, so you cannot change it
+				here.
 			</p>
 
 			<div class="locked-docs animate-item">
@@ -302,12 +302,12 @@ function useDetectedOrigin() {
 							<circle cx="12" cy="12" r="10" />
 							<path d="M9 12l2 2 4-4" stroke-linecap="round" stroke-linejoin="round" />
 						</svg>
-						<span>Origin verified - CSRF protection will work correctly</span>
+						<span>Origin verified. CSRF checks will accept this URL.</span>
 					</div>
 				{/if}
 				<p class="input-hint">
-					Enter the public URL where users will access Obzorarr. This protects against cross-site
-					request forgery attacks.
+					Enter the public URL where users reach Obzorarr. Obzorarr rejects form posts that come from
+					any other origin.
 				</p>
 			</div>
 
@@ -326,14 +326,14 @@ function useDetectedOrigin() {
 					/>
 				</svg>
 				<div class="callout-content">
-					<span class="callout-title">Why configure CSRF protection?</span>
+					<span class="callout-title">What CSRF protection does</span>
 					<span class="callout-text">
 						{#if data.detection.isReverseProxy}
-							You appear to be accessing through a reverse proxy. Setting the correct origin URL
-							ensures form submissions are validated against the actual URL users see.
+							You are connecting through a reverse proxy. Set the origin to the URL your users see so
+							Obzorarr checks form posts against that URL.
 						{:else}
-							CSRF protection validates that form submissions come from your application's domain.
-							If you plan to use a reverse proxy later, you can configure this setting now.
+							Obzorarr checks that form posts come from your own domain. Set this now if you plan to
+							add a reverse proxy later.
 						{/if}
 					</span>
 					<div class="callout-links">

--- a/src/routes/onboarding/plex/+page.server.ts
+++ b/src/routes/onboarding/plex/+page.server.ts
@@ -85,7 +85,7 @@ export const actions: Actions = {
 		try {
 			const plexToken = await getSessionPlexToken(sessionId);
 			if (!plexToken) {
-				return fail(401, { error: 'Session expired. Please sign in again.' });
+				return fail(401, { error: 'Session expired. Sign in again.' });
 			}
 
 			const membership = await verifyServerMembership(plexToken);
@@ -108,8 +108,7 @@ export const actions: Actions = {
 
 			if (!membership.isOwner) {
 				return fail(403, {
-					error:
-						'Only the server owner can configure Obzorarr. Please sign in with the server owner account.'
+					error: 'Only the server owner can configure Obzorarr. Sign in with the owner account.'
 				});
 			}
 
@@ -135,7 +134,7 @@ export const actions: Actions = {
 			);
 
 			return fail(500, {
-				error: 'Failed to verify admin status. Please try again.'
+				error: 'Could not verify admin status. Try again.'
 			});
 		}
 	},
@@ -250,7 +249,7 @@ export const actions: Actions = {
 
 		const plexToken = await getSessionPlexToken(sessionId);
 		if (!plexToken) {
-			return fail(401, { error: 'Session expired. Please sign in again.' });
+			return fail(401, { error: 'Session expired. Sign in again.' });
 		}
 
 		let membership: MembershipResult;
@@ -271,7 +270,7 @@ export const actions: Actions = {
 				`Ownership override verification failed: ${err instanceof Error ? err.message : String(err)}`,
 				'Onboarding'
 			);
-			return fail(500, { error: 'Failed to verify server ownership. Please try again.' });
+			return fail(500, { error: 'Could not verify server ownership. Try again.' });
 		}
 
 		const apiConfig = await getApiConfigWithSources();
@@ -289,7 +288,7 @@ export const actions: Actions = {
 			if (membership.reason !== 'not_in_resources' || !membership.configuredMachineId) {
 				return fail(403, {
 					error: membership.isMember
-						? 'Only the server owner can use the admin override. Please sign in with the server owner account.'
+						? 'Only the server owner can use the admin override. Sign in with the owner account.'
 						: messageForMembershipFailure(membership)
 				});
 			}

--- a/src/routes/onboarding/plex/+page.svelte
+++ b/src/routes/onboarding/plex/+page.svelte
@@ -168,7 +168,7 @@ async function fetchServers() {
 					body: new FormData()
 				});
 				await invalidateAll();
-				throw new Error('Session expired. Please sign in again.');
+				throw new Error('Session expired. Sign in again.');
 			}
 			const errorData = await response.json().catch(() => ({}));
 			throw new Error((errorData as { message?: string }).message || 'Failed to fetch servers');
@@ -236,7 +236,7 @@ function handleContinueWithRedirect(): void {
 	try {
 		commitRedirectFromPopupBlocked(pendingPinId, pendingAuthUrl, 'onboarding');
 	} catch (err) {
-		oauthError = err instanceof Error ? err.message : 'Failed to initiate redirect login';
+		oauthError = err instanceof Error ? err.message : 'Could not start the redirect login';
 	}
 }
 
@@ -320,7 +320,7 @@ function getConnectionInfo(connection: { uri: string; local: boolean; relay: boo
 			type: 'secure',
 			description: 'Encrypted connection',
 			tooltip:
-				'This connection uses plex.direct with TLS/SSL encryption. Your data is securely encrypted in transit, providing protection against eavesdropping and tampering.',
+				'This connection uses plex.direct with TLS encryption. Traffic is encrypted in transit, so nobody on the network can read or alter it.',
 			isSSL: true
 		};
 	}
@@ -369,14 +369,14 @@ function sortConnections(
 
 async function testCustomConnection(server: (typeof servers)[0]) {
 	if (!customUrl.trim()) {
-		customUrlTestResult = { success: false, error: 'Please enter a URL' };
+		customUrlTestResult = { success: false, error: 'Enter a URL' };
 		return;
 	}
 
 	try {
 		new URL(customUrl);
 	} catch {
-		customUrlTestResult = { success: false, error: 'Please enter a valid URL' };
+		customUrlTestResult = { success: false, error: 'Enter a valid URL' };
 		return;
 	}
 
@@ -496,7 +496,7 @@ function formatServerUrl(url: string | null): string {
 
 <OnboardingCard
 	title="Connect Your Plex Server"
-	subtitle="Link your Plex Media Server to unlock your personalized viewing journey"
+	subtitle="Connect the Plex Media Server that holds your viewing history"
 >
 	<div class="plex-content" bind:this={contentRef}>
 		<div class="plex-icon-wrapper animate-item" bind:this={iconRef}>
@@ -723,8 +723,7 @@ function formatServerUrl(url: string | null): string {
 					<div class="error-content">
 						<p class="error-title">Admin Access Required</p>
 						<p class="error-message">
-							Only the Plex server owner can configure Obzorarr. Please sign in with the server
-							owner account.
+							Only the Plex server owner can configure Obzorarr. Sign in with the owner account.
 						</p>
 					</div>
 				</div>
@@ -794,8 +793,8 @@ function formatServerUrl(url: string | null): string {
 					<div class="error-content">
 						<p class="error-title">Server Owner Required</p>
 						<p class="error-message">
-							You must be a server owner to configure Obzorarr. Please sign in with an account that
-							owns a Plex server.
+							Only a Plex server owner can configure Obzorarr. Sign in with an account that owns a
+							server.
 						</p>
 					</div>
 				</div>
@@ -810,7 +809,7 @@ function formatServerUrl(url: string | null): string {
 						</div>
 					{:else if ownedServers.length === 0}
 						<div class="no-servers">
-							<p>No servers found where you are the owner.</p>
+							<p>No servers found that you own.</p>
 							<p class="no-servers-hint">You must be the owner of a Plex server to use Obzorarr.</p>
 						</div>
 					{:else}
@@ -1007,7 +1006,7 @@ function formatServerUrl(url: string | null): string {
 												onclick={toggleCustomUrl}
 												disabled={isSavingServer || isTestingCustomUrl}
 											>
-												<span>Using a reverse proxy? Enter custom URL</span>
+												<span>Enter a custom URL for a reverse proxy</span>
 												<svg
 													class="toggle-chevron"
 													class:rotated={showCustomUrl}

--- a/src/routes/onboarding/proxy-trust/+page.server.ts
+++ b/src/routes/onboarding/proxy-trust/+page.server.ts
@@ -147,7 +147,8 @@ export const actions: Actions = {
 		});
 		if (!parsed.success) {
 			return fail(400, {
-				diagnosticError: parsed.error.issues[0]?.message ?? 'Could not read browser origin safely'
+				diagnosticError:
+					parsed.error.issues[0]?.message ?? 'Could not read the browser origin safely'
 			});
 		}
 
@@ -186,7 +187,7 @@ export const actions: Actions = {
 		if (!browserOriginParsed.success) {
 			return fail(400, {
 				trustProxyError:
-					browserOriginParsed.error.issues[0]?.message ?? 'Could not read browser origin safely'
+					browserOriginParsed.error.issues[0]?.message ?? 'Could not read the browser origin safely'
 			});
 		}
 

--- a/src/routes/onboarding/proxy-trust/+page.svelte
+++ b/src/routes/onboarding/proxy-trust/+page.svelte
@@ -132,7 +132,7 @@ async function runDiagnostic(afterSave = false) {
 	} catch {
 		if (token !== runToken) return;
 		diagnosticStatus = 'failure';
-		diagnosticError = 'Network error - could not complete diagnostic';
+		diagnosticError = 'Network error while running the diagnostic.';
 		if (afterSave) savedState = 'unverified';
 	}
 }

--- a/src/routes/onboarding/settings/+page.server.ts
+++ b/src/routes/onboarding/settings/+page.server.ts
@@ -391,7 +391,7 @@ export const actions: Actions = {
 			);
 
 			return fail(500, {
-				error: 'Failed to save settings. Please try again.'
+				error: 'Could not save your settings. Try again.'
 			});
 		}
 	},

--- a/src/routes/onboarding/settings/+page.svelte
+++ b/src/routes/onboarding/settings/+page.svelte
@@ -357,8 +357,8 @@ function getThemeColors(themeValue: string) {
 </script>
 
 <OnboardingCard
-	title="Configure Your Experience"
-	subtitle="Customize how Obzorarr looks and behaves. You can always change these later."
+	title="Configure Obzorarr"
+	subtitle="Set how Obzorarr looks and behaves. You can change all of it later."
 >
 	{#snippet children()}
 		<div class="settings-container">
@@ -447,7 +447,7 @@ function getThemeColors(themeValue: string) {
 						try {
 							if (result.type === 'failure') {
 								const payload = result.data as { error?: string } | undefined;
-								const message = payload?.error ?? 'Failed to save settings. Please try again.';
+								const message = payload?.error ?? 'Could not save your settings. Try again.';
 								submitError = message;
 								const isBaseUrlError = /openai\s*base\s*url/i.test(message);
 								const isApiKeyError =
@@ -471,14 +471,14 @@ function getThemeColors(themeValue: string) {
 								handleFormToast({ error: message });
 							} else if (result.type === 'error') {
 								const message =
-									result.error?.message ?? 'Failed to save settings. Please try again.';
+									result.error?.message ?? 'Could not save your settings. Try again.';
 								submitError = message;
 								handleFormToast({ error: message });
 							}
 							await update();
 						} catch (err) {
 							const message =
-								err instanceof Error ? err.message : 'Failed to save settings. Please try again.';
+								err instanceof Error ? err.message : 'Could not save your settings. Try again.';
 							submitError = message;
 							handleFormToast({ error: message });
 						} finally {
@@ -531,7 +531,7 @@ function getThemeColors(themeValue: string) {
 						<div class="step-fields">
 							<div class="setting-group">
 								<span class="setting-label">Dashboard Theme</span>
-								<p class="setting-description">Applied to the dashboard and admin pages</p>
+								<p class="setting-description">Used on the dashboard and admin pages</p>
 								<div class="theme-swatches">
 									{#each data.themeOptions as option}
 										{@const colors = getThemeColors(option.value)}
@@ -557,7 +557,7 @@ function getThemeColors(themeValue: string) {
 
 							<div class="setting-group">
 								<span class="setting-label">Wrapped Presentation Theme</span>
-								<p class="setting-description">Applied to the animated year-end slideshow</p>
+								<p class="setting-description">Used on the animated year-end slideshow</p>
 								<div class="theme-swatches">
 									{#each data.themeOptions as option}
 										{@const colors = getThemeColors(option.value)}
@@ -599,7 +599,7 @@ function getThemeColors(themeValue: string) {
 							<div class="setting-group preset-section">
 								<span class="setting-label">Privacy Preset</span>
 								<p class="setting-description">
-									Pick a starting point — then fine-tune anything in Advanced Options.
+									Pick a starting point, then adjust anything in Advanced Options.
 								</p>
 								<div class="preset-grid" role="radiogroup" aria-label="Privacy preset">
 									{#each PRIVACY_PRESETS as preset, i (preset.id)}
@@ -662,11 +662,11 @@ function getThemeColors(themeValue: string) {
 								</div>
 								{#if shouldShowCustomPresetNote(selectedPreset, privacyTouched)}
 									<p class="preset-custom-note" role="status">
-										Custom configuration — your choices don’t match a preset.
+										Custom configuration: your choices don’t match a preset.
 									</p>
 								{:else if selectedPreset === 'custom'}
 									<p class="preset-custom-note preset-custom-note-neutral" role="status">
-										No preset selected yet — pick one above, or continue with the current
+										No preset selected yet. Pick one above, or continue with the current
 										defaults.
 									</p>
 								{/if}
@@ -763,7 +763,7 @@ function getThemeColors(themeValue: string) {
 									</dl>
 								</Tooltip.Provider>
 								<div class="preview-boundary">
-									<strong>Protected areas stay protected.</strong>
+									<strong>Sign-in still guards everything else.</strong>
 									{publicLandingLookupCopy.protectedBoundary}
 									{shareDefaultCopy.summary}
 								</div>
@@ -812,7 +812,7 @@ function getThemeColors(themeValue: string) {
 
 							<div class="setting-group">
 								<span class="setting-label">Wrapped Page Logo</span>
-								<p class="setting-description">Control logo visibility on wrapped pages</p>
+								<p class="setting-description">Control logo visibility on Wrapped pages</p>
 								<div class="radio-cards">
 									{#each data.wrappedLogoOptions as option}
 										<label class="radio-card" class:selected={wrappedLogoMode === option.value}>
@@ -1003,7 +1003,7 @@ function getThemeColors(themeValue: string) {
 							</div>
 							<div class="step-title">
 								<h3>AI Features</h3>
-								<p>AI-powered fun facts and insights</p>
+								<p>Fun facts written by an OpenAI model</p>
 							</div>
 						</div>
 
@@ -1054,7 +1054,7 @@ function getThemeColors(themeValue: string) {
 								<div class="setting-group">
 									<label class="field-label" for="onboarding-openai-api-key">OpenAI API Key</label>
 									<p class="setting-description">
-										Your key is stored server-side and not returned to the browser once saved.
+										Obzorarr stores your key on the server and never returns it to the browser.
 									</p>
 									<input
 										id="onboarding-openai-api-key"
@@ -1075,8 +1075,8 @@ function getThemeColors(themeValue: string) {
 									{/if}
 									{#if showAiKeyWarning}
 										<p class="ai-key-warning" role="status">
-											Enter an OpenAI API key for AI fun facts to work — without it, the
-											built-in template generator is used.
+											Enter an OpenAI API key to use AI fun facts. Without a key, Obzorarr
+											falls back to the built-in templates.
 										</p>
 									{/if}
 								</div>
@@ -1142,7 +1142,7 @@ function getThemeColors(themeValue: string) {
 																};
 													} else if (result.type === 'error') {
 														const message =
-															result.error.message ?? 'An error occurred while testing connection';
+															result.error.message ?? 'The connection test failed';
 														handleFormToast({ error: message });
 														testAIResult = { type: 'error', message };
 													} else {
@@ -1152,7 +1152,7 @@ function getThemeColors(themeValue: string) {
 													}
 												} catch {
 													const message =
-														'Failed to test connection. Please check your network and try again.';
+														'Could not run the connection test. Check your network and try again.';
 													handleFormToast({ error: message });
 													testAIResult = { type: 'error', message };
 												} finally {
@@ -1177,7 +1177,7 @@ function getThemeColors(themeValue: string) {
 
 								<div class="setting-group">
 									<span class="setting-label">AI Persona</span>
-									<p class="setting-description">Tone used when generating AI fun facts</p>
+									<p class="setting-description">Tone for AI-generated fun facts</p>
 									<div class="frequency-options">
 										{#each aiPersonaOptions as option}
 											<label
@@ -1221,7 +1221,7 @@ function getThemeColors(themeValue: string) {
 				disabled={isFirstSubStep || isSubmitting}
 				title={isFirstSubStep ? 'You are on the first step' : undefined}
 				aria-label={isFirstSubStep
-					? 'Previous step (unavailable — this is the first step)'
+					? 'Previous step (unavailable, this is the first step)'
 					: 'Go to previous step'}
 				onclick={prevSubStep}
 			>

--- a/src/routes/onboarding/sync/+page.server.ts
+++ b/src/routes/onboarding/sync/+page.server.ts
@@ -70,14 +70,14 @@ export const actions: Actions = {
 
 			logger.info(`Onboarding: Initial sync started for year ${currentYear}`, 'Onboarding');
 
-			return { success: true, message: 'Sync started successfully' };
+			return { success: true, message: 'Sync started' };
 		} catch (err) {
 			logger.error(
 				`Failed to start sync: ${err instanceof Error ? err.message : String(err)}`,
 				'Onboarding'
 			);
 
-			return fail(500, { error: 'Failed to start sync. Please try again.' });
+			return fail(500, { error: 'Could not start the sync. Try again.' });
 		}
 	},
 

--- a/src/routes/onboarding/sync/+page.svelte
+++ b/src/routes/onboarding/sync/+page.svelte
@@ -339,7 +339,7 @@ function formatNumber(n: number): string {
 				<div class="warning-content">
 					<p class="warning-title">Sync will continue</p>
 					<p class="warning-text">
-						Navigate away anytime - the sync runs independently on the server.
+						Leave this page anytime. The sync keeps running on the server.
 					</p>
 				</div>
 			</div>
@@ -354,14 +354,14 @@ function formatNumber(n: number): string {
 						stroke-linejoin="round"
 					/>
 				</svg>
-				<span>Your viewing history has been synced successfully!</span>
+				<span>Obzorarr finished syncing your viewing history.</span>
 			</div>
 		{/if}
 
 		{#if hasStarted && !hasFailed}
 			<p class="continue-hint">
 				{#if isComplete}
-					You're all set! Continue to customize your experience.
+					Continue to choose your privacy and appearance settings.
 				{:else}
 					You can continue while sync runs in the background.
 				{/if}

--- a/src/routes/wrapped/+layout.svelte
+++ b/src/routes/wrapped/+layout.svelte
@@ -33,7 +33,7 @@ function hasLookupSyncMarker(layoutData: LayoutData): boolean {
 
 const MIN_LOADING_DISPLAY_MS = 300;
 const FAILED_LIVE_SYNC_MESSAGE =
-	"Couldn't refresh your viewing history from Plex. Showing your most recent data.";
+	'Could not refresh your viewing history from Plex. Showing the most recent data instead.';
 
 let isLoading = $state(
 	untrack(() => (canUseSyncStatus(data) ? (data.syncStatus?.inProgress ?? false) : false))

--- a/src/routes/wrapped/[year=year]/+error.svelte
+++ b/src/routes/wrapped/[year=year]/+error.svelte
@@ -38,17 +38,17 @@ const description = $derived.by(() => {
 	// land here; render the same generic 404 description for both rather than
 	// leaking two different raw messages. Narrowed to ONLY those two cases (plus an
 	// empty message) so other explicit 404s — e.g. the loader's user-safe
-	// "This share link is invalid, expired, or has been revoked." — still surface
+	// "This share link is invalid, expired, or revoked." — still surface
 	// their own actionable copy via the `if (message)` branch below. The
 	// isNoDataForYear empty-state above is checked first, so it stays untouched.
 	if (status === 404 && (!message || message === 'Not Found' || message === 'Invalid year')) {
-		return "We couldn't find the page you were looking for.";
+		return "That page doesn't exist.";
 	}
 	if (message) return message;
 	if (status === 403) return "You don't have permission to view this page.";
-	if (status === 429) return 'Please slow down and try again in a moment.';
-	if (status >= 500) return 'An unexpected error occurred on the server.';
-	return 'An unexpected error occurred.';
+	if (status === 429) return 'Wait a moment, then try again.';
+	if (status >= 500) return 'The server hit an unexpected error.';
+	return 'Something went wrong.';
 });
 
 function goBack(): void {

--- a/src/routes/wrapped/[year=year]/u/[identifier]/+page.server.ts
+++ b/src/routes/wrapped/[year=year]/u/[identifier]/+page.server.ts
@@ -148,7 +148,7 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 					404,
 					isAnonymous
 						? WRAPPED_NOT_FOUND_MESSAGE
-						: 'This share link is invalid, expired, or has been revoked.'
+						: 'This share link is invalid, expired, or revoked.'
 				);
 			}
 		} catch (err) {
@@ -157,7 +157,7 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 					404,
 					isAnonymous
 						? WRAPPED_NOT_FOUND_MESSAGE
-						: 'This share link is invalid, expired, or has been revoked.'
+						: 'This share link is invalid, expired, or revoked.'
 				);
 			}
 			if (err instanceof ShareAccessDeniedError) {
@@ -210,7 +210,7 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 					error(404, WRAPPED_NOT_FOUND_MESSAGE);
 				}
 				if (err instanceof InvalidShareTokenError) {
-					error(404, 'This share link is invalid, expired, or has been revoked.');
+					error(404, 'This share link is invalid, expired, or revoked.');
 				}
 				throw err;
 			}
@@ -251,7 +251,7 @@ export const load: PageServerLoad = async ({ params, locals, parent, setHeaders 
 					404,
 					isAnonymous
 						? WRAPPED_NOT_FOUND_MESSAGE
-						: 'This share link is invalid, expired, or has been revoked.'
+						: 'This share link is invalid, expired, or revoked.'
 				);
 			}
 			throw err;
@@ -418,7 +418,7 @@ export const actions: Actions = {
 			await setUserLogoPreference(locals.user.id, year, showLogo);
 			return { success: true, showLogo };
 		} catch (err) {
-			const message = err instanceof Error ? err.message : 'Failed to update preference';
+			const message = err instanceof Error ? err.message : 'Could not save your logo preference';
 			return fail(500, { error: message });
 		}
 	},
@@ -488,7 +488,7 @@ export const actions: Actions = {
 					}
 				});
 			}
-			const message = err instanceof Error ? err.message : 'Failed to update share settings';
+			const message = err instanceof Error ? err.message : 'Could not save the share settings';
 			return fail(500, { error: message });
 		}
 	},
@@ -520,7 +520,7 @@ export const actions: Actions = {
 			}
 
 			if (settings.mode !== ShareMode.PRIVATE_LINK) {
-				return fail(400, { error: 'Can only regenerate token for private-link mode' });
+				return fail(400, { error: 'Switch to private-link mode before regenerating the token' });
 			}
 
 			const newToken = await regenerateShareToken(userId, year);
@@ -540,7 +540,7 @@ export const actions: Actions = {
 			if (err instanceof PermissionExceededError) {
 				return fail(403, { error: err.message });
 			}
-			const message = err instanceof Error ? err.message : 'Failed to regenerate token';
+			const message = err instanceof Error ? err.message : 'Could not regenerate the share link';
 			return fail(500, { error: message });
 		}
 	}

--- a/tests/unit/admin/appearance-actions.test.ts
+++ b/tests/unit/admin/appearance-actions.test.ts
@@ -24,7 +24,7 @@ const adminLocals = {
 	user: { id: 1, plexId: 1, username: 'admin', isAdmin: true }
 } as unknown as App.Locals;
 
-const OCC_MESSAGE = 'Settings changed in another tab. Please reload.';
+const OCC_MESSAGE = 'Settings changed in another tab. Reload and try again.';
 
 beforeEach(async () => {
 	await resetSharedTestDb();

--- a/tests/unit/admin/csrf-action.test.ts
+++ b/tests/unit/admin/csrf-action.test.ts
@@ -239,7 +239,7 @@ describe('admin updateCsrfOrigin action', () => {
 		expect(result.status).toBe(409);
 		expect(result.data).toMatchObject({
 			conflict: true,
-			error: 'Settings changed in another tab. Please reload.'
+			error: 'Settings changed in another tab. Reload and try again.'
 		});
 		expect(await getAppSetting(AppSettingsKey.CSRF_ORIGIN)).toBeNull();
 	});

--- a/tests/unit/admin/dogfood-ui-invariants.test.ts
+++ b/tests/unit/admin/dogfood-ui-invariants.test.ts
@@ -269,20 +269,20 @@ describe('DF-16 source-guard — admin dashboard scheduler-cta callout', () => {
 });
 
 describe('ISSUE-005 source-guard — admin <title> separator uniformity', () => {
-	// All admin document titles use an em-dash separator. Dashboard and Wrapped
-	// previously used a hyphen; this guard pins the em-dash so the separator
-	// stays consistent across admin pages.
+	// Every document title in the app uses a hyphen separator. This guard pins the
+	// hyphen on the two admin pages that historically drifted, so the separator
+	// stays consistent with the dashboard, onboarding, and Wrapped titles.
 
-	it('admin dashboard title uses the em-dash separator', async () => {
+	it('admin dashboard title uses the hyphen separator', async () => {
 		const src = await readSource(ADMIN_DASHBOARD);
-		expect(src).toContain('<title>Dashboard — Admin — Obzorarr</title>');
-		expect(src).not.toContain('<title>Dashboard - Admin - Obzorarr</title>');
+		expect(src).toContain('<title>Dashboard - Admin - Obzorarr</title>');
+		expect(src).not.toContain('<title>Dashboard — Admin — Obzorarr</title>');
 	});
 
-	it('admin wrapped hub title uses the em-dash separator', async () => {
+	it('admin wrapped hub title uses the hyphen separator', async () => {
 		const src = await readSource(ADMIN_WRAPPED);
-		expect(src).toContain('<title>Wrapped — Admin — Obzorarr</title>');
-		expect(src).not.toContain('<title>Wrapped - Admin - Obzorarr</title>');
+		expect(src).toContain('<title>Wrapped - Admin - Obzorarr</title>');
+		expect(src).not.toContain('<title>Wrapped — Admin — Obzorarr</title>');
 	});
 });
 

--- a/tests/unit/admin/instance-reset.test.ts
+++ b/tests/unit/admin/instance-reset.test.ts
@@ -547,12 +547,12 @@ describe('instance reset — Danger zone UI wiring (no DOM harness in this suite
 
 	it('states honestly what is lost, including share-link breakage and manual curation', async () => {
 		const prose = await readProse();
-		expect(prose).toContain('re-synced from the official Plex API');
+		expect(prose).toContain('re-syncs play history from the official Plex API');
 		expect(prose).toContain('any link you have already handed out to a user stops working');
 		expect(prose).toContain('other curation you did by hand');
 		// Env-configured settings survive; the copy must not promise a blank slate.
 		expect(prose).toContain('TRUST_PROXY');
-		expect(prose).toContain('not a completely blank slate');
+		expect(prose).toContain('you do not start');
 	});
 
 	it('keeps both dialogs dismissible with no side effects', async () => {
@@ -591,7 +591,7 @@ describe('instance reset — Danger zone UI wiring (no DOM harness in this suite
 		expect(src).toContain('onclick={copyResetToken}');
 		expect(src).toContain('navigator.clipboard.writeText(resetToken)');
 		expect(src).toContain(
-			'{resetTokenExpiresInMinutes ?? data.resetTokenTtlMinutes} minutes and is not stored anywhere'
+			'{resetTokenExpiresInMinutes ?? data.resetTokenTtlMinutes} minutes and Obzorarr stores it'
 		);
 	});
 

--- a/tests/unit/admin/privacy-actions.test.ts
+++ b/tests/unit/admin/privacy-actions.test.ts
@@ -64,7 +64,7 @@ describe('privacy nested route — updateServerWrappedSettings', () => {
 			status: 409,
 			data: {
 				conflict: true,
-				error: 'Settings changed in another tab. Please reload.'
+				error: 'Settings changed in another tab. Reload and try again.'
 			}
 		});
 	});
@@ -217,7 +217,7 @@ describe('privacy nested route — updateUserDefaults', () => {
 			status: 409,
 			data: {
 				conflict: true,
-				error: 'Settings changed in another tab. Please reload.'
+				error: 'Settings changed in another tab. Reload and try again.'
 			}
 		});
 	});
@@ -267,7 +267,7 @@ describe('privacy nested route — updateUserDefaults', () => {
 		);
 		expect(stale).toMatchObject({
 			status: 409,
-			data: { conflict: true, error: 'Settings changed in another tab. Please reload.' }
+			data: { conflict: true, error: 'Settings changed in another tab. Reload and try again.' }
 		});
 		expect(await getGlobalDefaultShareMode()).toBe('public');
 	});

--- a/tests/unit/admin/privacy-preset-apply.test.ts
+++ b/tests/unit/admin/privacy-preset-apply.test.ts
@@ -22,7 +22,7 @@ const adminLocals = {
 } as unknown as App.Locals;
 
 const EPOCH = new Date(0).toISOString();
-const OCC_MESSAGE = 'Settings changed in another tab. Please reload.';
+const OCC_MESSAGE = 'Settings changed in another tab. Reload and try again.';
 
 function makeRequest(action: string, fields: Record<string, string>): Request {
 	const formData = new FormData();

--- a/tests/unit/admin/security-actions.test.ts
+++ b/tests/unit/admin/security-actions.test.ts
@@ -127,7 +127,7 @@ describe('security nested route — updateCsrfOrigin (OCC + set + clear)', () =>
 		const result = await run(csrfRequest({ csrfOrigin: ORIGIN, settingsVersion: '' }));
 		expect(result).toMatchObject({
 			status: 409,
-			data: { conflict: true, error: 'Settings changed in another tab. Please reload.' }
+			data: { conflict: true, error: 'Settings changed in another tab. Reload and try again.' }
 		});
 	});
 

--- a/tests/unit/admin/slides-actions.test.ts
+++ b/tests/unit/admin/slides-actions.test.ts
@@ -283,7 +283,7 @@ describe('admin slides actions', () => {
 
 			// ISSUE-006: the rejection is now branch-specific (the <script> branch),
 			// still routed to fieldErrors.content via slideErrorToFail.
-			const scriptReason = "Remove <script> tags — inline scripts aren't allowed in slide content.";
+			const scriptReason = 'Remove <script> tags. Slide content cannot include inline scripts.';
 			expect(result).toMatchObject({
 				status: 400,
 				data: {

--- a/tests/unit/admin/system-actions.test.ts
+++ b/tests/unit/admin/system-actions.test.ts
@@ -64,7 +64,7 @@ describe('system nested route — updateLogSettings (Superforms + inline OCC)', 
 			status: 409,
 			data: {
 				conflict: true,
-				error: 'Settings changed in another tab. Please reload.'
+				error: 'Settings changed in another tab. Reload and try again.'
 			}
 		});
 		expect(await getLogRetentionDays()).toBe(7);
@@ -214,7 +214,7 @@ describe('system nested route — updateLogSettings (Superforms + inline OCC)', 
 			status: 409,
 			data: {
 				conflict: true,
-				error: 'Settings changed in another tab. Please reload.'
+				error: 'Settings changed in another tab. Reload and try again.'
 			}
 		});
 	});

--- a/tests/unit/auth/core.test.ts
+++ b/tests/unit/auth/core.test.ts
@@ -84,14 +84,14 @@ describe('auth core contracts', () => {
 			[
 				'PinExpiredError',
 				PinExpiredError,
-				'Login session expired. Please try again.',
+				'Login session expired. Sign in again.',
 				'Custom PIN expired message',
 				'PIN_EXPIRED'
 			],
 			[
 				'SessionExpiredError',
 				SessionExpiredError,
-				'Your session has expired. Please log in again.',
+				'Your session expired. Sign in again.',
 				'Custom session expired message',
 				'SESSION_EXPIRED'
 			]

--- a/tests/unit/auth/lifecycle.test.ts
+++ b/tests/unit/auth/lifecycle.test.ts
@@ -118,7 +118,7 @@ describe('createSessionFromPlexToken', () => {
 		} catch (err) {
 			expect(err).toBeInstanceOf(NotServerMemberError);
 			expect((err as Error).message).toBe(
-				'Only the server owner can configure Obzorarr. Please sign in with the server owner account.'
+				'Only the server owner can configure Obzorarr. Sign in with the owner account.'
 			);
 		}
 		expect(await db.select().from(sessions)).toHaveLength(0);

--- a/tests/unit/dashboard/dashboard-empty-state.test.ts
+++ b/tests/unit/dashboard/dashboard-empty-state.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 
 // Source guards for dashboard empty-state invariants (ISSUE-003, ISSUE-004).
 // Pins the subtitle gate and the no-data personal-card affordance so regressions
-// cannot silently reintroduce the unconditional "ready to explore" subtitle or
+// cannot silently reintroduce the unconditional "ready to view" subtitle or
 // a link-bearing no-data card that would hit the ISSUE-001 incident class.
 
 const PROJECT_ROOT = join(import.meta.dir, '..', '..', '..');
@@ -15,19 +15,19 @@ async function readSource(relPath: string): Promise<string> {
 const DASHBOARD_PAGE = 'src/routes/dashboard/+page.svelte';
 
 describe('ISSUE-003 source-guard — dashboard subtitle is data-aware', () => {
-	it('subtitle "ready to explore" only appears inside the {#if data.wrappedHref} branch', async () => {
+	it('subtitle "ready to view" only appears inside the {#if data.wrappedHref} branch', async () => {
 		const src = await readSource(DASHBOARD_PAGE);
-		// The entire truthy branch must contain the "ready to explore" copy.
+		// The entire truthy branch must contain the "ready to view" copy.
 		const ifIdx = src.indexOf('{#if data.wrappedHref}');
 		expect(ifIdx).toBeGreaterThan(-1);
 		const elseIdx = src.indexOf('{:else}', ifIdx);
 		expect(elseIdx).toBeGreaterThan(ifIdx);
 		const truthyBranch = src.slice(ifIdx, elseIdx);
-		expect(truthyBranch).toContain('ready to explore');
-		// The "ready to explore" copy must NOT appear outside the truthy branch.
+		expect(truthyBranch).toContain('ready to view');
+		// The "ready to view" copy must NOT appear outside the truthy branch.
 		// Everything before the first {#if data.wrappedHref} must not have it.
 		const beforeIf = src.slice(0, ifIdx);
-		expect(beforeIf).not.toContain('ready to explore');
+		expect(beforeIf).not.toContain('ready to view');
 	});
 
 	it('{:else} branch contains the empty-state subtitle copy', async () => {
@@ -43,8 +43,8 @@ describe('ISSUE-003 source-guard — dashboard subtitle is data-aware', () => {
 		// The else branch must contain the empty-state subtitle text.
 		expect(elseBranch).toContain('viewing history synced yet');
 		expect(elseBranch).toContain('Wrapped will appear here');
-		// The "ready to explore" copy must NOT leak into the else branch.
-		expect(elseBranch).not.toContain('ready to explore');
+		// The "ready to view" copy must NOT leak into the else branch.
+		expect(elseBranch).not.toContain('ready to view');
 	});
 });
 

--- a/tests/unit/hooks-error-handler.test.ts
+++ b/tests/unit/hooks-error-handler.test.ts
@@ -96,7 +96,7 @@ describe('handleError — not-found demotion (ISSUE-010)', () => {
 			expect(infoSpy).not.toHaveBeenCalled();
 			expect(errorSpy).toHaveBeenCalledTimes(1);
 			expect(errorSpy.mock.calls[0]?.[1]).toBe('ErrorHandler');
-			expect(result).toEqual({ message: 'An unexpected error occurred' });
+			expect(result).toEqual({ message: 'Something went wrong. Try again.' });
 		} finally {
 			infoSpy.mockRestore();
 			errorSpy.mockRestore();
@@ -176,7 +176,7 @@ describe('handleError — 4xx demotion to WARN (ISSUE-009)', () => {
 			expect(warnSpy).not.toHaveBeenCalled();
 			expect(errorSpy).toHaveBeenCalledTimes(1);
 			expect(errorSpy.mock.calls[0]?.[1]).toBe('ErrorHandler');
-			expect(result).toEqual({ message: 'An unexpected error occurred' });
+			expect(result).toEqual({ message: 'Something went wrong. Try again.' });
 		} finally {
 			warnSpy.mockRestore();
 			errorSpy.mockRestore();
@@ -198,7 +198,7 @@ describe('handleError — 4xx demotion to WARN (ISSUE-009)', () => {
 			expect(warnSpy).not.toHaveBeenCalled();
 			expect(errorSpy).toHaveBeenCalledTimes(1);
 			expect(errorSpy.mock.calls[0]?.[1]).toBe('ErrorHandler');
-			expect(result).toEqual({ message: 'An unexpected error occurred' });
+			expect(result).toEqual({ message: 'Something went wrong. Try again.' });
 		} finally {
 			warnSpy.mockRestore();
 			errorSpy.mockRestore();

--- a/tests/unit/lib/server/funfacts/test-connection.test.ts
+++ b/tests/unit/lib/server/funfacts/test-connection.test.ts
@@ -140,7 +140,7 @@ describe('testOpenAIConnection', () => {
 
 		expect(result).toEqual({
 			success: false,
-			error: 'Authentication failed — check your API key — Unauthorized'
+			error: 'Authentication failed. Check your API key. (Unauthorized)'
 		});
 	});
 
@@ -153,7 +153,7 @@ describe('testOpenAIConnection', () => {
 
 		expect(result).toEqual({
 			success: false,
-			error: 'Model not found or base URL is incorrect — Not Found'
+			error: 'Model not found or base URL is incorrect (Not Found)'
 		});
 	});
 
@@ -166,7 +166,7 @@ describe('testOpenAIConnection', () => {
 
 		expect(result).toEqual({
 			success: false,
-			error: 'Request failed: 500 Internal Server Error — Server Error'
+			error: 'Request failed: 500 Internal Server Error (Server Error)'
 		});
 	});
 
@@ -221,7 +221,7 @@ describe('testOpenAIConnection', () => {
 		expect(result).toEqual({
 			success: false,
 			error:
-				"Request failed: 400 Bad Request — Unsupported parameter: 'max_tokens' is not supported with this model."
+				"Request failed: 400 Bad Request (Unsupported parameter: 'max_tokens' is not supported with this model.)"
 		});
 	});
 

--- a/tests/unit/lib/utils/form-toast-parity.test.ts
+++ b/tests/unit/lib/utils/form-toast-parity.test.ts
@@ -49,7 +49,7 @@ describe('handleFormToast parity', () => {
 		it('falls back to default success message when none provided', () => {
 			handleFormToast({ success: true });
 			expect(getTestToastCalls()[0]?.variant).toBe('success');
-			expect(getTestToastCalls()[0]?.message).toMatch(/completed/i);
+			expect(getTestToastCalls()[0]?.message).toBe('Saved');
 		});
 
 		it('is a no-op on null / undefined', () => {
@@ -88,12 +88,12 @@ describe('handleFormToast parity', () => {
 		it('uses default messages when data is missing', () => {
 			handleFormToast({ type: 'success', status: 200, data: undefined });
 			expect(getTestToastCalls()[0]?.variant).toBe('success');
-			expect(getTestToastCalls()[0]?.message).toMatch(/completed/i);
+			expect(getTestToastCalls()[0]?.message).toBe('Saved');
 
 			clearTestToastCalls();
 			handleFormToast({ type: 'failure', status: 400, data: undefined });
 			expect(getTestToastCalls()[0]?.variant).toBe('error');
-			expect(getTestToastCalls()[0]?.message).toMatch(/unexpected/i);
+			expect(getTestToastCalls()[0]?.message).toBe('Something went wrong. Try again.');
 		});
 	});
 

--- a/tests/unit/lib/utils/form-toast-parity.test.ts
+++ b/tests/unit/lib/utils/form-toast-parity.test.ts
@@ -46,10 +46,14 @@ describe('handleFormToast parity', () => {
 			expect(getTestToastCalls()).toEqual([{ variant: 'success', message: 'saved' }]);
 		});
 
-		it('falls back to default success message when none provided', () => {
+		it('falls back to an operation-neutral success message when none provided', () => {
+			// The util cannot know what the action did — `admin/slides` routes toggles,
+			// reorders AND `?/deleteCustom` (a bare `{ success: true }`) through one
+			// `$effect` on the `form` prop, so the fallback must never claim "Saved".
 			handleFormToast({ success: true });
 			expect(getTestToastCalls()[0]?.variant).toBe('success');
-			expect(getTestToastCalls()[0]?.message).toBe('Saved');
+			expect(getTestToastCalls()[0]?.message).toBe('Done');
+			expect(getTestToastCalls()[0]?.message).not.toMatch(/saved/i);
 		});
 
 		it('is a no-op on null / undefined', () => {
@@ -88,7 +92,7 @@ describe('handleFormToast parity', () => {
 		it('uses default messages when data is missing', () => {
 			handleFormToast({ type: 'success', status: 200, data: undefined });
 			expect(getTestToastCalls()[0]?.variant).toBe('success');
-			expect(getTestToastCalls()[0]?.message).toBe('Saved');
+			expect(getTestToastCalls()[0]?.message).toBe('Done');
 
 			clearTestToastCalls();
 			handleFormToast({ type: 'failure', status: 400, data: undefined });

--- a/tests/unit/onboarding/complete-notice.test.ts
+++ b/tests/unit/onboarding/complete-notice.test.ts
@@ -6,7 +6,7 @@ import {
 
 describe('_deriveAiKeyMissingNotice (ISSUE-010 stale-notice reconciliation)', () => {
 	it('shows the notice when fun facts were requested but no effective key exists', () => {
-		// Toggle fun facts on, leave it on, no key -> Template mode + notice.
+		// Toggle fun facts on, leave it on, no key -> template mode + notice.
 		expect(_deriveAiKeyMissingNotice(false, true)).toBe('ai-key-missing');
 	});
 
@@ -36,7 +36,7 @@ describe('_deriveFunFactsSummary (ISSUE-001 Done-page copy consistency)', () => 
 	it('shows template mode when fun facts were enabled but no key was provided', () => {
 		// No key + ai-key-missing notice -> built-in templates, not "Disabled".
 		expect(_deriveFunFactsSummary(false, true, frequency)).toBe(
-			'Template mode — add an OpenAI key to enable AI'
+			'Template mode: add an OpenAI key for AI fun facts'
 		);
 	});
 

--- a/tests/unit/onboarding/complete.test.ts
+++ b/tests/unit/onboarding/complete.test.ts
@@ -118,7 +118,7 @@ describe('onboarding completion page', () => {
 			'template mode when AI was requested without a key',
 			'?notice=ai-key-missing',
 			false,
-			'Template mode — add an OpenAI key to enable AI',
+			'Template mode: add an OpenAI key for AI fun facts',
 			async () => {
 				await setFunFactFrequency(FunFactFrequency.MANY);
 				await setAppSetting(AppSettingsKey.OPENAI_BASE_URL, 'https://api.example.com/v1');

--- a/tests/unit/onboarding/csrf-actions.test.ts
+++ b/tests/unit/onboarding/csrf-actions.test.ts
@@ -201,7 +201,7 @@ describe('onboarding CSRF actions', () => {
 		expect(result).toEqual({
 			status: 400,
 			data: {
-				testError: 'Could not detect browser origin. Ensure you are accessing via HTTP/HTTPS.'
+				testError: 'Could not detect the browser origin. Open Obzorarr over HTTP or HTTPS.'
 			}
 		});
 		expect(await getOnboardingStep()).toBe(OnboardingSteps.CSRF);

--- a/tests/unit/onboarding/plex.test.ts
+++ b/tests/unit/onboarding/plex.test.ts
@@ -146,8 +146,7 @@ describe('onboarding Plex owner verification', () => {
 			expect(result).toMatchObject({
 				status: 403,
 				data: {
-					error:
-						'Only the server owner can configure Obzorarr. Please sign in with the server owner account.'
+					error: 'Only the server owner can configure Obzorarr. Sign in with the owner account.'
 				}
 			});
 		} finally {

--- a/tests/unit/plex-login.test.ts
+++ b/tests/unit/plex-login.test.ts
@@ -531,7 +531,7 @@ describe('resolveRedirectPinData', () => {
 				{ pinId: 222, expiresAt: new Date(60_000).toISOString(), context: 'onboarding' },
 				2000
 			)
-		).toThrow('Invalid authentication data. Please try again.');
+		).toThrow('Invalid authentication data. Try again.');
 		expect(storage.getItem(PIN_STORAGE_KEY)).toBeNull();
 	});
 
@@ -549,7 +549,7 @@ describe('resolveRedirectPinData', () => {
 				{ pinId: 222, expiresAt: new Date(60_000).toISOString(), context: 'onboarding' },
 				2000
 			)
-		).toThrow('Invalid authentication data. Please try again.');
+		).toThrow('Invalid authentication data. Try again.');
 	});
 });
 
@@ -851,7 +851,7 @@ describe('startPlexLoginPopup', () => {
 		// Second tick: closed popup detected → cancel error fired exactly once.
 		await poll();
 		expect(onError).toHaveBeenCalledTimes(1);
-		expect((onError.mock.calls[0] as string[])[0]).toBe('Sign-in cancelled. You can try again.');
+		expect((onError.mock.calls[0] as string[])[0]).toBe('Sign-in cancelled.');
 		expect(onSuccess).not.toHaveBeenCalled();
 		expect(onPopupBlocked).not.toHaveBeenCalled();
 
@@ -1139,10 +1139,10 @@ describe('startPlexLoginPopup', () => {
 		globalThis.fetch = mock(async (input: string | URL | Request, init?: RequestInit) => {
 			const url = typeof input === 'string' ? input : input.toString();
 			if (url === '/auth/plex' && init?.method === 'POST') {
-				return new Response(
-					JSON.stringify({ message: 'Unable to connect to Plex. Please try again.' }),
-					{ status: 502, headers: { 'Content-Type': 'application/json' } }
-				);
+				return new Response(JSON.stringify({ message: 'Could not reach Plex. Try again.' }), {
+					status: 502,
+					headers: { 'Content-Type': 'application/json' }
+				});
 			}
 			return new Response(
 				JSON.stringify({ pinId: 42, authUrl: 'https://app.plex.tv/auth#?code=ABCD' }),
@@ -1168,9 +1168,7 @@ describe('startPlexLoginPopup', () => {
 		await poll();
 
 		expect(onError).toHaveBeenCalledTimes(1);
-		expect((onError.mock.calls[0] as string[])[0]).toBe(
-			'Unable to connect to Plex. Please try again.'
-		);
+		expect((onError.mock.calls[0] as string[])[0]).toBe('Could not reach Plex. Try again.');
 		expect(onSuccess).not.toHaveBeenCalled();
 
 		await poll();

--- a/tests/unit/security/rate-limit-handle.test.ts
+++ b/tests/unit/security/rate-limit-handle.test.ts
@@ -90,7 +90,7 @@ describe('rateLimitHandle landing page bucket', () => {
 		const body = await blockedResponse?.json();
 		expect(body).toMatchObject({ type: 'failure', status: 429 });
 		expect(parse(body.data)).toEqual({
-			error: `Too many requests. Please try again in ${retryAfterSeconds} second${retryAfterSeconds === 1 ? '' : 's'}.`,
+			error: `Too many requests. Try again in ${retryAfterSeconds} second${retryAfterSeconds === 1 ? '' : 's'}.`,
 			requiresAuth: false
 		});
 	});
@@ -174,7 +174,7 @@ describe('rateLimitHandle enhanced action responses', () => {
 		const body = await blockedResponse?.json();
 		expect(body).toMatchObject({ type: 'failure', status: 429 });
 		expect(parse(body.data)).toEqual({
-			error: `Too many requests. Please try again in ${retryAfterSeconds} second${retryAfterSeconds === 1 ? '' : 's'}.`,
+			error: `Too many requests. Try again in ${retryAfterSeconds} second${retryAfterSeconds === 1 ? '' : 's'}.`,
 			requiresAuth: false
 		});
 	});

--- a/tests/unit/sharing/access-control.test.ts
+++ b/tests/unit/sharing/access-control.test.ts
@@ -284,7 +284,7 @@ describe('Sharing Access Control', () => {
 				} catch (error) {
 					expect(error).toBeInstanceOf(ShareAccessDeniedError);
 					expect((error as ShareAccessDeniedError).message).toBe(
-						'Sign in with your Plex account to view this wrapped.'
+						'Sign in with your Plex account to view this Wrapped.'
 					);
 				}
 			});

--- a/tests/unit/sharing/anon-denial-uniformity.test.ts
+++ b/tests/unit/sharing/anon-denial-uniformity.test.ts
@@ -231,7 +231,7 @@ describe('wrapped/[year]/u/[identifier]: ISSUE-009 anonymous-denial uniformity',
 		expect(outcome.status).toBe(404);
 		// Authenticated callers keep the legacy differentiated message, NOT the
 		// anonymous anti-enumeration body.
-		expect(outcome.message).toBe('This share link is invalid, expired, or has been revoked.');
+		expect(outcome.message).toBe('This share link is invalid, expired, or revoked.');
 		expect(outcome.message).not.toBe(WRAPPED_NOT_FOUND_MESSAGE);
 	});
 

--- a/tests/unit/slides/contracts.test.ts
+++ b/tests/unit/slides/contracts.test.ts
@@ -244,26 +244,26 @@ describe('server slide error/type contracts', () => {
 			'CREATE_FAILED',
 			new SlideError('Insert returned no row', 'CREATE_FAILED'),
 			500,
-			{ error: 'Slide could not be saved. Please try again.' }
+			{ error: 'Could not save the slide. Try again.' }
 		],
 		[
 			'UPDATE_FAILED',
 			new SlideError('Update returned no row', 'UPDATE_FAILED'),
 			500,
-			{ error: 'Slide could not be saved. Please try again.' }
+			{ error: 'Could not save the slide. Try again.' }
 		],
 		[
 			'generic Error',
 			new Error('UNIQUE constraint failed: custom_slides.sort_order'),
 			500,
-			{ error: 'An unexpected error occurred' }
+			{ error: 'Something went wrong. Try again.' }
 		],
-		['non-Error throwable', 'something', 500, { error: 'An unexpected error occurred' }],
+		['non-Error throwable', 'something', 500, { error: 'Something went wrong. Try again.' }],
 		[
 			'unknown SlideError code',
 			new SlideError('Unknown failure', 'TOTALLY_NEW_CODE'),
 			500,
-			{ error: 'An unexpected error occurred' }
+			{ error: 'Something went wrong. Try again.' }
 		]
 	] as const)('maps %s safely', (_name, error, status, body) => {
 		const result = slideErrorToFail(error);

--- a/tests/unit/sync/schedule-action.test.ts
+++ b/tests/unit/sync/schedule-action.test.ts
@@ -55,7 +55,7 @@ describe('sync updateSchedule action (ISSUE-004 / ISSUE-005)', () => {
 		setupSyncScheduler({ cronExpression: '0 0 * * *', startImmediately: true });
 		const result = (await run('0 6 * * *')) as { success: boolean; message: string };
 		expect(result.success).toBe(true);
-		expect(result.message).toBe('Schedule updated successfully');
+		expect(result.message).toBe('Schedule updated');
 	});
 
 	it('rejects an invalid cron with a 400 and echoes the bad value back', async () => {


### PR DESCRIPTION
## Summary

Audits every string a user reads and revises the ones that read as generic, inflated, or machine-written. The editorial standard is the [Stop Slop](https://github.com/hardikpandya/stop-slop) skill and its `phrases.md`, `structures.md`, and `examples.md` references: cut filler and adverbs, break formulaic contrasts, use active voice with a named actor, be specific, address the reader as "you", and remove em dashes.

No behaviour, route, setting key, error code, or security property changes. Only the human-readable text moves, plus the tests that assert it.

## What changed, by surface

**Landing and error pages**
- Hero: `Discover your Plex viewing journey. Beautiful statistics, stunning animations, and shareable summaries of your media consumption.` → `See what you watched on Plex this year, with stats and animated slides you can share.`
- Public-lookup boundary: `Dashboards, settings, and admin controls remain protected.` → `... still need sign-in.`
- 404: `We couldn't find the page you were looking for.` → `That page doesn't exist.`; 429 loses the `Please slow down` softener.

**Onboarding wizard**
- Plex step subtitle: `Link your Plex Media Server to unlock your personalized viewing journey` → `Connect the Plex Media Server that holds your viewing history`.
- CSRF callout heading `Why configure CSRF protection?` → `What CSRF protection does`, and its body names the actor: `Obzorarr checks that form posts come from your own domain.`
- Sync success: `Your viewing history has been synced successfully!` → `Obzorarr finished syncing your viewing history.`
- Settings step: `Configure Your Experience` / `You can always change these later` → `Configure Obzorarr` / `You can change all of it later`.

**Dashboard and user settings**
- `Discover your personal viewing journey - your top shows, movies, and more` → `Your top shows and movies for the year, plus how your viewing changed`.
- `Sharing settings are managed by your server administrator` → `Your server administrator manages sharing settings`.
- `wrapped page` → `Wrapped page` throughout, matching the product noun used everywhere else.

**Wrapped slides**
- 30-day streak: `Incredible dedication!` → `A month or more!` (matching the specific `Two weeks strong!` / `A full week!` siblings).
- Top decile: `You're a super fan!` → `You're in the top 10%!`
- No rewatches: `Looks like you're always exploring new content!` → `Every play this year was something new.`

**Admin**
- Wrapped hub subtitle: `Discover viewing journeys and manage the wrapped experience` → `Preview Wrapped pages and configure how they look`.
- Sync header: `Sync Command` / `Plex Data Synchronization Center` → `Plex Sync` / `Start a sync, manage the schedule, and review past runs`.
- Connections card: fixes the lowercase `obzorarr` and turns `Locked fields are set via environment variables` into `Environment variables set the locked fields, so change them there.`
- Log dialogs drop the redundant `permanently ... cannot be undone` pairing; five agentless failure toasts now name their object (`Failed to update the logging settings`).
- Every admin `<title>` moves from `—` to the hyphen separator the dashboard, onboarding, and Wrapped titles already use.

**Shared server messages, toasts, and errors**
- `Operation completed successfully` → `Saved`; `An unexpected error occurred` → `Something went wrong. Try again.`
- `Please try again` softeners removed across auth, rate limiting, Plex, and the login client (`Login session expired. Sign in again.`).
- Hyphen-as-dash removed from the sanitized connection errors (`Connection timed out. The server may be unreachable.`).
- `Can only regenerate token for private-link mode` → `Switch to private-link mode before regenerating the token` (actionable, active).

**Accessibility text**
- `aria-label="Story presentation - use arrow keys to navigate"` → `Story presentation. Use the arrow keys to move between slides.`
- `aria-label="Select wrapped year"` → `Select Wrapped year`.

**README**
Only the two spots that duplicate app copy this PR changed: the AI Fun Facts bullet (`personalized insights` → the wording the app now uses) and the "Starting over" paragraph that mirrors the Danger zone prose.

## Security and privacy invariants preserved

- The anonymous public-lookup denial stays uniform. `Unknown usernames and users who opted out receive the same "not publicly shared" response` is unchanged in intent; the landing helper text still says unknown and opted-out usernames return the same response.
- The four share-link denials still emit one identical string (`This share link is invalid, expired, or revoked.`), so the endpoint cannot be used to enumerate users.
- The CSRF dismissal dialog still requires two confirmations and still states the risk being accepted; it just states it once instead of twice.
- The `TRUST_PROXY` confirm dialog, `SAFETY_NOTICE`, and the whole `src/lib/copy/reverse-proxy.ts` diagnostic corpus are untouched — that copy is already precise and active.

## Reviewed but left unchanged

- `src/lib/copy/reverse-proxy.ts` (449 lines of diagnostic copy): direct, active, no em dashes, no filler.
- Theme descriptions on the Appearance page: descriptive flavour that reads cleanly.
- The ~30 existing `Failed to <verb> <object>` admin toasts: an established terse convention. Only the five that named no object were touched.
- `'Just now'`, `Delete "<title>" permanently?`, and `Permanently Dismiss Warning`: "permanently" is load-bearing in each.
- Developer comments, log messages, test descriptions, error codes, setting keys, and the shadcn primitives under `src/lib/components/ui/**`.
- The em dashes and en dashes that remain are all in developer comments or numeric ranges (`Range 1–365`).

## OCC sentinel note

`OCC_CONFLICT_MESSAGE` moves from `Settings changed in another tab. Please reload.` to `Settings changed in another tab. Reload and try again.`, which also aligns it with the pre-existing connections-page wording. Per the duplication note in `CLAUDE.md`, this updates both `src/lib/server/admin/occ-helpers.ts` and the re-declared literal in `src/lib/utils/occ-form.ts`, plus the six test files that assert it verbatim, in the same change.

## Test updates

19 test files updated where they assert user-visible strings: the OCC sentinel, the generic error-handler message, slide error bodies, the rate-limit message, auth error defaults, the share-link denial, the login client messages, the fun-fact connection-test errors, the dashboard subtitle source guard, the danger-zone prose guard, and the admin title separator guard (repointed from `—` to `-` while keeping its uniformity intent).

## Validation

Run in the order `CLAUDE.md` documents, on the final branch state:

| Command | Result |
| --- | --- |
| `bun run check:biome` | Checked 653 files, no diagnostics |
| `bun run check` | 3157 files, 0 errors, 0 warnings |
| `bun run test` | 2416 pass, 0 fail (114 files) |
| `bun run build` | built in 6.82s, adapter done |

`bun run build` was included because the change touches `<svelte:head>` titles and other build-time rendered content.

## Follow-up needing product context

- `Sign-in still guards everything else.` (onboarding privacy preview) replaces `Protected areas stay protected.` but still sits directly above `publicLandingLookupCopy.protectedBoundary`, which repeats the same point. Collapsing the two would be a layout decision, not a copy one.
- The `admin/settings/appearance` theme descriptions ("Deep charcoal and soft green for a calmer dashboard feel") make subjective claims about each palette. Verifying them against the actual tokens needs someone who owns the design intent.
